### PR TITLE
feat(bigquery): Reduce the amount of times a table is checked

### DIFF
--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -239,7 +239,13 @@ where
         match result {
             Ok(()) => Ok(()),
             Err(err) => {
-                if err.kind() == ErrorKind::TableNotFound {
+                // From our testing, when trying to send data to a missing table, this is the error that is
+                // returned:
+                // `Status { code: PermissionDenied, message: "Permission 'TABLES_UPDATE_DATA' denied on
+                // resource 'x' (or it may not exist).", source: None }`
+                //
+                // If we get permission denied, we assume that the table doesn't exist.
+                if err.kind() == ErrorKind::PermissionDenied {
                     warn!(
                         "table {table_id} not found during streaming, removing from cache and recreating"
                     );

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -66,8 +66,6 @@ pub enum ErrorKind {
     InvalidState,
     /// Invalid data
     InvalidData,
-    /// Table not found
-    TableNotFound,
     /// Data validation error
     ValidationError,
     /// Apply worker error
@@ -76,6 +74,8 @@ pub enum ErrorKind {
     StateRollbackError,
     /// Table sync worker error
     TableSyncWorkerPanic,
+    /// Permission denied error
+    PermissionDenied,
     /// Destination-specific error
     DestinationError,
     /// Replication slot not found


### PR DESCRIPTION
This PR improves the performance of the `BigQueryDestination` by adding a simple cache that avoids trying to create the table each time a batch is received.