### PR TITLE
feat(bigquery): Escape table names in BigQuery destination

### DIFF
--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -43,6 +43,7 @@ fn generate_sequence_number(start_lsn: PgLsn, commit_lsn: PgLsn) -> String {
 pub fn table_name_to_bigquery_table_id(table_name: &TableName) -> BigQueryTableId {
     let escaped_schema = table_name.schema.replace('_', "__");
     let escaped_table = table_name.name.replace('_', "__");
+    
     format!("{escaped_schema}_{escaped_table}")
 }
 

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -46,6 +46,11 @@ fn generate_sequence_number(start_lsn: PgLsn, commit_lsn: PgLsn) -> String {
 ///
 /// We opted for this escaping strategy since it's easy to undo on the reading end. Just split at a
 /// single `_` and revert each `__` into `_`.
+///
+/// BigQuery accepts up to 1024 UTF-8 characters, whereas Postgres names operate with a maximum size
+/// determined by `NAMEDATALEN`. We assume that most people are running this as default value, which
+/// is 63, meaning that in the worst case of a schema name and table name containing only _, the resulting
+/// string will be made up of (63 * 2) + 1 + (63 * 2) = 253 characters which is much less than 1024.
 pub fn table_name_to_bigquery_table_id(table_name: &TableName) -> BigQueryTableId {
     let escaped_schema = table_name.schema.replace(
         BIGQUERY_TABLE_ID_DELIMITER,

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -385,19 +385,13 @@ mod tests {
     #[test]
     fn test_table_name_to_bigquery_table_id_no_underscores() {
         let table_name = TableName::new("schema".to_string(), "table".to_string());
-        assert_eq!(
-            table_name_to_bigquery_table_id(&table_name),
-            "schema_table"
-        );
+        assert_eq!(table_name_to_bigquery_table_id(&table_name), "schema_table");
     }
 
     #[test]
     fn test_table_name_to_bigquery_table_id_with_underscores() {
         let table_name = TableName::new("a_b".to_string(), "c_d".to_string());
-        assert_eq!(
-            table_name_to_bigquery_table_id(&table_name),
-            "a__b_c__d"
-        );
+        assert_eq!(table_name_to_bigquery_table_id(&table_name), "a__b_c__d");
     }
 
     #[test]
@@ -405,10 +399,10 @@ mod tests {
         // These two cases previously collided to "a_b_c"
         let table_name1 = TableName::new("a_b".to_string(), "c".to_string());
         let table_name2 = TableName::new("a".to_string(), "b_c".to_string());
-        
+
         let id1 = table_name_to_bigquery_table_id(&table_name1);
         let id2 = table_name_to_bigquery_table_id(&table_name2);
-        
+
         assert_eq!(id1, "a__b_c");
         assert_eq!(id2, "a_b__c");
         assert_ne!(id1, id2, "Table IDs should not collide");
@@ -422,5 +416,4 @@ mod tests {
             "a____b_c____d"
         );
     }
-
 }

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -43,7 +43,7 @@ fn generate_sequence_number(start_lsn: PgLsn, commit_lsn: PgLsn) -> String {
 pub fn table_name_to_bigquery_table_id(table_name: &TableName) -> BigQueryTableId {
     let escaped_schema = table_name.schema.replace('_', "__");
     let escaped_table = table_name.name.replace('_', "__");
-    
+
     format!("{escaped_schema}_{escaped_table}")
 }
 

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -33,8 +33,17 @@ fn generate_sequence_number(start_lsn: PgLsn, commit_lsn: PgLsn) -> String {
 }
 
 /// Returns the [`BigQueryTableId`] for a supplied [`TableName`].
+///
+/// Escapes underscores in schema and table names to prevent collisions when combining them.
+/// Original underscores become double underscores, and a single underscore separates schema from table.
+/// This ensures that `a_b.c` and `a.b_c` map to different BigQuery table names.
+///
+/// We opted for this escaping strategy since it's easy to undo on the reading end. Just split at a
+/// single `_` and revert each `__` into `_`.
 pub fn table_name_to_bigquery_table_id(table_name: &TableName) -> BigQueryTableId {
-    format!("{}_{}", table_name.schema, table_name.name)
+    let escaped_schema = table_name.schema.replace('_', "__");
+    let escaped_table = table_name.name.replace('_', "__");
+    format!("{escaped_schema}_{escaped_table}")
 }
 
 /// Internal state for [`BigQueryDestination`] wrapped in `Arc<Mutex<>>`.
@@ -372,4 +381,46 @@ mod tests {
             "0000000000000000/ffffffffffffffff"
         );
     }
+
+    #[test]
+    fn test_table_name_to_bigquery_table_id_no_underscores() {
+        let table_name = TableName::new("schema".to_string(), "table".to_string());
+        assert_eq!(
+            table_name_to_bigquery_table_id(&table_name),
+            "schema_table"
+        );
+    }
+
+    #[test]
+    fn test_table_name_to_bigquery_table_id_with_underscores() {
+        let table_name = TableName::new("a_b".to_string(), "c_d".to_string());
+        assert_eq!(
+            table_name_to_bigquery_table_id(&table_name),
+            "a__b_c__d"
+        );
+    }
+
+    #[test]
+    fn test_table_name_to_bigquery_table_id_collision_prevention() {
+        // These two cases previously collided to "a_b_c"
+        let table_name1 = TableName::new("a_b".to_string(), "c".to_string());
+        let table_name2 = TableName::new("a".to_string(), "b_c".to_string());
+        
+        let id1 = table_name_to_bigquery_table_id(&table_name1);
+        let id2 = table_name_to_bigquery_table_id(&table_name2);
+        
+        assert_eq!(id1, "a__b_c");
+        assert_eq!(id2, "a_b__c");
+        assert_ne!(id1, id2, "Table IDs should not collide");
+    }
+
+    #[test]
+    fn test_table_name_to_bigquery_table_id_multiple_underscores() {
+        let table_name = TableName::new("a__b".to_string(), "c__d".to_string());
+        assert_eq!(
+            table_name_to_bigquery_table_id(&table_name),
+            "a____b_c____d"
+        );
+    }
+
 }


### PR DESCRIPTION
This PR implements an escaping strategy for the `BigQuery` destination which avoids the introduction of ambiguity when the table schema and table names in Postgres were using the same `_` delimiter used to create tables in `BigQuery`.

The escaping strategy is implemented and explained in detail in the code.