### PR TITLE
refactor: move trusted root certs into tls config

### DIFF
--- a/etl/examples/bigquery.rs
+++ b/etl/examples/bigquery.rs
@@ -1,17 +1,14 @@
 use std::{error::Error, time::Duration};
 
 use clap::{Args, Parser, Subcommand};
-use etl::{
-    pipeline::{
-        batching::{data_pipeline::BatchDataPipeline, BatchConfig},
-        destinations::bigquery::BigQueryBatchDestination,
-        sources::postgres::{PostgresSource, TableNamesFrom},
-        PipelineAction,
-    },
-    SslMode,
-};
-use postgres::schema::TableName;
+use etl::{pipeline::{
+    batching::{data_pipeline::BatchDataPipeline, BatchConfig},
+    destinations::bigquery::BigQueryBatchDestination,
+    sources::postgres::{PostgresSource, TableNamesFrom},
+    PipelineAction,
+}, SslMode};
 use postgres::tokio::config::PgConnectionConfig;
+use postgres::{schema::TableName, tokio::config::PgTlsConfig};
 use tracing::error;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -127,7 +124,10 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         name: db_args.db_name,
         username: db_args.db_username,
         password: db_args.db_password.map(Into::into),
-        ssl_mode: SslMode::Disable,
+        tls_config: PgTlsConfig {
+            ssl_mode: SslMode::Disable,
+            trusted_root_certs: vec![],
+        },
     };
 
     let (postgres_source, action) = match args.command {

--- a/etl/examples/duckdb.rs
+++ b/etl/examples/duckdb.rs
@@ -10,8 +10,8 @@ use etl::{
     },
     SslMode,
 };
-use postgres::schema::TableName;
 use postgres::tokio::config::PgConnectionConfig;
+use postgres::{schema::TableName, tokio::config::PgTlsConfig};
 use tracing::error;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -121,7 +121,10 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         name: db_args.db_name,
         username: db_args.db_username,
         password: db_args.db_password.map(Into::into),
-        ssl_mode: SslMode::Disable,
+        tls_config: PgTlsConfig {
+            ssl_mode: SslMode::Disable,
+            trusted_root_certs: vec![],
+        },
     };
 
     let (postgres_source, action) = match args.command {

--- a/etl/examples/stdout.rs
+++ b/etl/examples/stdout.rs
@@ -10,8 +10,8 @@ use etl::{
     },
     SslMode,
 };
-use postgres::schema::TableName;
 use postgres::tokio::config::PgConnectionConfig;
+use postgres::{schema::TableName, tokio::config::PgTlsConfig};
 use tracing::error;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -97,7 +97,10 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         name: db_args.db_name,
         username: db_args.db_username,
         password: db_args.db_password.map(Into::into),
-        ssl_mode: SslMode::Disable,
+        tls_config: PgTlsConfig {
+            ssl_mode: SslMode::Disable,
+            trusted_root_certs: vec![],
+        },
     };
 
     let (postgres_source, action) = match args.command {

--- a/etl/src/pipeline/sources/postgres.rs
+++ b/etl/src/pipeline/sources/postgres.rs
@@ -59,7 +59,7 @@ impl PostgresSource {
         slot_name: Option<String>,
         table_names_from: TableNamesFrom,
     ) -> Result<PostgresSource, PostgresSourceError> {
-        let mut replication_client = match config.ssl_mode {
+        let mut replication_client = match config.tls_config.ssl_mode {
             SslMode::Disable => ReplicationClient::connect_no_tls(config).await?,
             _ => ReplicationClient::connect_tls(config, trusted_root_certs).await?,
         };

--- a/etl/tests/common/database.rs
+++ b/etl/tests/common/database.rs
@@ -1,5 +1,5 @@
 use postgres::schema::TableName;
-use postgres::tokio::config::PgConnectionConfig;
+use postgres::tokio::config::{PgConnectionConfig, PgTlsConfig};
 use postgres::tokio::test_utils::PgDatabase;
 use secrecy::Secret;
 use tokio_postgres::config::SslMode;
@@ -41,7 +41,10 @@ pub async fn spawn_database() -> PgDatabase<Client> {
         name: Uuid::new_v4().to_string(),
         username: "postgres".to_owned(),
         password: Some(Secret::from("postgres".to_owned())),
-        ssl_mode: SslMode::Disable,
+        tls_config: PgTlsConfig {
+            ssl_mode: SslMode::Disable,
+            trusted_root_certs: vec![],
+        },
     };
 
     let database = PgDatabase::new(options).await;

--- a/etl/tests/common/pipeline_v2.rs
+++ b/etl/tests/common/pipeline_v2.rs
@@ -37,5 +37,5 @@ where
         },
     };
 
-    Pipeline::new(identity.clone(), config, vec![], state_store, destination)
+    Pipeline::new(identity.clone(), config, state_store, destination)
 }

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 pg_escape = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 secrecy = { workspace = true, features = ["serde", "alloc"] }
 sqlx = { workspace = true, features = [


### PR DESCRIPTION
This PR:

* Makes trusted root certificates part of the `postgres::tokio::config::PgTlsConfig` struct. The `postgres::tokio::config::PgTlsConfig` in turn is now part of the `postgres::tokio::config::PgConnectionConfig` struct.
* This makes these config structs mirror their counterparts in the `postgres::sqlx::config` module.
* It also helps remove the `trusted_root_certs` member from `Pipeline` and is cleaner.