### PR TITLE
chore: silence coveralls uploads failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
             sleep 1
           done
 
-
       - name: Update WAL Settings
         # This step is necessary to enable logical replication for the tests
         # wal_level = logical is needed because we use logical replication in tests
@@ -122,6 +121,7 @@ jobs:
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
+          fail-on-error: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
           debug: true


### PR DESCRIPTION
Coveralls is very flaky when we try to upload coverage result to it. We plan to move away from it in future. For now silencing the errors which occur when a failure to upload to coveralls occurs.