### PR TITLE
chore: use panic=abort only in replicator binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,6 @@ members = [
     "telemetry",
 ]
 
-[profile.release]
-panic = 'abort'
-
-[profile.dev]
-panic = 'abort'
-
 [workspace.dependencies]
 api = { path = "api", default-features = false }
 config = { path = "config", default-features = false }

--- a/replicator/Cargo.toml
+++ b/replicator/Cargo.toml
@@ -3,6 +3,12 @@ name = "replicator"
 version = "0.1.0"
 edition = "2024"
 
+[profile.release]
+panic = 'abort'
+
+[profile.dev]
+panic = 'abort'
+
 [dependencies]
 config = { workspace = true }
 etl = { workspace = true, features = ["unknown-types-to-bytes"] }

--- a/replicator/src/main.rs
+++ b/replicator/src/main.rs
@@ -1,6 +1,4 @@
 use ::config::Environment;
-use std::backtrace::Backtrace;
-use std::panic;
 use std::sync::Arc;
 use telemetry::init_tracing;
 use thiserror::__private::AsDynError;
@@ -14,14 +12,6 @@ mod core;
 mod migrations;
 
 fn main() -> anyhow::Result<()> {
-    // We want to crash on any panic happening in the code. It's important to have this at the beginning
-    // so that any other panic hooks are chained to be executed before this.
-    panic::set_hook(Box::new(|info| {
-        let stacktrace = Backtrace::force_capture();
-        println!("Got panic. @info:{info}\n@stackTrace:{stacktrace}");
-        std::process::abort();
-    }));
-
     // Initialize tracing from the binary name
     let _log_flusher = init_tracing(env!("CARGO_BIN_NAME"))?;
 


### PR DESCRIPTION
This PR:

* Uses panic=abort only for the replicator binary.
* Removes an unnecessary panic hook.