### PR TITLE
feat(api): Do not return sensitive fields in responses

### DIFF
--- a/api/src/routes/destinations.rs
+++ b/api/src/routes/destinations.rs
@@ -1,7 +1,3 @@
-use crate::db;
-use crate::db::destinations::DestinationsDbError;
-use crate::encryption::EncryptionKey;
-use crate::routes::{extract_tenant_id, ErrorMessage, TenantIdError};
 use actix_web::{
     delete, get,
     http::{header::ContentType, StatusCode},
@@ -14,6 +10,11 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use thiserror::Error;
 use utoipa::ToSchema;
+
+use crate::db;
+use crate::db::destinations::DestinationsDbError;
+use crate::encryption::EncryptionKey;
+use crate::routes::{extract_tenant_id, ErrorMessage, TenantIdError};
 
 #[derive(Debug, Error)]
 pub enum DestinationError {

--- a/api/src/routes/destinations.rs
+++ b/api/src/routes/destinations.rs
@@ -1,3 +1,7 @@
+use crate::db;
+use crate::db::destinations::DestinationsDbError;
+use crate::encryption::EncryptionKey;
+use crate::routes::{extract_tenant_id, ErrorMessage, TenantIdError};
 use actix_web::{
     delete, get,
     http::{header::ContentType, StatusCode},
@@ -10,11 +14,6 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use thiserror::Error;
 use utoipa::ToSchema;
-
-use crate::db;
-use crate::db::destinations::DestinationsDbError;
-use crate::encryption::EncryptionKey;
-use crate::routes::{extract_tenant_id, ErrorMessage, TenantIdError};
 
 #[derive(Debug, Error)]
 pub enum DestinationError {
@@ -62,6 +61,36 @@ impl ResponseError for DestinationError {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StrippedDestinationConfig {
+    Memory,
+    BigQuery {
+        project_id: String,
+        dataset_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_staleness_mins: Option<u16>,
+    },
+}
+
+impl From<DestinationConfig> for StrippedDestinationConfig {
+    fn from(config: DestinationConfig) -> Self {
+        match config {
+            DestinationConfig::Memory => Self::Memory,
+            DestinationConfig::BigQuery {
+                project_id,
+                dataset_id,
+                max_staleness_mins,
+                ..
+            } => Self::BigQuery {
+                project_id,
+                dataset_id,
+                max_staleness_mins,
+            },
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CreateDestinationRequest {
     #[schema(example = "My BigQuery Destination", required = true)]
@@ -92,7 +121,7 @@ pub struct ReadDestinationResponse {
     pub tenant_id: String,
     #[schema(example = "My BigQuery Destination")]
     pub name: String,
-    pub config: DestinationConfig,
+    pub config: StrippedDestinationConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -160,7 +189,7 @@ pub async fn read_destination(
                 id: s.id,
                 tenant_id: s.tenant_id,
                 name: s.name,
-                config: s.config,
+                config: s.config.into(),
             })
             .ok_or(DestinationError::DestinationNotFound(destination_id))?;
 
@@ -262,7 +291,7 @@ pub async fn read_all_destinations(
             id: destination.id,
             tenant_id: destination.tenant_id,
             name: destination.name,
-            config: destination.config,
+            config: destination.config.into(),
         };
         destinations.push(destination);
     }

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read-2.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read-2.snap
@@ -5,7 +5,6 @@ expression: destination.config
 BigQuery {
     project_id: "project-id-updated",
     dataset_id: "dataset-id-updated",
-    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: Some(
         10,
     ),

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read.snap
@@ -5,6 +5,5 @@ expression: destination.config
 BigQuery {
     project_id: "project-id",
     dataset_id: "dataset-id",
-    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: None,
 }

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_read.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_read.snap
@@ -5,6 +5,5 @@ expression: response.config
 BigQuery {
     project_id: "project-id",
     dataset_id: "dataset-id",
-    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: None,
 }

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_updated.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_updated.snap
@@ -5,7 +5,6 @@ expression: response.config
 BigQuery {
     project_id: "project-id-updated",
     dataset_id: "dataset-id-updated",
-    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: Some(
         10,
     ),

--- a/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__an_existing_destination_and_pipeline_can_be_updated.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__an_existing_destination_and_pipeline_can_be_updated.snap
@@ -5,7 +5,6 @@ expression: response.config
 BigQuery {
     project_id: "project-id-updated",
     dataset_id: "dataset-id-updated",
-    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: Some(
         10,
     ),

--- a/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__destination_and_pipeline_can_be_created.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__destination_and_pipeline_can_be_created.snap
@@ -5,6 +5,5 @@ expression: response.config
 BigQuery {
     project_id: "project-id",
     dataset_id: "dataset-id",
-    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: None,
 }

--- a/api/tests/integration/snapshots/r#mod__integration__sources_test__all_sources_can_be_read-2.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__sources_test__all_sources_can_be_read-2.snap
@@ -2,12 +2,9 @@
 source: api/tests/integration/sources_test.rs
 expression: source.config
 ---
-SourceConfig {
+StrippedSourceConfig {
     host: "example.com",
     port: 2345,
     name: "sergtsop",
     username: "sergtsop",
-    password: Some(
-        Secret([REDACTED alloc::string::String]),
-    ),
 }

--- a/api/tests/integration/snapshots/r#mod__integration__sources_test__all_sources_can_be_read.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__sources_test__all_sources_can_be_read.snap
@@ -2,12 +2,9 @@
 source: api/tests/integration/sources_test.rs
 expression: source.config
 ---
-SourceConfig {
+StrippedSourceConfig {
     host: "localhost",
     port: 5432,
     name: "postgres",
     username: "postgres",
-    password: Some(
-        Secret([REDACTED alloc::string::String]),
-    ),
 }

--- a/api/tests/integration/snapshots/r#mod__integration__sources_test__an_existing_source_can_be_read.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__sources_test__an_existing_source_can_be_read.snap
@@ -2,12 +2,9 @@
 source: api/tests/integration/sources_test.rs
 expression: response.config
 ---
-SourceConfig {
+StrippedSourceConfig {
     host: "localhost",
     port: 5432,
     name: "postgres",
     username: "postgres",
-    password: Some(
-        Secret([REDACTED alloc::string::String]),
-    ),
 }

--- a/api/tests/integration/snapshots/r#mod__integration__sources_test__an_existing_source_can_be_updated.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__sources_test__an_existing_source_can_be_updated.snap
@@ -2,12 +2,9 @@
 source: api/tests/integration/sources_test.rs
 expression: response.config
 ---
-SourceConfig {
+StrippedSourceConfig {
     host: "example.com",
     port: 2345,
     name: "sergtsop",
     username: "sergtsop",
-    password: Some(
-        Secret([REDACTED alloc::string::String]),
-    ),
 }

--- a/api/tests/integration/snapshots/r#mod__integration__tenants_sources_test__tenant_and_source_can_be_created.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__tenants_sources_test__tenant_and_source_can_be_created.snap
@@ -2,12 +2,9 @@
 source: api/tests/integration/tenants_sources_test.rs
 expression: response.config
 ---
-SourceConfig {
+StrippedSourceConfig {
     host: "localhost",
     port: 5432,
     name: "postgres",
     username: "postgres",
-    password: Some(
-        Secret([REDACTED alloc::string::String]),
-    ),
 }


### PR DESCRIPTION
This PR strips away sensitive fields when returning data from responses.