### PR TITLE
feat(ci): make clippy in ci go even faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run cargo clippy
         if: matrix.check == 'clippy'
-        run: cargo clippy --all-targets --features "test-utils tokio sqlx bigquery duckdb stdout unknown_types_to_bytes" -- -D warnings
+        run: cargo clippy --all-targets --all-features --no-deps -- -D warnings
 
   test:
     name: Test


### PR DESCRIPTION
We no longer run clippy on our dependencies, saving a lot of time in CI. Also replaced explicitly listed features with `--all-features` again as it no longer enables features for deps.