### PR TITLE
feat: remove duplicate method and simplify replication client

### DIFF
--- a/etl/tests/integration/replication_test.rs
+++ b/etl/tests/integration/replication_test.rs
@@ -206,7 +206,9 @@ async fn test_table_schema_copy_across_multiple_connections() {
     let first_client = PgReplicationClient::connect(database.config.clone())
         .await
         .unwrap();
-    let second_client = first_client.duplicate().await.unwrap();
+    let second_client = PgReplicationClient::connect(database.config.clone())
+        .await
+        .unwrap();
 
     let age_schema = ColumnSchema {
         name: "age".to_string(),


### PR DESCRIPTION
This PR:

* Removes the `PgReplicationClient::duplicate` method to simplify the interface because the `PgReplicationClient::connect` method is enough. If someone wants to create two connections with the same config they can call the `PgReplicationClient::connect` method again with the same config.
* Removes the `pg_connection_config` and `with_tls` members from `PgReplicationClient`. This was made possible because of removing the `PgReplicationClient::duplicate` method.