### PR TITLE
fix: process_syncing_tables returned a wrong value

### DIFF
--- a/etl/src/v2/workers/apply.rs
+++ b/etl/src/v2/workers/apply.rs
@@ -364,9 +364,9 @@ where
                 TableReplicationPhase::SyncDone { lsn } => {
                     if current_lsn >= lsn {
                         info!(
-                        "Table {} is ready, its events are now processed by the main apply worker",
-                        table_id
-                    );
+                            "Table {} is ready, its events are now processed by the main apply worker",
+                            table_id
+                        );
                         self.state_store
                             .update_table_replication_state(table_id, TableReplicationPhase::Ready)
                             .await?;


### PR DESCRIPTION
The `process_syncing_tables` function always returned `Ok(false)` when a table was in catch up phase, whether or not it had caught up with the catch up lsn value. This caused the table's catch up apply loop to end earlier than required.