### PR TITLE
fix: make ci run faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run cargo clippy
         if: matrix.check == 'clippy'
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --features "test-utils tokio sqlx bigquery duckdb stdout unknown_types_to_bytes" -- -D warnings
 
   test:
     name: Test


### PR DESCRIPTION
This PR makes the following changes to make ci run faster:

* Removes the `test` job's dependency on `check` job, making it run in parallel with `cargo clippy` and `cargo fmt`.
* Only use features from our own crates instead of `--all-features` which enabled all features for our dependencies as well.