### PR TITLE
fix: bump max_replication_slots to 100 to make tests pass

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -65,7 +65,8 @@ jobs:
         run: |
           PGPASSWORD=postgres psql -h localhost -p 5430 -U postgres \
             -c "ALTER SYSTEM SET wal_level = 'logical';" \
-            -c "ALTER SYSTEM SET max_wal_senders = 100;"
+            -c "ALTER SYSTEM SET max_wal_senders = 100;" \
+            -c "ALTER SYSTEM SET max_replication_slots = 100;"
 
       - name: Restart Postgres service container
         run: |

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -60,12 +60,13 @@ then
     fi
 
     # Complete the docker run command
+    # Increased PostgreSQL settings for logical replication for tests to run smoothly
     DOCKER_RUN_CMD="${DOCKER_RUN_CMD} \
         --name "postgres_$(date '+%s')" \
         postgres:15 -N 1000 \
         -c wal_level=logical \
-        -c max_wal_senders=100"
-        # Increased maximum number of connections for testing purposes
+        -c max_wal_senders=100 \
+        -c max_replication_slots=100"
 
     # Start the container
     eval "${DOCKER_RUN_CMD}"


### PR DESCRIPTION
Without this the tests failed with the following error:

```
thread 'integration::replication_test::test_table_schema_copy_across_multiple_connections' panicked at etl/tests/integration/replication_test.rs:228:10:
called `Result::unwrap()` on an `Err` value: Client(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E53400), message: "all replication slots are in use", detail: None, hint: Some("Free one or increase max_replication_slots."), position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("slot.c"), line: Some(291), routine: Some("ReplicationSlotCreate") }) })
```