### PR TITLE
fix: ignore tests which get stuck

### DIFF
--- a/etl/tests/integration/pipeline_v2_test.rs
+++ b/etl/tests/integration/pipeline_v2_test.rs
@@ -308,6 +308,7 @@ async fn test_pipeline_with_table_sync_worker_error() {
     ));
 }
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_table_schema_copy_with_data_sync_retry() {
     let database = spawn_database().await;
@@ -431,6 +432,7 @@ async fn test_table_schema_copy_with_data_sync_retry() {
     assert_eq!(first_table_schemas[1], database_schema.users_table_schema);
 }
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_table_schema_copy_with_finished_copy_retry() {
     let database = spawn_database().await;
@@ -552,6 +554,7 @@ async fn test_table_schema_copy_with_finished_copy_retry() {
     assert_eq!(first_table_schemas[1], database_schema.users_table_schema);
 }
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_table_copy() {
     let database = spawn_database().await;


### PR DESCRIPTION
Temporarily ignoring tests which commonly get stuck. Effort to fix them is ongoing, meanwhile we ignore them to avoid having to manually cancel jobs in CI.