### PR TITLE
feat(api): Add new endpoint for rolling back the state

### DIFF
--- a/api/src/routes/pipelines.rs
+++ b/api/src/routes/pipelines.rs
@@ -29,7 +29,7 @@ use crate::routes::{
 };
 use postgres::replication::{
     TableLookupError, TableReplicationState, get_table_name_from_oid,
-    get_table_replication_state_rows,
+    get_table_replication_state_rows, rollback_replication_state,
 };
 use secrecy::ExposeSecret;
 
@@ -61,6 +61,9 @@ enum PipelineError {
 
     #[error("The table replication state is not valid: {0}")]
     InvalidTableReplicationState(serde_json::Error),
+
+    #[error("The table state is not rollbackable: {0}")]
+    NotRollbackable(String),
 
     #[error("invalid destination config")]
     InvalidConfig(#[from] serde_json::Error),
@@ -144,6 +147,7 @@ impl ResponseError for PipelineError {
             | PipelineError::TableLookup(_)
             | PipelineError::InvalidTableReplicationState(_)
             | PipelineError::MissingTableReplicationState => StatusCode::INTERNAL_SERVER_ERROR,
+            PipelineError::NotRollbackable(_) => StatusCode::BAD_REQUEST,
             PipelineError::PipelineNotFound(_) | PipelineError::ImageNotFoundById(_) => {
                 StatusCode::NOT_FOUND
             }
@@ -248,8 +252,27 @@ pub enum SimpleTableReplicationState {
     Queued,
     CopyingTable,
     CopiedTable,
-    FollowingWal { lag: u64 },
-    Error { message: String },
+    FollowingWal {
+        lag: u64,
+    },
+    Error {
+        reason: String,
+        solution: Option<String>,
+        retry_policy: SimpleRetryPolicy,
+    },
+}
+
+/// Simplified retry policy for UI display
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
+pub enum SimpleRetryPolicy {
+    NoRetry,
+    ManualRetry,
+    TimedRetry {
+        #[schema(example = "2023-12-25T12:00:00Z")]
+        next_retry: String,
+    },
 }
 
 impl From<TableReplicationState> for SimpleTableReplicationState {
@@ -264,13 +287,27 @@ impl From<TableReplicationState> for SimpleTableReplicationState {
             }
             TableReplicationState::Ready => SimpleTableReplicationState::FollowingWal { lag: 0 },
             TableReplicationState::Errored {
-                reason, solution, ..
+                reason,
+                solution,
+                retry_policy,
             } => {
-                let message = match solution {
-                    Some(solution) => format!("{reason}: {solution}"),
-                    None => reason,
+                let simple_retry_policy = match retry_policy {
+                    postgres::replication::RetryPolicy::NoRetry => SimpleRetryPolicy::NoRetry,
+                    postgres::replication::RetryPolicy::ManualRetry => {
+                        SimpleRetryPolicy::ManualRetry
+                    }
+                    postgres::replication::RetryPolicy::TimedRetry { next_retry } => {
+                        SimpleRetryPolicy::TimedRetry {
+                            next_retry: next_retry.to_rfc3339(),
+                        }
+                    }
                 };
-                SimpleTableReplicationState::Error { message }
+
+                SimpleTableReplicationState::Error {
+                    reason,
+                    solution,
+                    retry_policy: simple_retry_policy,
+                }
             }
         }
     }
@@ -290,6 +327,21 @@ pub struct GetPipelineReplicationStatusResponse {
     #[schema(example = 1)]
     pub pipeline_id: i64,
     pub table_statuses: Vec<TableReplicationStatus>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct RollbackTableStateRequest {
+    #[schema(example = 1)]
+    pub table_id: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct RollbackTableStateResponse {
+    #[schema(example = 1)]
+    pub pipeline_id: i64,
+    #[schema(example = 1)]
+    pub table_id: u32,
+    pub new_state: SimpleTableReplicationState,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -761,6 +813,106 @@ pub async fn get_pipeline_replication_status(
     let response = GetPipelineReplicationStatusResponse {
         pipeline_id,
         table_statuses: tables,
+    };
+
+    Ok(Json(response))
+}
+
+#[utoipa::path(
+    request_body = RollbackTableStateRequest,
+    params(
+        ("pipeline_id" = i64, Path, description = "Id of the pipeline"),
+        ("tenant_id" = String, Header, description = "The tenant ID")
+    ),
+    responses(
+        (status = 200, description = "Table state rolled back successfully", body = RollbackTableStateResponse),
+        (status = 400, description = "Bad request - state is not rollbackable", body = ErrorMessage),
+        (status = 404, description = "Pipeline or table not found", body = ErrorMessage),
+        (status = 500, description = "Internal server error", body = ErrorMessage)
+    ),
+    tag = "Pipelines"
+)]
+#[post("/pipelines/{pipeline_id}/rollback-table-state")]
+pub async fn rollback_table_state(
+    req: HttpRequest,
+    pool: Data<PgPool>,
+    encryption_key: Data<EncryptionKey>,
+    pipeline_id: Path<i64>,
+    rollback_request: Json<RollbackTableStateRequest>,
+) -> Result<impl Responder, PipelineError> {
+    let tenant_id = extract_tenant_id(&req)?;
+    let pipeline_id = pipeline_id.into_inner();
+    let table_id = rollback_request.table_id;
+
+    let mut txn = pool.begin().await?;
+
+    // Read the pipeline to ensure it exists and get the source configuration
+    let pipeline = db::pipelines::read_pipeline(txn.deref_mut(), tenant_id, pipeline_id)
+        .await?
+        .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
+
+    // Get the source configuration
+    let source = db::sources::read_source(
+        txn.deref_mut(),
+        tenant_id,
+        pipeline.source_id,
+        &encryption_key,
+    )
+    .await?
+    .ok_or(PipelineError::SourceNotFound(pipeline.source_id))?;
+
+    txn.commit().await?;
+
+    // Connect to the source database to perform rollback
+    let source_pool =
+        connect_to_source_database_with_defaults(&source.config.into_connection_config()).await?;
+
+    // First, check current state to ensure it's rollbackable (manual retry policy)
+    let state_rows = get_table_replication_state_rows(&source_pool, pipeline_id).await?;
+    let current_row = state_rows
+        .into_iter()
+        .find(|row| row.table_id.0 == table_id)
+        .ok_or(PipelineError::MissingTableReplicationState)?;
+
+    // Check if the current state is rollbackable (has ManualRetry policy)
+    let current_state = current_row
+        .deserialize_metadata()
+        .map_err(PipelineError::InvalidTableReplicationState)?
+        .ok_or(PipelineError::MissingTableReplicationState)?;
+
+    let is_rollbackable = matches!(
+        current_state,
+        TableReplicationState::Errored {
+            retry_policy: postgres::replication::RetryPolicy::ManualRetry,
+            ..
+        }
+    );
+
+    if !is_rollbackable {
+        return Err(PipelineError::NotRollbackable(
+            "Only manual retry errors can be rolled back".to_string(),
+        ));
+    }
+
+    // Perform the rollback
+    let Some(new_state) =
+        rollback_replication_state(&source_pool, pipeline_id as u64, TableId::new(table_id))
+            .await?
+    else {
+        return Err(PipelineError::NotRollbackable(
+            "No previous state to rollback to".to_string(),
+        ));
+    };
+
+    let new_state = new_state
+        .deserialize_metadata()
+        .map_err(PipelineError::InvalidTableReplicationState)?
+        .ok_or(PipelineError::MissingTableReplicationState)?;
+
+    let response = RollbackTableStateResponse {
+        pipeline_id,
+        table_id,
+        new_state: new_state.into(),
     };
 
     Ok(Json(response))

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -40,8 +40,8 @@ use crate::{
             SimpleTableReplicationState, TableReplicationStatus, UpdatePipelineImageRequest,
             UpdatePipelineRequest, create_pipeline, delete_pipeline,
             get_pipeline_replication_status, get_pipeline_status, read_all_pipelines,
-            read_pipeline, start_pipeline, stop_all_pipelines, stop_pipeline, update_pipeline,
-            update_pipeline_config, update_pipeline_image,
+            read_pipeline, rollback_table_state, start_pipeline, stop_all_pipelines, stop_pipeline,
+            update_pipeline, update_pipeline_config, update_pipeline_image,
         },
         sources::{
             CreateSourceRequest, CreateSourceResponse, ReadSourceResponse, ReadSourcesResponse,
@@ -213,6 +213,7 @@ pub async fn run(
         crate::routes::pipelines::read_all_pipelines,
         crate::routes::pipelines::get_pipeline_status,
         crate::routes::pipelines::get_pipeline_replication_status,
+        crate::routes::pipelines::rollback_table_state,
         crate::routes::pipelines::update_pipeline_image,
         crate::routes::tenants::create_tenant,
         crate::routes::tenants::create_or_update_tenant,
@@ -292,6 +293,7 @@ pub async fn run(
                     .service(stop_all_pipelines)
                     .service(get_pipeline_status)
                     .service(get_pipeline_replication_status)
+                    .service(rollback_table_state)
                     .service(update_pipeline_image)
                     .service(update_pipeline_config)
                     //tables

--- a/api/tests/common/test_app.rs
+++ b/api/tests/common/test_app.rs
@@ -7,8 +7,8 @@ use api::routes::destinations_pipelines::{
 };
 use api::routes::images::{CreateImageRequest, UpdateImageRequest};
 use api::routes::pipelines::{
-    CreatePipelineRequest, UpdatePipelineConfigRequest, UpdatePipelineImageRequest,
-    UpdatePipelineRequest,
+    CreatePipelineRequest, RollbackTableStateRequest, UpdatePipelineConfigRequest,
+    UpdatePipelineImageRequest, UpdatePipelineRequest,
 };
 use api::routes::sources::{CreateSourceRequest, UpdateSourceRequest};
 use api::routes::tenants::{CreateOrUpdateTenantRequest, CreateTenantRequest, UpdateTenantRequest};
@@ -450,6 +450,23 @@ impl TestApp {
             &self.address, pipeline_id
         ))
         .header("tenant_id", tenant_id)
+        .send()
+        .await
+        .expect("failed to execute request")
+    }
+
+    pub async fn rollback_table_state(
+        &self,
+        tenant_id: &str,
+        pipeline_id: i64,
+        rollback_request: &RollbackTableStateRequest,
+    ) -> reqwest::Response {
+        self.post_authenticated(format!(
+            "{}/v1/pipelines/{}/rollback-table-state",
+            &self.address, pipeline_id
+        ))
+        .header("tenant_id", tenant_id)
+        .json(rollback_request)
         .send()
         .await
         .expect("failed to execute request")

--- a/api/tests/integration/pipelines_test.rs
+++ b/api/tests/integration/pipelines_test.rs
@@ -9,7 +9,7 @@ use api::routes::pipelines::{
 };
 use api::routes::sources::{CreateSourceRequest, CreateSourceResponse};
 use config::SerializableSecretString;
-use config::shared::BatchConfig;
+use config::shared::{BatchConfig, PgConnectionConfig};
 use postgres::sqlx::test_utils::{create_pg_database, drop_pg_database};
 use reqwest::StatusCode;
 use secrecy::ExposeSecret;
@@ -112,149 +112,142 @@ pub async fn create_pipeline_with_config(
     response.id
 }
 
-pub struct PipelineTestSetup {
-    pub app: TestApp,
-    pub tenant_id: String,
-    pub source_pool: sqlx::PgPool,
-    pub pipeline_id: i64,
-    pub source_db_config: config::shared::PgConnectionConfig,
+/// Creates a basic pipeline setup for tests that don't need source databases.
+async fn setup_basic_pipeline() -> (TestApp, String, i64, i64, i64) {
+    let app = spawn_test_app().await;
+    create_default_image(&app).await;
+    let tenant_id = create_tenant(&app).await;
+    let source_id = create_source(&app, &tenant_id).await;
+    let destination_id = create_destination(&app, &tenant_id).await;
+    let pipeline_id = create_pipeline_with_config(
+        &app,
+        &tenant_id,
+        source_id,
+        destination_id,
+        new_pipeline_config(),
+    )
+    .await;
+    (app, tenant_id, source_id, destination_id, pipeline_id)
 }
 
-impl PipelineTestSetup {
-    pub async fn new_with_source_db() -> Self {
-        let app = spawn_test_app().await;
-        create_default_image(&app).await;
-        let tenant_id = create_tenant(&app).await;
-        let (source_pool, source_id, source_db_config) =
-            create_test_source_database(&app, &tenant_id).await;
-        let destination_id = create_destination(&app, &tenant_id).await;
-        let pipeline_id = create_pipeline_with_config(
-            &app,
-            &tenant_id,
-            source_id,
-            destination_id,
-            new_pipeline_config(),
-        )
-        .await;
+/// Creates a pipeline setup with a real source database for replication state tests.
+async fn setup_pipeline_with_source_db() -> (TestApp, String, i64, sqlx::PgPool, PgConnectionConfig)
+{
+    let app = spawn_test_app().await;
+    create_default_image(&app).await;
+    let tenant_id = create_tenant(&app).await;
+    let (source_pool, source_id, source_db_config) =
+        create_test_source_database(&app, &tenant_id).await;
+    let destination_id = create_destination(&app, &tenant_id).await;
+    let pipeline_id = create_pipeline_with_config(
+        &app,
+        &tenant_id,
+        source_id,
+        destination_id,
+        new_pipeline_config(),
+    )
+    .await;
+    (app, tenant_id, pipeline_id, source_pool, source_db_config)
+}
 
-        Self {
-            app,
+/// Creates a table with a chain of replication states.
+/// Each state in the chain becomes the previous state of the next one.
+async fn create_table_with_state_chain(
+    source_pool: &sqlx::PgPool,
+    pipeline_id: i64,
+    table_name: &str,
+    state_chain: &[(&str, &str)],
+) -> i64 {
+    create_etl_table_schema(source_pool).await;
+    let table_oid = create_test_table(source_pool, table_name).await;
+
+    let mut prev_id: Option<i64> = None;
+    for (i, (state, metadata)) in state_chain.iter().enumerate() {
+        let is_current = i == state_chain.len() - 1;
+        let id = sqlx::query_scalar::<_, i64>(
+            "INSERT INTO etl.replication_state (pipeline_id, table_id, state, metadata, prev, is_current) VALUES ($1, $2, $3::etl.table_state, $4::jsonb, $5, $6) RETURNING id"
+        )
+        .bind(pipeline_id)
+        .bind(table_oid)
+        .bind(state)
+        .bind(metadata)
+        .bind(prev_id)
+        .bind(is_current)
+        .fetch_one(source_pool)
+        .await
+        .unwrap();
+
+        if i < state_chain.len() - 1 {
+            prev_id = Some(id);
+        }
+    }
+
+    table_oid
+}
+
+/// Creates multiple tables with single states.
+async fn create_tables_with_states(
+    source_pool: &sqlx::PgPool,
+    pipeline_id: i64,
+    tables: &[(&str, &str, &str)],
+) -> Vec<(i64, String)> {
+    create_etl_table_schema(source_pool).await;
+    let mut results = Vec::new();
+
+    for (table_name, state, metadata) in tables {
+        let table_oid = create_test_table(source_pool, table_name).await;
+
+        sqlx::query(
+            "INSERT INTO etl.replication_state (pipeline_id, table_id, state, metadata, prev, is_current) VALUES ($1, $2, $3::etl.table_state, $4::jsonb, NULL, true)"
+        )
+        .bind(pipeline_id)
+        .bind(table_oid)
+        .bind(state)
+        .bind(metadata)
+        .execute(source_pool)
+        .await
+        .unwrap();
+
+        results.push((table_oid, format!("public.{table_name}")));
+    }
+
+    results
+}
+
+/// Tests rollback functionality and returns response if successful.
+/// Asserts the expected status code and returns the response for successful calls.
+async fn test_rollback(
+    app: &TestApp,
+    tenant_id: &str,
+    pipeline_id: i64,
+    table_oid: i64,
+    rollback_type: RollbackType,
+    expected_status: StatusCode,
+) -> Option<RollbackTableStateResponse> {
+    let response = app
+        .rollback_table_state(
             tenant_id,
-            source_pool,
             pipeline_id,
-            source_db_config,
-        }
-    }
-
-    pub async fn new_simple() -> (TestApp, String, i64, i64, i64) {
-        let app = spawn_test_app().await;
-        create_default_image(&app).await;
-        let tenant_id = create_tenant(&app).await;
-        let source_id = create_source(&app, &tenant_id).await;
-        let destination_id = create_destination(&app, &tenant_id).await;
-        let pipeline_id = create_pipeline_with_config(
-            &app,
-            &tenant_id,
-            source_id,
-            destination_id,
-            new_pipeline_config(),
+            &RollbackTableStateRequest {
+                table_id: table_oid as u32,
+                rollback_type,
+            },
         )
         .await;
 
-        (app, tenant_id, source_id, destination_id, pipeline_id)
-    }
+    assert_eq!(response.status(), expected_status);
 
-    pub async fn create_table_with_state(
-        &self,
-        table_name: &str,
-        state_chain: &[(&str, &str)],
-    ) -> i64 {
-        create_etl_table_schema(&self.source_pool).await;
-        let table_oid = create_test_table(&self.source_pool, table_name).await;
-
-        let mut prev_id: Option<i64> = None;
-        for (i, (state, metadata)) in state_chain.iter().enumerate() {
-            let is_current = i == state_chain.len() - 1;
-            let id = sqlx::query_scalar::<_, i64>(
-                "INSERT INTO etl.replication_state (pipeline_id, table_id, state, metadata, prev, is_current) VALUES ($1, $2, $3::etl.table_state, $4::jsonb, $5, $6) RETURNING id"
-            )
-            .bind(self.pipeline_id)
-            .bind(table_oid)
-            .bind(state)
-            .bind(metadata)
-            .bind(prev_id)
-            .bind(is_current)
-            .fetch_one(&self.source_pool)
-            .await
-            .unwrap();
-
-            if i < state_chain.len() - 1 {
-                prev_id = Some(id);
-            }
-        }
-
-        table_oid
-    }
-
-    pub async fn create_tables_with_states(
-        &self,
-        tables: &[(&str, &str, &str)],
-    ) -> Vec<(i64, String)> {
-        create_etl_table_schema(&self.source_pool).await;
-        let mut results = Vec::new();
-
-        for (table_name, state, metadata) in tables {
-            let table_oid = create_test_table(&self.source_pool, table_name).await;
-
-            sqlx::query(
-                "INSERT INTO etl.replication_state (pipeline_id, table_id, state, metadata, prev, is_current) VALUES ($1, $2, $3::etl.table_state, $4::jsonb, NULL, true)"
-            )
-            .bind(self.pipeline_id)
-            .bind(table_oid)
-            .bind(state)
-            .bind(metadata)
-            .execute(&self.source_pool)
-            .await
-            .unwrap();
-
-            results.push((table_oid, format!("public.{}", table_name)));
-        }
-
-        results
-    }
-
-    pub async fn test_rollback(
-        &self,
-        table_oid: i64,
-        rollback_type: RollbackType,
-        expected_status: StatusCode,
-    ) -> Option<RollbackTableStateResponse> {
-        let response = self
-            .app
-            .rollback_table_state(
-                &self.tenant_id,
-                self.pipeline_id,
-                &RollbackTableStateRequest {
-                    table_id: table_oid as u32,
-                    rollback_type,
-                },
-            )
-            .await;
-
-        assert_eq!(response.status(), expected_status);
-
-        if expected_status.is_success() {
-            Some(response.json().await.unwrap())
-        } else {
-            None
-        }
+    if expected_status.is_success() {
+        Some(response.json().await.unwrap())
+    } else {
+        None
     }
 }
 
 async fn create_test_source_database(
     app: &TestApp,
     tenant_id: &str,
-) -> (sqlx::PgPool, i64, config::shared::PgConnectionConfig) {
+) -> (sqlx::PgPool, i64, PgConnectionConfig) {
     let mut source_db_config = app.database_config().clone();
     source_db_config.name = format!("test_source_db_{}", Uuid::new_v4());
     let source_pool = create_pg_database(&source_db_config).await;
@@ -1051,8 +1044,7 @@ async fn update_image_fails_when_no_default_image_exists() {
 #[tokio::test(flavor = "multi_thread")]
 async fn pipeline_config_can_be_updated() {
     init_test_tracing();
-    let (app, tenant_id, _source_id, _destination_id, pipeline_id) =
-        PipelineTestSetup::new_simple().await;
+    let (app, tenant_id, _source_id, _destination_id, pipeline_id) = setup_basic_pipeline().await;
 
     // Act
     let update_request = UpdatePipelineConfigRequest {
@@ -1163,8 +1155,7 @@ async fn update_config_fails_for_pipeline_from_another_tenant() {
 #[tokio::test(flavor = "multi_thread")]
 async fn an_existing_pipeline_can_be_started() {
     init_test_tracing();
-    let (app, tenant_id, _source_id, _destination_id, pipeline_id) =
-        PipelineTestSetup::new_simple().await;
+    let (app, tenant_id, _source_id, _destination_id, pipeline_id) = setup_basic_pipeline().await;
 
     // Act
     let response = app.start_pipeline(&tenant_id, pipeline_id).await;
@@ -1233,24 +1224,27 @@ async fn all_pipelines_can_be_stopped() {
 #[tokio::test(flavor = "multi_thread")]
 async fn pipeline_replication_status_returns_table_states_and_names() {
     init_test_tracing();
-    let setup = PipelineTestSetup::new_with_source_db().await;
+    let (app, tenant_id, pipeline_id, source_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
 
     // Create tables with different states
-    let tables = setup
-        .create_tables_with_states(&[
+    let tables = create_tables_with_states(
+        &source_pool,
+        pipeline_id,
+        &[
             ("test_table_users", "data_sync", r#"{"type": "data_sync"}"#),
             ("test_table_orders", "ready", r#"{"type": "ready"}"#),
-        ])
-        .await;
+        ],
+    )
+    .await;
 
     // Test the endpoint
-    let response = setup
-        .app
-        .get_pipeline_replication_status(&setup.tenant_id, setup.pipeline_id)
+    let response = app
+        .get_pipeline_replication_status(&tenant_id, pipeline_id)
         .await;
     let response: GetPipelineReplicationStatusResponse = response.json().await.unwrap();
 
-    assert_eq!(response.pipeline_id, setup.pipeline_id);
+    assert_eq!(response.pipeline_id, pipeline_id);
     assert_eq!(response.table_statuses.len(), 2);
 
     // Verify table states
@@ -1272,90 +1266,116 @@ async fn pipeline_replication_status_returns_table_states_and_names() {
                 table_status.state,
                 SimpleTableReplicationState::FollowingWal { .. }
             )),
-            _ => panic!("Unexpected table name: {}", table_name),
+            _ => panic!("Unexpected table name: {table_name}"),
         }
     }
 
-    drop_pg_database(&setup.source_db_config).await;
+    drop_pg_database(&source_db_config).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rollback_table_state_succeeds_for_manual_retry_errors() {
     init_test_tracing();
-    let setup = PipelineTestSetup::new_with_source_db().await;
+    let (app, tenant_id, pipeline_id, source_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
 
-    let table_oid = setup
-        .create_table_with_state(
-            "test_users",
-            &[
-                ("ready", r#"{"type": "ready"}"#),
-                (
-                    "errored",
-                    r#"{"type": "errored", "retry_policy": {"type": "manual_retry"}}"#,
-                ),
-            ],
-        )
-        .await;
+    let table_oid = create_table_with_state_chain(
+        &source_pool,
+        pipeline_id,
+        "test_users",
+        &[
+            ("ready", r#"{"type": "ready"}"#),
+            (
+                "errored",
+                r#"{"type": "errored", "retry_policy": {"type": "manual_retry"}}"#,
+            ),
+        ],
+    )
+    .await;
 
-    let response = setup
-        .test_rollback(table_oid, RollbackType::Individual, StatusCode::OK)
-        .await
-        .unwrap();
-    assert_eq!(response.pipeline_id, setup.pipeline_id);
+    let response = test_rollback(
+        &app,
+        &tenant_id,
+        pipeline_id,
+        table_oid,
+        RollbackType::Individual,
+        StatusCode::OK,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.pipeline_id, pipeline_id);
     assert_eq!(response.table_id, table_oid as u32);
     assert!(matches!(
         response.new_state,
         SimpleTableReplicationState::FollowingWal { .. }
     ));
 
-    drop_pg_database(&setup.source_db_config).await;
+    drop_pg_database(&source_db_config).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rollback_table_state_fails_for_non_manual_retry_errors() {
     init_test_tracing();
-    let setup = PipelineTestSetup::new_with_source_db().await;
+    let (app, tenant_id, pipeline_id, source_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
 
-    let table_oid = setup
-        .create_table_with_state(
-            "test_users",
-            &[(
-                "errored",
-                r#"{"type": "errored", "retry_policy": {"type": "no_retry"}}"#,
-            )],
-        )
-        .await;
+    let table_oid = create_table_with_state_chain(
+        &source_pool,
+        pipeline_id,
+        "test_users",
+        &[(
+            "errored",
+            r#"{"type": "errored", "retry_policy": {"type": "no_retry"}}"#,
+        )],
+    )
+    .await;
 
-    setup
-        .test_rollback(table_oid, RollbackType::Individual, StatusCode::BAD_REQUEST)
-        .await;
+    test_rollback(
+        &app,
+        &tenant_id,
+        pipeline_id,
+        table_oid,
+        RollbackType::Individual,
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
 
-    drop_pg_database(&setup.source_db_config).await;
+    drop_pg_database(&source_db_config).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rollback_table_state_with_full_reset_succeeds() {
     init_test_tracing();
-    let setup = PipelineTestSetup::new_with_source_db().await;
+    let (app, tenant_id, pipeline_id, source_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
 
-    let table_oid = setup
-        .create_table_with_state(
-            "test_users",
-            &[
-                ("ready", r#"{"type": "ready"}"#),
-                (
-                    "errored",
-                    r#"{"type": "errored", "retry_policy": {"type": "manual_retry"}}"#,
-                ),
-            ],
-        )
-        .await;
+    let table_oid = create_table_with_state_chain(
+        &source_pool,
+        pipeline_id,
+        "test_users",
+        &[
+            ("ready", r#"{"type": "ready"}"#),
+            (
+                "errored",
+                r#"{"type": "errored", "retry_policy": {"type": "manual_retry"}}"#,
+            ),
+        ],
+    )
+    .await;
 
-    let response = setup
-        .test_rollback(table_oid, RollbackType::Full, StatusCode::OK)
-        .await
-        .unwrap();
-    assert_eq!(response.pipeline_id, setup.pipeline_id);
+    let response = test_rollback(
+        &app,
+        &tenant_id,
+        pipeline_id,
+        table_oid,
+        RollbackType::Full,
+        StatusCode::OK,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.pipeline_id, pipeline_id);
     assert_eq!(response.table_id, table_oid as u32);
     assert!(matches!(
         response.new_state,
@@ -1366,12 +1386,12 @@ async fn rollback_table_state_with_full_reset_succeeds() {
     let count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM etl.replication_state WHERE pipeline_id = $1 AND table_id = $2",
     )
-    .bind(setup.pipeline_id)
+    .bind(pipeline_id)
     .bind(table_oid)
-    .fetch_one(&setup.source_pool)
+    .fetch_one(&source_pool)
     .await
     .unwrap();
     assert_eq!(count, 1);
 
-    drop_pg_database(&setup.source_db_config).await;
+    drop_pg_database(&source_db_config).await;
 }

--- a/etl/src/state/store/postgres.rs
+++ b/etl/src/state/store/postgres.rs
@@ -226,7 +226,7 @@ impl StateStore for PostgresStateStore {
 
         // Here we perform locking for the same reasons stated in `update_table_replication_state`.
         let mut inner = self.inner.lock().await;
-        match rollback_replication_state(&pool, self.pipeline_id, table_id).await? {
+        match rollback_replication_state(&pool, self.pipeline_id as i64, table_id).await? {
             Some(restored_row) => {
                 let restored_phase: TableReplicationPhase = restored_row.try_into()?;
                 inner.table_states.insert(table_id, restored_phase.clone());


### PR DESCRIPTION
This PR adds a new endpoint for rolling back the state which accepts a table id and a rollback type and rolls it back based on the rollback type. In addition, it improves the pipelines tests by generalizing lots of duplicated code to make tests less verbose.