### PR TITLE
feat(postgres): Add sane defaults for the connection

### DIFF
--- a/config/src/shared/connection.rs
+++ b/config/src/shared/connection.rs
@@ -258,7 +258,7 @@ mod tests {
         let options = PgConnectionOptions::default();
         let pairs = options.to_key_value_pairs();
 
-        assert_eq!(pairs.len(), 9);
+        assert_eq!(pairs.len(), 8);
         assert!(pairs.contains(&("datestyle".to_string(), "ISO".to_string())));
         assert!(pairs.contains(&("intervalstyle".to_string(), "postgres".to_string())));
         assert!(pairs.contains(&("extra_float_digits".to_string(), "3".to_string())));

--- a/config/src/shared/connection.rs
+++ b/config/src/shared/connection.rs
@@ -249,7 +249,7 @@ mod tests {
 
         assert_eq!(
             options_string,
-            "-c datestyle=ISO -c intervalstyle=postgres -c extra_float_digits=3 -c client_encoding=UTF8 -c timezone=UTC -c statement_timeout=7200000 -c lock_timeout=30000 -c idle_in_transaction_session_timeout=300000 -c application_name=etl"
+            "-c datestyle=ISO -c intervalstyle=postgres -c extra_float_digits=3 -c client_encoding=UTF8 -c timezone=UTC -c lock_timeout=30000 -c idle_in_transaction_session_timeout=300000 -c application_name=etl"
         );
     }
 
@@ -264,7 +264,6 @@ mod tests {
         assert!(pairs.contains(&("extra_float_digits".to_string(), "3".to_string())));
         assert!(pairs.contains(&("client_encoding".to_string(), "UTF8".to_string())));
         assert!(pairs.contains(&("timezone".to_string(), "UTC".to_string())));
-        assert!(pairs.contains(&("statement_timeout".to_string(), "7200000".to_string())));
         assert!(pairs.contains(&("lock_timeout".to_string(), "30000".to_string())));
         assert!(pairs.contains(&(
             "idle_in_transaction_session_timeout".to_string(),

--- a/config/src/shared/connection.rs
+++ b/config/src/shared/connection.rs
@@ -52,7 +52,7 @@ impl Default for PgConnectionOptions {
             extra_float_digits: 3,
             client_encoding: "UTF8".to_string(),
             timezone: "UTC".to_string(),
-            lock_timeout: 30_000,         // 30 seconds in milliseconds
+            lock_timeout: 30_000, // 30 seconds in milliseconds
             idle_in_transaction_session_timeout: 300_000, // 5 minutes in milliseconds
             application_name: "etl".to_string(),
         }

--- a/config/src/shared/connection.rs
+++ b/config/src/shared/connection.rs
@@ -22,8 +22,6 @@ pub struct PgConnectionOptions {
     pub client_encoding: String,
     /// Sets the time zone for displaying and interpreting time stamps.
     pub timezone: String,
-    /// Aborts any statement that takes more than the specified number of milliseconds.
-    pub statement_timeout: u32,
     /// Aborts any statement that waits longer than the specified milliseconds to acquire a lock.
     pub lock_timeout: u32,
     /// Terminates any session that has been idle within a transaction for longer than the specified milliseconds.
@@ -44,7 +42,6 @@ impl Default for PgConnectionOptions {
     /// - `extra_float_digits = 3`: Ensures sufficient precision for numeric replication
     /// - `client_encoding = "UTF8"`: Supports international character sets
     /// - `timezone = "UTC"`: Eliminates timezone ambiguity in distributed ETL systems
-    /// - `statement_timeout = 7200000` (2 hours): Allows large COPY operations while preventing runaway queries
     /// - `lock_timeout = 30000` (30 seconds): Prevents indefinite blocking on table locks during replication
     /// - `idle_in_transaction_session_timeout = 300000` (5 minutes): Cleans up abandoned transactions that could block VACUUM
     /// - `application_name = "etl"`: Enables easy identification in monitoring and pg_stat_activity
@@ -55,7 +52,6 @@ impl Default for PgConnectionOptions {
             extra_float_digits: 3,
             client_encoding: "UTF8".to_string(),
             timezone: "UTC".to_string(),
-            statement_timeout: 7_200_000, // 2 hours in milliseconds
             lock_timeout: 30_000,         // 30 seconds in milliseconds
             idle_in_transaction_session_timeout: 300_000, // 5 minutes in milliseconds
             application_name: "etl".to_string(),
@@ -69,13 +65,12 @@ impl PgConnectionOptions {
     /// Returns a space-separated list of `-c key=value` pairs.
     pub fn to_options_string(&self) -> String {
         format!(
-            "-c datestyle={} -c intervalstyle={} -c extra_float_digits={} -c client_encoding={} -c timezone={} -c statement_timeout={} -c lock_timeout={} -c idle_in_transaction_session_timeout={} -c application_name={}",
+            "-c datestyle={} -c intervalstyle={} -c extra_float_digits={} -c client_encoding={} -c timezone={} -c lock_timeout={} -c idle_in_transaction_session_timeout={} -c application_name={}",
             self.datestyle,
             self.intervalstyle,
             self.extra_float_digits,
             self.client_encoding,
             self.timezone,
-            self.statement_timeout,
             self.lock_timeout,
             self.idle_in_transaction_session_timeout,
             self.application_name
@@ -95,10 +90,6 @@ impl PgConnectionOptions {
             ),
             ("client_encoding".to_string(), self.client_encoding.clone()),
             ("timezone".to_string(), self.timezone.clone()),
-            (
-                "statement_timeout".to_string(),
-                self.statement_timeout.to_string(),
-            ),
             ("lock_timeout".to_string(), self.lock_timeout.to_string()),
             (
                 "idle_in_transaction_session_timeout".to_string(),

--- a/config/src/shared/connection.rs
+++ b/config/src/shared/connection.rs
@@ -12,21 +12,21 @@ use crate::shared::ValidationError;
 /// session-specific settings that affect how the server processes queries and data.
 #[derive(Debug, Clone)]
 pub struct PgConnectionOptions {
-    /// Sets the display format for date values. Common values: "ISO", "Postgres", "SQL", "German".
+    /// Sets the display format for date values.
     pub datestyle: String,
-    /// Sets the display format for interval values. Common values: "postgres", "sql_standard", "iso_8601".
+    /// Sets the display format for interval values.
     pub intervalstyle: String,
-    /// Controls the number of digits displayed for floating-point values. Range: -15 to 3.
+    /// Controls the number of digits displayed for floating-point values.
     pub extra_float_digits: i32,
-    /// Sets the client-side character set encoding. Common values: "UTF8", "LATIN1", "WIN1252".
+    /// Sets the client-side character set encoding.
     pub client_encoding: String,
-    /// Sets the time zone for displaying and interpreting time stamps. Use "UTC" or local timezone names.
+    /// Sets the time zone for displaying and interpreting time stamps.
     pub timezone: String,
-    /// Aborts any statement that takes more than the specified number of milliseconds. 0 disables timeout.
+    /// Aborts any statement that takes more than the specified number of milliseconds.
     pub statement_timeout: u32,
-    /// Aborts any statement that waits longer than the specified milliseconds to acquire a lock. 0 disables timeout.
+    /// Aborts any statement that waits longer than the specified milliseconds to acquire a lock.
     pub lock_timeout: u32,
-    /// Terminates any session that has been idle within a transaction for longer than the specified milliseconds. 0 disables timeout.
+    /// Terminates any session that has been idle within a transaction for longer than the specified milliseconds.
     pub idle_in_transaction_session_timeout: u32,
     /// Sets the application name to be reported in statistics views and logs for connection identification.
     pub application_name: String,


### PR DESCRIPTION
This PR implements sane defaults for the Postgres connection to avoid having the database misconfigured.
