### PR TITLE
feat(docs): Write rust docs for some crates

### DIFF
--- a/etl-api/src/authentication.rs
+++ b/etl-api/src/authentication.rs
@@ -7,6 +7,10 @@ use constant_time_eq::constant_time_eq_n;
 
 use crate::config::{ApiConfig, ApiKey};
 
+/// Validates bearer token authentication for API requests.
+///
+/// Compares the provided token against the configured API key using constant-time
+/// comparison to prevent timing attacks. Returns authentication errors for invalid tokens.
 pub async fn auth_validator(
     req: ServiceRequest,
     credentials: BearerAuth,

--- a/etl-api/src/lib.rs
+++ b/etl-api/src/lib.rs
@@ -1,3 +1,9 @@
+//! ETL API service for managing data replication pipelines.
+//!
+//! Provides a REST API for configuring and managing ETL pipelines, including tenants,
+//! sources, destinations, and replication monitoring. Includes authentication, encryption,
+//! Kubernetes integration, and comprehensive OpenAPI documentation.
+
 pub mod authentication;
 pub mod config;
 pub mod db;

--- a/etl-api/src/main.rs
+++ b/etl-api/src/main.rs
@@ -6,6 +6,10 @@ use std::env;
 use std::sync::Arc;
 use tracing::{error, info};
 
+/// Entry point for the ETL API service.
+///
+/// Initializes tracing, Sentry, and starts the Actix web server with command-line
+/// argument handling for both server mode and database migration.
 fn main() -> anyhow::Result<()> {
     // Initialize tracing from the binary name
     let _log_flusher = init_tracing(env!("CARGO_BIN_NAME"))?;
@@ -19,6 +23,9 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Main async function that handles command-line arguments and starts the service.
+///
+/// Supports two modes: server mode (no arguments) and migration mode ("migrate" argument).
 async fn async_main() -> anyhow::Result<()> {
     let mut args = env::args();
     match args.len() {
@@ -56,6 +63,10 @@ async fn async_main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Initializes Sentry error tracking and performance monitoring.
+///
+/// Configures Sentry with environment-specific settings and service tagging.
+/// Returns `None` if Sentry configuration is not provided.
 fn init_sentry() -> anyhow::Result<Option<sentry::ClientInitGuard>> {
     if let Ok(config) = load_config::<ApiConfig>()
         && let Some(sentry_config) = &config.sentry

--- a/etl-config/src/environment.rs
+++ b/etl-config/src/environment.rs
@@ -1,21 +1,22 @@
 use std::fmt;
 use std::io::Error;
 
-/// Names of the environment variable which contains the environment name.
+/// Environment variable name containing the environment identifier.
 const APP_ENVIRONMENT_ENV_NAME: &str = "APP_ENVIRONMENT";
 
-/// The name of the production environment.
+/// Production environment identifier.
 const PROD_ENV_NAME: &str = "prod";
 
-/// The name of the staging environment.
+/// Staging environment identifier.
 const STAGING_ENV_NAME: &str = "staging";
 
-/// The name of the development environment.
+/// Development environment identifier.
 const DEV_ENV_NAME: &str = "dev";
 
-/// Represents the runtime environment for the application.
+/// Runtime environment for the application.
 ///
-/// Use [`Environment`] to distinguish between development and production modes.
+/// Used to distinguish between development, staging, and production modes
+/// for configuration loading and feature toggles.
 #[derive(Debug, Clone)]
 pub enum Environment {
     /// Production environment.
@@ -27,19 +28,23 @@ pub enum Environment {
 }
 
 impl Environment {
-    /// Loads the environment from the `APP_ENVIRONMENT` env variable.
+    /// Loads the environment from the `APP_ENVIRONMENT` environment variable.
     ///
-    /// In case no environment is specified, we default to [`Environment::Prod`].
+    /// Defaults to [`Environment::Prod`] if the variable is not set.
     pub fn load() -> Result<Environment, Error> {
         std::env::var(APP_ENVIRONMENT_ENV_NAME)
             .unwrap_or_else(|_| PROD_ENV_NAME.into())
             .try_into()
     }
 
+    /// Sets the `APP_ENVIRONMENT` environment variable to this environment's value.
     pub fn set(&self) {
         unsafe { std::env::set_var(APP_ENVIRONMENT_ENV_NAME, self.to_string()) }
     }
 
+    /// Returns whether this is a production-like environment.
+    ///
+    /// Returns `true` for both [`Environment::Prod`] and [`Environment::Staging`].
     pub fn is_prod(&self) -> bool {
         matches!(self, Self::Prod | Self::Staging)
     }
@@ -58,9 +63,9 @@ impl fmt::Display for Environment {
 impl TryFrom<String> for Environment {
     type Error = Error;
 
-    /// Attempts to create an [`Environment`] from a string, case-insensitively.
+    /// Creates an [`Environment`] from a string, case-insensitively.
     ///
-    /// Accepts "dev" or "prod". Returns an error if the input does not match a supported environment.
+    /// Accepts "dev", "staging", or "prod". Returns an error for unsupported values.
     fn try_from(s: String) -> Result<Self, Self::Error> {
         match s.to_lowercase().as_str() {
             PROD_ENV_NAME => Ok(Self::Prod),

--- a/etl-config/src/lib.rs
+++ b/etl-config/src/lib.rs
@@ -1,3 +1,9 @@
+//! Configuration management for ETL applications.
+//!
+//! Provides environment detection, configuration loading from YAML files,
+//! secret handling, and shared configuration types for various ETL services
+//! and components.
+
 mod environment;
 mod load;
 mod secret;

--- a/etl-config/src/load.rs
+++ b/etl-config/src/load.rs
@@ -2,40 +2,35 @@ use serde::de::DeserializeOwned;
 
 use crate::environment::Environment;
 
-/// Directory containing configuration files relative to the application root.
+/// Directory containing configuration files relative to application root.
 const CONFIGURATION_DIR: &str = "configuration";
 
-/// Name of the base configuration file loaded for all environments.
+/// Base configuration file loaded for all environments.
 const BASE_CONFIG_FILE: &str = "base.yaml";
 
-/// Prefix for environment variable overrides in configuration.
-///
-/// Environment variables with this prefix are used to override configuration values.
+/// Prefix for environment variable configuration overrides.
 const ENV_PREFIX: &str = "APP";
 
-/// Separator between the environment variable prefix and the first key segment.
+/// Separator between environment variable prefix and key segments.
 const ENV_PREFIX_SEPARATOR: &str = "_";
 
 /// Separator for nested configuration keys in environment variables.
 ///
-/// For example, `APP_DATABASE__URL` sets the `database.url` field.
+/// Example: `APP_DATABASE__URL` sets the `database.url` field.
 const ENV_SEPARATOR: &str = "__";
 
-/// Loads the application configuration from YAML files and environment variables.
+/// Loads hierarchical configuration from YAML files and environment variables.
 ///
-/// This function loads the base configuration file, then an environment-specific file
-/// (determined by the `APP_ENVIRONMENT` variable, defaulting to `dev`), and finally
-/// applies overrides from environment variables prefixed with `APP`. Nested keys are
-/// separated by double underscores (`__`).
+/// Loads configuration in this order:
+/// 1. Base configuration from `configuration/base.yaml`
+/// 2. Environment-specific file from `configuration/{environment}.yaml`
+/// 3. Environment variable overrides prefixed with `APP`
 ///
-/// The resulting configuration is deserialized into the type `T`.
+/// Nested keys use double underscores: `APP_DATABASE__URL` → `database.url`
 ///
 /// # Panics
-///
-/// Panics if the current working directory cannot be determined or if the value of
-/// `APP_ENVIRONMENT` cannot be parsed into an [`Environment`].
-///
-/// Returns an error if configuration loading or deserialization fails.
+/// Panics if current directory cannot be determined or if `APP_ENVIRONMENT`
+/// cannot be parsed.
 pub fn load_config<T>() -> Result<T, config::ConfigError>
 where
     T: DeserializeOwned,

--- a/etl-config/src/secret.rs
+++ b/etl-config/src/secret.rs
@@ -4,7 +4,10 @@ use std::ops::Deref;
 #[cfg(feature = "utoipa")]
 use utoipa::ToSchema;
 
-/// Wrapper around [`Secret<String>`] that implements [`Serialize`] and [`Deserialize`].
+/// Serializable wrapper around [`SecretString`].
+///
+/// Provides serde support for [`SecretString`] while maintaining its security properties.
+/// The secret value is only exposed during serialization and deserialization operations.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema), schema(value_type = String, example = "secret123"))]
 pub struct SerializableSecretString(SecretString);
@@ -18,24 +21,30 @@ impl Deref for SerializableSecretString {
 }
 
 impl From<String> for SerializableSecretString {
+    /// Creates a [`SerializableSecretString`] from a plain string.
     fn from(value: String) -> Self {
         Self(value.into())
     }
 }
 
 impl From<SecretString> for SerializableSecretString {
+    /// Creates a [`SerializableSecretString`] from a [`SecretString`].
     fn from(value: SecretString) -> Self {
         Self(value)
     }
 }
 
 impl From<SerializableSecretString> for SecretString {
+    /// Extracts the underlying [`SecretString`].
     fn from(value: SerializableSecretString) -> Self {
         value.0
     }
 }
 
 impl Serialize for SerializableSecretString {
+    /// Serializes the secret by exposing its value.
+    ///
+    /// The secret value is temporarily exposed during serialization.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -45,6 +54,9 @@ impl Serialize for SerializableSecretString {
 }
 
 impl<'de> Deserialize<'de> for SerializableSecretString {
+    /// Deserializes a string into a [`SerializableSecretString`].
+    ///
+    /// The deserialized string is immediately wrapped in a secret container.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/etl-config/src/shared/base.rs
+++ b/etl-config/src/shared/base.rs
@@ -1,9 +1,9 @@
 use thiserror::Error;
 
-/// Errors that can occur during configuration validation.
+/// Configuration validation errors.
 #[derive(Debug, Error)]
 pub enum ValidationError {
-    /// Max table sync workers can't be zero
+    /// Maximum table sync workers cannot be zero.
     #[error("`max_table_sync_workers` cannot be zero")]
     MaxTableSyncWorkersZero,
     /// TLS is enabled but no trusted root certificates are provided.

--- a/etl-config/src/shared/destination.rs
+++ b/etl-config/src/shared/destination.rs
@@ -4,10 +4,10 @@ use utoipa::ToSchema;
 
 use crate::SerializableSecretString;
 
-/// Configuration options for supported data destinations.
+/// Configuration for supported ETL data destinations.
 ///
-/// This enum is used to specify the destination type and its configuration
-/// for the replicator. Variants correspond to different supported destinations.
+/// Specifies the destination type and its associated configuration parameters.
+/// Each variant corresponds to a different supported destination system.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]

--- a/etl-config/src/shared/pipeline.rs
+++ b/etl-config/src/shared/pipeline.rs
@@ -4,7 +4,10 @@ use utoipa::ToSchema;
 
 use crate::shared::{PgConnectionConfig, ValidationError, batch::BatchConfig};
 
-/// Configuration for a pipeline's batching and worker retry behavior.
+/// Configuration for an ETL pipeline.
+///
+/// Contains all settings required to run a replication pipeline including
+/// source database connection, batching parameters, and worker limits.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]
@@ -31,11 +34,9 @@ pub struct PipelineConfig {
 }
 
 impl PipelineConfig {
-    /// Validates the [`PipelineConfig`].
+    /// Validates pipeline configuration settings.
     ///
-    /// This method checks that the [`PipelineConfig::pg_connection`] and [`PipelineConfig::max_table_sync_workers`] are valid.
-    ///
-    /// Returns [`ValidationError::MaxTableSyncWorkersZero`] if [`PipelineConfig::max_table_sync_workers`] is zero.
+    /// Checks connection settings and ensures worker count is non-zero.
     pub fn validate(&self) -> Result<(), ValidationError> {
         self.pg_connection.tls.validate()?;
 

--- a/etl-config/src/shared/replicator.rs
+++ b/etl-config/src/shared/replicator.rs
@@ -2,13 +2,11 @@ use crate::shared::pipeline::PipelineConfig;
 use crate::shared::{DestinationConfig, SentryConfig, SupabaseConfig, ValidationError};
 use serde::{Deserialize, Serialize};
 
-/// Configuration for the replicator service.
+/// Complete configuration for the replicator service.
 ///
-/// This struct aggregates all configuration required to run the replicator, including source,
-/// destination, pipeline, state store, and optional Supabase-specific settings.
-///
-/// The [`ReplicatorConfig`] is typically deserialized from a configuration file and passed to the
-/// replicator at startup.
+/// Aggregates all configuration required to run a replicator including pipeline
+/// settings, destination configuration, and optional service integrations like
+/// Sentry and Supabase. Typically loaded from configuration files at startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ReplicatorConfig {
@@ -29,13 +27,9 @@ pub struct ReplicatorConfig {
 }
 
 impl ReplicatorConfig {
-    /// Validates the loaded [`ReplicatorConfig`].
+    /// Validates the complete replicator configuration.
     ///
-    /// Checks the validity of the configuration.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ValidationError`] if validation fails.
+    /// Performs comprehensive validation of all configuration components.
     pub fn validate(&self) -> Result<(), ValidationError> {
         self.pipeline.validate()
     }

--- a/etl-config/src/shared/retry.rs
+++ b/etl-config/src/shared/retry.rs
@@ -2,7 +2,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "utoipa")]
 use utoipa::ToSchema;
 
-/// Retry policy configuration for operations such as worker initialization.
+/// Retry policy with exponential backoff configuration.
+///
+/// Configures retry behavior for operations that may fail temporarily,
+/// such as worker initialization or external service connections.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 pub struct RetryConfig {

--- a/etl-config/src/shared/sentry.rs
+++ b/etl-config/src/shared/sentry.rs
@@ -1,13 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-/// Configuration for Sentry error tracking and performance monitoring.
+/// Sentry error tracking and monitoring configuration.
 ///
-/// This struct holds the necessary configuration to initialize Sentry in the application.
-/// It includes the DSN (Data Source Name) and optional service-specific tags to differentiate
-/// between different services reporting to the same Sentry project.
+/// Contains the DSN and other settings required to initialize Sentry for
+/// error tracking and performance monitoring in ETL applications.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct SentryConfig {
-    /// Sentry DSN (Data Source Name) for error reporting.
+    /// Sentry DSN (Data Source Name) for error reporting and monitoring.
     pub dsn: String,
 }

--- a/etl-config/src/shared/supabase.rs
+++ b/etl-config/src/shared/supabase.rs
@@ -1,15 +1,21 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-/// Configuration options for Supabase related information.
+/// Supabase integration configuration.
+///
+/// Contains Supabase-specific settings for ETL applications that
+/// integrate with Supabase services.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct SupabaseConfig {
-    /// The project to which this replicator belongs.
+    /// Supabase project reference identifier.
     pub project_ref: String,
 }
 
 impl fmt::Debug for SupabaseConfig {
+    /// Formats the config for debugging with redacted project reference.
+    ///
+    /// The project reference is redacted in debug output for security.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SupabaseConfig")
             .field("project_ref", &"REDACTED")

--- a/etl-destinations/src/bigquery/client.rs
+++ b/etl-destinations/src/bigquery/client.rs
@@ -28,8 +28,11 @@ const BIGQUERY_CDC_SPECIAL_COLUMN: &str = "_CHANGE_TYPE";
 /// Special column name for Change Data Capture sequence ordering in BigQuery.
 const BIGQUERY_CDC_SEQUENCE_COLUMN: &str = "_CHANGE_SEQUENCE_NUMBER";
 
+/// BigQuery project identifier.
 pub type BigQueryProjectId = String;
+/// BigQuery dataset identifier.
 pub type BigQueryDatasetId = String;
+/// BigQuery table identifier.
 pub type BigQueryTableId = String;
 
 /// Change Data Capture operation types for BigQuery streaming.
@@ -40,7 +43,7 @@ pub enum BigQueryOperationType {
 }
 
 impl BigQueryOperationType {
-    /// Converts the [`BigQueryOperationType`] into a [`Cell`] value.
+    /// Converts the operation type into a [`Cell`] for streaming.
     pub fn into_cell(self) -> Cell {
         Cell::String(self.to_string())
     }
@@ -55,20 +58,19 @@ impl fmt::Display for BigQueryOperationType {
     }
 }
 
-/// A client for interacting with Google BigQuery.
+/// Client for interacting with Google BigQuery.
 ///
-/// This client provides methods for managing tables, inserting data,
-/// and executing queries against a BigQuery project.
+/// Provides methods for table management, data insertion, and query execution
+/// against BigQuery datasets with authentication and error handling.
 pub struct BigQueryClient {
     project_id: BigQueryProjectId,
     client: Client,
 }
 
 impl BigQueryClient {
-    /// Creates a new [`BigQueryClient`] from a Google Cloud service account key file.
+    /// Creates a new [`BigQueryClient`] from a service account key file.
     ///
-    /// Reads the service account key from the specified file path and uses it to
-    /// authenticate with the BigQuery API.
+    /// Authenticates with BigQuery using the service account key at the specified file path.
     pub async fn new_with_key_path(
         project_id: BigQueryProjectId,
         sa_key_path: &str,
@@ -80,10 +82,9 @@ impl BigQueryClient {
         Ok(BigQueryClient { project_id, client })
     }
 
-    /// Creates a new [`BigQueryClient`] from a Google Cloud service account key string.
+    /// Creates a new [`BigQueryClient`] from a service account key JSON string.
     ///
-    /// Parses the provided service account key string to authenticate with the
-    /// BigQuery API.
+    /// Parses and uses the provided service account key to authenticate with BigQuery.
     pub async fn new_with_key(
         project_id: BigQueryProjectId,
         sa_key: &str,
@@ -98,7 +99,9 @@ impl BigQueryClient {
         Ok(BigQueryClient { project_id, client })
     }
 
-    /// Returns the full BigQuery table name in the form `project_id.dataset_id.table_id`.
+    /// Returns the fully qualified BigQuery table name.
+    ///
+    /// Formats the table name as `project_id.dataset_id.table_id` with proper quoting.
     pub fn full_table_name(
         &self,
         dataset_id: &BigQueryDatasetId,
@@ -107,10 +110,9 @@ impl BigQueryClient {
         format!("`{}.{}.{}`", self.project_id, dataset_id, table_id)
     }
 
-    /// Creates a new table in the specified dataset if it does not already exist.
+    /// Creates a table in BigQuery if it doesn't already exist.
     ///
-    /// Returns `true` if the table was created, and `false` if the table
-    /// already existed.
+    /// Returns `true` if the table was created, `false` if it already existed.
     pub async fn create_table_if_missing(
         &self,
         dataset_id: &BigQueryDatasetId,
@@ -128,7 +130,10 @@ impl BigQueryClient {
         Ok(true)
     }
 
-    /// Creates a table in a BigQuery dataset.
+    /// Creates a new table in the BigQuery dataset.
+    ///
+    /// Builds and executes a CREATE TABLE statement with the provided column schemas
+    /// and optional staleness configuration for CDC operations.
     pub async fn create_table(
         &self,
         dataset_id: &BigQueryDatasetId,
@@ -154,7 +159,9 @@ impl BigQueryClient {
         Ok(())
     }
 
-    /// Truncates a table in a BigQuery dataset.
+    /// Truncates all data from a BigQuery table.
+    ///
+    /// Executes a TRUNCATE TABLE statement to remove all rows while preserving the table structure.
     #[allow(dead_code)]
     pub async fn truncate_table(
         &self,
@@ -172,11 +179,9 @@ impl BigQueryClient {
         Ok(())
     }
 
-    /// Checks if a table exists in the specified dataset.
+    /// Checks whether a table exists in the BigQuery dataset.
     ///
-    /// # Panics
-    ///
-    /// Panics if the query result does not contain the expected `table_exists` column.
+    /// Returns `true` if the table exists, `false` otherwise.
     pub async fn table_exists(
         &self,
         dataset_id: &BigQueryDatasetId,
@@ -194,10 +199,10 @@ impl BigQueryClient {
         Ok(exists)
     }
 
-    /// Streams rows to a BigQuery table using the Storage Write API.
+    /// Streams rows to BigQuery using the Storage Write API.
     ///
-    /// This method is efficient for high-throughput ingestion. It batches rows
-    /// to respect the maximum request size.
+    /// Efficiently ingests data by batching rows to respect size limits and
+    /// using the high-performance Storage Write API.
     pub async fn stream_rows(
         &mut self,
         dataset_id: &BigQueryDatasetId,
@@ -259,7 +264,7 @@ impl BigQueryClient {
         Ok(())
     }
 
-    /// Executes an SQL query and returns the result set.
+    /// Executes a BigQuery SQL query and returns the result set.
     pub async fn query(&self, request: QueryRequest) -> EtlResult<ResultSet> {
         let query_response = self
             .client
@@ -271,7 +276,7 @@ impl BigQueryClient {
         Ok(ResultSet::new_from_query_response(query_response))
     }
 
-    /// Generates an SQL column specification for a `CREATE TABLE` statement.
+    /// Generates SQL column specification for CREATE TABLE statements.
     fn column_spec(column_schema: &ColumnSchema) -> String {
         let mut column_spec = format!(
             "`{}` {}",
@@ -286,7 +291,9 @@ impl BigQueryClient {
         column_spec
     }
 
-    /// Creates a primary key clause string for table creation.
+    /// Creates a primary key clause for table creation.
+    ///
+    /// Generates a primary key constraint clause from columns marked as primary key.
     fn add_primary_key_clause(column_schemas: &[ColumnSchema]) -> String {
         let identity_columns: Vec<String> = column_schemas
             .iter()
@@ -304,7 +311,7 @@ impl BigQueryClient {
         )
     }
 
-    /// Builds the complete column specification clause for table creation.
+    /// Builds complete column specifications for CREATE TABLE statements.
     fn create_columns_spec(column_schemas: &[ColumnSchema]) -> String {
         let mut s = column_schemas
             .iter()
@@ -317,12 +324,12 @@ impl BigQueryClient {
         format!("({s})")
     }
 
-    /// Creates the max staleness option clause for table creation.
+    /// Creates max staleness option clause for CDC table creation.
     fn max_staleness_option(max_staleness_mins: u16) -> String {
         format!("options (max_staleness = interval {max_staleness_mins} minute)")
     }
 
-    /// Converts a PostgreSQL [`Type`] to its BigQuery equivalent data type string.
+    /// Converts PostgreSQL data types to BigQuery equivalent types.
     fn postgres_to_bigquery_type(typ: &Type) -> String {
         if Self::is_array_type(typ) {
             let element_type = match typ {
@@ -366,7 +373,7 @@ impl BigQueryClient {
         .to_string()
     }
 
-    /// Returns true if the PostgreSQL [`Type`] represents an array type.
+    /// Returns whether the PostgreSQL type is an array type.
     fn is_array_type(typ: &Type) -> bool {
         matches!(
             typ,
@@ -394,11 +401,10 @@ impl BigQueryClient {
         )
     }
 
-    /// Converts PostgreSQL column schemas to a BigQuery [`TableDescriptor`] for Storage Write API.
+    /// Converts PostgreSQL column schemas to a BigQuery [`TableDescriptor`].
     ///
-    /// Maps PostgreSQL data types to BigQuery column types and sets the appropriate
-    /// column mode (`NULLABLE`, `REQUIRED`, or `REPEATED`). Automatically adds the
-    /// Change Data Capture special column.
+    /// Maps data types and nullability to BigQuery column specifications, setting
+    /// appropriate column modes and automatically adding CDC special columns.
     pub fn column_schemas_to_table_descriptor(
         column_schemas: &[ColumnSchema],
         use_cdc_sequence_column: bool,
@@ -490,6 +496,7 @@ impl BigQueryClient {
 }
 
 impl fmt::Debug for BigQueryClient {
+    /// Formats the client for debugging, excluding sensitive client details.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BigQueryClient")
             .field("project_id", &self.project_id)
@@ -497,9 +504,9 @@ impl fmt::Debug for BigQueryClient {
     }
 }
 
-/// Converts [`BQError`] to [`EtlError`] with appropriate error kind.
+/// Converts BigQuery errors to ETL errors with appropriate classification.
 ///
-/// Maps errors based on their specific type for better error classification and handling.
+/// Maps BigQuery error types to ETL error kinds for consistent error handling.
 fn bq_error_to_etl_error(err: BQError) -> EtlError {
     use BQError;
 
@@ -574,7 +581,7 @@ fn bq_error_to_etl_error(err: BQError) -> EtlError {
     etl_error!(kind, description, err.to_string())
 }
 
-/// Converts BigQuery row errors to [`EtlError`] with [`ErrorKind::DestinationError`].
+/// Converts BigQuery row errors to ETL destination errors.
 fn row_error_to_etl_error(err: RowError) -> EtlError {
     etl_error!(
         ErrorKind::DestinationError,

--- a/etl-destinations/src/bigquery/encryption.rs
+++ b/etl-destinations/src/bigquery/encryption.rs
@@ -1,7 +1,12 @@
 use std::sync::Once;
 
+/// Ensures crypto provider is only initialized once.
 static INIT_CRYPTO: Once = Once::new();
 
+/// Installs the default cryptographic provider for BigQuery operations.
+///
+/// Uses AWS LC cryptographic provider and ensures it's only installed once
+/// across the application lifetime to avoid conflicts.
 pub fn install_crypto_provider_for_bigquery() {
     INIT_CRYPTO.call_once(|| {
         rustls::crypto::aws_lc_rs::default_provider()

--- a/etl-destinations/src/lib.rs
+++ b/etl-destinations/src/lib.rs
@@ -1,2 +1,7 @@
+//! ETL destination implementations.
+//!
+//! Provides implementations of the ETL [`Destination`] trait for various data warehouses
+//! and analytics platforms, enabling data replication from PostgreSQL to cloud services.
+
 #[cfg(feature = "bigquery")]
 pub mod bigquery;

--- a/etl-postgres/src/replication/db.rs
+++ b/etl-postgres/src/replication/db.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 use crate::schema::{TableId, TableName};
 
+/// Errors that can occur during table lookups.
 #[derive(Debug, Error)]
 pub enum TableLookupError {
     #[error("Database error: {0}")]
@@ -13,7 +14,10 @@ pub enum TableLookupError {
     TableNotFound(TableId),
 }
 
-/// Connect to the source database with a minimal connection pool
+/// Connects to the source database with a connection pool.
+///
+/// Creates a PostgreSQL connection pool with the specified minimum and maximum
+/// connection counts for accessing the source database.
 #[cfg(feature = "replication")]
 pub async fn connect_to_source_database(
     config: &PgConnectionConfig,
@@ -31,10 +35,10 @@ pub async fn connect_to_source_database(
     Ok(pool)
 }
 
-/// Loads the table name from a table OID by querying the source database.
+/// Retrieves table name from table OID by querying system catalogs.
 ///
-/// This function connects to the source database and looks up the schema and table name
-/// for the given table OID using the pg_class and pg_namespace system tables.
+/// Looks up the schema and table name for the given table OID using PostgreSQL's
+/// pg_class and pg_namespace system tables.
 pub async fn get_table_name_from_oid(
     pool: &PgPool,
     table_id: TableId,

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -6,10 +6,10 @@ use tokio_postgres::types::Type as PgType;
 
 use crate::schema::{ColumnSchema, TableId, TableName, TableSchema};
 
-/// Converts a PostgreSQL type name string back to a [`PgType`].
+/// Converts a PostgreSQL type name string to a [`PgType`].
 ///
-/// This function maps string representations back to their corresponding PostgreSQL types.
-/// It handles the most common PostgreSQL types and falls back to `TEXT` for unknown types.
+/// Maps string representations to their corresponding PostgreSQL types,
+/// handling common types and falling back to `TEXT` for unknown types.
 pub fn string_to_postgres_type(type_str: &str) -> PgType {
     match type_str {
         "BOOL" => PgType::BOOL,
@@ -36,8 +36,8 @@ pub fn string_to_postgres_type(type_str: &str) -> PgType {
 
 /// Converts a PostgreSQL [`PgType`] to its string representation.
 ///
-/// This function maps PostgreSQL types to their string equivalents for storage in the database.
-/// It handles the most common PostgreSQL types and provides a fallback for unknown types.
+/// Maps PostgreSQL types to string equivalents for database storage,
+/// handling common types with fallback for unknown types.
 pub fn postgres_type_to_string(pg_type: &PgType) -> String {
     match *pg_type {
         PgType::BOOL => "BOOL".to_string(),
@@ -64,8 +64,8 @@ pub fn postgres_type_to_string(pg_type: &PgType) -> String {
 
 /// Stores a table schema in the database.
 ///
-/// This function inserts or updates a table schema and its columns in the schema storage tables.
-/// It uses a transaction to ensure atomicity.
+/// Inserts or updates table schema and column information in schema storage tables
+/// using a transaction to ensure atomicity.
 pub async fn store_table_schema(
     pool: &PgPool,
     pipeline_id: i64,
@@ -127,14 +127,10 @@ pub async fn store_table_schema(
     Ok(())
 }
 
-/// Loads all table schemas for a given pipeline from the database.
+/// Loads all table schemas for a pipeline from the database.
 ///
-/// This function retrieves table schemas and their columns from the schema storage tables,
-/// reconstructing [`TableSchema`] objects.
-/// Loads all table schemas for a given pipeline from the database.
-///
-/// This function retrieves table schemas and their columns from the schema storage tables,
-/// reconstructing [`TableSchema`] objects.
+/// Retrieves table schemas and columns from schema storage tables,
+/// reconstructing complete [`TableSchema`] objects.
 pub async fn load_table_schemas(
     pool: &PgPool,
     pipeline_id: i64,
@@ -179,11 +175,10 @@ pub async fn load_table_schemas(
     Ok(table_schemas.into_values().collect())
 }
 
-/// Deletes all table schemas for a given pipeline from the database.
+/// Deletes all table schemas for a pipeline from the database.
 ///
-/// This function removes all table schema records and their associated columns
-/// for a specific pipeline. Uses CASCADE delete from the foreign key constraint
-/// to automatically remove related column records.
+/// Removes all table schema records and associated columns for the specified
+/// pipeline, using CASCADE delete for automatic cleanup of related column records.
 pub async fn delete_pipeline_table_schemas<'c, E>(
     executor: E,
     pipeline_id: i64,
@@ -204,9 +199,9 @@ where
     Ok(result.rows_affected())
 }
 
-/// Builds a `ColumnSchema` from a database row.
+/// Builds a [`ColumnSchema`] from a database row.
 ///
-/// Assumes all required fields are present (e.g. after INNER JOIN).
+/// Assumes all required fields are present in the row after appropriate joins.
 fn parse_column_schema(row: &PgRow) -> ColumnSchema {
     let column_name: String = row.get("column_name");
     let column_type: String = row.get("column_type");

--- a/etl-postgres/src/schema.rs
+++ b/etl-postgres/src/schema.rs
@@ -5,13 +5,13 @@ use std::str::FromStr;
 use pg_escape::quote_identifier;
 use tokio_postgres::types::{FromSql, ToSql, Type};
 
-/// An object identifier in PostgreSQL.
+/// PostgreSQL object identifier.
 pub type Oid = u32;
 
-/// A fully qualified PostgreSQL table name consisting of a schema and table name.
+/// Fully qualified PostgreSQL table name with schema and table components.
 ///
-/// This type represents a table identifier in PostgreSQL, which requires both a schema name
-/// and a table name. It provides methods for formatting the name in different contexts.
+/// Represents a complete table identifier that includes both schema and table name,
+/// providing methods for proper SQL identifier quoting and formatting.
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct TableName {
     /// The schema name containing the table
@@ -21,14 +21,15 @@ pub struct TableName {
 }
 
 impl TableName {
+    /// Creates a new [`TableName`] with the given schema and table name.
     pub fn new(schema: String, name: String) -> TableName {
         Self { schema, name }
     }
 
     /// Returns the table name as a properly quoted PostgreSQL identifier.
     ///
-    /// This method ensures the schema and table names are properly escaped according to
-    /// PostgreSQL identifier quoting rules.
+    /// Escapes both schema and table names according to PostgreSQL identifier
+    /// quoting rules to handle special characters and reserved keywords safely.
     pub fn as_quoted_identifier(&self) -> String {
         let quoted_schema = quote_identifier(&self.schema);
         let quoted_name = quote_identifier(&self.name);
@@ -43,16 +44,15 @@ impl fmt::Display for TableName {
     }
 }
 
-/// A type alias for PostgreSQL type modifiers.
+/// PostgreSQL type modifier for specifying type-specific attributes.
 ///
-/// Type modifiers in PostgreSQL are used to specify additional type-specific attributes,
-/// such as length for varchar or precision for numeric types.
+/// Used to store additional type information such as varchar length or numeric precision.
 type TypeModifier = i32;
 
-/// Represents the schema of a single column in a PostgreSQL table.
+/// Schema metadata for a single PostgreSQL table column.
 ///
-/// This type contains all metadata about a column including its name, data type,
-/// type modifier, nullability, and whether it's part of the primary key.
+/// Contains complete column information including name, data type, type modifier,
+/// nullability constraint, and primary key membership.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ColumnSchema {
     /// The name of the column
@@ -68,6 +68,7 @@ pub struct ColumnSchema {
 }
 
 impl ColumnSchema {
+    /// Creates a new [`ColumnSchema`] with the specified metadata.
     pub fn new(
         name: String,
         typ: Type,
@@ -84,14 +85,11 @@ impl ColumnSchema {
         }
     }
 
-    /// Compares two [`ColumnSchema`] instances, excluding the `nullable` field.
-    ///
-    /// Return `true` if all fields except `nullable` are equal, `false` otherwise.
-    ///
-    /// This method is used for comparing table schemas loaded via the initial table sync and the
-    /// relation messages received via CDC. The reason for skipping the `nullable` field is that
-    /// unfortunately Postgres doesn't seem to propagate nullable information of a column via
-    /// relation messages.
+    /// Compares two [`ColumnSchema`] instances excluding the nullable field.
+    /// 
+    /// Returns `true` if all fields except `nullable` are equal. Used for comparing
+    /// schemas from initial table sync against CDC relation messages, which don't
+    /// include nullability information.
     fn partial_eq(&self, other: &ColumnSchema) -> bool {
         self.name == other.name
             && self.typ == other.typ
@@ -100,22 +98,20 @@ impl ColumnSchema {
     }
 }
 
-/// A type-safe wrapper for PostgreSQL table OIDs.
+/// Type-safe wrapper for PostgreSQL table OIDs.
 ///
-/// Table OIDs are unique identifiers assigned to tables in PostgreSQL.
-///
-/// This newtype provides type safety by preventing accidental use of raw [`Oid`] values
-/// where a table identifier is expected.
+/// Provides type safety for table identifiers by wrapping raw [`Oid`] values
+/// and preventing accidental misuse in function parameters.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct TableId(pub Oid);
 
 impl TableId {
-    /// Creates a new [`TableId`] from an [`Oid`].
+    /// Creates a new [`TableId`] from the given [`Oid`].
     pub fn new(oid: Oid) -> Self {
         Self(oid)
     }
 
-    /// Returns the underlying [`Oid`] value.
+    /// Returns the wrapped [`Oid`] value.
     pub fn into_inner(self) -> Oid {
         self.0
     }
@@ -182,10 +178,10 @@ impl ToSql for TableId {
     tokio_postgres::types::to_sql_checked!();
 }
 
-/// Represents the complete schema of a PostgreSQL table.
+/// Complete schema metadata for a PostgreSQL table.
 ///
-/// This type contains all metadata about a table including its name, OID,
-/// and the schemas of all its columns.
+/// Contains table identification (OID and name) along with the schemas
+/// of all columns in the table.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TableSchema {
     /// The PostgreSQL OID of the table
@@ -197,6 +193,7 @@ pub struct TableSchema {
 }
 
 impl TableSchema {
+    /// Creates a new [`TableSchema`] with the given components.
     pub fn new(id: TableId, name: TableName, column_schemas: Vec<ColumnSchema>) -> Self {
         Self {
             id,
@@ -205,21 +202,21 @@ impl TableSchema {
         }
     }
 
-    /// Adds a new column schema to this [`TableSchema`].
+    /// Adds a column schema to this table schema.
     pub fn add_column_schema(&mut self, column_schema: ColumnSchema) {
         self.column_schemas.push(column_schema);
     }
 
-    /// Returns whether the table has any primary key columns.
+    /// Returns whether the table has primary key columns.
     ///
-    /// This method checks if any column in the table is marked as part of the primary key.
+    /// Checks if any column in the table is marked as part of the primary key.
     pub fn has_primary_keys(&self) -> bool {
         self.column_schemas.iter().any(|cs| cs.primary)
     }
 
-    /// Compares two [`TableSchema`] instances, excluding the [`ColumnSchema`]'s `nullable` field.
+    /// Compares two [`TableSchema`] instances excluding column nullable fields.
     ///
-    /// Return `true` if all fields except `nullable` are equal, `false` otherwise.
+    /// Returns `true` if all fields match except for column nullability information.
     pub fn partial_eq(&self, other: &TableSchema) -> bool {
         self.id == other.id
             && self.name == other.name

--- a/etl-postgres/src/schema.rs
+++ b/etl-postgres/src/schema.rs
@@ -86,7 +86,7 @@ impl ColumnSchema {
     }
 
     /// Compares two [`ColumnSchema`] instances excluding the nullable field.
-    /// 
+    ///
     /// Returns `true` if all fields except `nullable` are equal. Used for comparing
     /// schemas from initial table sync against CDC relation messages, which don't
     /// include nullability information.

--- a/etl-postgres/src/sqlx/test_utils.rs
+++ b/etl-postgres/src/sqlx/test_utils.rs
@@ -1,11 +1,13 @@
 use etl_config::shared::{IntoConnectOptions, PgConnectionConfig};
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 
-/// Creates a new PostgreSQL database and returns a connection pool to it.
+/// Creates a new PostgreSQL database and returns a connection pool.
 ///
-/// Establishes a connection to the PostgreSQL server using the provided options,
-/// creates a new database, and returns a [`PgPool`] connected to the new database.
-/// Panics if the connection fails or if database creation fails.
+/// Connects to PostgreSQL server, creates a new database, and returns a [`PgPool`]
+/// connected to the newly created database.
+/// 
+/// # Panics
+/// Panics if connection or database creation fails.
 pub async fn create_pg_database(config: &PgConnectionConfig) -> PgPool {
     // Create the database via a single connection.
     let mut connection = PgConnection::connect_with(&config.without_db())
@@ -22,12 +24,13 @@ pub async fn create_pg_database(config: &PgConnectionConfig) -> PgPool {
         .expect("Failed to connect to Postgres")
 }
 
-/// Drops a PostgreSQL database and cleans up all connections.
+/// Drops a PostgreSQL database and terminates all connections.
 ///
-/// Connects to the PostgreSQL server, forcefully terminates all active connections
-/// to the target database, and drops the database if it exists. Useful for cleaning
-/// up test databases. Takes a reference to [`PgConnectionConfig`] specifying the database
-/// to drop. Panics if any operation fails.
+/// Connects to PostgreSQL server, forcefully terminates active connections
+/// to the target database, and drops it if it exists. Used for test cleanup.
+///
+/// # Panics
+/// Panics if any database operation fails.
 pub async fn drop_pg_database(config: &PgConnectionConfig) {
     // Connect to the default database.
     let mut connection = PgConnection::connect_with(&config.without_db())

--- a/etl-postgres/src/sqlx/test_utils.rs
+++ b/etl-postgres/src/sqlx/test_utils.rs
@@ -5,7 +5,7 @@ use sqlx::{Connection, Executor, PgConnection, PgPool};
 ///
 /// Connects to PostgreSQL server, creates a new database, and returns a [`PgPool`]
 /// connected to the newly created database.
-/// 
+///
 /// # Panics
 /// Panics if connection or database creation fails.
 pub async fn create_pg_database(config: &PgConnectionConfig) -> PgPool {

--- a/etl-postgres/src/time.rs
+++ b/etl-postgres/src/time.rs
@@ -1,9 +1,9 @@
 use std::sync::LazyLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// The number of seconds between Unix epoch (1970-01-01) and PostgreSQL epoch (2000-01-01)
+/// Number of seconds between Unix epoch (1970-01-01) and PostgreSQL epoch (2000-01-01).
 const POSTGRES_EPOCH_OFFSET_SECONDS: u64 = 946_684_800;
 
-/// The PostgreSQL epoch (2000-01-01 00:00:00 UTC) used for timestamp calculations
+/// PostgreSQL epoch (2000-01-01 00:00:00 UTC) for timestamp calculations.
 pub static POSTGRES_EPOCH: LazyLock<SystemTime> =
     LazyLock::new(|| UNIX_EPOCH + Duration::from_secs(POSTGRES_EPOCH_OFFSET_SECONDS));

--- a/etl-postgres/src/tokio/test_utils.rs
+++ b/etl-postgres/src/tokio/test_utils.rs
@@ -8,12 +8,22 @@ use tracing::info;
 /// Table modification operations for ALTER TABLE statements.
 pub enum TableModification<'a> {
     /// Add a new column with specified name and data type.
-    AddColumn { name: &'a str, data_type: &'a str },
+    AddColumn {
+        name: &'a str,
+        data_type: &'a str,
+    },
     /// Drop an existing column by name.
-    DropColumn { name: &'a str },
+    DropColumn {
+        name: &'a str,
+    },
     /// Alter an existing column with the specified alteration.
-    AlterColumn { name: &'a str, alteration: &'a str },
-    ReplicaIdentity { value: &'a str },
+    AlterColumn {
+        name: &'a str,
+        alteration: &'a str,
+    },
+    ReplicaIdentity {
+        value: &'a str,
+    },
 }
 
 /// PostgreSQL database wrapper for testing operations.

--- a/etl-postgres/src/types.rs
+++ b/etl-postgres/src/types.rs
@@ -1,7 +1,9 @@
 use tokio_postgres::types::{Kind, Type};
 
-/// Converts a type oid to a [`Type`] defaulting to an unnamed type in case of failure to
-/// look up the type.
+/// Converts a PostgreSQL type OID to a [`Type`] instance.
+///
+/// Returns a properly constructed [`Type`] for the given OID, or creates an unnamed
+/// type as fallback if the OID lookup fails.
 pub fn convert_type_oid_to_type(type_oid: u32) -> Type {
     Type::from_oid(type_oid).unwrap_or(Type::new(
         format!("unnamed_type({type_oid})"),

--- a/etl-replicator/src/config.rs
+++ b/etl-replicator/src/config.rs
@@ -1,7 +1,10 @@
 use etl_config::load_config;
 use etl_config::shared::ReplicatorConfig;
 
-/// Loads the [`ReplicatorConfig`] and validates it.
+/// Loads and validates the replicator configuration.
+///
+/// Uses the standard configuration loading mechanism from [`etl_config`] and
+/// validates the resulting [`ReplicatorConfig`] before returning it.
 pub fn load_replicator_config() -> anyhow::Result<ReplicatorConfig> {
     let config = load_config::<ReplicatorConfig>()?;
     config.validate()?;

--- a/etl-replicator/src/core.rs
+++ b/etl-replicator/src/core.rs
@@ -15,6 +15,11 @@ use tracing::{debug, info, warn};
 
 use crate::migrations::migrate_state_store;
 
+/// Starts the replicator service with the provided configuration.
+///
+/// Initializes the state store, creates the appropriate destination based on
+/// configuration, and starts the pipeline. Handles both memory and BigQuery
+/// destinations with proper initialization and error handling.
 pub async fn start_replicator_with_config(
     replicator_config: ReplicatorConfig,
 ) -> anyhow::Result<()> {
@@ -130,6 +135,10 @@ fn log_batch_config(config: &BatchConfig) {
     );
 }
 
+/// Initializes the state store with migrations.
+///
+/// Runs necessary database migrations on the state store and creates a
+/// [`PostgresStore`] instance for the given pipeline and connection configuration.
 async fn init_store(
     pipeline_id: PipelineId,
     pg_connection_config: PgConnectionConfig,
@@ -139,6 +148,11 @@ async fn init_store(
     Ok(PostgresStore::new(pipeline_id, pg_connection_config))
 }
 
+/// Starts a pipeline and handles graceful shutdown signals.
+///
+/// Launches the pipeline, sets up signal handlers for SIGTERM and SIGINT,
+/// and ensures proper cleanup on shutdown. The pipeline will attempt to
+/// finish processing current batches before terminating.
 #[tracing::instrument(skip(pipeline), fields(pipeline_id = pipeline.id()))]
 async fn start_pipeline<S, D>(mut pipeline: Pipeline<S, D>) -> anyhow::Result<()>
 where

--- a/etl-replicator/src/main.rs
+++ b/etl-replicator/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 /// Main async entry point that starts the replicator pipeline.
-/// 
+///
 /// Launches the replicator with the provided configuration and captures any errors
 /// to Sentry before propagating them up.
 async fn async_main(replicator_config: ReplicatorConfig) -> anyhow::Result<()> {

--- a/etl-replicator/src/main.rs
+++ b/etl-replicator/src/main.rs
@@ -1,3 +1,9 @@
+//! ETL replicator service binary.
+//!
+//! Initializes and runs the replicator pipeline that handles PostgreSQL logical replication
+//! and routes data to configured destinations. Includes telemetry, error handling, and
+//! graceful shutdown capabilities.
+
 use crate::config::load_replicator_config;
 use crate::core::start_replicator_with_config;
 use etl_config::Environment;
@@ -11,6 +17,11 @@ mod config;
 mod core;
 mod migrations;
 
+/// Entry point for the replicator service.
+///
+/// Loads configuration, initializes tracing and Sentry, starts the async runtime,
+/// and launches the replicator pipeline. Handles all errors and ensures proper
+/// service initialization sequence.
 fn main() -> anyhow::Result<()> {
     // Load replicator config
     let replicator_config = load_replicator_config()?;
@@ -36,6 +47,10 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Main async entry point that starts the replicator pipeline.
+/// 
+/// Launches the replicator with the provided configuration and captures any errors
+/// to Sentry before propagating them up.
 async fn async_main(replicator_config: ReplicatorConfig) -> anyhow::Result<()> {
     // We start the replicator and catch any errors.
     if let Err(err) = start_replicator_with_config(replicator_config).await {
@@ -50,9 +65,9 @@ async fn async_main(replicator_config: ReplicatorConfig) -> anyhow::Result<()> {
 
 /// Initializes Sentry with replicator-specific configuration.
 ///
-/// Loads the configuration and initializes Sentry if a DSN is provided.
-/// Tags all errors and transactions with the "replicator" service identifier.
-/// Configures panic handling to automatically capture panics and send them to Sentry.
+/// Loads configuration and sets up Sentry if a DSN is provided in the config.
+/// Tags all errors with the "replicator" service identifier and configures
+/// panic handling to automatically capture and send panics to Sentry.
 fn init_sentry() -> anyhow::Result<Option<sentry::ClientInitGuard>> {
     if let Ok(config) = load_replicator_config()
         && let Some(sentry_config) = &config.sentry

--- a/etl-replicator/src/migrations.rs
+++ b/etl-replicator/src/migrations.rs
@@ -9,7 +9,7 @@ use tracing::info;
 const NUM_POOL_CONNECTIONS: u32 = 1;
 
 /// Runs database migrations on the state store.
-/// 
+///
 /// Creates a connection pool to the source database, sets up the `etl` schema,
 /// and applies all pending migrations. The migrations are run in the `etl` schema
 /// to avoid cluttering the public schema with migration metadata tables created by `sqlx`.

--- a/etl-replicator/src/migrations.rs
+++ b/etl-replicator/src/migrations.rs
@@ -5,10 +5,14 @@ use sqlx::{
 };
 use tracing::info;
 
+/// Number of database connections to use for the migration pool.
 const NUM_POOL_CONNECTIONS: u32 = 1;
 
-/// This function runs migrations on the source database when the source database acts
-/// as a state store.
+/// Runs database migrations on the state store.
+/// 
+/// Creates a connection pool to the source database, sets up the `etl` schema,
+/// and applies all pending migrations. The migrations are run in the `etl` schema
+/// to avoid cluttering the public schema with migration metadata tables created by `sqlx`.
 pub async fn migrate_state_store(
     connection_config: &PgConnectionConfig,
 ) -> Result<(), sqlx::Error> {


### PR DESCRIPTION
This PR adds rust docs to all crates except `etl` (those docs will be added down the line once the implementation is more stable, meaning it will change less frequently). 