### PR TITLE
feat(api): Add new destinations pipelines delete endpoint and rework constraints

### DIFF
--- a/etl-api/.sqlx/query-32d4ef8790cd672f7ad264113224bbf3cd8579f64afde9edec81f8580419f122.json
+++ b/etl-api/.sqlx/query-32d4ef8790cd672f7ad264113224bbf3cd8579f64afde9edec81f8580419f122.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        delete from app.replicators\n        where tenant_id = $1 and id = $2\n        returning id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "32d4ef8790cd672f7ad264113224bbf3cd8579f64afde9edec81f8580419f122"
+}

--- a/etl-api/migrations/20250807150000_remove_cascade_delete_from_destinations_sources.sql
+++ b/etl-api/migrations/20250807150000_remove_cascade_delete_from_destinations_sources.sql
@@ -1,0 +1,14 @@
+-- Remove CASCADE DELETE for destinations and sources to prevent automatic pipeline deletion since
+-- we want full control over deleting resources (except when a tenant id deleted)
+
+alter table app.pipelines
+drop constraint pipelines_sink_id_fkey,
+add constraint pipelines_sink_id_fkey
+    foreign key (destination_id)
+    references app.destinations (id);
+
+alter table app.pipelines
+drop constraint pipelines_source_id_fkey,
+add constraint pipelines_source_id_fkey
+    foreign key (source_id)
+    references app.sources (id);

--- a/etl-api/src/db/pipelines.rs
+++ b/etl-api/src/db/pipelines.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use utoipa::ToSchema;
 
 use crate::db;
-use crate::db::destinations::Destination;
+use crate::db::destinations::{Destination, DestinationsDbError};
 use crate::db::replicators::{ReplicatorsDbError, create_replicator};
 use crate::db::serde::{
     DbDeserializationError, DbSerializationError, deserialize_from_value, serialize,
@@ -94,7 +94,7 @@ pub enum PipelinesDbError {
     ReplicatorsDb(#[from] ReplicatorsDbError),
 
     #[error(transparent)]
-    DestinationsDb(#[from] crate::db::destinations::DestinationsDbError),
+    DestinationsDb(#[from] DestinationsDbError),
 }
 
 pub async fn create_pipeline(
@@ -255,10 +255,10 @@ pub async fn delete_pipeline_cascading(
     // Manually delete the replicator since there's no cascade constraint
     db::replicators::delete_replicator(txn.deref_mut(), tenant_id, pipeline.replicator_id).await?;
 
-    // If a destination is supplied, also the destination will be deleted.
-    if let Some(destination) = destination {
-        db::destinations::delete_destination(txn.deref_mut(), tenant_id, destination.id).await?;
-    }
+    // // If a destination is supplied, also the destination will be deleted.
+    // if let Some(destination) = destination {
+    //     db::destinations::delete_destination(txn.deref_mut(), tenant_id, destination.id).await?;
+    // }
 
     // Delete state and schema from the source database
     state::delete_pipeline_replication_state(source_txn.deref_mut(), pipeline.id).await?;

--- a/etl-api/src/db/pipelines.rs
+++ b/etl-api/src/db/pipelines.rs
@@ -255,10 +255,10 @@ pub async fn delete_pipeline_cascading(
     // Manually delete the replicator since there's no cascade constraint
     db::replicators::delete_replicator(txn.deref_mut(), tenant_id, pipeline.replicator_id).await?;
 
-    // // If a destination is supplied, also the destination will be deleted.
-    // if let Some(destination) = destination {
-    //     db::destinations::delete_destination(txn.deref_mut(), tenant_id, destination.id).await?;
-    // }
+    // If a destination is supplied, also the destination will be deleted.
+    if let Some(destination) = destination {
+        db::destinations::delete_destination(txn.deref_mut(), tenant_id, destination.id).await?;
+    }
 
     // Delete state and schema from the source database
     state::delete_pipeline_replication_state(source_txn.deref_mut(), pipeline.id).await?;

--- a/etl-api/src/db/replicators.rs
+++ b/etl-api/src/db/replicators.rs
@@ -118,3 +118,26 @@ where
 
     Ok(record.map(|r| r.id))
 }
+
+pub async fn delete_replicator<'c, E>(
+    executor: E,
+    tenant_id: &str,
+    replicator_id: i64,
+) -> Result<Option<i64>, ReplicatorsDbError>
+where
+    E: PgExecutor<'c>,
+{
+    let record = sqlx::query!(
+        r#"
+        delete from app.replicators
+        where tenant_id = $1 and id = $2
+        returning id
+        "#,
+        tenant_id,
+        replicator_id
+    )
+    .fetch_optional(executor)
+    .await?;
+
+    Ok(record.map(|r| r.id))
+}

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -8,7 +8,7 @@ use etl_config::shared::{
     DestinationConfig, PgConnectionConfig, PipelineConfig as SharedPipelineConfig,
     ReplicatorConfig, SupabaseConfig, TlsConfig,
 };
-use etl_postgres::replication::{TableLookupError, get_table_name_from_oid, schema, state};
+use etl_postgres::replication::{TableLookupError, get_table_name_from_oid, state};
 use etl_postgres::schema::TableId;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ use crate::routes::{
 };
 
 #[derive(Debug, Error)]
-enum PipelineError {
+pub enum PipelineError {
     #[error("The pipeline with id {0} was not found")]
     PipelineNotFound(i64),
 
@@ -541,26 +541,8 @@ pub async fn delete_pipeline(
     .await?
     .ok_or(PipelineError::SourceNotFound(pipeline.source_id))?;
 
-    // Delete the pipeline from the main database (this will cascade delete the replicator)
-    db::pipelines::delete_pipeline(txn.deref_mut(), tenant_id, pipeline_id)
-        .await?
-        .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
-
-    let source_pool =
-        connect_to_source_database_with_defaults(&source.config.into_connection_config()).await?;
-
-    // We start a transaction in the source database while the other transaction is active in the
-    // api database so that in case of failures when deleting the state, we also rollback the transaction
-    // in the api database.
-    let mut source_txn = source_pool.begin().await?;
-
-    state::delete_pipeline_replication_state(source_txn.deref_mut(), pipeline_id).await?;
-    schema::delete_pipeline_table_schemas(source_txn.deref_mut(), pipeline_id).await?;
-
-    // Here we finish `txn` before `source_txn` since we want the guarantee that the pipeline has
-    // been deleted before committing the state deletions.
-    txn.commit().await?;
-    source_txn.commit().await?;
+    // Use the helper function to delete pipeline and its state
+    db::pipelines::delete_pipeline_full(txn, tenant_id, pipeline_id, &pipeline, &source).await?;
 
     Ok(HttpResponse::Ok().finish())
 }

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -527,7 +527,6 @@ pub async fn delete_pipeline(
 
     let mut txn = pool.begin().await?;
 
-    // First, verify the pipeline exists and get source info for cleanup
     let pipeline = db::pipelines::read_pipeline(txn.deref_mut(), tenant_id, pipeline_id)
         .await?
         .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
@@ -541,8 +540,7 @@ pub async fn delete_pipeline(
     .await?
     .ok_or(PipelineError::SourceNotFound(pipeline.source_id))?;
 
-    // Use the helper function to delete pipeline and its state
-    db::pipelines::delete_pipeline_full(txn, tenant_id, pipeline_id, &pipeline, &source).await?;
+    db::pipelines::delete_pipeline_cascading(txn, tenant_id, &pipeline, &source, None).await?;
 
     Ok(HttpResponse::Ok().finish())
 }

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -26,7 +26,7 @@ use crate::{
         destinations_pipelines::{
             CreateDestinationPipelineRequest, CreateDestinationPipelineResponse,
             UpdateDestinationPipelineRequest, create_destination_and_pipeline,
-            update_destination_and_pipeline,
+            delete_destination_and_pipeline, update_destination_and_pipeline,
         },
         health_check::health_check,
         images::{
@@ -240,6 +240,7 @@ pub async fn run(
         crate::routes::tenants_sources::create_tenant_and_source,
         crate::routes::destinations_pipelines::create_destination_and_pipeline,
         crate::routes::destinations_pipelines::update_destination_and_pipeline,
+        crate::routes::destinations_pipelines::delete_destination_and_pipeline,
     ))]
     struct ApiV1;
 
@@ -314,7 +315,8 @@ pub async fn run(
                     .service(create_tenant_and_source)
                     // destinations-pipelines
                     .service(create_destination_and_pipeline)
-                    .service(update_destination_and_pipeline),
+                    .service(update_destination_and_pipeline)
+                    .service(delete_destination_and_pipeline),
             )
             .app_data(config.clone())
             .app_data(connection_pool.clone())

--- a/etl-api/tests/common/database.rs
+++ b/etl-api/tests/common/database.rs
@@ -1,6 +1,14 @@
+use etl_api::db::sources::SourceConfig;
+use etl_api::routes::sources::{CreateSourceRequest, CreateSourceResponse};
+use etl_config::SerializableSecretString;
 use etl_config::shared::PgConnectionConfig;
+use etl_postgres::replication::connect_to_source_database;
 use etl_postgres::sqlx::test_utils::create_pg_database;
+use secrecy::ExposeSecret;
 use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::common::test_app::TestApp;
 
 /// Creates and configures a new PostgreSQL database for the API.
 ///
@@ -17,4 +25,64 @@ pub async fn create_etl_api_database(config: &PgConnectionConfig) -> PgPool {
         .expect("Failed to migrate the database");
 
     connection_pool
+}
+
+pub async fn create_test_source_database(
+    app: &TestApp,
+    tenant_id: &str,
+) -> (PgPool, i64, PgConnectionConfig) {
+    let mut source_db_config = app.database_config().clone();
+    source_db_config.name = format!("test_source_db_{}", Uuid::new_v4());
+
+    let source_pool = create_pg_database(&source_db_config).await;
+
+    let source_config = SourceConfig {
+        host: source_db_config.host.clone(),
+        port: source_db_config.port,
+        name: source_db_config.name.clone(),
+        username: source_db_config.username.clone(),
+        password: source_db_config
+            .password
+            .as_ref()
+            .map(|p| SerializableSecretString::from(p.expose_secret().to_string())),
+    };
+
+    let source = CreateSourceRequest {
+        name: "Test Source".to_string(),
+        config: source_config,
+    };
+
+    let response = app.create_source(tenant_id, &source).await;
+    let response: CreateSourceResponse = response
+        .json()
+        .await
+        .expect("failed to deserialize response");
+
+    (source_pool, response.id, source_db_config)
+}
+
+pub async fn run_etl_migrations_on_source_database(source_db_config: &PgConnectionConfig) {
+    // We create a pool just for the migrations.
+    let source_pool = connect_to_source_database(source_db_config, 1, 1)
+        .await
+        .unwrap();
+
+    // Create the `etl` schema first.
+    sqlx::query("create schema if not exists etl")
+        .execute(&source_pool)
+        .await
+        .unwrap();
+
+    // Set the `etl` schema as search path (this is done to have the migrations metadata table created
+    // by sqlx within the `etl` schema).
+    sqlx::query("set search_path = 'etl';")
+        .execute(&source_pool)
+        .await
+        .unwrap();
+
+    // Run replicator migrations to create the state store tables.
+    sqlx::migrate!("../etl-replicator/migrations")
+        .run(&source_pool)
+        .await
+        .unwrap();
 }

--- a/etl-api/tests/common/test_app.rs
+++ b/etl-api/tests/common/test_app.rs
@@ -353,6 +353,22 @@ impl TestApp {
         .expect("Failed to execute request.")
     }
 
+    pub async fn delete_destination_pipeline(
+        &self,
+        tenant_id: &str,
+        destination_id: i64,
+        pipeline_id: i64,
+    ) -> reqwest::Response {
+        self.delete_authenticated(format!(
+            "{}/v1/destinations-pipelines/{destination_id}/{pipeline_id}",
+            &self.address
+        ))
+        .header("tenant_id", tenant_id)
+        .send()
+        .await
+        .expect("Failed to execute request.")
+    }
+
     pub async fn create_image(&self, image: &CreateImageRequest) -> reqwest::Response {
         self.post_authenticated(format!("{}/v1/images", &self.address))
             .json(image)

--- a/etl-api/tests/integration/pipelines_test.rs
+++ b/etl-api/tests/integration/pipelines_test.rs
@@ -19,6 +19,7 @@ use sqlx::PgPool;
 use sqlx::postgres::types::Oid;
 use uuid::Uuid;
 
+use crate::common::database::{create_test_source_database, run_etl_migrations_on_source_database};
 use crate::{
     common::test_app::{TestApp, spawn_test_app},
     integration::destination_test::create_destination,
@@ -150,36 +151,9 @@ async fn setup_pipeline_with_source_db() -> (TestApp, String, i64, PgPool, PgCon
     .await;
 
     // We run the migrations to create all the tables used by `etl`.
-    run_etl_migrations_on_source_db(&source_db_config).await;
+    run_etl_migrations_on_source_database(&source_db_config).await;
 
     (app, tenant_id, pipeline_id, source_pool, source_db_config)
-}
-
-/// Runs etl migrations on the source database.
-async fn run_etl_migrations_on_source_db(source_db_config: &PgConnectionConfig) {
-    // We create a pool just for the migrations.
-    let source_pool = connect_to_source_database(source_db_config, 1, 1)
-        .await
-        .unwrap();
-
-    // Create the `etl` schema first.
-    sqlx::query("create schema if not exists etl")
-        .execute(&source_pool)
-        .await
-        .unwrap();
-
-    // Set the `etl` schema as search path (this is done to have the migrations metadata table created
-    // by sqlx within the `etl` schema).
-    sqlx::query("set search_path = 'etl';")
-        .execute(&source_pool)
-        .await
-        .unwrap();
-
-    // Run replicator migrations to create the state store tables.
-    sqlx::migrate!("../etl-replicator/migrations")
-        .run(&source_pool)
-        .await
-        .unwrap();
 }
 
 /// Creates a table with a chain of replication states.
@@ -272,40 +246,6 @@ async fn test_rollback(
     } else {
         None
     }
-}
-
-async fn create_test_source_database(
-    app: &TestApp,
-    tenant_id: &str,
-) -> (PgPool, i64, PgConnectionConfig) {
-    let mut source_db_config = app.database_config().clone();
-    source_db_config.name = format!("test_source_db_{}", Uuid::new_v4());
-
-    let source_pool = create_pg_database(&source_db_config).await;
-
-    let source_config = SourceConfig {
-        host: source_db_config.host.clone(),
-        port: source_db_config.port,
-        name: source_db_config.name.clone(),
-        username: source_db_config.username.clone(),
-        password: source_db_config
-            .password
-            .as_ref()
-            .map(|p| SerializableSecretString::from(p.expose_secret().to_string())),
-    };
-
-    let source = CreateSourceRequest {
-        name: "Test Source".to_string(),
-        config: source_config,
-    };
-
-    let response = app.create_source(tenant_id, &source).await;
-    let response: CreateSourceResponse = response
-        .json()
-        .await
-        .expect("failed to deserialize response");
-
-    (source_pool, response.id, source_db_config)
 }
 
 async fn create_test_table(source_pool: &PgPool, table_name: &str) -> Oid {
@@ -723,66 +663,6 @@ async fn all_pipelines_can_be_read() {
             insta::assert_debug_snapshot!(pipeline.config);
         }
     }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn deleting_a_source_cascade_deletes_the_pipeline() {
-    init_test_tracing();
-    // Arrange
-    let app = spawn_test_app().await;
-    create_default_image(&app).await;
-    let tenant_id = &create_tenant(&app).await;
-    let source_id = create_source(&app, tenant_id).await;
-    let destination_id = create_destination(&app, tenant_id).await;
-
-    let pipeline = CreatePipelineRequest {
-        source_id,
-        destination_id,
-        config: new_pipeline_config(),
-    };
-    let response = app.create_pipeline(tenant_id, &pipeline).await;
-    let response: CreatePipelineResponse = response
-        .json()
-        .await
-        .expect("failed to deserialize response");
-    let pipeline_id = response.id;
-
-    // Act
-    app.delete_source(tenant_id, source_id).await;
-
-    // Assert
-    let response = app.read_pipeline(tenant_id, pipeline_id).await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn deleting_a_destination_cascade_deletes_the_pipeline() {
-    init_test_tracing();
-    // Arrange
-    let app = spawn_test_app().await;
-    create_default_image(&app).await;
-    let tenant_id = &create_tenant(&app).await;
-    let source_id = create_source(&app, tenant_id).await;
-    let destination_id = create_destination(&app, tenant_id).await;
-
-    let pipeline = CreatePipelineRequest {
-        source_id,
-        destination_id,
-        config: new_pipeline_config(),
-    };
-    let response = app.create_pipeline(tenant_id, &pipeline).await;
-    let response: CreatePipelineResponse = response
-        .json()
-        .await
-        .expect("failed to deserialize response");
-    let pipeline_id = response.id;
-
-    // Act
-    app.delete_destination(tenant_id, destination_id).await;
-
-    // Assert
-    let response = app.read_pipeline(tenant_id, pipeline_id).await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/etl-api/tests/integration/pipelines_test.rs
+++ b/etl-api/tests/integration/pipelines_test.rs
@@ -1,5 +1,4 @@
 use etl_api::db::pipelines::{OptionalPipelineConfig, PipelineConfig};
-use etl_api::db::sources::SourceConfig;
 use etl_api::routes::pipelines::{
     CreatePipelineRequest, CreatePipelineResponse, GetPipelineReplicationStatusResponse,
     ReadPipelineResponse, ReadPipelinesResponse, RollbackTableStateRequest,
@@ -7,17 +6,12 @@ use etl_api::routes::pipelines::{
     UpdatePipelineConfigRequest, UpdatePipelineConfigResponse, UpdatePipelineImageRequest,
     UpdatePipelineRequest,
 };
-use etl_api::routes::sources::{CreateSourceRequest, CreateSourceResponse};
-use etl_config::SerializableSecretString;
 use etl_config::shared::{BatchConfig, PgConnectionConfig};
-use etl_postgres::replication::connect_to_source_database;
-use etl_postgres::sqlx::test_utils::{create_pg_database, drop_pg_database};
+use etl_postgres::sqlx::test_utils::drop_pg_database;
 use etl_telemetry::init_test_tracing;
 use reqwest::StatusCode;
-use secrecy::ExposeSecret;
 use sqlx::PgPool;
 use sqlx::postgres::types::Oid;
-use uuid::Uuid;
 
 use crate::common::database::{create_test_source_database, run_etl_migrations_on_source_database};
 use crate::{


### PR DESCRIPTION
This PR introduces a new endpoint that atomically deletes both a destination and its associated pipeline. It also includes the following improvements:
- Ensures that the replicator entry is deleted when its corresponding pipeline is removed. This is done assuming that there can be a single replicator bound per pipeline.
- Removes ON DELETE CASCADE constraints for sources and destinations. Instead, the system now explicitly throws an error if a source or destination with active pipelines is deleted. This makes deletion behavior more predictable and explicit.