### PR TITLE
fix: add missing project ref in logs

### DIFF
--- a/replicator/src/core.rs
+++ b/replicator/src/core.rs
@@ -26,7 +26,10 @@ pub async fn start_replicator() -> anyhow::Result<()> {
     start_with_config(replicator_config, &project_ref).await
 }
 
-#[instrument(name = "replication", skip(replicator_config), fields(project = project_ref))]
+// The name of the field emitted in the instrumented span should be `project`
+// not `project_ref` because the vector config in the etl-k8s project expects
+// this. These should be kept in sync if changed in future.
+#[instrument(skip(replicator_config, project_ref), fields(project = project_ref))]
 async fn start_with_config(
     replicator_config: ReplicatorConfig,
     project_ref: &str,


### PR DESCRIPTION
This PR adds the emits project field to the logflare logs for the replicator binary. The project is needed to only look at logs from one project in logflare. We used to send the project field in the past, but a regression was introduced in one of the later PRs which this PR corrects.