### PR TITLE
Add failpoints for worker failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tracing-subscriber = { version = "0.3", default-features = false }
 utoipa = { version = "4.2.3", default-features = false }
 utoipa-swagger-ui = { version = "7.1.0", default-features = false }
 uuid = { version = "1.10.0", default-features = false }
+fail = { version = "0.5.1", features = ["failpoints"], default-features = false }
 
 # [patch."https://github.com/imor/gcp-bigquery-client"]
 # gcp-bigquery-client = { path = "../gcp-bigquery-client" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true, default-features = false }
 tracing-actix-web = { workspace = true, features = ["emit_event_on_error"] }
 utoipa = { workspace = true, features = ["actix_extras"] }
-utoipa-swagger-ui = { workspace = true, features = ["actix-web", "reqwest"] }
+utoipa-swagger-ui = { workspace = true, features = ["actix-web", "reqwest", "vendored"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/etl/Cargo.toml
+++ b/etl/Cargo.toml
@@ -53,6 +53,7 @@ tracing-subscriber = { workspace = true, default-features = true, features = [
     "env-filter",
 ] }
 uuid = { workspace = true, features = ["v4"] }
+fail = { workspace = true }
 
 [dev-dependencies]
 postgres = { workspace = true, features = ["test-utils", "tokio"] }


### PR DESCRIPTION
## Summary
- enable vendored assets for swagger UI
- inject `fail-rs` hooks in apply and table sync workers
- switch integration tests to new fail points

## Testing
- `cargo test --all --tests -- --nocapture` *(fails: connection refused for postgres tests)*

------
https://chatgpt.com/codex/tasks/task_e_68508c8393c8833299763175d68d2906