### PR TITLE
feat(k8s): Run vector as sidecar container

### DIFF
--- a/api/src/k8s_client.rs
+++ b/api/src/k8s_client.rs
@@ -366,6 +366,8 @@ impl K8sClient for HttpK8sClient {
                     "emptyDir": {}
                   }
                 ],
+                // We want to wait at most 60 seconds before sending `SIGKILL` to the containers.
+                "terminationGracePeriodSeconds": 60,
                 "containers": [
                   {
                     "name": replicator_container_name,
@@ -438,6 +440,16 @@ impl K8sClient for HttpK8sClient {
                         "mountPath": "/var/log"
                       }
                     ],
+                    "lifecycle": {
+                      "preStop": {
+                        "exec": {
+                          // We sleep for 5 seconds before sending a `SIGTERM` to Vector to let it
+                          // have some time to flush data. This is a temporary fix until we find a
+                          // way to properly have Vector working as sidecar.
+                          "command": ["sleep", "5"]
+                        }
+                      }
+                    }
                   }
                 ]
               }

--- a/api/src/k8s_client.rs
+++ b/api/src/k8s_client.rs
@@ -366,19 +366,13 @@ impl K8sClient for HttpK8sClient {
                     "emptyDir": {}
                   }
                 ],
-                // We want to wait at most 60 seconds before sending `SIGKILL` to the containers.
+                // We want to wait at most 60 seconds before K8S sends a `SIGKILL` to the containers.
                 "terminationGracePeriodSeconds": 60,
                 "initContainers": [
                   {
                     "name": vector_container_name,
                     "image": VECTOR_IMAGE_NAME,
                     "restartPolicy": "Always",
-                    "command": [
-                      "vector",
-                      "--config",
-                      "/etc/vector/vector.yaml",
-                      "--no-graceful-shutdown-limit"
-                    ],
                     "env": [
                       {
                         "name": "LOGFLARE_API_KEY",

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -57,29 +57,29 @@ async fn async_main() -> anyhow::Result<()> {
 }
 
 fn init_sentry() -> anyhow::Result<Option<sentry::ClientInitGuard>> {
-    if let Ok(config) = load_config::<ApiConfig>() {
-        if let Some(sentry_config) = &config.sentry {
-            info!("initializing sentry with supplied dsn");
+    if let Ok(config) = load_config::<ApiConfig>()
+        && let Some(sentry_config) = &config.sentry
+    {
+        info!("initializing sentry with supplied dsn");
 
-            let environment = Environment::load()?;
-            let guard = sentry::init(sentry::ClientOptions {
-                dsn: Some(sentry_config.dsn.parse()?),
-                environment: Some(environment.to_string().into()),
-                traces_sample_rate: 1.0,
-                max_request_body_size: sentry::MaxRequestBodySize::Always,
-                integrations: vec![Arc::new(
-                    sentry::integrations::panic::PanicIntegration::new(),
-                )],
-                ..Default::default()
-            });
+        let environment = Environment::load()?;
+        let guard = sentry::init(sentry::ClientOptions {
+            dsn: Some(sentry_config.dsn.parse()?),
+            environment: Some(environment.to_string().into()),
+            traces_sample_rate: 1.0,
+            max_request_body_size: sentry::MaxRequestBodySize::Always,
+            integrations: vec![Arc::new(
+                sentry::integrations::panic::PanicIntegration::new(),
+            )],
+            ..Default::default()
+        });
 
-            // Set service tag to differentiate API from other services
-            sentry::configure_scope(|scope| {
-                scope.set_tag("service", "api");
-            });
+        // Set service tag to differentiate API from other services
+        sentry::configure_scope(|scope| {
+            scope.set_tag("service", "api");
+        });
 
-            return Ok(Some(guard));
-        }
+        return Ok(Some(guard));
     }
 
     info!("sentry not configured for api, skipping initialization");

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::pin;
 use tokio_postgres::types::PgLsn;
+use tracing::field::debug;
 use tracing::{debug, error, info};
 
 /// The amount of milliseconds that pass between one refresh and the other of the system, in case no
@@ -547,6 +548,9 @@ where
     // We perform the conversion of the message to our own event format which is used downstream
     // by the destination.
     let event = convert_message_to_event(schema_cache, &message).await?;
+
+    let event_type = EventType::from(&event);
+    debug!("message converted to event type {}", event_type);
 
     match message {
         LogicalReplicationMessage::Begin(message) => {

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -22,7 +22,6 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::pin;
 use tokio_postgres::types::PgLsn;
-use tracing::field::debug;
 use tracing::{debug, error, info};
 
 /// The amount of milliseconds that pass between one refresh and the other of the system, in case no

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -332,6 +332,7 @@ impl PgReplicationClient {
             }
             Err(PgReplicationError::SlotNotFound(_)) => {
                 info!("creating new replication slot '{}'", slot_name);
+
                 let create_result = self.create_slot_internal(slot_name, false).await?;
 
                 Ok(GetOrCreateSlotResult::CreateSlot(create_result))
@@ -354,6 +355,7 @@ impl PgReplicationClient {
         match self.client.simple_query(&query).await {
             Ok(_) => {
                 info!("successfully deleted replication slot '{}'", slot_name);
+
                 Ok(())
             }
             Err(err) => {

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -1,3 +1,4 @@
+use crate::conversions::table_row::{TableRow, TableRowConversionError, TableRowConverter};
 use futures::{Stream, ready};
 use pin_project_lite::pin_project;
 use postgres::schema::ColumnSchema;
@@ -10,8 +11,7 @@ use std::time::{Duration, Instant, SystemTimeError};
 use thiserror::Error;
 use tokio_postgres::CopyOutStream;
 use tokio_postgres::types::PgLsn;
-
-use crate::conversions::table_row::{TableRow, TableRowConversionError, TableRowConverter};
+use tracing::debug;
 
 /// The amount of milliseconds between two consecutive status updates in case no forced update
 /// is requested.
@@ -156,6 +156,11 @@ impl EventsStream {
         this.stream
             .standby_status_update(write_lsn, flush_lsn, apply_lsn, ts, 0)
             .await?;
+
+        debug!(
+            "status update successfully sent (write_lsn = {}, flush_lsn = {}, apply_lsn = {})",
+            write_lsn, flush_lsn, apply_lsn
+        );
 
         // Update the state after successful send.
         *this.last_update = Some(Instant::now());

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -405,7 +405,7 @@ where
                 replication_client.delete_slot(&slot_name),
             )
             .await;
-            if let Err(_) = result {
+            if result.is_err() {
                 warn!(
                     "failed to delete the replication slot {slot_name} of the table sync worker {} due to timeout",
                     self.table_id

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -405,25 +405,11 @@ where
                 replication_client.delete_slot(&slot_name),
             )
             .await;
-            match result {
-                Ok(Ok(())) => {
-                    info!(
-                        "successfully deleted replication slot '{}' for table {}",
-                        slot_name, self.table_id
-                    );
-                }
-                Ok(Err(err)) => {
-                    warn!(
-                        "failed to delete the replication slot {slot_name} of the table sync worker {}: {err}",
-                        self.table_id
-                    )
-                }
-                Err(_) => {
-                    warn!(
+            if let Err(_) = result {
+                warn!(
                         "failed to delete the replication slot {slot_name} of the table sync worker {} due to timeout",
                         self.table_id
                     );
-                }
             }
 
             // This explicit drop is not strictly necessary but is added to make it extra clear

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -407,9 +407,9 @@ where
             .await;
             if let Err(_) = result {
                 warn!(
-                        "failed to delete the replication slot {slot_name} of the table sync worker {} due to timeout",
-                        self.table_id
-                    );
+                    "failed to delete the replication slot {slot_name} of the table sync worker {} due to timeout",
+                    self.table_id
+                );
             }
 
             // This explicit drop is not strictly necessary but is added to make it extra clear

--- a/replicator/src/core.rs
+++ b/replicator/src/core.rs
@@ -13,7 +13,7 @@ use etl::state::store::postgres::PostgresStateStore;
 use etl::{destination::base::Destination, pipeline::PipelineId};
 use secrecy::ExposeSecret;
 use std::fmt;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 pub async fn start_replicator() -> anyhow::Result<()> {
     info!("starting replicator service");
@@ -69,6 +69,7 @@ pub async fn start_replicator() -> anyhow::Result<()> {
     }
 
     info!("replicator service completed");
+
     Ok(())
 }
 
@@ -80,7 +81,7 @@ fn log_config(config: &ReplicatorConfig) {
 fn log_destination_config(config: &DestinationConfig) {
     match config {
         DestinationConfig::Memory => {
-            info!("memory config");
+            debug!("using memory destination config");
         }
         DestinationConfig::BigQuery {
             project_id,
@@ -88,16 +89,16 @@ fn log_destination_config(config: &DestinationConfig) {
             service_account_key: _,
             max_staleness_mins,
         } => {
-            info!(
+            debug!(
                 project_id,
-                dataset_id, max_staleness_mins, "bigquery config"
+                dataset_id, max_staleness_mins, "using bigquery destination config"
             )
         }
     }
 }
 
 fn log_pipeline_config(config: &PipelineConfig) {
-    info!(
+    debug!(
         pipeline_id = config.id,
         publication_name = config.publication_name,
         max_table_sync_workers = config.max_table_sync_workers,
@@ -109,7 +110,7 @@ fn log_pipeline_config(config: &PipelineConfig) {
 }
 
 fn log_pg_connection_config(config: &PgConnectionConfig) {
-    info!(
+    debug!(
         host = config.host,
         port = config.port,
         dbname = config.name,
@@ -120,7 +121,7 @@ fn log_pg_connection_config(config: &PgConnectionConfig) {
 }
 
 fn log_batch_config(config: &BatchConfig) {
-    info!(
+    debug!(
         max_size = config.max_size,
         max_fill_ms = config.max_fill_ms,
         "batch config"
@@ -128,7 +129,7 @@ fn log_batch_config(config: &BatchConfig) {
 }
 
 fn log_apply_worker_init_retry(config: &RetryConfig) {
-    info!(
+    debug!(
         max_attempts = config.max_attempts,
         initial_delay_ms = config.initial_delay_ms,
         max_delay_ms = config.max_delay_ms,

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -32,6 +32,7 @@ async fn async_main() -> anyhow::Result<()> {
     if let Err(err) = start_replicator().await {
         sentry::capture_error(err.as_dyn_error());
         error!("an error occurred in the replicator: {err}");
+
         return Err(err);
     }
 

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -45,27 +45,27 @@ async fn async_main() -> anyhow::Result<()> {
 /// Tags all errors and transactions with the "replicator" service identifier.
 /// Configures panic handling to automatically capture panics and send them to Sentry.
 fn init_sentry() -> anyhow::Result<Option<sentry::ClientInitGuard>> {
-    if let Ok(config) = load_replicator_config() {
-        if let Some(sentry_config) = &config.sentry {
-            info!("initializing sentry with supplied dsn");
+    if let Ok(config) = load_replicator_config()
+        && let Some(sentry_config) = &config.sentry
+    {
+        info!("initializing sentry with supplied dsn");
 
-            let environment = Environment::load()?;
-            let guard = sentry::init(sentry::ClientOptions {
-                dsn: Some(sentry_config.dsn.parse()?),
-                environment: Some(environment.to_string().into()),
-                integrations: vec![Arc::new(
-                    sentry::integrations::panic::PanicIntegration::new(),
-                )],
-                ..Default::default()
-            });
+        let environment = Environment::load()?;
+        let guard = sentry::init(sentry::ClientOptions {
+            dsn: Some(sentry_config.dsn.parse()?),
+            environment: Some(environment.to_string().into()),
+            integrations: vec![Arc::new(
+                sentry::integrations::panic::PanicIntegration::new(),
+            )],
+            ..Default::default()
+        });
 
-            // Set service tag to differentiate replicator from other services
-            sentry::configure_scope(|scope| {
-                scope.set_tag("service", "replicator");
-            });
+        // Set service tag to differentiate replicator from other services
+        sentry::configure_scope(|scope| {
+            scope.set_tag("service", "replicator");
+        });
 
-            return Ok(Some(guard));
-        }
+        return Ok(Some(guard));
     }
 
     info!("sentry not configured for replicator, skipping initialization");


### PR DESCRIPTION
This PR runs vector as a sidecar container so that it starts and stops before and after the main containers.

In addition, it adds more logs around the code.