### PR TITLE
refactor: use TableId instead of Oid and rename a couple of structs

### DIFF
--- a/etl/src/v2/conversions/event.rs
+++ b/etl/src/v2/conversions/event.rs
@@ -4,7 +4,7 @@ use crate::conversions::Cell;
 use crate::v2::schema::cache::SchemaCache;
 use crate::v2::state::store::base::StateStoreError;
 use core::str;
-use postgres::schema::{ColumnSchema, Oid, TableName, TableSchema};
+use postgres::schema::{ColumnSchema, TableId, TableName, TableSchema};
 use postgres::types::convert_type_oid_to_type;
 use postgres_replication::protocol;
 use postgres_replication::protocol::LogicalReplicationMessage;
@@ -23,7 +23,7 @@ pub enum EventConversionError {
     MissingTupleInDeleteBody,
 
     #[error("Table schema not found for table id {0}")]
-    MissingSchema(Oid),
+    MissingSchema(TableId),
 
     #[error("Error converting from bytes: {0}")]
     FromBytes(#[from] FromTextError),
@@ -116,20 +116,20 @@ impl RelationEvent {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct InsertEvent {
-    pub table_id: Oid,
+    pub table_id: TableId,
     pub row: TableRow,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UpdateEvent {
-    pub table_id: Oid,
+    pub table_id: TableId,
     pub row: TableRow,
     pub identity_row: Option<TableRow>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteEvent {
-    pub table_id: Oid,
+    pub table_id: TableId,
     pub identity_row: Option<TableRow>,
 }
 
@@ -215,7 +215,7 @@ impl From<Event> for EventType {
 
 async fn get_table_schema(
     schema_cache: &SchemaCache,
-    table_id: Oid,
+    table_id: TableId,
 ) -> Result<TableSchema, EventConversionError> {
     schema_cache
         .get_table_schema(&table_id)

--- a/etl/src/v2/destination/base.rs
+++ b/etl/src/v2/destination/base.rs
@@ -1,4 +1,4 @@
-use postgres::schema::{Oid, TableSchema};
+use postgres::schema::{TableId, TableSchema};
 use std::future::Future;
 use thiserror::Error;
 
@@ -20,7 +20,7 @@ pub trait Destination {
 
     fn write_table_rows(
         &self,
-        id: Oid,
+        table_id: TableId,
         rows: Vec<TableRow>,
     ) -> impl Future<Output = Result<(), DestinationError>> + Send;
 

--- a/etl/src/v2/destination/memory.rs
+++ b/etl/src/v2/destination/memory.rs
@@ -1,4 +1,4 @@
-use postgres::schema::{Oid, TableSchema};
+use postgres::schema::{TableId, TableSchema};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::info;
@@ -11,7 +11,7 @@ use crate::v2::destination::base::{Destination, DestinationError};
 struct Inner {
     events: Vec<Event>,
     table_schemas: Vec<TableSchema>,
-    table_rows: Vec<(Oid, Vec<TableRow>)>,
+    table_rows: Vec<(TableId, Vec<TableRow>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -56,17 +56,21 @@ impl Destination for MemoryDestination {
         Ok(schemas)
     }
 
-    async fn write_table_rows(&self, id: Oid, rows: Vec<TableRow>) -> Result<(), DestinationError> {
+    async fn write_table_rows(
+        &self,
+        table_id: TableId,
+        rows: Vec<TableRow>,
+    ) -> Result<(), DestinationError> {
         let mut inner = self.inner.write().await;
         info!(
             "Writing batch of {} table rows for table id {:?}:",
             rows.len(),
-            id
+            table_id
         );
         for row in &rows {
             info!("  {:?}", row);
         }
-        inner.table_rows.push((id, rows));
+        inner.table_rows.push((table_id, rows));
         Ok(())
     }
 

--- a/etl/src/v2/replication/apply.rs
+++ b/etl/src/v2/replication/apply.rs
@@ -16,7 +16,7 @@ use crate::v2::workers::base::WorkerType;
 use crate::v2::workers::table_sync::TableSyncWorkerHookError;
 
 use futures::StreamExt;
-use postgres::schema::Oid;
+use postgres::schema::TableId;
 use postgres_replication::protocol;
 use postgres_replication::protocol::{LogicalReplicationMessage, ReplicationMessage};
 use std::future::Future;
@@ -71,7 +71,7 @@ pub enum ApplyLoopError {
     InvalidEvent(EventType, EventType),
 
     #[error("The table schema for table {0} was not found in the cache")]
-    MissingTableSchema(Oid),
+    MissingTableSchema(TableId),
 
     #[error("The received table schema doesn't match the table schema loaded during table sync")]
     MismatchedTableSchema,
@@ -105,11 +105,14 @@ pub trait ApplyLoopHook {
         current_lsn: PgLsn,
     ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
-    fn skip_table(&self, table_id: Oid) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+    fn skip_table(
+        &self,
+        table_id: TableId,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
     fn should_apply_changes(
         &self,
-        table_id: Oid,
+        table_id: TableId,
         remote_final_lsn: PgLsn,
     ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 

--- a/etl/src/v2/replication/table_sync.rs
+++ b/etl/src/v2/replication/table_sync.rs
@@ -12,7 +12,7 @@ use crate::v2::state::table::{TableReplicationPhase, TableReplicationPhaseType};
 use crate::v2::workers::base::WorkerType;
 use crate::v2::workers::table_sync::{TableSyncWorkerState, TableSyncWorkerStateError};
 use futures::StreamExt;
-use postgres::schema::Oid;
+use postgres::schema::TableId;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::pin;
@@ -55,7 +55,7 @@ pub async fn start_table_sync<S, D>(
     identity: PipelineIdentity,
     config: Arc<PipelineConfig>,
     replication_client: PgReplicationClient,
-    table_id: Oid,
+    table_id: TableId,
     table_sync_worker_state: TableSyncWorkerState,
     schema_cache: SchemaCache,
     state_store: S,

--- a/etl/src/v2/schema/cache.rs
+++ b/etl/src/v2/schema/cache.rs
@@ -1,11 +1,11 @@
-use postgres::schema::{Oid, TableSchema};
+use postgres::schema::{TableId, TableSchema};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[derive(Debug)]
 struct Inner {
-    table_schemas: HashMap<Oid, TableSchema>,
+    table_schemas: HashMap<TableId, TableSchema>,
 }
 
 // TODO: implement eviction of the entries if they go over a certain threshold.
@@ -37,7 +37,7 @@ impl SchemaCache {
         }
     }
 
-    pub async fn get_table_schema(&self, table_id: &Oid) -> Option<TableSchema> {
+    pub async fn get_table_schema(&self, table_id: &TableId) -> Option<TableSchema> {
         let inner = self.inner.read().await;
         inner.table_schemas.get(table_id).cloned()
     }

--- a/etl/src/v2/state/store/memory.rs
+++ b/etl/src/v2/state/store/memory.rs
@@ -1,4 +1,4 @@
-use postgres::schema::{Oid, TableId};
+use postgres::schema::TableId;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -8,7 +8,7 @@ use crate::v2::state::table::TableReplicationPhase;
 
 #[derive(Debug)]
 struct Inner {
-    table_replication_states: HashMap<Oid, TableReplicationPhase>,
+    table_replication_states: HashMap<TableId, TableReplicationPhase>,
 }
 
 #[derive(Debug, Clone)]

--- a/etl/src/v2/state/store/postgres.rs
+++ b/etl/src/v2/state/store/postgres.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use config::shared::SourceConfig;
 use postgres::schema::TableId;
 use sqlx::{
-    postgres::{types::Oid as SqlxOid, PgPoolOptions},
+    postgres::{types::Oid as SqlxTableId, PgPoolOptions},
     prelude::{FromRow, Type},
     PgPool,
 };
@@ -67,7 +67,7 @@ pub enum FromTableStateError {
 #[derive(Debug, FromRow)]
 pub struct ReplicationStateRow {
     pub pipeline_id: i64,
-    pub table_id: SqlxOid,
+    pub table_id: SqlxTableId,
     pub state: TableState,
     pub sync_done_lsn: Option<String>,
 }
@@ -153,7 +153,7 @@ impl PostgresStateStore {
         "#,
         )
         .bind(pipeline_id as i64)
-        .bind(SqlxOid(table_id))
+        .bind(SqlxTableId(table_id))
         .bind(state)
         .bind(sync_done_lsn)
         .execute(&pool)

--- a/etl/src/v2/workers/base.rs
+++ b/etl/src/v2/workers/base.rs
@@ -1,6 +1,6 @@
 use crate::v2::workers::apply::ApplyWorkerError;
 use crate::v2::workers::table_sync::TableSyncWorkerError;
-use postgres::schema::Oid;
+use postgres::schema::TableId;
 use std::fmt;
 use std::future::Future;
 use thiserror::Error;
@@ -62,7 +62,7 @@ impl fmt::Display for WorkerWaitErrors {
 #[derive(Debug)]
 pub enum WorkerType {
     Apply,
-    TableSync { table_id: Oid },
+    TableSync { table_id: TableId },
 }
 
 /// A trait for types that can be started as workers.

--- a/etl/tests/common/event.rs
+++ b/etl/tests/common/event.rs
@@ -1,5 +1,5 @@
 use etl::v2::conversions::event::{Event, EventType};
-use postgres::schema::Oid;
+use postgres::schema::TableId;
 use std::collections::HashMap;
 
 pub fn group_events_by_type(events: &[Event]) -> HashMap<EventType, Vec<Event>> {
@@ -17,7 +17,7 @@ pub fn group_events_by_type(events: &[Event]) -> HashMap<EventType, Vec<Event>> 
 
 pub fn group_events_by_type_and_table_id(
     events: &[Event],
-) -> HashMap<(EventType, Oid), Vec<Event>> {
+) -> HashMap<(EventType, TableId), Vec<Event>> {
     let mut grouped = HashMap::new();
     for event in events {
         let event_type = EventType::from(event);

--- a/etl/tests/integration/pipeline_v2_test.rs
+++ b/etl/tests/integration/pipeline_v2_test.rs
@@ -4,7 +4,7 @@ use etl::v2::conversions::event::{Event, EventType, InsertEvent};
 use etl::v2::pipeline::PipelineError;
 use etl::v2::state::table::TableReplicationPhaseType;
 use etl::v2::workers::base::WorkerWaitError;
-use postgres::schema::{ColumnSchema, Oid, TableName, TableSchema};
+use postgres::schema::{ColumnSchema, TableId, TableName, TableSchema};
 use postgres::tokio::test_utils::{id_column_schema, PgDatabase, TableModification};
 use std::ops::RangeInclusive;
 use tokio_postgres::types::Type;
@@ -197,7 +197,7 @@ async fn insert_mock_data(
     }
 }
 
-async fn get_users_age_sum_from_rows(destination: &TestDestination, table_id: Oid) -> i32 {
+async fn get_users_age_sum_from_rows(destination: &TestDestination, table_id: TableId) -> i32 {
     let mut actual_sum = 0;
 
     let tables_rows = destination.get_table_rows().await;
@@ -217,7 +217,7 @@ fn get_n_integers_sum(n: usize) -> i32 {
 
 fn build_expected_users_inserts(
     mut starting_id: i64,
-    users_table_id: Oid,
+    users_table_id: TableId,
     expected_rows: Vec<(&str, i32)>,
 ) -> Vec<Event> {
     let mut events = Vec::new();
@@ -242,7 +242,7 @@ fn build_expected_users_inserts(
 
 fn build_expected_orders_inserts(
     mut starting_id: i64,
-    orders_table_id: Oid,
+    orders_table_id: TableId,
     expected_rows: Vec<&str>,
 ) -> Vec<Event> {
     let mut events = Vec::new();

--- a/postgres/src/schema.rs
+++ b/postgres/src/schema.rs
@@ -101,8 +101,7 @@ impl ColumnSchema {
 /// A type alias for PostgreSQL table OIDs.
 ///
 /// Table OIDs are unique identifiers assigned to tables in PostgreSQL.
-// TODO: delete this in favor of `Oid`.
-pub type TableId = u32;
+pub type TableId = Oid;
 
 /// Represents the complete schema of a PostgreSQL table.
 ///
@@ -111,7 +110,7 @@ pub type TableId = u32;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TableSchema {
     /// The PostgreSQL OID of the table
-    pub id: Oid,
+    pub id: TableId,
     /// The fully qualified name of the table
     pub name: TableName,
     /// The schemas of all columns in the table
@@ -119,7 +118,7 @@ pub struct TableSchema {
 }
 
 impl TableSchema {
-    pub fn new(id: Oid, name: TableName, column_schemas: Vec<ColumnSchema>) -> Self {
+    pub fn new(id: TableId, name: TableName, column_schemas: Vec<ColumnSchema>) -> Self {
         Self {
             id,
             name,

--- a/postgres/src/tokio/test_utils.rs
+++ b/postgres/src/tokio/test_utils.rs
@@ -1,4 +1,4 @@
-use crate::schema::{ColumnSchema, Oid, TableName};
+use crate::schema::{ColumnSchema, TableId, TableName};
 use crate::tokio::config::PgConnectionConfig;
 use tokio::runtime::Handle;
 use tokio_postgres::types::Type;
@@ -47,7 +47,7 @@ impl<G: GenericClient> PgDatabase<G> {
         &self,
         table_name: TableName,
         columns: &[(&str, &str)], // (column_name, column_type)
-    ) -> Result<Oid, tokio_postgres::Error> {
+    ) -> Result<TableId, tokio_postgres::Error> {
         let columns_str = columns
             .iter()
             .map(|(name, typ)| format!("{} {}", name, typ))
@@ -77,7 +77,7 @@ impl<G: GenericClient> PgDatabase<G> {
             )
             .await?;
 
-        let table_id: Oid = row.get(0);
+        let table_id: TableId = row.get(0);
 
         Ok(table_id)
     }


### PR DESCRIPTION
This PR:

* Uses the type alias `TableId` everywhere an `Oid` was used to refer to a table id.
* Renames the `Hook` structs to `ApplyWorkerHook` and `TableSyncWorkerHook` respectively to make them easier to distinguish.