### PR TITLE
feat(api): Do not return the stripped destination config

### DIFF
--- a/api/src/routes/destinations.rs
+++ b/api/src/routes/destinations.rs
@@ -261,7 +261,7 @@ pub async fn read_all_destinations(
             id: destination.id,
             tenant_id: destination.tenant_id,
             name: destination.name,
-            config: destination.config.into(),
+            config: destination.config,
         };
         destinations.push(destination);
     }

--- a/api/src/routes/destinations.rs
+++ b/api/src/routes/destinations.rs
@@ -61,36 +61,6 @@ impl ResponseError for DestinationError {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum StrippedDestinationConfig {
-    Memory,
-    BigQuery {
-        project_id: String,
-        dataset_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        max_staleness_mins: Option<u16>,
-    },
-}
-
-impl From<DestinationConfig> for StrippedDestinationConfig {
-    fn from(config: DestinationConfig) -> Self {
-        match config {
-            DestinationConfig::Memory => Self::Memory,
-            DestinationConfig::BigQuery {
-                project_id,
-                dataset_id,
-                max_staleness_mins,
-                ..
-            } => Self::BigQuery {
-                project_id,
-                dataset_id,
-                max_staleness_mins,
-            },
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CreateDestinationRequest {
     #[schema(example = "My BigQuery Destination", required = true)]
@@ -121,7 +91,7 @@ pub struct ReadDestinationResponse {
     pub tenant_id: String,
     #[schema(example = "My BigQuery Destination")]
     pub name: String,
-    pub config: StrippedDestinationConfig,
+    pub config: DestinationConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -189,7 +159,7 @@ pub async fn read_destination(
                 id: s.id,
                 tenant_id: s.tenant_id,
                 name: s.name,
-                config: s.config.into(),
+                config: s.config,
             })
             .ok_or(DestinationError::DestinationNotFound(destination_id))?;
 

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read-2.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read-2.snap
@@ -5,6 +5,7 @@ expression: destination.config
 BigQuery {
     project_id: "project-id-updated",
     dataset_id: "dataset-id-updated",
+    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: Some(
         10,
     ),

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__all_destinations_can_be_read.snap
@@ -5,5 +5,6 @@ expression: destination.config
 BigQuery {
     project_id: "project-id",
     dataset_id: "dataset-id",
+    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: None,
 }

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_read.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_read.snap
@@ -5,5 +5,6 @@ expression: response.config
 BigQuery {
     project_id: "project-id",
     dataset_id: "dataset-id",
+    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: None,
 }

--- a/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_updated.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destination_test__an_existing_destination_can_be_updated.snap
@@ -5,6 +5,7 @@ expression: response.config
 BigQuery {
     project_id: "project-id-updated",
     dataset_id: "dataset-id-updated",
+    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: Some(
         10,
     ),

--- a/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__an_existing_destination_and_pipeline_can_be_updated.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__an_existing_destination_and_pipeline_can_be_updated.snap
@@ -5,6 +5,7 @@ expression: response.config
 BigQuery {
     project_id: "project-id-updated",
     dataset_id: "dataset-id-updated",
+    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: Some(
         10,
     ),

--- a/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__destination_and_pipeline_can_be_created.snap
+++ b/api/tests/integration/snapshots/r#mod__integration__destinations_pipelines_test__destination_and_pipeline_can_be_created.snap
@@ -5,5 +5,6 @@ expression: response.config
 BigQuery {
     project_id: "project-id",
     dataset_id: "dataset-id",
+    service_account_key: Secret([REDACTED alloc::string::String]),
     max_staleness_mins: None,
 }


### PR DESCRIPTION
This PR returns the non-stripped config for the destination. We are backtracking on our decision since right now not sending the key overcomplicates a lot of downstream code.