### PR TITLE
chore: use expect instead of allow

### DIFF
--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -824,7 +824,6 @@ struct Secrets {
     big_query_service_account_key: Option<String>,
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn create_or_update_pipeline_in_k8s(
     k8s_client: &dyn K8sClient,
     tenant_id: &str,

--- a/etl/benches/table_copies.rs
+++ b/etl/benches/table_copies.rs
@@ -209,10 +209,6 @@ enum Commands {
         /// Enable TLS
         #[arg(long, default_value = "false")]
         tls_enabled: bool,
-
-        /// TLS trusted root certificates
-        #[arg(long, default_value = "")]
-        tls_certs: String,
     },
 }
 
@@ -286,7 +282,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             username,
             password,
             tls_enabled,
-            tls_certs,
         } => {
             prepare_benchmark(PrepareArgs {
                 host,
@@ -295,7 +290,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 username,
                 password,
                 tls_enabled,
-                tls_certs,
             })
             .await
         }
@@ -328,7 +322,6 @@ struct RunArgs {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 struct PrepareArgs {
     host: String,
     port: u16,
@@ -336,7 +329,6 @@ struct PrepareArgs {
     username: String,
     password: Option<String>,
     tls_enabled: bool,
-    tls_certs: String,
 }
 
 async fn prepare_benchmark(args: PrepareArgs) -> Result<(), Box<dyn Error>> {

--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -224,7 +224,6 @@ where
         Ok(())
     }
 
-    #[allow(clippy::result_large_err)]
     pub fn shutdown(&self) {
         info!("trying to shut down the pipeline");
 

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -190,7 +190,7 @@ impl ApplyLoopState {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn start_apply_loop<D, T>(
     pipeline_id: PipelineId,
     start_lsn: PgLsn,
@@ -547,7 +547,6 @@ where
     }
 }
 
-#[allow(clippy::result_large_err)]
 fn get_commit_lsn(state: &ApplyLoopState, message: &LogicalReplicationMessage) -> EtlResult<PgLsn> {
     // If we are in a `Begin` message, the `commit_lsn` is the `final_lsn` of the payload, in all the
     // other cases we read the `remote_final_lsn` which should be always set in case we are within or

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -36,7 +36,7 @@ pub enum TableSyncResult {
     SyncCompleted { start_lsn: PgLsn },
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn start_table_sync<S, D>(
     pipeline_id: PipelineId,
     config: Arc<PipelineConfig>,

--- a/etl/src/test_utils/test_schema.rs
+++ b/etl/src/test_utils/test_schema.rs
@@ -13,7 +13,6 @@ use crate::test_utils::test_destination_wrapper::TestDestinationWrapper;
 #[derive(Debug, Clone, Copy)]
 pub enum TableSelection {
     Both,
-    #[allow(dead_code)]
     UsersOnly,
     OrdersOnly,
 }
@@ -421,7 +420,7 @@ pub mod bigquery {
             }
         }
 
-        #[allow(clippy::too_many_arguments)]
+        #[expect(clippy::too_many_arguments)]
         pub fn with_non_null_values(
             id: i32,
             b: bool,
@@ -629,7 +628,7 @@ pub mod bigquery {
             }
         }
 
-        #[allow(clippy::too_many_arguments)]
+        #[expect(clippy::too_many_arguments)]
         pub fn with_non_null_values(
             id: i32,
             b_arr: Vec<bool>,
@@ -869,7 +868,7 @@ pub mod bigquery {
     }
 
     impl NonNullableColsScalar {
-        #[allow(clippy::too_many_arguments)]
+        #[expect(clippy::too_many_arguments)]
         pub fn new(
             id: i32,
             b: bool,

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -62,7 +62,7 @@ pub struct ApplyWorker<S, D> {
 }
 
 impl<S, D> ApplyWorker<S, D> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         pipeline_id: PipelineId,
         config: Arc<PipelineConfig>,
@@ -180,7 +180,7 @@ struct ApplyWorkerHook<S, D> {
 }
 
 impl<S, D> ApplyWorkerHook<S, D> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         pipeline_id: PipelineId,
         config: Arc<PipelineConfig>,


### PR DESCRIPTION
This PR uses `#[expect(clippy...)]` instead of `#[allow(clippy...)]` because when the code on which the attribute is applies is changed such that the lint is no longer needed, `expect` raises a warning `this lint expectation is unfulfilled`. This allows the developer to notice unnecessary suppressions of clippy lints and remove them.

Also removed some dead code.