### PR TITLE
chore: use @supabase/etl group in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @supabase/postgres
+* @supabase/etl


### PR DESCRIPTION
To reduce noise for the Postgres team we now use [`@supabse/etl`](https://github.com/orgs/supabase/teams/etl/members) in codeowners.