### PR TITLE
bump rust version to 1.88 in dockerfiles

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage with cargo-chef for better layer caching
-FROM lukemathwalker/cargo-chef:latest-rust-1.85.0-slim-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.88.0-slim-bookworm AS chef
 WORKDIR /app
 
 # Install system dependencies

--- a/replicator/Dockerfile
+++ b/replicator/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage with cargo-chef for better layer caching
-FROM lukemathwalker/cargo-chef:latest-rust-1.85.0-slim-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.88.0-slim-bookworm AS chef
 WORKDIR /app
 
 # Install system dependencies


### PR DESCRIPTION
We use [let chains](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/) in the code which needs Rust version 1.88 to compile. This PR bumps the Rust version in dockerfiles to 1.88 to fix docker builds.