### PR TITLE
feat(api): Return also table id from the status endpoint

### DIFF
--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -250,6 +250,8 @@ impl From<TableReplicationState> for SimpleTableReplicationState {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct TableReplicationStatus {
+    #[schema(example = 1)]
+    pub table_id: u32,
     #[schema(example = "public.users")]
     pub table_name: String,
     pub state: SimpleTableReplicationState,
@@ -715,8 +717,10 @@ pub async fn get_pipeline_replication_status(
     // Convert database states to UI-friendly format and fetch table names
     let mut tables: Vec<TableReplicationStatus> = Vec::new();
     for row in state_rows {
-        let table_name = get_table_name_from_oid(&source_pool, row.table_id.0).await?;
+        let table_id = row.table_id.0;
+        let table_name = get_table_name_from_oid(&source_pool, table_id).await?;
         tables.push(TableReplicationStatus {
+            table_id,
             table_name: table_name.to_string(),
             state: row.state.into(),
         });

--- a/api/tests/integration/pipelines_test.rs
+++ b/api/tests/integration/pipelines_test.rs
@@ -1,6 +1,10 @@
 use api::db::pipelines::PipelineConfig;
 use api::db::sources::SourceConfig;
-use api::routes::pipelines::{CreatePipelineRequest, CreatePipelineResponse, GetPipelineReplicationStatusResponse, ReadPipelineResponse, ReadPipelinesResponse, SimpleTableReplicationState, UpdatePipelineImageRequest, UpdatePipelineRequest};
+use api::routes::pipelines::{
+    CreatePipelineRequest, CreatePipelineResponse, GetPipelineReplicationStatusResponse,
+    ReadPipelineResponse, ReadPipelinesResponse, SimpleTableReplicationState,
+    UpdatePipelineImageRequest, UpdatePipelineRequest,
+};
 use api::routes::sources::{CreateSourceRequest, CreateSourceResponse};
 use config::SerializableSecretString;
 use config::shared::{BatchConfig, RetryConfig};

--- a/api/tests/integration/pipelines_test.rs
+++ b/api/tests/integration/pipelines_test.rs
@@ -1,9 +1,6 @@
 use api::db::pipelines::PipelineConfig;
 use api::db::sources::SourceConfig;
-use api::routes::pipelines::{
-    CreatePipelineRequest, CreatePipelineResponse, GetPipelineReplicationStatusResponse,
-    ReadPipelineResponse, ReadPipelinesResponse, UpdatePipelineImageRequest, UpdatePipelineRequest,
-};
+use api::routes::pipelines::{CreatePipelineRequest, CreatePipelineResponse, GetPipelineReplicationStatusResponse, ReadPipelineResponse, ReadPipelinesResponse, SimpleTableReplicationState, UpdatePipelineImageRequest, UpdatePipelineRequest};
 use api::routes::sources::{CreateSourceRequest, CreateSourceResponse};
 use config::SerializableSecretString;
 use config::shared::{BatchConfig, RetryConfig};
@@ -1034,12 +1031,12 @@ async fn pipeline_replication_status_returns_table_states_and_names() {
         .expect("Orders table not found in response");
 
     // Verify states are correctly mapped
-    use api::routes::pipelines::SimpleTableReplicationState;
+    assert_eq!(users_table_status.table_id, users_table_oid as u32);
     match &users_table_status.state {
         SimpleTableReplicationState::CopyingTable => {} // Expected for data_sync state
         other => panic!("Expected CopyingTable state for users table, got {other:?}"),
     }
-
+    assert_eq!(orders_table_status.table_id, orders_table_oid as u32);
     match &orders_table_status.state {
         SimpleTableReplicationState::FollowingWal { lag: _ } => {} // Expected for ready state
         other => panic!("Expected FollowingWal state for orders table, got {other:?}"),


### PR DESCRIPTION
This PR returns the table id from the replication status endpoint.