### PR TITLE
fix(core): Improve edge cases of replication

### DIFF
--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -216,12 +216,10 @@ where
             //  automatically sends a shutdown signal to table sync workers on apply worker failure.
             // If there was an error in the apply worker, we want to shut down all table sync
             // workers, since without an apply worker they are lost.
-            if let Err(err) = self.shutdown_tx.shutdown() {
-                info!(
-                    "shut down signal could not be delivered, likely because no workers are running: {:?}",
-                    err
-                );
-            }
+            //
+            // If we fail to send the shutdown signal, we are not going to capture the error since
+            // it means that no table sync workers are running, which is fine.
+            let _ = self.shutdown_tx.shutdown();
 
             info!("apply worker completed with an error, shutting down table sync workers");
         } else {

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -390,18 +390,16 @@ where
                             .await?;
                     }
                 }
-                _ => {
-                    match self.handle_syncing_table(table_id, current_lsn).await {
-                        Ok(continue_loop) => {
-                            if !continue_loop {
-                                return Ok(false);
-                            }
-                        },
-                        Err(err) => {
-                            error!("error handling syncing for table {}: {}", table_id, err);
+                _ => match self.handle_syncing_table(table_id, current_lsn).await {
+                    Ok(continue_loop) => {
+                        if !continue_loop {
+                            return Ok(false);
                         }
                     }
-                }
+                    Err(err) => {
+                        error!("error handling syncing for table {}: {}", table_id, err);
+                    }
+                },
             }
         }
 

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -227,8 +227,10 @@ where
     S: StateStore + Clone + Send + Sync + 'static,
     D: Destination + Clone + Send + Sync + 'static,
 {
-    async fn start_table_sync_worker(&self, table_id: TableId) -> Result<(), ApplyWorkerHookError> {
-        let worker = TableSyncWorker::new(
+    async fn build_table_sync_worker(&self, table_id: TableId) -> TableSyncWorker<S, D> {
+        info!("creating a new table sync worker for table {}", table_id);
+
+        TableSyncWorker::new(
             self.pipeline_id,
             self.config.clone(),
             self.pool.clone(),
@@ -238,21 +240,7 @@ where
             self.destination.clone(),
             self.shutdown_rx.clone(),
             self.table_sync_worker_permits.clone(),
-        );
-
-        let mut pool = self.pool.write().await;
-        if let Err(err) = pool.start_worker(worker).await {
-            // TODO: check if we want to build a backoff mechanism for retrying the
-            //  spawning of new table sync workers.
-            error!(
-                "failed to start table sync worker for table {}: {}",
-                table_id, err
-            );
-
-            return Err(err.into());
-        }
-
-        Ok(())
+        )
     }
 
     async fn handle_syncing_table(
@@ -260,14 +248,13 @@ where
         table_id: TableId,
         current_lsn: PgLsn,
     ) -> Result<bool, ApplyWorkerHookError> {
-        let table_sync_worker_state = {
-            let pool = self.pool.read().await;
-            pool.get_active_worker_state(table_id)
-        };
+        let mut pool = self.pool.write().await;
+        let table_sync_worker_state = pool.get_active_worker_state(table_id);
 
+        // If there is no worker state, we start a new worker.
         let Some(table_sync_worker_state) = table_sync_worker_state else {
-            info!("creating a new table sync worker for table {}", table_id);
-            self.start_table_sync_worker(table_id).await?;
+            let table_sync_worker = self.build_table_sync_worker(table_id).await;
+            pool.start_worker(table_sync_worker).await?;
 
             return Ok(true);
         };
@@ -339,19 +326,28 @@ where
         let active_table_replication_states =
             get_table_replication_states(&self.state_store, false).await?;
 
-        for table_id in active_table_replication_states.keys() {
-            let table_sync_worker_state = {
-                let pool = self.pool.read().await;
-                pool.get_active_worker_state(*table_id)
-            };
+        for (table_id, table_replication_phase) in active_table_replication_states {
+            // A table in `SyncDone` doesn't need to have its worker started, since the main apply
+            // worker will move it into `Ready` state automatically once the condition is met.
+            if let TableReplicationPhaseType::SyncDone = table_replication_phase.as_type() {
+                continue;
+            }
 
-            if table_sync_worker_state.is_none() {
-                if let Err(err) = self.start_table_sync_worker(*table_id).await {
-                    error!(
-                        "error starting table sync worker for table {}: {}",
-                        table_id, err
-                    );
-                }
+            // If there is already an active worker for this table in the pool, we can avoid starting
+            // it.
+            let mut pool = self.pool.write().await;
+            if pool.get_active_worker_state(table_id).is_some() {
+                continue;
+            }
+
+            // If we fail, we just show an error, and hopefully we will succeed when starting it
+            // during syncing tables.
+            let table_sync_worker = self.build_table_sync_worker(table_id).await;
+            if let Err(err) = pool.start_worker(table_sync_worker).await {
+                error!(
+                    "error starting table sync worker for table {} during initialization: {}",
+                    table_id, err
+                );
             }
         }
 
@@ -395,8 +391,15 @@ where
                     }
                 }
                 _ => {
-                    if let Err(err) = self.handle_syncing_table(table_id, current_lsn).await {
-                        error!("error handling syncing for table {}: {}", table_id, err);
+                    match self.handle_syncing_table(table_id, current_lsn).await {
+                        Ok(continue_loop) => {
+                            if !continue_loop {
+                                return Ok(false);
+                            }
+                        },
+                        Err(err) => {
+                            error!("error handling syncing for table {}: {}", table_id, err);
+                        }
                     }
                 }
             }

--- a/etl/tests/integration/pipeline_test.rs
+++ b/etl/tests/integration/pipeline_test.rs
@@ -1,15 +1,3 @@
-use crate::common::database::spawn_database;
-use crate::common::event::{group_events_by_type, group_events_by_type_and_table_id};
-use crate::common::pipeline::{create_pipeline, create_pipeline_with};
-use crate::common::state_store::{
-    FaultConfig, FaultInjectingStateStore, FaultType, TestStateStore,
-};
-use crate::common::test_destination_wrapper::TestDestinationWrapper;
-use crate::common::test_schema::{
-    TableSelection, build_expected_orders_inserts, build_expected_users_inserts,
-    get_n_integers_sum, get_users_age_sum_from_rows, insert_mock_data, insert_users_data,
-    setup_test_database_schema,
-};
 use config::shared::BatchConfig;
 use etl::conversions::event::EventType;
 use etl::destination::memory::MemoryDestination;
@@ -22,6 +10,19 @@ use postgres::tokio::test_utils::TableModification;
 use rand::random;
 use telemetry::init_test_tracing;
 use tokio_postgres::types::Type;
+
+use crate::common::database::spawn_database;
+use crate::common::event::{group_events_by_type, group_events_by_type_and_table_id};
+use crate::common::pipeline::{create_pipeline, create_pipeline_with};
+use crate::common::state_store::{
+    FaultConfig, FaultInjectingStateStore, FaultType, TestStateStore,
+};
+use crate::common::test_destination_wrapper::TestDestinationWrapper;
+use crate::common::test_schema::{
+    TableSelection, build_expected_orders_inserts, build_expected_users_inserts,
+    get_n_integers_sum, get_users_age_sum_from_rows, insert_mock_data, insert_users_data,
+    setup_test_database_schema,
+};
 
 // TODO: find a way to inject errors in a way that is predictable.
 #[ignore]

--- a/etl/tests/integration/pipeline_test.rs
+++ b/etl/tests/integration/pipeline_test.rs
@@ -9,17 +9,17 @@ use postgres::tokio::test_utils::TableModification;
 use rand::random;
 use telemetry::init_test_tracing;
 use tokio_postgres::types::Type;
-
+use config::shared::BatchConfig;
 use crate::common::database::spawn_database;
 use crate::common::event::{group_events_by_type, group_events_by_type_and_table_id};
-use crate::common::pipeline::create_pipeline;
+use crate::common::pipeline::{create_pipeline, create_pipeline_with};
 use crate::common::state_store::{
     FaultConfig, FaultInjectingStateStore, FaultType, TestStateStore,
 };
 use crate::common::test_destination_wrapper::TestDestinationWrapper;
 use crate::common::test_schema::{
     TableSelection, build_expected_orders_inserts, build_expected_users_inserts,
-    get_n_integers_sum, get_users_age_sum_from_rows, insert_mock_data, setup_test_database_schema,
+    get_n_integers_sum, get_users_age_sum_from_rows, insert_mock_data, insert_users_data, setup_test_database_schema,
 };
 
 // TODO: find a way to inject errors in a way that is predictable.
@@ -363,40 +363,6 @@ async fn table_schema_copy_retries_after_finished_copy_failure() {
     assert_eq!(table_schemas.len(), 2);
     assert_eq!(table_schemas[0], database_schema.orders_schema());
     assert_eq!(table_schemas[1], database_schema.users_schema());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn table_state_converges_with_no_data() {
-    init_test_tracing();
-    let database = spawn_database().await;
-    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
-
-    let state_store = TestStateStore::new();
-    let destination = TestDestinationWrapper::wrap(MemoryDestination::new());
-
-    // We start the pipeline from scratch.
-    let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        database_schema.publication_name(),
-        state_store.clone(),
-        destination.clone(),
-    );
-
-    // We wait for the user table to be in sync done.
-    let users_state_notify = state_store
-        .notify_on_replication_phase(
-            database_schema.users_schema().id,
-            TableReplicationPhaseType::Ready,
-        )
-        .await;
-
-    pipeline.start().await.unwrap();
-
-    users_state_notify.notified().await;
-
-    pipeline.shutdown_and_wait().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -777,6 +743,86 @@ async fn table_copy_and_sync_streams_new_data() {
             .await
             .unwrap()
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_sync_streams_new_data_with_batch() {
+    init_test_tracing();
+    let mut database = spawn_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+
+    let state_store = TestStateStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new());
+
+    // Start pipeline from scratch.
+    let pipeline_id: PipelineId = random();
+    // We set a batch of 1000 elements to still check that even with batching we are getting all the
+    // data.
+    let batch_config = BatchConfig {
+        max_size: 1000,
+        max_fill_ms: 10000
+    };
+    let mut pipeline = create_pipeline_with(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        state_store.clone(),
+        destination.clone(),
+        Some(batch_config)
+    );
+
+    // Register notifications for initial table copy completion.
+    let users_state_notify = state_store
+        .notify_on_replication_phase(
+            database_schema.users_schema().id,
+            TableReplicationPhaseType::SyncDone,
+        )
+        .await;
+
+    pipeline.start().await.unwrap();
+
+    users_state_notify.notified().await;
+
+    // Insert additional data to test streaming.
+    let rows_inserted = 5;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=rows_inserted).await;
+
+    // Register notifications for ready state.
+    let users_state_notify = state_store
+        .notify_on_replication_phase(
+            database_schema.users_schema().id,
+            TableReplicationPhaseType::Ready,
+        )
+        .await;
+
+    // We wait for all the inserts to be received.
+    let events_notify = destination
+        .wait_for_events_count(vec![(EventType::Insert, 5)])
+        .await;
+
+    users_state_notify.notified().await;
+    events_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let events = destination.get_events().await;
+    let grouped_events = group_events_by_type_and_table_id(&events);
+    let users_inserts = grouped_events
+        .get(&(EventType::Insert, database_schema.users_schema().id))
+        .unwrap();
+    // Build expected events for verification
+    let expected_users_inserts = build_expected_users_inserts(
+        1,
+        database_schema.users_schema().id,
+        vec![
+            ("user_1", 1),
+            ("user_2", 2),
+            ("user_3", 3),
+            ("user_4", 4),
+            ("user_5", 5),
+        ],
+    );
+    assert_eq!(*users_inserts, expected_users_inserts);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR improves the apply worker by changing how locking is performed while starting table sync workers and checking their state. In addition, it adds a new integration test for batching and renames all integration tests following Rust's best practices for naming tests.