### PR TITLE
feat: add metrics to the api crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ etl-telemetry = { path = "etl-telemetry", default-features = false }
 
 actix-web = { version = "4.11.0", default-features = false }
 actix-web-httpauth = { version = "0.8.2", default-features = false }
+actix-web-metrics = { version = "0.2.0", default-features = false }
 anyhow = { version = "1.0.98", default-features = false }
 async-trait = { version = "0.1.88" }
 aws-lc-rs = { version = "1.13.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ gcp-bigquery-client = { version = "0.26.0", default-features = false }
 insta = { version = "1.43.1", default-features = false }
 k8s-openapi = { version = "0.25.0", default-features = false }
 kube = { version = "1.1.0", default-features = false }
+metrics-exporter-prometheus = { version = "0.17.2", default-features = false }
 pg_escape = { version = "0.1.1", default-features = false }
 pin-project-lite = { version = "0.2.16", default-features = false }
 postgres-replication = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, rev = "c4b473b478b3adfbf8667d2fbe895d8423f1290b" }

--- a/etl-api/Cargo.toml
+++ b/etl-api/Cargo.toml
@@ -29,6 +29,7 @@ kube = { workspace = true, features = [
     "client",
     "rustls-tls",
 ] }
+metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 pg_escape = { workspace = true }
 rand = { workspace = true, features = ["std"] }
 reqwest = { workspace = true, features = ["json"] }

--- a/etl-api/Cargo.toml
+++ b/etl-api/Cargo.toml
@@ -17,6 +17,7 @@ etl-telemetry = { workspace = true }
 
 actix-web = { workspace = true, features = ["macros", "http2"] }
 actix-web-httpauth = { workspace = true }
+actix-web-metrics = { workspace = true }
 anyhow = { workspace = true, features = ["std"] }
 async-trait = { workspace = true }
 aws-lc-rs = { workspace = true, features = ["alloc", "aws-lc-sys"] }

--- a/etl-api/src/lib.rs
+++ b/etl-api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod db;
 pub mod encryption;
 pub mod k8s_client;
+pub mod metrics;
 pub mod routes;
 pub mod span_builder;
 pub mod startup;

--- a/etl-api/src/metrics.rs
+++ b/etl-api/src/metrics.rs
@@ -1,0 +1,6 @@
+use metrics_exporter_prometheus::{BuildError, PrometheusBuilder, PrometheusHandle};
+
+pub fn init_metrics() -> Result<PrometheusHandle, BuildError> {
+    // TODO: run upkeep task at regular intervals
+    PrometheusBuilder::new().install_recorder()
+}

--- a/etl-api/src/metrics.rs
+++ b/etl-api/src/metrics.rs
@@ -1,12 +1,32 @@
-use std::time::Duration;
+use std::{sync::Mutex, time::Duration};
 
 use metrics_exporter_prometheus::{BuildError, PrometheusBuilder, PrometheusHandle};
 use tracing::trace;
 
+// One time initialization objects like Once, OnceCell, OnceLock or other variants
+// are not used here and instead a mutex is used because the initialization code
+// is fallible and ideally we'd like to use OnceLock::get_or_try_init which
+// allows fallibe code to run as part of initialization but it is currently
+// unstable.
+//
+// The reason we want to only initialize this once is because the call to
+// builder.install_recorder installs a global metrics recorder and any subsequent
+// calls to it fail. init_metrics will not be called multiple times during normal
+// operations but is called multiple times during tests.
+static PROMETHEUS_HANDLE: Mutex<Option<PrometheusHandle>> = Mutex::new(None);
+
 pub fn init_metrics() -> Result<PrometheusHandle, BuildError> {
+    let mut prometheus_handle = PROMETHEUS_HANDLE.lock().unwrap();
+
+    if let Some(handle) = &*prometheus_handle {
+        return Ok(handle.clone());
+    }
+
     let builder = PrometheusBuilder::new();
 
     let handle = builder.install_recorder()?;
+    *prometheus_handle = Some(handle.clone());
+
     let handle_clone = handle.clone();
 
     // This task periodically performs upkeep to avoid unbounded memory growth due to

--- a/etl-api/src/metrics.rs
+++ b/etl-api/src/metrics.rs
@@ -9,7 +9,7 @@ pub fn init_metrics() -> Result<PrometheusHandle, BuildError> {
     let handle = builder.install_recorder()?;
     let handle_clone = handle.clone();
 
-    // This task periodically performs upkeep to avoid unbounded memory growth due to 
+    // This task periodically performs upkeep to avoid unbounded memory growth due to
     // metrics collection
     tokio::spawn(async move {
         loop {

--- a/etl-api/src/metrics.rs
+++ b/etl-api/src/metrics.rs
@@ -1,6 +1,25 @@
+use std::time::Duration;
+
 use metrics_exporter_prometheus::{BuildError, PrometheusBuilder, PrometheusHandle};
+use tracing::trace;
 
 pub fn init_metrics() -> Result<PrometheusHandle, BuildError> {
-    // TODO: run upkeep task at regular intervals
-    PrometheusBuilder::new().install_recorder()
+    let builder = PrometheusBuilder::new();
+
+    let handle = builder.install_recorder()?;
+    let handle_clone = handle.clone();
+
+    // This task periodically performs upkeep to avoid unbounded memory growth due to 
+    // metrics collection
+    tokio::spawn(async move {
+        loop {
+            // upkeep_timeout hardcoded for now. Will make it configurable later if it creates a problem
+            let upkeep_timeout = Duration::from_secs(5);
+            tokio::time::sleep(upkeep_timeout).await;
+            trace!("running metrics upkeep");
+            handle_clone.run_upkeep();
+        }
+    });
+
+    Ok(handle)
 }

--- a/etl-api/src/routes/metrics.rs
+++ b/etl-api/src/routes/metrics.rs
@@ -1,0 +1,15 @@
+use actix_web::{Responder, get, web};
+use metrics_exporter_prometheus::PrometheusHandle;
+
+#[utoipa::path(
+    summary = "Get prometheus metrics",
+    description = "Returns prometheus metrics collected since the last call to this endpoint.",
+    responses(
+        (status = 200, description = "Metrics returned successfully", body = String),
+    ),
+    tag = "Metrics"
+)]
+#[get("/metrics")]
+pub(crate) async fn metrics(metrics_handle: web::ThinData<PrometheusHandle>) -> impl Responder {
+    metrics_handle.render()
+}

--- a/etl-api/src/routes/mod.rs
+++ b/etl-api/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub mod destinations;
 pub mod destinations_pipelines;
 pub mod health_check;
 pub mod images;
+pub mod metrics;
 pub mod pipelines;
 pub mod sources;
 pub mod tenants;

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -158,8 +158,7 @@ pub async fn run(
     encryption_key: encryption::EncryptionKey,
     http_k8s_client: Option<Arc<dyn K8sClient>>,
 ) -> Result<Server, anyhow::Error> {
-    let prometheus_handle = init_metrics()?;
-    let prometheus_handle = web::ThinData(prometheus_handle);
+    let prometheus_handle = web::ThinData(init_metrics()?);
     let config = web::Data::new(config);
     let connection_pool = web::Data::new(connection_pool);
     let encryption_key = web::Data::new(encryption_key);

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -17,6 +17,7 @@ use crate::{
     db::publications::Publication,
     encryption,
     k8s_client::{HttpK8sClient, K8sClient},
+    metrics::init_metrics,
     routes::{
         destinations::{
             CreateDestinationRequest, CreateDestinationResponse, ReadDestinationResponse,
@@ -34,6 +35,7 @@ use crate::{
             UpdateImageRequest, create_image, delete_image, read_all_images, read_image,
             update_image,
         },
+        metrics::metrics,
         pipelines::{
             CreatePipelineRequest, CreatePipelineResponse, GetPipelineReplicationStatusResponse,
             GetPipelineStatusResponse, ReadPipelineResponse, ReadPipelinesResponse,
@@ -155,6 +157,8 @@ pub async fn run(
     encryption_key: encryption::EncryptionKey,
     http_k8s_client: Option<Arc<dyn K8sClient>>,
 ) -> Result<Server, anyhow::Error> {
+    let prometheus_handle = init_metrics()?;
+    let prometheus_handle = web::ThinData(prometheus_handle);
     let config = web::Data::new(config);
     let connection_pool = web::Data::new(connection_pool);
     let encryption_key = web::Data::new(encryption_key);
@@ -164,6 +168,7 @@ pub async fn run(
     #[openapi(
         paths(
             crate::routes::health_check::health_check,
+            crate::routes::metrics::metrics,
         ),
         components(schemas(
             CreateImageRequest,
@@ -272,6 +277,7 @@ pub async fn run(
             )
             .wrap(tracing_logger)
             .service(health_check)
+            .service(metrics)
             .service(
                 SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-docs/openapi.json", openapi.clone()),
             )
@@ -327,11 +333,12 @@ pub async fn run(
                     .service(read_all_images)
                     //tenants_sources
                     .service(create_tenant_and_source)
-                    // destinations-pipelines
+                    //destinations-pipelines
                     .service(create_destination_and_pipeline)
                     .service(update_destination_and_pipeline)
                     .service(delete_destination_and_pipeline),
             )
+            .app_data(prometheus_handle.clone())
             .app_data(config.clone())
             .app_data(connection_pool.clone())
             .app_data(encryption_key.clone());

--- a/etl-api/tests/integration/metrics_test.rs
+++ b/etl-api/tests/integration/metrics_test.rs
@@ -1,0 +1,22 @@
+use etl_telemetry::init_test_tracing;
+
+use crate::common::test_app::spawn_test_app;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_endpoint_works() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+
+    let client = reqwest::Client::new();
+
+    // Act
+    let response = client
+        .get(format!("{}/metrics", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert!(response.status().is_success());
+}

--- a/etl-api/tests/integration/mod.rs
+++ b/etl-api/tests/integration/mod.rs
@@ -6,3 +6,5 @@ mod pipelines_test;
 mod sources_test;
 mod tenants_sources_test;
 mod tenants_test;
+
+mod metrics_test;


### PR DESCRIPTION
This PR returns metrics from the api crate on the `/metrics` endpoint. These metrics will be scraped from this endpoint by victoria metrics. Following metrics are currently returned:

* `http_requests_total` (labels: endpoint, method, status): the total number of HTTP requests handled by the api.
* `http_requests_duration_seconds` (labels: endpoint, method, status): the request duration for all HTTP requests handled by the api.

More metrics will be added later.