### PR TITLE
fix: update api binary name to etl-api

### DIFF
--- a/etl-api/Cargo.toml
+++ b/etl-api/Cargo.toml
@@ -8,7 +8,7 @@ path = "src/lib.rs"
 
 [[bin]]
 path = "src/main.rs"
-name = "api"
+name = "etl-api"
 
 [dependencies]
 etl-config = { workspace = true, features = ["utoipa"] }


### PR DESCRIPTION
The Dockerfile expected the binary generated by the `etl-api` to be named `etl-api` but it was actually named `api` thus failing the build. This PR renamed the binary to fix this problem.