### PR TITLE
feat(pipeline): Improve performance of the pipeline

### DIFF
--- a/etl/src/concurrency/mod.rs
+++ b/etl/src/concurrency/mod.rs
@@ -1,3 +1,4 @@
 pub mod future;
 pub mod shutdown;
+pub mod signal;
 pub mod stream;

--- a/etl/src/concurrency/shutdown.rs
+++ b/etl/src/concurrency/shutdown.rs
@@ -1,10 +1,12 @@
 use tokio::sync::watch;
 
+use crate::concurrency::signal::{SignalRx, SignalTx, create_signal};
+
 #[derive(Debug, Clone)]
-pub struct ShutdownTx(watch::Sender<()>);
+pub struct ShutdownTx(SignalTx);
 
 impl ShutdownTx {
-    pub fn wrap(tx: watch::Sender<()>) -> Self {
+    pub fn wrap(tx: SignalTx) -> Self {
         Self(tx)
     }
 
@@ -17,7 +19,7 @@ impl ShutdownTx {
     }
 }
 
-pub type ShutdownRx = watch::Receiver<()>;
+pub type ShutdownRx = SignalRx;
 
 pub enum ShutdownResult<T, I> {
     Ok(T),
@@ -31,6 +33,6 @@ impl<T, I> ShutdownResult<T, I> {
 }
 
 pub fn create_shutdown_channel() -> (ShutdownTx, ShutdownRx) {
-    let (tx, rx) = watch::channel(());
+    let (tx, rx) = create_signal();
     (ShutdownTx::wrap(tx), rx)
 }

--- a/etl/src/concurrency/signal.rs
+++ b/etl/src/concurrency/signal.rs
@@ -1,0 +1,13 @@
+use tokio::sync::watch;
+
+/// Type alias to abstract a watch channel of `()`.
+pub type SignalTx = watch::Sender<()>;
+
+/// Type alias to abstract a watch channel of `()`.
+pub type SignalRx = watch::Receiver<()>;
+
+/// Creates a new pair of [`SignalTx`] and [`SignalRx`].
+pub fn create_signal() -> (SignalTx, SignalRx) {
+    let (tx, rx) = watch::channel(());
+    (tx, rx)
+}

--- a/etl/src/concurrency/stream.rs
+++ b/etl/src/concurrency/stream.rs
@@ -87,7 +87,15 @@ impl<B, S: Stream<Item = B>> Stream for BatchStream<B, S> {
             // remaining elements, irrespectively of boundaries.
             if this.shutdown_rx.has_changed().unwrap_or(false) {
                 info!("the stream has been forcefully stopped");
+
+                // We mark the stream as stopped, in this way any further call with return
+                // `Poll::Ready(None)`.
                 *this.stream_stopped = true;
+
+                // We mark the current value as unchanged, effectively acknowledging that we have
+                // seen it. This does not affect the correctness, but it makes the implementation
+                // semantically more correct.
+                this.shutdown_rx.mark_unchanged();
 
                 // Even if we have no items, we return this result, since we signal that a shutdown
                 // signal was received and the consumer side of the stream, can decide what to do.

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -10,12 +10,13 @@ use crate::workers::apply::ApplyWorkerHookError;
 use crate::workers::base::WorkerType;
 use crate::workers::table_sync::TableSyncWorkerHookError;
 
+use crate::concurrency::signal::SignalRx;
 use config::shared::PipelineConfig;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use postgres::schema::TableId;
 use postgres_replication::protocol;
 use postgres_replication::protocol::{LogicalReplicationMessage, ReplicationMessage};
-use std::future::Future;
+use std::future::{Future, pending};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -88,7 +89,10 @@ pub enum ApplyLoopResult {
 pub trait ApplyLoopHook {
     type Error: Into<ApplyLoopError>;
 
-    fn initialize(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    fn before_loop(
+        &self,
+        start_lsn: PgLsn,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 
     fn process_syncing_tables(
         &self,
@@ -257,12 +261,27 @@ pub async fn start_apply_loop<D, T>(
     destination: D,
     hook: T,
     mut shutdown_rx: ShutdownRx,
+    mut force_syncing_tables_rx: Option<SignalRx>,
 ) -> Result<ApplyLoopResult, ApplyLoopError>
 where
     D: Destination + Clone + Send + 'static,
     T: ApplyLoopHook,
     ApplyLoopError: From<<T as ApplyLoopHook>::Error>,
 {
+    info!(
+        "starting apply loop in worker '{:?}' from lsn {}",
+        hook.worker_type(),
+        start_lsn
+    );
+
+    // We call the `before_loop` hook and stop the loop immediately in case we are told to stop.
+    let continue_loop = hook.before_loop(start_lsn).await?;
+    if !continue_loop {
+        info!("apply loop stopped before having started");
+
+        return Ok(ApplyLoopResult::ApplyStopped);
+    }
+
     // The first status update is defaulted from the start lsn since at this point we haven't
     // processed anything.
     let first_status_update = StatusUpdate {
@@ -270,15 +289,6 @@ where
         flush_lsn: start_lsn,
         apply_lsn: start_lsn,
     };
-
-    // We initialize the apply loop which is based on the hook implementation.
-    hook.initialize().await?;
-
-    info!(
-        "starting apply loop in worker '{:?}' from lsn {}",
-        hook.worker_type(),
-        start_lsn
-    );
 
     // We compute the slot name for the replication slot that we are going to use for the logical
     // replication. At this point we assume that the slot already exists.
@@ -324,9 +334,29 @@ where
                     max_batch_fill_duration,
                 )
                 .await?;
-
                 if end_loop {
                     return Ok(ApplyLoopResult::ApplyStopped);
+                }
+            }
+
+            // If we are given a signal which tells us when to forcefully perform table syncing, we
+            // will subscribe to it.
+            _ = force_syncing_tables_rx.as_mut().map_or_else(|| pending().boxed(), |rx| rx.changed().boxed()) => {
+                // If we are told to force syncing tables, call the hook's `process_syncing_tables`
+                // method so that we can advance the state of tables.
+                //
+                // Note that for consistency we can perform table syncing only when we are not in
+                // a transaction, meaning that if we get a signal while in the middle of a transaction
+                // it will be received but no syncing will happen. We are fine with that since we assume
+                // that if we are in the middle of a transaction, Postgres will send us the remaining
+                // events of the transaction within a reasonable amount of time and that will drive the
+                // sync at the next transaction boundary.
+                if !state.handling_transaction() {
+                    debug!("forcefully processing syncing tables");
+                    let continue_loop = hook.process_syncing_tables(state.next_status_update.flush_lsn, true).await?;
+                    if !continue_loop {
+                        return Ok(ApplyLoopResult::ApplyStopped);
+                    }
                 }
             }
 
@@ -341,26 +371,6 @@ where
                         false
                     )
                     .await?;
-
-                // If the apply loop is not in the middle of processing a transaction, call the hook's
-                // process_syncing_tables method so that apply worker:
-                //
-                // * Marks any table sync workers in sync wait state as catchup
-                // * Marks any sync done table sync workers as ready
-                //
-                // and the table sync worker:
-                //
-                // * Marks itself as sync done if it completes its catch phase
-                //
-                // This is done here as well in addition to at a commit boundary because we do not want
-                // the table sync workers to get stuck if there are no changes in the cdc stream.
-                if !state.handling_transaction() {
-                    debug!("processing syncing tables after a period of inactivity of {} seconds", REFRESH_INTERVAL.as_secs());
-                    let continue_loop = hook.process_syncing_tables(state.next_status_update.flush_lsn, true).await?;
-                    if !continue_loop {
-                        break Ok(ApplyLoopResult::ApplyStopped);
-                    }
-                }
             }
         }
     }
@@ -473,6 +483,11 @@ where
             // and ack for the batch from the destination. This is important to keep a consistent state.
             // Without this order it could happen that the table's state was updated but sending the batch
             // to the destination failed.
+            //
+            // For this loop, we use the `flush_lsn` as LSN instead of the `last_commit_end_lsn` just
+            // because we want to semantically process syncing tables with the same LSN that we tell
+            // Postgres that we flushed durably to disk. In practice, `flush_lsn` and `last_commit_end_lsn`
+            // will be always equal, since LSNs are guaranteed to be monotonically increasing.
             end_loop |= !hook
                 .process_syncing_tables(state.next_status_update.flush_lsn, true)
                 .await?;

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -175,7 +175,7 @@ struct HandleMessageResult {
     end_lsn: Option<PgLsn>,
 
     /// Set when a batch should be ended earlier than the normal batching parameters of
-    /// max size and max fill duration. Currently this will be set in the following
+    /// max size and max fill duration. Currently, this will be set in the following
     /// conditions:
     ///
     /// * Set to [`EndBatch::Inclusive`]` when a commit message indicates that it will
@@ -245,7 +245,7 @@ impl ApplyLoopState {
         }
     }
 
-    /// Returns true if the apply loop is in the middle of processing a trasaction, false otherwise.
+    /// Returns true if the apply loop is in the middle of processing a transaction, false otherwise.
     fn handling_transaction(&self) -> bool {
         self.remote_final_lsn.is_some()
     }

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -1,4 +1,5 @@
 use crate::concurrency::shutdown::{ShutdownResult, ShutdownRx};
+use crate::concurrency::signal::SignalTx;
 use crate::concurrency::stream::BatchStream;
 use crate::destination::base::{Destination, DestinationError};
 use crate::pipeline::PipelineId;
@@ -18,7 +19,6 @@ use thiserror::Error;
 use tokio::pin;
 use tokio_postgres::types::PgLsn;
 use tracing::{error, info, warn};
-use crate::concurrency::signal::SignalTx;
 
 #[derive(Debug, Error)]
 pub enum TableSyncError {
@@ -62,7 +62,7 @@ pub async fn start_table_sync<S, D>(
     state_store: S,
     destination: D,
     shutdown_rx: ShutdownRx,
-    force_syncing_tables_tx: SignalTx
+    force_syncing_tables_tx: SignalTx,
 ) -> Result<TableSyncResult, TableSyncError>
 where
     S: StateStore + Clone + Send + 'static,

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -129,7 +129,6 @@ where
             publication_name = self.config.publication_name
         );
         let apply_worker = async move {
-            // We load the start lsn
             let start_lsn = get_start_lsn(self.pipeline_id, &self.replication_client).await?;
 
             // We create the signal used to notify the apply worker that it should force syncing tables.

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -10,6 +10,7 @@ use tracing::{Instrument, debug, error, info, warn};
 
 use crate::concurrency::future::ReactiveFuture;
 use crate::concurrency::shutdown::{ShutdownResult, ShutdownRx};
+use crate::concurrency::signal::SignalTx;
 use crate::destination::base::Destination;
 use crate::pipeline::PipelineId;
 use crate::replication::apply::{ApplyLoopError, ApplyLoopHook, start_apply_loop};
@@ -249,6 +250,7 @@ pub struct TableSyncWorker<S, D> {
     state_store: S,
     destination: D,
     shutdown_rx: ShutdownRx,
+    force_syncing_tables_tx: SignalTx,
     run_permit: Arc<Semaphore>,
 }
 
@@ -263,6 +265,7 @@ impl<S, D> TableSyncWorker<S, D> {
         state_store: S,
         destination: D,
         shutdown_rx: ShutdownRx,
+        force_syncing_tables_tx: SignalTx,
         run_permit: Arc<Semaphore>,
     ) -> Self {
         Self {
@@ -274,6 +277,7 @@ impl<S, D> TableSyncWorker<S, D> {
             state_store,
             destination,
             shutdown_rx,
+            force_syncing_tables_tx,
             run_permit,
         }
     }
@@ -367,13 +371,12 @@ where
             .await;
 
             let start_lsn = match result {
+                Ok(TableSyncResult::SyncCompleted { start_lsn }) => start_lsn,
                 Ok(TableSyncResult::SyncStopped | TableSyncResult::SyncNotRequired) => {
                     return Ok(());
                 }
-                Ok(TableSyncResult::SyncCompleted { start_lsn }) => start_lsn,
                 Err(err) => {
                     error!("table sync failed for table {}: {}", self.table_id, err);
-
                     return Err(err.into());
                 }
             };
@@ -387,6 +390,7 @@ where
                 self.destination,
                 TableSyncWorkerHook::new(self.table_id, state_clone, self.state_store),
                 self.shutdown_rx,
+                None,
             )
             .await?;
 
@@ -456,46 +460,28 @@ impl<S> TableSyncWorkerHook<S> {
     }
 }
 
-impl<S> ApplyLoopHook for TableSyncWorkerHook<S>
+impl<S> TableSyncWorkerHook<S>
 where
-    S: StateStore + Clone + Send + Sync + 'static,
+    S: StateStore + Clone,
 {
-    type Error = TableSyncWorkerHookError;
-
-    async fn initialize(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    /// This function compares `current_lsn` against the table's catch up lsn
-    /// and if it is greater than or equal to the catch up `lsn`:
+    /// Tries to advance the [`TableReplicationPhase`] of this table based on the current lsn.
     ///
-    /// * Marks the table as sync done in state store if `update_state` is true.
-    /// * Returns Ok(false) to indicate to the callers that this table has been marked sync done.
-    ///
-    /// In all other cases it returns Ok(true)
-    async fn process_syncing_tables(
+    /// Returns `Ok(false)` when the worker is done with its work, signaling the caller that the apply
+    /// loop should be stopped.
+    async fn try_advance_phase(
         &self,
         current_lsn: PgLsn,
         update_state: bool,
-    ) -> Result<bool, Self::Error> {
-        info!(
-            "processing syncing tables for table sync worker with lsn {}",
-            current_lsn
-        );
-
+    ) -> Result<bool, TableSyncWorkerHookError> {
         let mut inner = self.table_sync_worker_state.get_inner().write().await;
 
         // If we caught up with the lsn, we mark this table as `SyncDone` and stop the worker.
         if let TableReplicationPhase::Catchup { lsn } = inner.replication_phase() {
-            // TODO: there is currently a correctness bug in which we mark this table as sync done
-            //  before we actually acknowledged writes to dis  (since they are acknowledged after the
-            //  batch is processed). This is fine for apply workers since progress is tracked after
-            //  the batch is written, but for table sync workers this causes the problem where we might
-            //  crash after marking ourselves as `SynCdONE` and we end up not actually sending that data
-            //  and the apply worker still assumes that data is there so it will be lost forever.
-            //  Postgres doesn't have this problem since they process and acknowledge each commit message
-            //  individually.
             if current_lsn >= lsn {
+                // If we are told to update the state, we mark the phase as actually changes. We do
+                // this because we want to update the actual state only when we are sure that the
+                // progress has been persisted to the destination. When `update_state` is `false` this
+                // function is used as a lookahead, to determine whether the worker should be stopped.
                 if update_state {
                     inner
                         .set_phase_with(
@@ -515,6 +501,39 @@ where
         }
 
         Ok(true)
+    }
+}
+
+impl<S> ApplyLoopHook for TableSyncWorkerHook<S>
+where
+    S: StateStore + Clone + Send + Sync + 'static,
+{
+    type Error = TableSyncWorkerHookError;
+
+    async fn before_loop(&self, start_lsn: PgLsn) -> Result<bool, Self::Error> {
+        info!("checking ");
+
+        self.try_advance_phase(start_lsn, true).await
+    }
+
+    /// This function compares `current_lsn` against the table's catch up lsn
+    /// and if it is greater than or equal to the catch up `lsn`:
+    ///
+    /// * Marks the table as sync done in state store if `update_state` is true.
+    /// * Returns Ok(false) to indicate to the callers that this table has been marked sync done.
+    ///
+    /// In all other cases it returns Ok(true)
+    async fn process_syncing_tables(
+        &self,
+        current_lsn: PgLsn,
+        update_state: bool,
+    ) -> Result<bool, Self::Error> {
+        info!(
+            "processing syncing tables for table sync worker with lsn {}",
+            current_lsn
+        );
+
+        self.try_advance_phase(current_lsn, update_state).await
     }
 
     async fn skip_table(&self, table_id: TableId) -> Result<bool, Self::Error> {

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -367,6 +367,7 @@ where
                 self.state_store.clone(),
                 self.destination.clone(),
                 self.shutdown_rx.clone(),
+                self.force_syncing_tables_tx,
             )
             .await;
 

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -512,13 +512,13 @@ where
     type Error = TableSyncWorkerHookError;
 
     async fn before_loop(&self, start_lsn: PgLsn) -> Result<bool, Self::Error> {
-        info!("checking ");
+        info!("checking if the table sync worker is already caught up with the apply worker");
 
         self.try_advance_phase(start_lsn, true).await
     }
 
     /// This function compares `current_lsn` against the table's catch up lsn
-    /// and if it is greater than or equal to the catch up `lsn`:
+    /// and if it is greater than or equal to the `Catchup` `lsn`:
     ///
     /// * Marks the table as sync done in state store if `update_state` is true.
     /// * Returns Ok(false) to indicate to the callers that this table has been marked sync done.

--- a/etl/tests/integration/pipeline_test.rs
+++ b/etl/tests/integration/pipeline_test.rs
@@ -848,7 +848,7 @@ async fn table_processing_converges_to_apply_loop_with_no_events_coming() {
         &database_schema.users_schema().name,
         1..=rows_inserted,
     )
-        .await;
+    .await;
 
     // Start pipeline from scratch.
     let pipeline_id: PipelineId = random();
@@ -878,6 +878,8 @@ async fn table_processing_converges_to_apply_loop_with_no_events_coming() {
     pipeline.start().await.unwrap();
 
     users_state_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
 
     // Verify initial table copy data.
     let table_rows = destination.get_table_rows().await;

--- a/etl/tests/integration/pipeline_test.rs
+++ b/etl/tests/integration/pipeline_test.rs
@@ -12,7 +12,7 @@ use telemetry::init_test_tracing;
 use tokio_postgres::types::Type;
 
 use crate::common::database::spawn_database;
-use crate::common::event::{group_events_by_type, group_events_by_type_and_table_id};
+use crate::common::event::group_events_by_type_and_table_id;
 use crate::common::pipeline::{create_pipeline, create_pipeline_with};
 use crate::common::state_store::{
     FaultConfig, FaultInjectingStateStore, FaultType, TestStateStore,
@@ -894,97 +894,7 @@ async fn table_processing_converges_to_apply_loop_with_no_events_coming() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn table_sync_worker_skips_on_schema_change() {
-    init_test_tracing();
-    let database = spawn_database().await;
-    let database_schema = setup_test_database_schema(&database, TableSelection::OrdersOnly).await;
-
-    // Insert data in the table.
-    database
-        .insert_values(
-            database_schema.orders_schema().name.clone(),
-            &["description"],
-            &[&"description_1"],
-        )
-        .await
-        .unwrap();
-
-    let state_store = TestStateStore::new();
-    let destination = TestDestinationWrapper::wrap(MemoryDestination::new());
-
-    // Start pipeline from scratch.
-    let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        database_schema.publication_name(),
-        state_store.clone(),
-        destination.clone(),
-    );
-
-    // Register notifications for initial table copy completion.
-    let orders_state_notify = state_store
-        .notify_on_replication_phase(
-            database_schema.orders_schema().id,
-            TableReplicationPhaseType::FinishedCopy,
-        )
-        .await;
-
-    pipeline.start().await.unwrap();
-
-    orders_state_notify.notified().await;
-
-    // Register notification for the skipped state.
-    let orders_state_notify = state_store
-        .notify_on_replication_phase(
-            database_schema.orders_schema().id,
-            TableReplicationPhaseType::Skipped,
-        )
-        .await;
-
-    // Change the schema of orders by adding a new column.
-    database
-        .alter_table(
-            database_schema.orders_schema().name.clone(),
-            &[TableModification::AddColumn {
-                name: "date",
-                data_type: "integer",
-            }],
-        )
-        .await
-        .unwrap();
-
-    // Insert new data in the table.
-    database
-        .insert_values(
-            database_schema.orders_schema().name.clone(),
-            &["description", "date"],
-            &[&"description_with_date", &(10i32)],
-        )
-        .await
-        .unwrap();
-
-    orders_state_notify.notified().await;
-
-    pipeline.shutdown_and_wait().await.unwrap();
-
-    // We assert that the schema is the initial one.
-    let table_schemas = destination.get_table_schemas().await;
-    assert_eq!(table_schemas.len(), 1);
-    assert_eq!(table_schemas[0], database_schema.orders_schema());
-
-    let events = destination.get_events().await;
-    let grouped_events = group_events_by_type(&events);
-
-    // We assert that only one `Commit` message was received, since the apply worker doesn't filter
-    // transaction control operations by table id, so those should always go out for each apply +
-    // table sync worker. And since we are skipping a table on the table schema change, we only expect
-    // the first `Commit` to be sent by the apply worker.
-    assert_eq!(grouped_events.get(&EventType::Commit).unwrap().len(), 1);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn apply_worker_skips_on_schema_change() {
+async fn table_processing_with_schema_change_skips_table() {
     init_test_tracing();
     let database = spawn_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::OrdersOnly).await;


### PR DESCRIPTION
This PR improves the syncing algorithm for tables by making it reactive instead of time-based, resulting in a performance improvement in the time it takes for a table to transition from copying data to syncing data.

A clear outcome of this implementation is that our tests now run much more quickly. However, some tests had to be removed because certain behaviors became more difficult to test, as the advancement of phases is now driven not only by the apply worker’s incoming traffic but also by the table sync worker (e.g., the worker goes from `SyncWait` to `SyncDone` nearly instantly even if no events are coming in the apply worker).