### PR TITLE
fix(etl-api): allow creating empty publications

### DIFF
--- a/etl-api/src/db/publications.rs
+++ b/etl-api/src/db/publications.rs
@@ -27,7 +27,9 @@ pub async fn create_publication(
     let quoted_publication_name = quote_identifier(&publication.name);
     query.push_str("create publication ");
     query.push_str(&quoted_publication_name);
-    query.push_str(" for table only ");
+    if !publication.tables.is_empty() {
+        query.push_str(" for table only ");
+    }
 
     for (i, table) in publication.tables.iter().enumerate() {
         let quoted_schema = quote_identifier(&table.schema);


### PR DESCRIPTION
For our setup on the hosted platform, we want `supabase_etl_admin` to own the publication, but it can't add tables to this publication.

So we let `supabase_etl_admin` create the (empty) publication first and `postgres` will add the tables.