### PR TITLE
feat(store): Add new table mappings in the state store

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,8 +62,8 @@ This documentation is designed to help you effectively use the ETL crate to buil
 
 - [**Tutorials**](tutorials/index.md): Step-by-step guides to get started with the ETL crate, including setting up a basic data pipeline, configuring Postgres logical replication, and connecting to destinations like BigQuery or other OLAP databases. Check the [examples folder](https://github.com/supabase/etl/tree/main/etl/examples) for practical code samples.
 - [**Guides**](guides/index.md): In-depth explanations of key concepts, such as building custom data pipelines, handling change data capture (CDC), and optimizing performance for specific use cases.
-- [**Reference**](reference/index.md): Detailed documentation of the crate’s API, including modules like `etl::pipeline`, `etl::sources::postgres`, and available destinations (e.g., `BigQueryDestination`). Each destination is feature-gated, so you can enable only what you need.
-- [**Design**](design/index.md): Overview of the crate’s architecture, including its modular pipeline structure, source-destination flow, and extensibility for custom integrations.
+- [**Reference**](reference/index.md): Detailed documentation of the crate's API, including modules like `etl::pipeline`, `etl::sources::postgres`, and available destinations (e.g., `BigQueryDestination`). Each destination is feature-gated, so you can enable only what you need.
+- [**Design**](design/index.md): Overview of the crate's architecture, including its modular pipeline structure, source-destination flow, and extensibility for custom integrations.
 
 The ETL crate is distributed under the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0). See the [LICENSE](https://github.com/supabase/etl/blob/main/LICENSE) file for more information.
 

--- a/etl-benchmarks/benches/table_copies.rs
+++ b/etl-benchmarks/benches/table_copies.rs
@@ -437,6 +437,13 @@ enum BenchDestination {
 }
 
 impl Destination for BenchDestination {
+    async fn truncate_table(&self, table_id: TableId) -> EtlResult<()> {
+        match self {
+            BenchDestination::Null(dest) => dest.truncate_table(table_id).await,
+            BenchDestination::BigQuery(dest) => dest.truncate_table(table_id).await,
+        }
+    }
+
     async fn write_table_rows(
         &self,
         table_id: TableId,
@@ -444,7 +451,6 @@ impl Destination for BenchDestination {
     ) -> EtlResult<()> {
         match self {
             BenchDestination::Null(dest) => dest.write_table_rows(table_id, table_rows).await,
-
             BenchDestination::BigQuery(dest) => dest.write_table_rows(table_id, table_rows).await,
         }
     }
@@ -452,13 +458,16 @@ impl Destination for BenchDestination {
     async fn write_events(&self, events: Vec<Event>) -> EtlResult<()> {
         match self {
             BenchDestination::Null(dest) => dest.write_events(events).await,
-
             BenchDestination::BigQuery(dest) => dest.write_events(events).await,
         }
     }
 }
 
 impl Destination for NullDestination {
+    async fn truncate_table(&self, _table_id: TableId) -> EtlResult<()> {
+        Ok(())
+    }
+
     async fn write_table_rows(
         &self,
         _table_id: TableId,

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -722,6 +722,10 @@ impl<S> Destination for BigQueryDestination<S>
 where
     S: StateStore + SchemaStore + Send + Sync,
 {
+    fn truncate_table(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send {
+        todo!()
+    }
+
     async fn write_table_rows(
         &self,
         table_id: TableId,

--- a/etl-destinations/tests/common/bigquery.rs
+++ b/etl-destinations/tests/common/bigquery.rs
@@ -2,6 +2,7 @@ use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use etl::store::schema::SchemaStore;
+use etl::store::state::StateStore;
 use etl::types::{PgNumeric, TableName};
 use etl_destinations::bigquery::{BigQueryDestination, table_name_to_bigquery_table_id};
 use gcp_bigquery_client::Client;
@@ -101,7 +102,7 @@ impl BigQueryDatabase {
     /// zero staleness to ensure immediate consistency for testing.
     pub async fn build_destination<S>(&self, schema_store: S) -> BigQueryDestination<S>
     where
-        S: SchemaStore,
+        S: StateStore + SchemaStore,
     {
         BigQueryDestination::new_with_key_path(
             self.project_id.clone(),

--- a/etl-postgres/src/replication/mod.rs
+++ b/etl-postgres/src/replication/mod.rs
@@ -1,5 +1,6 @@
 mod db;
 pub mod schema;
 pub mod state;
+pub mod table_mappings;
 
 pub use db::*;

--- a/etl-postgres/src/replication/table_mappings.rs
+++ b/etl-postgres/src/replication/table_mappings.rs
@@ -1,0 +1,88 @@
+use sqlx::{PgExecutor, PgPool, Row};
+use std::collections::HashMap;
+
+use crate::schema::TableId;
+
+/// Stores a table mapping in the database.
+///
+/// Inserts or updates a mapping between source table ID and destination table ID
+/// for the specified pipeline.
+pub async fn store_table_mapping(
+    pool: &PgPool,
+    pipeline_id: i64,
+    source_table_id: &str,
+    destination_table_id: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO etl.table_mappings (pipeline_id, source_table_id, destination_table_id)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (pipeline_id, source_table_id)
+        DO UPDATE SET 
+            destination_table_id = EXCLUDED.destination_table_id,
+            updated_at = now()
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(source_table_id)
+    .bind(destination_table_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Loads all table mappings for a pipeline from the database.
+///
+/// Retrieves all source table ID to destination table ID mappings for the specified pipeline.
+pub async fn load_table_mappings(
+    pool: &PgPool,
+    pipeline_id: i64,
+) -> Result<HashMap<TableId, String>, sqlx::Error> {
+    let rows = sqlx::query(
+        r#"
+        SELECT source_table_id, destination_table_id
+        FROM etl.table_mappings
+        WHERE pipeline_id = $1
+        "#,
+    )
+    .bind(pipeline_id)
+    .fetch_all(pool)
+    .await?;
+
+    let mut mappings = HashMap::new();
+    for row in rows {
+        let source_table_id: String = row.get("source_table_id");
+        let destination_table_id: String = row.get("destination_table_id");
+
+        let source_table_id = TableId::new(source_table_id.parse()?);
+        
+        mappings.insert(source_table_id, destination_table_id);
+    }
+
+    Ok(mappings)
+}
+
+/// Deletes all table mappings for a pipeline from the database.
+///
+/// Removes all table mapping records for the specified pipeline.
+/// Used during pipeline cleanup.
+pub async fn delete_pipeline_table_mappings<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    let result = sqlx::query(
+        r#"
+        DELETE FROM etl.table_mappings
+        WHERE pipeline_id = $1
+        "#,
+    )
+    .bind(pipeline_id)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}

--- a/etl-replicator/migrations/20250812120000_create_table_mappings.sql
+++ b/etl-replicator/migrations/20250812120000_create_table_mappings.sql
@@ -5,7 +5,7 @@
 create table etl.table_mappings (
     id bigserial primary key,
     pipeline_id bigint not null,
-    source_table_id text not null,
+    source_table_id oid not null,
     destination_table_id text not null,
     created_at timestamptz not null default now(),
     updated_at timestamptz not null default now(),

--- a/etl-replicator/migrations/20250812120000_create_table_mappings.sql
+++ b/etl-replicator/migrations/20250812120000_create_table_mappings.sql
@@ -1,0 +1,23 @@
+-- Create table mappings storage system in the state store
+-- This stores mappings between source table IDs (postgres OIDs) and destination table IDs
+
+-- Table to store table ID mappings from source to destination
+create table etl.table_mappings (
+    id bigserial primary key,
+    pipeline_id bigint not null,
+    source_table_id text not null,
+    destination_table_id text not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    
+    -- Ensure unique combination per pipeline and source table
+    unique (pipeline_id, source_table_id)
+);
+
+-- Index to speed up queries by pipeline_id for loading all mappings
+create index idx_table_mappings_pipeline 
+    on etl.table_mappings (pipeline_id);
+
+-- Index to speed up queries by pipeline_id and source_table_id for single mapping lookups
+create index idx_table_mappings_pipeline_source 
+    on etl.table_mappings (pipeline_id, source_table_id);

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -184,6 +184,24 @@ impl Event {
     pub fn event_type(&self) -> EventType {
         self.into()
     }
+
+    /// Returns true if the event has the supplied table_id.
+    pub fn has_table_id(&self, table_id: &TableId) -> bool {
+        match self {
+            Event::Insert(insert_event) => insert_event.table_id == *table_id,
+            Event::Update(update_event) => update_event.table_id == *table_id,
+            Event::Delete(delete_event) => delete_event.table_id == *table_id,
+            Event::Relation(relation_event) => relation_event.table_schema.id == *table_id,
+            Event::Truncate(event) => {
+                let Some(_) = event.rel_ids.iter().find(|&&id| table_id.0 == id) else {
+                    return false;
+                };
+
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/etl/src/destination/base.rs
+++ b/etl/src/destination/base.rs
@@ -6,6 +6,8 @@ use crate::conversions::table_row::TableRow;
 use crate::error::EtlResult;
 
 pub trait Destination {
+    fn truncate_table(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send;
+
     fn write_table_rows(
         &self,
         table_id: TableId,

--- a/etl/src/destination/memory.rs
+++ b/etl/src/destination/memory.rs
@@ -43,6 +43,8 @@ impl Destination for MemoryDestination {
         // of that table.
         let mut inner = self.inner.lock().await;
 
+        info!("truncating table {}", table_id);
+
         inner.table_rows.remove(&table_id);
         inner.events.retain_mut(|event| {
             let has_table_id = event.has_table_id(&table_id);
@@ -73,7 +75,9 @@ impl Destination for MemoryDestination {
         table_rows: Vec<TableRow>,
     ) -> EtlResult<()> {
         let mut inner = self.inner.lock().await;
+
         info!("writing a batch of {} table rows:", table_rows.len());
+
         for table_row in &table_rows {
             info!("  {:?}", table_row);
         }
@@ -84,7 +88,9 @@ impl Destination for MemoryDestination {
 
     async fn write_events(&self, events: Vec<Event>) -> EtlResult<()> {
         let mut inner = self.inner.lock().await;
+
         info!("writing a batch of {} events:", events.len());
+
         for event in &events {
             info!("  {:?}", event);
         }

--- a/etl/src/destination/memory.rs
+++ b/etl/src/destination/memory.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -9,7 +10,7 @@ use crate::types::{Event, TableId, TableRow};
 #[derive(Debug)]
 struct Inner {
     events: Vec<Event>,
-    table_rows: Vec<(TableId, Vec<TableRow>)>,
+    table_rows: HashMap<TableId, Vec<TableRow>>,
 }
 
 #[derive(Debug, Clone)]
@@ -21,7 +22,7 @@ impl MemoryDestination {
     pub fn new() -> Self {
         let inner = Inner {
             events: Vec::new(),
-            table_rows: Vec::new(),
+            table_rows: HashMap::new(),
         };
 
         Self {
@@ -37,6 +38,35 @@ impl Default for MemoryDestination {
 }
 
 impl Destination for MemoryDestination {
+    async fn truncate_table(&self, table_id: TableId) -> EtlResult<()> {
+        // For truncation, we simulate removing all table rows for a specific table and also the events
+        // of that table.
+        let mut inner = self.inner.lock().await;
+
+        inner.table_rows.remove(&table_id);
+        inner.events.retain_mut(|event| {
+            let has_table_id = event.has_table_id(&table_id);
+            if let Event::Truncate(event) = event
+                && has_table_id
+            {
+                let Some(index) = event.rel_ids.iter().position(|&id| table_id.0 == id) else {
+                    return true;
+                };
+
+                event.rel_ids.remove(index);
+                if event.rel_ids.is_empty() {
+                    return false;
+                }
+
+                return true;
+            }
+
+            !has_table_id
+        });
+
+        Ok(())
+    }
+
     async fn write_table_rows(
         &self,
         table_id: TableId,
@@ -47,7 +77,7 @@ impl Destination for MemoryDestination {
         for table_row in &table_rows {
             info!("  {:?}", table_row);
         }
-        inner.table_rows.push((table_id, table_rows));
+        inner.table_rows.insert(table_id, table_rows);
 
         Ok(())
     }

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -40,53 +40,31 @@ enum ErrorRepr {
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// Database connection failed or resource limitations
     ConnectionFailed,
-    /// Query execution failed
     QueryFailed,
-    /// Source schema mismatch or validation error
     SourceSchemaError,
-    /// Missing table schema
     MissingTableSchema,
-    /// Data type conversion error
+    MissingTableMapping,
     ConversionError,
-    /// Configuration error
     ConfigError,
-    /// Network or I/O error
     IoError,
-    /// Serialization error
     SerializationError,
-    /// Deserialization error
     DeserializationError,
-    /// Encryption/decryption error
     EncryptionError,
-    /// Authentication failed
     AuthenticationError,
-    /// Invalid state error
     InvalidState,
-    /// Invalid data
     InvalidData,
-    /// NULL values are unsupported in an array
     NullValuesNotSupportedInArray,
-    /// Data validation error
     ValidationError,
-    /// Apply worker error
     ApplyWorkerPanic,
-    /// State rollback error,
     StateRollbackError,
-    /// Table sync worker error
     TableSyncWorkerPanic,
-    /// Permission denied error
     PermissionDenied,
-    /// Destination-specific error
     DestinationError,
-    /// Replication slot not found
+    InvalidTableName,
     ReplicationSlotNotFound,
-    /// Replication slot already exists
     ReplicationSlotAlreadyExists,
-    /// Replication slot could not be created
     ReplicationSlotNotCreated,
-    /// Unknown error
     Unknown,
 
     // Special error kinds used for tests that trigger specific retry behaviors via fault injection.

--- a/etl/src/failpoints.rs
+++ b/etl/src/failpoints.rs
@@ -10,6 +10,7 @@ use crate::bail;
 use crate::error::{ErrorKind, EtlError, EtlResult};
 
 pub const START_TABLE_SYNC__AFTER_DATA_SYNC: &str = "start_table_sync.after_data_sync";
+pub const START_TABLE_SYNC__DURING_DATA_SYNC: &str = "start_table_sync.during_data_sync";
 
 /// Executes a configurable failpoint for testing error scenarios.
 ///

--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -78,7 +78,13 @@ where
         let replication_client =
             PgReplicationClient::connect(self.config.pg_connection.clone()).await?;
 
-        // We load the table schemas from the store.
+        // We load the table mappings and schemas from the store to have them cached for quick
+        // access.
+        //
+        // It's really important to load the mappings and schemas before starting the apply worker
+        // since downstream code relies on the assumption that the mappings and schemas are loaded
+        // in the cache.
+        self.store.load_table_mappings().await?;
         self.store.load_table_schemas().await?;
 
         // We load the table states by checking the table ids of a publication and loading/creating

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -13,7 +13,9 @@ use crate::concurrency::stream::BatchStream;
 use crate::destination::Destination;
 use crate::error::{ErrorKind, EtlError, EtlResult};
 #[cfg(feature = "failpoints")]
-use crate::failpoints::{START_TABLE_SYNC__AFTER_DATA_SYNC, START_TABLE_SYNC__DURING_DATA_SYNC, etl_fail_point};
+use crate::failpoints::{
+    START_TABLE_SYNC__AFTER_DATA_SYNC, START_TABLE_SYNC__DURING_DATA_SYNC, etl_fail_point,
+};
 use crate::replication::client::PgReplicationClient;
 use crate::replication::slot::get_slot_name;
 use crate::replication::stream::TableCopyStream;

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -12,9 +12,8 @@ use crate::concurrency::signal::SignalTx;
 use crate::concurrency::stream::BatchStream;
 use crate::destination::Destination;
 use crate::error::{ErrorKind, EtlError, EtlResult};
-use crate::failpoints::START_TABLE_SYNC__DURING_DATA_SYNC;
 #[cfg(feature = "failpoints")]
-use crate::failpoints::{START_TABLE_SYNC__AFTER_DATA_SYNC, etl_fail_point};
+use crate::failpoints::{START_TABLE_SYNC__AFTER_DATA_SYNC, START_TABLE_SYNC__DURING_DATA_SYNC, etl_fail_point};
 use crate::replication::client::PgReplicationClient;
 use crate::replication::slot::get_slot_name;
 use crate::replication::stream::TableCopyStream;

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -110,25 +110,26 @@ where
     // In case the phase is any other phase, we will return an error.
     let start_lsn = match phase_type {
         TableReplicationPhaseType::Init | TableReplicationPhaseType::DataSync => {
-            // If we are in `DataSync` it means we failed during table copying, so we want to delete the
-            // existing slot before continuing.
             if phase_type == TableReplicationPhaseType::DataSync {
-                // TODO: After we delete the slot we will have to truncate the table in the destination,
-                // otherwise there can be an inconsistent copy of the data. E.g. consider this scenario:
-                // A table had a single row with id 1 and this was copied to the destination during initial
-                // table copy. Before the table's phase was set to FinishedCopy, the process crashed.
-                // While the process was down, row with id 1 in the source was deleted and another row with
-                // id 2 was inserted. The process comes back up to find the table's state in DataSync,
-                // deletes the slot and makes a copy again. This time it copies the row with id 2. Now
-                // the destinations contains two rows (with id 1 and 2) instead of only one (with id 2).
-                // The simplest fix here would be to unconditionally send a truncate to the destination
-                // before starting a table copy.
+                // If we are in `DataSync` it means we failed during table copying, so we want to delete the
+                // existing slot before continuing.
                 if let Err(err) = replication_client.delete_slot(&slot_name).await {
                     // If the slot is not found, we are safe to continue, for any other error, we bail.
                     if err.kind() != ErrorKind::ReplicationSlotNotFound {
                         return Err(err);
                     }
                 }
+
+                // We must truncate the destination table before starting a copy to avoid data inconsistencies.
+                // Example scenario:
+                // 1. The source table has a single row (id = 1) that is copied to the destination during the initial copy.
+                // 2. Before the table’s phase is set to `FinishedCopy`, the process crashes.
+                // 3. While down, the source deletes row id = 1 and inserts row id = 2.
+                // 4. When restarted, the process sees the table in the ` DataSync ` state, deletes the slot, and copies again.
+                // 5. This time, only row id = 2 is copied, but row id = 1 still exists in the destination.
+                // Result: the destination has two rows (id = 1 and id = 2) instead of only one (id = 2).
+                // Fix: Always truncate the destination table before starting a copy.
+                destination.truncate_table(table_id).await?;
             }
 
             // We are ready to start copying table data, and we update the state accordingly.

--- a/etl/src/store/schema/base.rs
+++ b/etl/src/store/schema/base.rs
@@ -1,4 +1,5 @@
 use etl_postgres::schema::{TableId, TableSchema};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::error::EtlResult;
@@ -26,5 +27,32 @@ pub trait SchemaStore {
     fn store_table_schema(
         &self,
         table_schema: TableSchema,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
+
+    /// Returns table mapping for a specific source table ID from the cache.
+    ///
+    /// Does not load any new data into the cache.
+    fn get_table_mapping(
+        &self,
+        source_table_id: &TableId,
+    ) -> impl Future<Output = EtlResult<Option<String>>> + Send;
+
+    /// Returns all table mappings from the cache.
+    ///
+    /// Does not read from the persistent store.
+    fn get_table_mappings(
+        &self,
+    ) -> impl Future<Output = EtlResult<HashMap<TableId, String>>> + Send;
+
+    /// Loads all table mappings from the persistent state into the cache.
+    ///
+    /// This can be called lazily when table mappings are needed by the destination.
+    fn load_table_mappings(&self) -> impl Future<Output = EtlResult<usize>> + Send;
+
+    /// Stores a table mapping in both the cache and the persistent store.
+    fn store_table_mapping(
+        &self,
+        source_table_id: TableId,
+        destination_table_id: String,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 }

--- a/etl/tests/failpoints/pipeline_test.rs
+++ b/etl/tests/failpoints/pipeline_test.rs
@@ -1,6 +1,6 @@
 use etl::destination::memory::MemoryDestination;
 use etl::error::ErrorKind;
-use etl::failpoints::START_TABLE_SYNC__AFTER_DATA_SYNC;
+use etl::failpoints::{START_TABLE_SYNC__AFTER_DATA_SYNC, START_TABLE_SYNC__DURING_DATA_SYNC};
 use etl::state::table::TableReplicationPhaseType;
 use etl::test_utils::database::spawn_source_database;
 use etl::test_utils::notify::NotifyingStore;
@@ -74,6 +74,69 @@ async fn table_copy_fails_after_data_sync_threw_an_error_with_no_retry() {
 async fn table_copy_is_consistent_after_data_sync_threw_an_error_with_timed_retry() {
     let _scenario = FailScenario::setup();
     fail::cfg(START_TABLE_SYNC__AFTER_DATA_SYNC, "1*return(timed_retry)").unwrap();
+
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+
+    // Insert initial test data.
+    let rows_inserted = 10;
+    insert_users_data(
+        &mut database,
+        &database_schema.users_schema().name,
+        1..=rows_inserted,
+    )
+    .await;
+
+    let store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new());
+
+    // We start the pipeline from scratch.
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    // We register the interest in waiting for both table syncs to have started.
+    let users_state_notify = store
+        .notify_on_table_state(
+            database_schema.users_schema().id,
+            TableReplicationPhaseType::SyncDone,
+        )
+        .await;
+
+    pipeline.start().await.unwrap();
+
+    users_state_notify.notified().await;
+
+    // We expect no errors, since the same table sync worker task is retried.
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    // Verify copied data.
+    let table_rows = destination.get_table_rows().await;
+    let users_table_rows = table_rows.get(&database_schema.users_schema().id).unwrap();
+    assert_eq!(users_table_rows.len(), rows_inserted);
+
+    // Verify table schemas were correctly stored.
+    let table_schemas = store.get_table_schemas().await;
+    assert_eq!(table_schemas.len(), 1);
+    assert_eq!(
+        *table_schemas
+            .get(&database_schema.users_schema().id)
+            .unwrap(),
+        database_schema.users_schema()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_copy_is_consistent_during_data_sync_threw_an_error_with_timed_retry() {
+    let _scenario = FailScenario::setup();
+    fail::cfg(START_TABLE_SYNC__DURING_DATA_SYNC, "1*return(timed_retry)").unwrap();
 
     init_test_tracing();
 


### PR DESCRIPTION
This PR implements new table mappings in the state store with the goal of mapping the source table ID to the destination table ID. This is necessary because a pipeline might need to store the mapping between a specific source table ID and an internal table ID, and this mapping cannot be computed using only basic information such as the table ID and table schema/name.

In addition, it adds a new truncate table method, which is called to restore the table state if the data sync operation is interrupted.