### PR TITLE
docs: use `Postgres` instead of `PostgreSQL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   </p>
 </p>
 
-ETL is a Rust framework by [Supabase](https://supabase.com) for building high‑performance, real‑time data replication apps on PostgreSQL. It sits on top of Postgres [logical replication](https://www.postgresql.org/docs/current/protocol-logical-replication.html) and gives you a clean, Rust‑native API for streaming changes to your own destinations.
+ETL is a Rust framework by [Supabase](https://supabase.com) for building high‑performance, real‑time data replication apps on Postgres. It sits on top of Postgres [logical replication](https://www.postgresql.org/docs/current/protocol-logical-replication.html) and gives you a clean, Rust‑native API for streaming changes to your own destinations.
 
 ## Highlights
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,4 +1,3 @@
-
 # Explanations
 
 **Deep dives into ETL concepts, architecture, and design decisions**
@@ -8,11 +7,12 @@ Explanations help you build mental models of how ETL works and why it's designed
 ## Core Concepts
 
 ### [ETL Architecture Overview](architecture.md)
+
 **The big picture of how ETL components work together**
 
-Understand the relationship between pipelines, destinations, stores, and the PostgreSQL replication protocol. Learn how data flows through the system and where extension points exist.
+Understand the relationship between pipelines, destinations, stores, and the Postgres replication protocol. Learn how data flows through the system and where extension points exist.
 
-*Topics covered:* Component architecture, data flow, extension patterns, scalability considerations.
+_Topics covered:_ Component architecture, data flow, extension patterns, scalability considerations.
 
 ## Reading Guide
 
@@ -32,5 +32,5 @@ After building a conceptual understanding:
 
 ## Contributing to Explanations
 
-Found gaps in these explanations? See something that could be clearer? 
+Found gaps in these explanations? See something that could be clearer?
 [Open an issue](https://github.com/supabase/etl/issues) or contribute improvements to help other users build better mental models of ETL.

--- a/docs/how-to/configure-postgres.md
+++ b/docs/how-to/configure-postgres.md
@@ -1,40 +1,41 @@
-# Configure PostgreSQL for Replication
+# Configure Postgres for Replication
 
-**Set up PostgreSQL with the correct permissions and settings for ETL logical replication**
+**Set up Postgres with the correct permissions and settings for ETL logical replication**
 
-This guide covers the essential PostgreSQL concepts and configuration needed for logical replication with ETL.
+This guide covers the essential Postgres concepts and configuration needed for logical replication with ETL.
 
 ## Prerequisites
 
-- PostgreSQL 10 or later
-- Superuser access to the PostgreSQL server
-- Ability to restart PostgreSQL server (for configuration changes)
+- Postgres 10 or later
+- Superuser access to the Postgres server
+- Ability to restart Postgres server (for configuration changes)
 
 ## Understanding WAL Logical
 
-PostgreSQL's Write-Ahead Log (WAL) is the foundation of logical replication. When `wal_level = logical`, PostgreSQL:
+Postgres's Write-Ahead Log (WAL) is the foundation of logical replication. When `wal_level = logical`, Postgres:
 
 - Records detailed information about data changes (not just physical changes)
 - Includes enough metadata to reconstruct logical changes
 - Allows external tools to decode and stream these changes
 
 ```ini
-# Enable logical replication in postgresql.conf
+# Enable logical replication in Postgres.conf
 wal_level = logical
 ```
 
-**Restart PostgreSQL** after changing this setting:
+**Restart Postgres** after changing this setting:
+
 ```bash
-sudo systemctl restart postgresql
+sudo systemctl restart Postgres
 ```
 
 ## Replication Slots
 
-Replication slots ensure that PostgreSQL retains WAL data for logical replication consumers, even if they disconnect temporarily.
+Replication slots ensure that Postgres retains WAL data for logical replication consumers, even if they disconnect temporarily.
 
 ### What are Replication Slots?
 
-- **Persistent markers** in PostgreSQL that track replication progress
+- **Persistent markers** in Postgres that track replication progress
 - **Prevent WAL cleanup** until the consumer catches up
 - **Guarantee data consistency** across disconnections
 
@@ -49,7 +50,7 @@ SELECT pg_create_logical_replication_slot('my_slot', 'pgoutput');
 
 ```sql
 -- See all replication slots
-SELECT slot_name, slot_type, active, restart_lsn 
+SELECT slot_name, slot_type, active, restart_lsn
 FROM pg_replication_slots;
 ```
 
@@ -64,15 +65,15 @@ SELECT pg_drop_replication_slot('my_slot');
 
 ## Max Replication Slots
 
-Controls how many replication slots PostgreSQL can maintain simultaneously.
+Controls how many replication slots Postgres can maintain simultaneously.
 
 ```ini
 # Increase max replication slots (default is 10)
 max_replication_slots = 20
 ```
 
-ETL uses a **single replication slot** for its main apply worker. However, additional slots may be created for parallel table 
-copies when the pipeline is initialized or when a new table is added to the publication. The `max_table_sync_workers` parameter 
+ETL uses a **single replication slot** for its main apply worker. However, additional slots may be created for parallel table
+copies when the pipeline is initialized or when a new table is added to the publication. The `max_table_sync_workers` parameter
 controls the number of these parallel copies, ensuring that the total replication slots used by ETL never exceed `max_table_sync_workers + 1`.
 
 **When to increase:**
@@ -85,10 +86,10 @@ controls the number of these parallel copies, ensuring that the total replicatio
 Determines how much WAL data to retain on disk, providing a safety buffer for replication consumers.
 
 ```ini
-# Keep 1GB of WAL data (PostgreSQL 13+)
+# Keep 1GB of WAL data (Postgres 13+)
 wal_keep_size = 1GB
 
-# For PostgreSQL 12 and earlier, use:
+# For Postgres 12 and earlier, use:
 # wal_keep_segments = 256  # Each segment is typically 16MB
 ```
 
@@ -136,7 +137,7 @@ DROP PUBLICATION my_publication;
 
 ## Complete Configuration Example
 
-Here's a minimal `postgresql.conf` setup:
+Here's a minimal `Postgres.conf` setup:
 
 ```ini
 # Enable logical replication
@@ -147,13 +148,13 @@ max_replication_slots = 20
 max_wal_senders = 20
 
 # Keep WAL data for safety
-wal_keep_size = 1GB  # PostgreSQL 13+
-# wal_keep_segments = 64  # PostgreSQL 12 and earlier
+wal_keep_size = 1GB  # Postgres 13+
+# wal_keep_segments = 64  # Postgres 12 and earlier
 ```
 
 After editing the configuration:
 
-1. **Restart PostgreSQL**
+1. **Restart Postgres**
 2. **Create your publication**:
    ```sql
    CREATE PUBLICATION etl_publication FOR TABLE your_table;

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,4 +1,3 @@
-
 # How-To Guides
 
 **Practical solutions for common ETL tasks**
@@ -7,10 +6,11 @@ How-to guides provide step-by-step instructions for accomplishing specific goals
 
 ## Database Configuration
 
-### [Configure PostgreSQL for Replication](configure-postgres.md)
-Set up PostgreSQL with the correct settings, and publications for ETL pipelines.
+### [Configure Postgres for Replication](configure-postgres.md)
 
-**When to use:** Setting up a new PostgreSQL source for replication.
+Set up Postgres with the correct settings, and publications for ETL pipelines.
+
+**When to use:** Setting up a new Postgres source for replication.
 
 ## Next Steps
 
@@ -23,6 +23,7 @@ After solving your immediate problem:
 ## Need Help?
 
 If these guides don't cover your specific situation:
-1. Check the [PostgreSQL configuration guide](configure-postgres.md)
+
+1. Check the [Postgres configuration guide](configure-postgres.md)
 2. Search existing [GitHub issues](https://github.com/supabase/etl/issues)
 3. [Open a new issue](https://github.com/supabase/etl/issues/new) with details about your use case

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,27 +1,29 @@
-
 # ETL Documentation
 
 **Build real-time Postgres replication applications in Rust**
 
-ETL is a Rust framework by [Supabase](https://supabase.com) that enables you to build high-performance, real-time data replication applications for PostgreSQL. Whether you're creating ETL pipelines, implementing CDC (Change Data Capture), or building custom data synchronization solutions, ETL provides the building blocks you need.
+ETL is a Rust framework by [Supabase](https://supabase.com) that enables you to build high-performance, real-time data replication applications for Postgres. Whether you're creating ETL pipelines, implementing CDC (Change Data Capture), or building custom data synchronization solutions, ETL provides the building blocks you need.
 
 ## Getting Started
 
 Choose your path based on your needs:
 
 ### New to ETL?
+
 Start with our **[Tutorials](tutorials/index.md)** to learn ETL through hands-on examples:
 
 - [Build your first ETL pipeline](tutorials/first-pipeline.md) - Complete beginner's guide (15 minutes)
 - [Build custom stores and destinations](tutorials/custom-implementations.md) - Advanced patterns (30 minutes)
 
 ### Ready to solve specific problems?
+
 Jump to our **[How-To Guides](how-to/index.md)** for practical solutions:
 
-- [Configure PostgreSQL for replication](how-to/configure-postgres.md)
+- [Configure Postgres for replication](how-to/configure-postgres.md)
 - More guides coming soon
 
 ### Want to understand the bigger picture?
+
 Read our **[Explanations](explanation/index.md)** for deeper insights:
 
 - [ETL architecture overview](explanation/architecture.md)
@@ -29,7 +31,7 @@ Read our **[Explanations](explanation/index.md)** for deeper insights:
 
 ## Core Concepts
 
-**Postgres Logical Replication** streams data changes from PostgreSQL databases in real-time using the Write-Ahead Log (WAL). ETL builds on this foundation to provide:
+**Postgres Logical Replication** streams data changes from Postgres databases in real-time using the Write-Ahead Log (WAL). ETL builds on this foundation to provide:
 
 - 🚀 **Real-time replication** - Stream changes as they happen
 - 🔄 **Multiple destinations** - BigQuery and more coming soon
@@ -49,7 +51,7 @@ use etl::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Configure PostgreSQL connection
+    // Configure Postgres connection
     let pg_config = PgConnectionConfig {
         host: "localhost".to_string(),
         port: 5432,
@@ -87,6 +89,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Next Steps
 
 - **First time using ETL?** → Start with [Build your first pipeline](tutorials/first-pipeline.md)
-- **Need PostgreSQL setup help?** → Check [Configure PostgreSQL for Replication](how-to/configure-postgres.md)
+- **Need Postgres setup help?** → Check [Configure Postgres for Replication](how-to/configure-postgres.md)
 - **Need technical details?** → Check the [Reference](reference/index.md)
 - **Want to understand the architecture?** → Read [ETL Architecture](explanation/architecture.md)

--- a/docs/tutorials/first-pipeline.md
+++ b/docs/tutorials/first-pipeline.md
@@ -1,21 +1,21 @@
-
 # Build Your First ETL Pipeline
 
 **Learn the fundamentals by building a working pipeline in 15 minutes**
 
-By the end of this tutorial, you'll have a complete ETL pipeline that streams data changes from PostgreSQL to a memory destination in real-time. You'll see how to set up publications, configure pipelines, and handle live data replication.
+By the end of this tutorial, you'll have a complete ETL pipeline that streams data changes from Postgres to a memory destination in real-time. You'll see how to set up publications, configure pipelines, and handle live data replication.
 
 ## What You'll Build
 
 A real-time data pipeline that:
-- Monitors a PostgreSQL table for changes
-- Streams INSERT, UPDATE, and DELETE operations  
+
+- Monitors a Postgres table for changes
+- Streams INSERT, UPDATE, and DELETE operations
 - Stores replicated data in memory for immediate access
 
 ## Who This Tutorial Is For
 
 - Rust developers new to ETL
-- Anyone interested in PostgreSQL logical replication
+- Anyone interested in Postgres logical replication
 - Developers building data synchronization tools
 
 **Time required:** 15 minutes  
@@ -44,9 +44,9 @@ tokio = { version = "1.0", features = ["full"] }
 
 **Checkpoint:** Run `cargo check` - it should compile successfully.
 
-## Step 2: Prepare PostgreSQL
+## Step 2: Prepare Postgres
 
-Connect to your PostgreSQL server and create a test database:
+Connect to your Postgres server and create a test database:
 
 ```sql
 CREATE DATABASE etl_tutorial;
@@ -61,7 +61,7 @@ CREATE TABLE users (
 );
 
 -- Insert sample data
-INSERT INTO users (name, email) VALUES 
+INSERT INTO users (name, email) VALUES
     ('Alice Johnson', 'alice@example.com'),
     ('Bob Smith', 'bob@example.com');
 ```
@@ -73,9 +73,11 @@ CREATE PUBLICATION my_publication FOR TABLE users;
 ```
 
 **Checkpoint:** Verify the publication exists:
+
 ```sql
 SELECT * FROM pg_publication WHERE pubname = 'my_publication';
 ```
+
 You should see one row returned.
 
 ## Step 3: Configure Your Pipeline
@@ -91,7 +93,7 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Configure PostgreSQL connection.
+    // Configure Postgres connection.
     let pg_connection_config = PgConnectionConfig {
         host: "localhost".to_string(),
         port: 5432,
@@ -159,7 +161,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 
-**Important:** Replace `"your_password"` with your PostgreSQL password.
+**Important:** Replace `"your_password"` with your Postgres password.
 
 ## Step 4: Start Your Pipeline
 
@@ -170,6 +172,7 @@ cargo run
 ```
 
 You should see output like:
+
 ```
 Starting ETL pipeline...
 Waiting for pipeline to finish...
@@ -186,7 +189,7 @@ Table (TableId(245615)): [TableRow { values: [I32(1), Array(I32([Some(1), Some(2
 
 ## Step 5: Test Real-Time Replication
 
-With your pipeline running, open a new terminal and connect to PostgreSQL:
+With your pipeline running, open a new terminal and connect to Postgres:
 
 ```bash
 psql -d etl_tutorial
@@ -198,7 +201,7 @@ Make some changes to test replication:
 -- Insert a new user
 INSERT INTO users (name, email) VALUES ('Charlie Brown', 'charlie@example.com');
 
--- Update an existing user  
+-- Update an existing user
 UPDATE users SET name = 'Alice Cooper' WHERE email = 'alice@example.com';
 
 -- Delete a user
@@ -235,7 +238,7 @@ DROP DATABASE etl_tutorial;
 Now that you understand the basics:
 
 - **Build custom implementations** → [Custom Stores and Destinations](custom-implementations.md)
-- **Configure PostgreSQL properly** → [Configure PostgreSQL for Replication](../how-to/configure-postgres.md)
+- **Configure Postgres properly** → [Configure Postgres for Replication](../how-to/configure-postgres.md)
 - **Understand the architecture** → [ETL Architecture](../explanation/architecture.md)
 
 ## See Also

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,4 +1,3 @@
-
 # Tutorials
 
 **Learn ETL through guided, hands-on experiences**
@@ -8,28 +7,29 @@ Tutorials provide step-by-step learning paths that take you from zero knowledge 
 ## Getting Started
 
 ### [Build Your First ETL Pipeline](first-pipeline.md)
-**15 minutes** • **Beginner** 
 
-Create a complete ETL pipeline that replicates data from PostgreSQL to a memory destination. You'll learn the core concepts of publications, replication slots, and pipeline configuration.
+**15 minutes** • **Beginner**
 
-*What you'll build:* A working pipeline that streams changes from a sample PostgreSQL table to an in-memory destination.
+Create a complete ETL pipeline that replicates data from Postgres to a memory destination. You'll learn the core concepts of publications, replication slots, and pipeline configuration.
 
+_What you'll build:_ A working pipeline that streams changes from a sample Postgres table to an in-memory destination.
 
 ## Advanced Topics
 
 ### [Build Custom Stores and Destinations](custom-implementations.md)
+
 **45 minutes** • **Advanced**
 
 Implement production-ready custom stores and destinations. Learn ETL's design patterns, build persistent SQLite storage, and create HTTP-based destinations with retry logic.
 
-*What you'll build:* Custom in-memory store for state/schema storage and HTTP destination.
+_What you'll build:_ Custom in-memory store for state/schema storage and HTTP destination.
 
 ## Before You Start
 
 **Prerequisites for all tutorials:**
 
 - Rust installed (1.75 or later)
-- PostgreSQL server (local or remote)
+- Postgres server (local or remote)
 - Basic familiarity with Rust and SQL
 
 **What you'll need:**
@@ -50,6 +50,6 @@ After completing the tutorials:
 If you get stuck:
 
 1. Double-check the prerequisites
-2. Ensure your PostgreSQL setup matches the requirements
-3. Check the [PostgreSQL configuration guide](../how-to/configure-postgres.md)
+2. Ensure your Postgres setup matches the requirements
+3. Check the [Postgres configuration guide](../how-to/configure-postgres.md)
 4. [Open an issue](https://github.com/supabase/etl/issues) with your specific problem

--- a/etl-api/README.md
+++ b/etl-api/README.md
@@ -1,8 +1,8 @@
 # `etl` - API
 
-This API service provides a RESTful interface for managing PostgreSQL replication pipelines. It enables you to:
+This API service provides a RESTful interface for managing Postgres replication pipelines. It enables you to:
 
-- Create and manage replication pipelines between PostgreSQL sources and destinations
+- Create and manage replication pipelines between Postgres sources and destinations
 - Handle multi-tenant replication configurations
 - Manage publications and tables for replication
 - Control pipeline lifecycle (start/stop/status)
@@ -28,7 +28,7 @@ This API service provides a RESTful interface for managing PostgreSQL replicatio
 
 Before running the API, you must have:
 
-- A running PostgreSQL instance reachable via `DATABASE_URL`.
+- A running Postgres instance reachable via `DATABASE_URL`.
 - The `etl-api` database schema applied (SQLx migrations).
 
 Quickest way: use the setup script to start Postgres (via Docker) and run migrations automatically.

--- a/etl-api/src/db/destinations.rs
+++ b/etl-api/src/db/destinations.rs
@@ -85,7 +85,7 @@ impl Decrypt<DestinationConfig> for EncryptedDestinationConfig {
 
 #[derive(Debug, Error)]
 pub enum DestinationsDbError {
-    #[error("Error while interacting with PostgreSQL for destinations: {0}")]
+    #[error("Error while interacting with Postgres for destinations: {0}")]
     Database(#[from] sqlx::Error),
 
     #[error("Error while serializing destination config: {0}")]

--- a/etl-api/src/db/destinations_pipelines.rs
+++ b/etl-api/src/db/destinations_pipelines.rs
@@ -10,7 +10,7 @@ use crate::encryption::EncryptionKey;
 
 #[derive(Debug, Error)]
 pub enum DestinationPipelinesDbError {
-    #[error("Error while interacting with PostgreSQL for destination and/or pipelines: {0}")]
+    #[error("Error while interacting with Postgres for destination and/or pipelines: {0}")]
     Database(#[from] sqlx::Error),
 
     #[error("The destination with id {0} was not found")]

--- a/etl-api/src/db/images.rs
+++ b/etl-api/src/db/images.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ImagesDbError {
-    #[error("Error while interacting with PostgreSQL for images: {0}")]
+    #[error("Error while interacting with Postgres for images: {0}")]
     Database(#[from] sqlx::Error),
 
     #[error("Cannot delete the default image")]

--- a/etl-api/src/db/pipelines.rs
+++ b/etl-api/src/db/pipelines.rs
@@ -81,7 +81,7 @@ pub struct Pipeline {
 
 #[derive(Debug, Error)]
 pub enum PipelinesDbError {
-    #[error("Error while interacting with PostgreSQL for pipelines: {0}")]
+    #[error("Error while interacting with Postgres for pipelines: {0}")]
     Database(#[from] sqlx::Error),
 
     #[error("Error while serializing pipeline config: {0}")]
@@ -387,7 +387,7 @@ pub async fn update_pipeline_config(
 pub fn is_duplicate_pipeline_error(err: &sqlx::Error) -> bool {
     match err {
         sqlx::Error::Database(db_err) => {
-            // 23505 is PostgreSQL's unique constraint violation code
+            // 23505 is Postgres's unique constraint violation code
             // Check for our unique constraint name defined
             // in the migrations/20250605064229_add_unique_constraint_pipelines_source_destination.sql file
             db_err.code().as_deref() == Some("23505")

--- a/etl-api/src/db/publications.rs
+++ b/etl-api/src/db/publications.rs
@@ -9,7 +9,7 @@ use crate::db::tables::Table;
 
 #[derive(Debug, Error)]
 pub enum PublicationsDbError {
-    #[error("Error while interacting with PostgreSQL for publications: {0}")]
+    #[error("Error while interacting with Postgres for publications: {0}")]
     Database(#[from] sqlx::Error),
 }
 

--- a/etl-api/src/db/replicators.rs
+++ b/etl-api/src/db/replicators.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ReplicatorsDbError {
-    #[error("Error while interacting with PostgreSQL for replicators: {0}")]
+    #[error("Error while interacting with Postgres for replicators: {0}")]
     Database(#[from] sqlx::Error),
 }
 

--- a/etl-api/src/db/sources.rs
+++ b/etl-api/src/db/sources.rs
@@ -109,7 +109,7 @@ pub struct Source {
 
 #[derive(Debug, Error)]
 pub enum SourcesDbError {
-    #[error("Error while interacting with PostgreSQL for sources: {0}")]
+    #[error("Error while interacting with Postgres for sources: {0}")]
     Database(#[from] sqlx::Error),
 
     #[error("Error while serializing source config: {0}")]

--- a/etl-api/src/db/tables.rs
+++ b/etl-api/src/db/tables.rs
@@ -5,7 +5,7 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Error)]
 pub enum TablesDbError {
-    #[error("Error while interacting with PostgreSQL for tables: {0}")]
+    #[error("Error while interacting with Postgres for tables: {0}")]
     Database(#[from] sqlx::Error),
 }
 

--- a/etl-api/src/db/tenants.rs
+++ b/etl-api/src/db/tenants.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum TenantsDbError {
-    #[error("Error while interacting with PostgreSQL for tenants: {0}")]
+    #[error("Error while interacting with Postgres for tenants: {0}")]
     Database(#[from] sqlx::Error),
 }
 

--- a/etl-api/src/db/tenants_sources.rs
+++ b/etl-api/src/db/tenants_sources.rs
@@ -9,7 +9,7 @@ use crate::encryption::EncryptionKey;
 
 #[derive(Debug, Error)]
 pub enum TenantSourceDbError {
-    #[error("Error while interacting with PostgreSQL for tenants and/or sources: {0}")]
+    #[error("Error while interacting with Postgres for tenants and/or sources: {0}")]
     Database(#[from] sqlx::Error),
 
     #[error("Error while serializing tenant or source config: {0}")]

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -142,7 +142,7 @@ impl Application {
     }
 }
 
-/// Creates a PostgreSQL connection pool from the provided configuration.
+/// Creates a Postgres connection pool from the provided configuration.
 pub fn get_connection_pool(config: &PgConnectionConfig) -> PgPool {
     PgPoolOptions::new().connect_lazy_with(config.with_db())
 }

--- a/etl-api/tests/common/database.rs
+++ b/etl-api/tests/common/database.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::common::test_app::TestApp;
 
-/// Creates and configures a new PostgreSQL database for the API.
+/// Creates and configures a new Postgres database for the API.
 ///
 /// Similar to [`create_pg_database`], but additionally runs all database migrations
 /// from the "./migrations" directory after creation. Returns a [`PgPool`]

--- a/etl-benchmarks/README.md
+++ b/etl-benchmarks/README.md
@@ -9,7 +9,8 @@ Performance benchmarks for the ETL system to measure and track replication perfo
 ## Prerequisites
 
 Before running benchmarks, ensure you have:
-- A PostgreSQL database set up
+
+- A Postgres database set up
 - A publication created with the tables you want to benchmark
 - For BigQuery benchmarks: GCP project, dataset, and service account key file
 
@@ -58,42 +59,43 @@ cargo bench --bench table_copies --features bigquery -- --log-target terminal ru
 
 ### Common Parameters
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `--host` | PostgreSQL host | `localhost` |
-| `--port` | PostgreSQL port | `5432` |
-| `--database` | Database name | `bench` |
-| `--username` | PostgreSQL username | `postgres` |
-| `--password` | PostgreSQL password | (optional) |
-| `--publication-name` | Publication to replicate from | `bench_pub` |
-| `--table-ids` | Comma-separated table IDs to replicate | (required) |
-| `--destination` | Destination type (`null` or `big-query`) | `null` |
+| Parameter            | Description                              | Default     |
+| -------------------- | ---------------------------------------- | ----------- |
+| `--host`             | Postgres host                            | `localhost` |
+| `--port`             | Postgres port                            | `5432`      |
+| `--database`         | Database name                            | `bench`     |
+| `--username`         | Postgres username                        | `postgres`  |
+| `--password`         | Postgres password                        | (optional)  |
+| `--publication-name` | Publication to replicate from            | `bench_pub` |
+| `--table-ids`        | Comma-separated table IDs to replicate   | (required)  |
+| `--destination`      | Destination type (`null` or `big-query`) | `null`      |
 
 ### Performance Tuning Parameters
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `--batch-max-size` | Maximum batch size | `100000` |
-| `--batch-max-fill-ms` | Maximum batch fill time (ms) | `10000` |
-| `--max-table-sync-workers` | Max concurrent table sync workers | `8` |
+| Parameter                  | Description                       | Default  |
+| -------------------------- | --------------------------------- | -------- |
+| `--batch-max-size`         | Maximum batch size                | `100000` |
+| `--batch-max-fill-ms`      | Maximum batch fill time (ms)      | `10000`  |
+| `--max-table-sync-workers` | Max concurrent table sync workers | `8`      |
 
 ### BigQuery Parameters
 
-| Parameter | Description | Required for BigQuery |
-|-----------|-------------|----------------------|
-| `--bq-project-id` | GCP project ID | Yes |
-| `--bq-dataset-id` | BigQuery dataset ID | Yes |
-| `--bq-sa-key-file` | Service account key file path | Yes |
-| `--bq-max-staleness-mins` | Max staleness in minutes | No |
+| Parameter                 | Description                   | Required for BigQuery |
+| ------------------------- | ----------------------------- | --------------------- |
+| `--bq-project-id`         | GCP project ID                | Yes                   |
+| `--bq-dataset-id`         | BigQuery dataset ID           | Yes                   |
+| `--bq-sa-key-file`        | Service account key file path | Yes                   |
+| `--bq-max-staleness-mins` | Max staleness in minutes      | No                    |
 
 ### Logging Options
 
-| Parameter | Description |
-|-----------|-------------|
+| Parameter               | Description                         |
+| ----------------------- | ----------------------------------- |
 | `--log-target terminal` | Colorized terminal output (default) |
-| `--log-target file` | Write logs to `logs/` directory |
+| `--log-target file`     | Write logs to `logs/` directory     |
 
 Set `RUST_LOG` environment variable to control log levels (default: `info`):
+
 ```bash
 RUST_LOG=debug cargo bench --bench table_copies -- run ...
 ```
@@ -101,6 +103,7 @@ RUST_LOG=debug cargo bench --bench table_copies -- run ...
 ## Complete Examples
 
 ### Production-like Testing with File Logging
+
 ```bash
 cargo bench --bench table_copies -- --log-target file run \
   --host localhost --port 5432 --database bench \
@@ -111,6 +114,7 @@ cargo bench --bench table_copies -- --log-target file run \
 ```
 
 ### High-throughput BigQuery Test
+
 ```bash
 cargo bench --bench table_copies --features bigquery -- --log-target terminal run \
   --host localhost --port 5432 --database bench \

--- a/etl-benchmarks/benches/table_copies.rs
+++ b/etl-benchmarks/benches/table_copies.rs
@@ -59,11 +59,11 @@ enum DestinationType {
 enum Commands {
     /// Run the table copies benchmark
     Run {
-        /// PostgreSQL host
+        /// Postgres host
         #[arg(long, default_value = "localhost")]
         host: String,
 
-        /// PostgreSQL port
+        /// Postgres port
         #[arg(long, default_value = "5432")]
         port: u16,
 
@@ -71,11 +71,11 @@ enum Commands {
         #[arg(long, default_value = "bench")]
         database: String,
 
-        /// PostgreSQL username
+        /// Postgres username
         #[arg(long, default_value = "postgres")]
         username: String,
 
-        /// PostgreSQL password (optional)
+        /// Postgres password (optional)
         #[arg(long)]
         password: Option<String>,
 
@@ -133,11 +133,11 @@ enum Commands {
     },
     /// Prepare the benchmark environment by cleaning up replication slots
     Prepare {
-        /// PostgreSQL host
+        /// Postgres host
         #[arg(long, default_value = "localhost")]
         host: String,
 
-        /// PostgreSQL port
+        /// Postgres port
         #[arg(long, default_value = "5432")]
         port: u16,
 
@@ -145,11 +145,11 @@ enum Commands {
         #[arg(long, default_value = "bench")]
         database: String,
 
-        /// PostgreSQL username
+        /// Postgres username
         #[arg(long, default_value = "postgres")]
         username: String,
 
-        /// PostgreSQL password (optional)
+        /// Postgres password (optional)
         #[arg(long)]
         password: Option<String>,
 

--- a/etl-config/src/shared/connection.rs
+++ b/etl-config/src/shared/connection.rs
@@ -8,10 +8,10 @@ use utoipa::ToSchema;
 use crate::SerializableSecretString;
 use crate::shared::ValidationError;
 
-/// PostgreSQL server options for ETL workloads.
+/// Postgres server options for ETL workloads.
 ///
 /// Configures session-specific settings that are applied during connection
-/// establishment to optimize PostgreSQL behavior for ETL operations.
+/// establishment to optimize Postgres behavior for ETL operations.
 #[derive(Debug, Clone)]
 pub struct PgConnectionOptions {
     /// Sets the display format for date values.
@@ -37,12 +37,12 @@ pub struct PgConnectionOptions {
 impl Default for PgConnectionOptions {
     /// Returns default configuration values optimized for ETL/replication workloads.
     ///
-    /// These defaults ensure consistent behavior across different PostgreSQL installations
+    /// These defaults ensure consistent behavior across different Postgres installations
     /// and are specifically tuned for ETL systems that perform logical replication and
     /// large data operations:
     ///
     /// - `datestyle = "ISO"`: Provides consistent date formatting for reliable parsing
-    /// - `intervalstyle = "postgres"`: Uses standard PostgreSQL interval format
+    /// - `intervalstyle = "postgres"`: Uses standard Postgres interval format
     /// - `extra_float_digits = 3`: Ensures sufficient precision for numeric replication
     /// - `client_encoding = "UTF8"`: Supports international character sets
     /// - `timezone = "UTC"`: Eliminates timezone ambiguity in distributed ETL systems
@@ -114,9 +114,9 @@ impl PgConnectionOptions {
     }
 }
 
-/// PostgreSQL database connection configuration.
+/// Postgres database connection configuration.
 ///
-/// Contains all parameters required to establish a connection to a PostgreSQL
+/// Contains all parameters required to establish a connection to a Postgres
 /// database, including authentication, TLS settings, and connection options.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
@@ -141,7 +141,7 @@ pub struct PgConnectionConfig {
     pub tls: TlsConfig,
 }
 
-/// TLS configuration for secure PostgreSQL connections.
+/// TLS configuration for secure Postgres connections.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]
@@ -175,13 +175,13 @@ impl TlsConfig {
 /// Trait for converting configuration to database client connection options.
 ///
 /// Provides a common interface for creating connection options for different
-/// PostgreSQL client libraries (sqlx and tokio-postgres) while centralizing
+/// Postgres client libraries (sqlx and tokio-postgres) while centralizing
 /// configuration in [`PgConnectionConfig`].
 pub trait IntoConnectOptions<Output> {
     /// Creates connection options without specifying a database.
     ///
     /// Used for administrative operations like database creation that require
-    /// connecting to the PostgreSQL server without targeting a specific database.
+    /// connecting to the Postgres server without targeting a specific database.
     fn without_db(&self) -> Output;
 
     /// Creates connection options for connecting to the configured database.

--- a/etl-destinations/src/bigquery/client.rs
+++ b/etl-destinations/src/bigquery/client.rs
@@ -422,7 +422,7 @@ impl BigQueryClient {
         format!("options (max_staleness = interval {max_staleness_mins} minute)")
     }
 
-    /// Converts PostgreSQL data types to BigQuery equivalent types.
+    /// Converts Postgres data types to BigQuery equivalent types.
     fn postgres_to_bigquery_type(typ: &Type) -> String {
         if Self::is_array_type(typ) {
             let element_type = match typ {
@@ -466,7 +466,7 @@ impl BigQueryClient {
         .to_string()
     }
 
-    /// Returns whether the PostgreSQL type is an array type.
+    /// Returns whether the Postgres type is an array type.
     fn is_array_type(typ: &Type) -> bool {
         matches!(
             typ,
@@ -494,7 +494,7 @@ impl BigQueryClient {
         )
     }
 
-    /// Converts PostgreSQL column schemas to a BigQuery [`TableDescriptor`].
+    /// Converts Postgres column schemas to a BigQuery [`TableDescriptor`].
     ///
     /// Maps data types and nullability to BigQuery column specifications, setting
     /// appropriate column modes and automatically adding CDC special columns.

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -19,10 +19,10 @@ use crate::metrics::register_metrics;
 
 /// Delimiter separating schema from table name in BigQuery table identifiers.
 const BIGQUERY_TABLE_ID_DELIMITER: &str = "_";
-/// Replacement string for escaping underscores in PostgreSQL names.
+/// Replacement string for escaping underscores in Postgres names.
 const BIGQUERY_TABLE_ID_DELIMITER_ESCAPE_REPLACEMENT: &str = "__";
 
-/// Creates a hex-encoded sequence number from PostgreSQL LSNs to ensure correct event ordering.
+/// Creates a hex-encoded sequence number from Postgres LSNs to ensure correct event ordering.
 ///
 /// Creates a hex-encoded sequence number that ensures events are processed in the correct order
 /// even when they have the same system time. The format is compatible with BigQuery's
@@ -183,7 +183,7 @@ struct Inner<S> {
 
 /// A BigQuery destination that implements the ETL [`Destination`] trait.
 ///
-/// Provides PostgreSQL-to-BigQuery data pipeline functionality including streaming inserts
+/// Provides Postgres-to-BigQuery data pipeline functionality including streaming inserts
 /// and CDC operation handling.
 #[derive(Debug, Clone)]
 pub struct BigQueryDestination<S> {

--- a/etl-destinations/src/lib.rs
+++ b/etl-destinations/src/lib.rs
@@ -1,7 +1,7 @@
 //! ETL destination implementations.
 //!
 //! Provides implementations of the ETL destination trait for various data warehouses
-//! and analytics platforms, enabling data replication from PostgreSQL to cloud services.
+//! and analytics platforms, enabling data replication from Postgres to cloud services.
 
 #[cfg(feature = "bigquery")]
 pub mod bigquery;

--- a/etl-examples/README.md
+++ b/etl-examples/README.md
@@ -1,10 +1,10 @@
 # `etl` - Examples
 
-This crate contains practical examples demonstrating how to use the ETL system for data replication from PostgreSQL to various destinations.
+This crate contains practical examples demonstrating how to use the ETL system for data replication from Postgres to various destinations.
 
 ## Available Examples
 
-- **BigQuery Integration**: Demonstrates replicating PostgreSQL data to Google BigQuery
+- **BigQuery Integration**: Demonstrates replicating Postgres data to Google BigQuery
 
 ## Quick Start
 
@@ -34,7 +34,7 @@ In the above example, `etl` connects to a Postgres database named `postgres` run
 
 ## Prerequisites
 
-Before running the examples, you'll need to set up a PostgreSQL database with logical replication enabled.
+Before running the examples, you'll need to set up a Postgres database with logical replication enabled.
 
 ## BigQuery Setup
 
@@ -44,4 +44,4 @@ To run the BigQuery example, you'll need:
 2. A service account key file with BigQuery permissions
 3. A BigQuery dataset created in your project
 
-The example will automatically create tables in the specified dataset based on your PostgreSQL schema.
+The example will automatically create tables in the specified dataset based on your Postgres schema.

--- a/etl-examples/src/main.rs
+++ b/etl-examples/src/main.rs
@@ -3,11 +3,11 @@
 BigQuery Example
 
 This example demonstrates how to use the pipeline to stream
-data from PostgreSQL to BigQuery using change data capture (CDC).
+data from Postgres to BigQuery using change data capture (CDC).
 
 Prerequisites:
-1. PostgreSQL server with logical replication enabled (wal_level = logical)
-2. A publication created in PostgreSQL (CREATE PUBLICATION my_publication FOR ALL TABLES;)
+1. Postgres server with logical replication enabled (wal_level = logical)
+2. A publication created in Postgres (CREATE PUBLICATION my_publication FOR ALL TABLES;)
 3. GCP service account with BigQuery Data Editor and Job User permissions
 4. Service account key file downloaded from GCP console
 
@@ -24,7 +24,7 @@ Usage:
         --publication my_publication
 
 The pipeline will automatically:
-- Create tables in BigQuery matching your PostgreSQL schema
+- Create tables in BigQuery matching your Postgres schema
 - Perform initial data sync for existing tables
 - Stream real-time changes using logical replication
 - Handle schema changes and DDL operations
@@ -45,18 +45,18 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 #[derive(Debug, Parser)]
 #[command(name = "bigquery", version, about, arg_required_else_help = true)]
 struct AppArgs {
-    // PostgreSQL connection parameters
+    // Postgres connection parameters
     #[clap(flatten)]
     db_args: DbArgs,
     // BigQuery destination parameters
     #[clap(flatten)]
     bq_args: BqArgs,
-    /// PostgreSQL publication name (must be created beforehand with CREATE PUBLICATION)
+    /// Postgres publication name (must be created beforehand with CREATE PUBLICATION)
     #[arg(long)]
     publication: String,
 }
 
-// PostgreSQL database connection configuration
+// Postgres database connection configuration
 #[derive(Debug, Args)]
 struct DbArgs {
     /// Host on which Postgres is running (e.g., localhost or IP address)
@@ -142,7 +142,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
     // Parse command line arguments
     let args = AppArgs::parse();
 
-    // Configure PostgreSQL connection settings
+    // Configure Postgres connection settings
     // Note: TLS is disabled in this example - enable for production use
     let pg_connection_config = PgConnectionConfig {
         host: args.db_args.db_host,
@@ -161,7 +161,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
     let store = MemoryStore::new();
 
     // Initialize BigQuery destination with service account authentication
-    // Tables will be automatically created to match PostgreSQL schema
+    // Tables will be automatically created to match Postgres schema
     let bigquery_destination = BigQueryDestination::new_with_key_path(
         args.bq_args.bq_project_id,
         args.bq_args.bq_dataset_id,
@@ -188,11 +188,11 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
     let mut pipeline = Pipeline::new(pipeline_config, store, bigquery_destination);
 
     info!(
-        "Starting BigQuery CDC pipeline - connecting to PostgreSQL and initializing replication..."
+        "Starting BigQuery CDC pipeline - connecting to Postgres and initializing replication..."
     );
 
     // Start the pipeline - this will:
-    // 1. Connect to PostgreSQL
+    // 1. Connect to Postgres
     // 2. Initialize table states based on the publication
     // 3. Start apply and table sync workers
     // 4. Begin streaming replication data

--- a/etl-postgres/README.md
+++ b/etl-postgres/README.md
@@ -1,3 +1,3 @@
 # `etl` - Postgres
 
-PostgreSQL-specific functionality and utilities for the ETL system.
+Postgres-specific functionality and utilities for the ETL system.

--- a/etl-postgres/src/lib.rs
+++ b/etl-postgres/src/lib.rs
@@ -1,6 +1,6 @@
-//! PostgreSQL database connection utilities for all crates.
+//! Postgres database connection utilities for all crates.
 //!
-//! This crate provides database connection options and utilities for working with PostgreSQL.
+//! This crate provides database connection options and utilities for working with Postgres.
 //! It supports both the [`sqlx`] and [`tokio-postgres`] crates through feature flags.
 
 #[cfg(feature = "replication")]

--- a/etl-postgres/src/replication/db.rs
+++ b/etl-postgres/src/replication/db.rs
@@ -16,7 +16,7 @@ pub enum TableLookupError {
 
 /// Connects to the source database with a connection pool.
 ///
-/// Creates a PostgreSQL connection pool with the specified minimum and maximum
+/// Creates a Postgres connection pool with the specified minimum and maximum
 /// connection counts for accessing the source database.
 #[cfg(feature = "replication")]
 pub async fn connect_to_source_database(
@@ -37,7 +37,7 @@ pub async fn connect_to_source_database(
 
 /// Retrieves table name from table OID by querying system catalogs.
 ///
-/// Looks up the schema and table name for the given table OID using PostgreSQL's
+/// Looks up the schema and table name for the given table OID using Postgres's
 /// pg_class and pg_namespace system tables.
 pub async fn get_table_name_from_oid(
     pool: &PgPool,

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -12,9 +12,9 @@ macro_rules! define_type_mappings {
             $pg_type:ident => $string_name:literal
         ),* $(,)?
     ) => {
-        /// Converts a PostgreSQL type name string to a [`PgType`].
+        /// Converts a Postgres type name string to a [`PgType`].
         ///
-        /// Maps string representations to their corresponding PostgreSQL types,
+        /// Maps string representations to their corresponding Postgres types,
         /// handling common types and falling back to `TEXT` for unknown types.
         pub fn string_to_postgres_type(type_str: &str) -> PgType {
             match type_str {
@@ -25,9 +25,9 @@ macro_rules! define_type_mappings {
             }
         }
 
-        /// Converts a PostgreSQL [`PgType`] to its string representation.
+        /// Converts a Postgres [`PgType`] to its string representation.
         ///
-        /// Maps PostgreSQL types to string equivalents for database storage,
+        /// Maps Postgres types to string equivalents for database storage,
         /// handling common types with fallback for unknown types.
         pub fn postgres_type_to_string(pg_type: &PgType) -> String {
             match *pg_type {

--- a/etl-postgres/src/replication/slots.rs
+++ b/etl-postgres/src/replication/slots.rs
@@ -3,7 +3,7 @@ use sqlx::PgPool;
 use crate::replication::worker::WorkerType;
 use crate::schema::TableId;
 
-/// Maximum length for a PostgreSQL replication slot name in bytes.
+/// Maximum length for a Postgres replication slot name in bytes.
 const MAX_SLOT_NAME_LENGTH: usize = 63;
 
 /// Prefixes for different types of replication slots

--- a/etl-postgres/src/replication/state.rs
+++ b/etl-postgres/src/replication/state.rs
@@ -377,7 +377,7 @@ where
         .collect())
 }
 
-/// Serde serialization helpers for PostgreSQL LSN values.
+/// Serde serialization helpers for Postgres LSN values.
 mod lsn_serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use tokio_postgres::types::PgLsn;

--- a/etl-postgres/src/schema.rs
+++ b/etl-postgres/src/schema.rs
@@ -5,12 +5,12 @@ use std::str::FromStr;
 use pg_escape::quote_identifier;
 use tokio_postgres::types::{FromSql, ToSql, Type};
 
-/// An object identifier in PostgreSQL.
+/// An object identifier in Postgres.
 pub type Oid = u32;
 
-/// A fully qualified PostgreSQL table name consisting of a schema and table name.
+/// A fully qualified Postgres table name consisting of a schema and table name.
 ///
-/// This type represents a table identifier in PostgreSQL, which requires both a schema name
+/// This type represents a table identifier in Postgres, which requires both a schema name
 /// and a table name. It provides methods for formatting the name in different contexts.
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct TableName {
@@ -25,10 +25,10 @@ impl TableName {
         Self { schema, name }
     }
 
-    /// Returns the table name as a properly quoted PostgreSQL identifier.
+    /// Returns the table name as a properly quoted Postgres identifier.
     ///
     /// This method ensures the schema and table names are properly escaped according to
-    /// PostgreSQL identifier quoting rules.
+    /// Postgres identifier quoting rules.
     pub fn as_quoted_identifier(&self) -> String {
         let quoted_schema = quote_identifier(&self.schema);
         let quoted_name = quote_identifier(&self.name);
@@ -43,13 +43,13 @@ impl fmt::Display for TableName {
     }
 }
 
-/// A type alias for PostgreSQL type modifiers.
+/// A type alias for Postgres type modifiers.
 ///
-/// Type modifiers in PostgreSQL are used to specify additional type-specific attributes,
+/// Type modifiers in Postgres are used to specify additional type-specific attributes,
 /// such as length for varchar or precision for numeric types.
 type TypeModifier = i32;
 
-/// Represents the schema of a single column in a PostgreSQL table.
+/// Represents the schema of a single column in a Postgres table.
 ///
 /// This type contains all metadata about a column including its name, data type,
 /// type modifier, nullability, and whether it's part of the primary key.
@@ -57,7 +57,7 @@ type TypeModifier = i32;
 pub struct ColumnSchema {
     /// The name of the column
     pub name: String,
-    /// The PostgreSQL data type of the column
+    /// The Postgres data type of the column
     pub typ: Type,
     /// Type-specific modifier value (e.g., length for varchar)
     pub modifier: TypeModifier,
@@ -99,9 +99,9 @@ impl ColumnSchema {
     }
 }
 
-/// A type-safe wrapper for PostgreSQL table OIDs.
+/// A type-safe wrapper for Postgres table OIDs.
 ///
-/// Table OIDs are unique identifiers assigned to tables in PostgreSQL.
+/// Table OIDs are unique identifiers assigned to tables in Postgres.
 ///
 /// This newtype provides type safety by preventing accidental use of raw [`Oid`] values
 /// where a table identifier is expected.
@@ -181,13 +181,13 @@ impl ToSql for TableId {
     tokio_postgres::types::to_sql_checked!();
 }
 
-/// Represents the complete schema of a PostgreSQL table.
+/// Represents the complete schema of a Postgres table.
 ///
 /// This type contains all metadata about a table including its name, OID,
 /// and the schemas of all its columns.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TableSchema {
-    /// The PostgreSQL OID of the table
+    /// The Postgres OID of the table
     pub id: TableId,
     /// The fully qualified name of the table
     pub name: TableName,

--- a/etl-postgres/src/sqlx/test_utils.rs
+++ b/etl-postgres/src/sqlx/test_utils.rs
@@ -1,9 +1,9 @@
 use etl_config::shared::{IntoConnectOptions, PgConnectionConfig};
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 
-/// Creates a new PostgreSQL database and returns a connection pool.
+/// Creates a new Postgres database and returns a connection pool.
 ///
-/// Connects to PostgreSQL server, creates a new database, and returns a [`PgPool`]
+/// Connects to Postgres server, creates a new database, and returns a [`PgPool`]
 /// connected to the newly created database.
 ///
 /// # Panics
@@ -24,9 +24,9 @@ pub async fn create_pg_database(config: &PgConnectionConfig) -> PgPool {
         .expect("Failed to connect to Postgres")
 }
 
-/// Drops a PostgreSQL database and terminates all connections.
+/// Drops a Postgres database and terminates all connections.
 ///
-/// Connects to PostgreSQL server, forcefully terminates active connections
+/// Connects to Postgres server, forcefully terminates active connections
 /// to the target database, and drops it if it exists. Used for test cleanup.
 ///
 /// # Panics

--- a/etl-postgres/src/time.rs
+++ b/etl-postgres/src/time.rs
@@ -1,24 +1,24 @@
 use std::sync::LazyLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// PostgreSQL date format string for parsing dates in YYYY-MM-DD format.
+/// Postgres date format string for parsing dates in YYYY-MM-DD format.
 pub const DATE_FORMAT: &str = "%Y-%m-%d";
 
-/// PostgreSQL time format string for parsing times with optional fractional seconds.
+/// Postgres time format string for parsing times with optional fractional seconds.
 pub const TIME_FORMAT: &str = "%H:%M:%S%.f";
 
-/// PostgreSQL timestamp format string for parsing timestamps with optional fractional seconds.
+/// Postgres timestamp format string for parsing timestamps with optional fractional seconds.
 pub const TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.f";
 
-/// PostgreSQL timestamptz format string with timezone offset in +HHMM format.
+/// Postgres timestamptz format string with timezone offset in +HHMM format.
 pub const TIMESTAMPTZ_FORMAT_HHMM: &str = "%Y-%m-%d %H:%M:%S%.f%#z";
 
-/// PostgreSQL timestamptz format string with timezone offset in +HH:MM format.
+/// Postgres timestamptz format string with timezone offset in +HH:MM format.
 pub const TIMESTAMPTZ_FORMAT_HH_MM: &str = "%Y-%m-%d %H:%M:%S%.f%:z";
 
-/// Number of seconds between Unix epoch (1970-01-01) and PostgreSQL epoch (2000-01-01).
+/// Number of seconds between Unix epoch (1970-01-01) and Postgres epoch (2000-01-01).
 const POSTGRES_EPOCH_OFFSET_SECONDS: u64 = 946_684_800;
 
-/// PostgreSQL epoch (2000-01-01 00:00:00 UTC) for timestamp calculations.
+/// Postgres epoch (2000-01-01 00:00:00 UTC) for timestamp calculations.
 pub static POSTGRES_EPOCH: LazyLock<SystemTime> =
     LazyLock::new(|| UNIX_EPOCH + Duration::from_secs(POSTGRES_EPOCH_OFFSET_SECONDS));

--- a/etl-postgres/src/tokio/test_utils.rs
+++ b/etl-postgres/src/tokio/test_utils.rs
@@ -26,7 +26,7 @@ pub enum TableModification<'a> {
     },
 }
 
-/// PostgreSQL database wrapper for testing operations.
+/// Postgres database wrapper for testing operations.
 ///
 /// Provides a unified interface for database operations across different client types
 /// with automatic cleanup functionality.
@@ -37,7 +37,7 @@ pub struct PgDatabase<G> {
 }
 
 impl<G: GenericClient> PgDatabase<G> {
-    /// Creates a PostgreSQL publication for the specified tables.
+    /// Creates a Postgres publication for the specified tables.
     ///
     /// Sets up logical replication by creating a publication that includes
     /// the given tables for change data capture.
@@ -68,7 +68,7 @@ impl<G: GenericClient> PgDatabase<G> {
     /// Creates a new table with the given name and column definitions.
     ///
     /// Optionally adds a primary key column named `id` of type `bigserial`.
-    /// Returns the PostgreSQL OID of the created table.
+    /// Returns the Postgres OID of the created table.
     pub async fn create_table(
         &self,
         table_name: TableName,
@@ -184,7 +184,7 @@ impl<G: GenericClient> PgDatabase<G> {
             .await
     }
 
-    /// Inserts multiple rows using PostgreSQL's `generate_series` function.
+    /// Inserts multiple rows using Postgres's `generate_series` function.
     ///
     /// Generates and inserts rows with values created by `generate_series`
     /// for efficient bulk data insertion during testing.
@@ -311,7 +311,7 @@ impl<G: GenericClient> PgDatabase<G> {
         Ok(())
     }
 
-    /// Checks whether a PostgreSQL replication slot exists.
+    /// Checks whether a Postgres replication slot exists.
     ///
     /// Queries the `pg_replication_slots` system catalog to determine
     /// if a replication slot with the given name exists.
@@ -339,7 +339,7 @@ impl<G: GenericClient> PgDatabase<G> {
 impl PgDatabase<Client> {
     /// Creates a new test database with automatic cleanup.
     ///
-    /// Creates a new PostgreSQL database and establishes a client connection.
+    /// Creates a new Postgres database and establishes a client connection.
     /// The database will be dropped automatically when this instance is dropped.
     pub async fn new(config: PgConnectionConfig) -> Self {
         let client = create_pg_database(&config).await;
@@ -420,9 +420,9 @@ pub fn id_column_schema() -> ColumnSchema {
     }
 }
 
-/// Creates a new PostgreSQL database and returns a connected client.
+/// Creates a new Postgres database and returns a connected client.
 ///
-/// Establishes connection to PostgreSQL server, creates a new database,
+/// Establishes connection to Postgres server, creates a new database,
 /// and returns a [`Client`] connected to the newly created database.
 ///
 /// # Panics
@@ -454,7 +454,7 @@ pub async fn create_pg_database(config: &PgConnectionConfig) -> Client {
     connect_to_pg_database(config).await
 }
 
-/// Connects to an existing PostgreSQL database.
+/// Connects to an existing Postgres database.
 ///
 /// Establishes a client connection to the database specified in the configuration.
 /// Assumes the database already exists.
@@ -478,7 +478,7 @@ pub async fn connect_to_pg_database(config: &PgConnectionConfig) -> Client {
     client
 }
 
-/// Drops a PostgreSQL database and cleans up all resources.
+/// Drops a Postgres database and cleans up all resources.
 ///
 /// Terminates all active connections, drops replication slots, and removes
 /// the database. Used for thorough cleanup of test databases.

--- a/etl-postgres/src/types.rs
+++ b/etl-postgres/src/types.rs
@@ -1,6 +1,6 @@
 use tokio_postgres::types::{Kind, Type};
 
-/// Converts a PostgreSQL type OID to a [`Type`] instance.
+/// Converts a Postgres type OID to a [`Type`] instance.
 ///
 /// Returns a properly constructed [`Type`] for the given OID, or creates an unnamed
 /// type as fallback if the OID lookup fails.

--- a/etl-replicator/README.md
+++ b/etl-replicator/README.md
@@ -1,3 +1,3 @@
 # `etl` - Replicator
 
-Long-lived process that performs PostgreSQL logical replication using the `etl` crate.
+Long-lived process that performs Postgres logical replication using the `etl` crate.

--- a/etl-replicator/src/main.rs
+++ b/etl-replicator/src/main.rs
@@ -1,6 +1,6 @@
 //! ETL replicator service binary.
 //!
-//! Initializes and runs the replicator pipeline that handles PostgreSQL logical replication
+//! Initializes and runs the replicator pipeline that handles Postgres logical replication
 //! and routes data to configured destinations. Includes telemetry, error handling, and
 //! graceful shutdown capabilities.
 

--- a/etl/README.md
+++ b/etl/README.md
@@ -1,23 +1,23 @@
 # `etl` - Core
 
-This is the main crate of the ETL system, providing the core functionality for PostgreSQL logical replication. It abstracts the complexities of PostgreSQL's logical streaming replication protocol and provides a unified interface for data replication and transformation.
+This is the main crate of the ETL system, providing the core functionality for Postgres logical replication. It abstracts the complexities of Postgres's logical streaming replication protocol and provides a unified interface for data replication and transformation.
 
 ## Features
 
-| Feature                  | Description                                |
-| ------------------------ | ------------------------------------------ |
-| `unknown-types-to-bytes` | Converts unknown PostgreSQL types to bytes (enabled by default) |
-| `test-utils`             | Enables testing utilities and helpers      |
-| `failpoints`             | Enables failure injection for testing      |
+| Feature                  | Description                                                   |
+| ------------------------ | ------------------------------------------------------------- |
+| `unknown-types-to-bytes` | Converts unknown Postgres types to bytes (enabled by default) |
+| `test-utils`             | Enables testing utilities and helpers                         |
+| `failpoints`             | Enables failure injection for testing                         |
 
 ## Architecture
 
-The ETL core implements a pipeline architecture that replicates data from PostgreSQL to various destinations.
+The ETL core implements a pipeline architecture that replicates data from Postgres to various destinations.
 
 ### Key Components
 
 - **Pipeline**: Main orchestrator that manages the replication process
-- **Replication Client**: Connects to PostgreSQL's logical replication protocol
+- **Replication Client**: Connects to Postgres's logical replication protocol
 - **Apply Worker**: Main worker that handles the creation of table sync workers and processes CDC events
 - **Table Sync Worker**: Handles initial copying of existing table data and processes CDC events until it has caught up
   to the apply worker
@@ -27,32 +27,32 @@ The ETL core implements a pipeline architecture that replicates data from Postgr
 ### Information Flow
 
 ```mermaid
-graph TB    
+graph TB
     subgraph "ETL Pipeline"
         Pipeline["🎭 Pipeline"]
-        
+
         ApplyWorker["⚙️ Apply Worker"]
 
         subgraph "Worker Pool"
             TSWorker1["🔄 Table Sync Worker 1"]
             TSWorkerN["🔄 Table Sync Worker N"]
         end
-        
+
         subgraph "Store"
             StateStore["💾 State Store"]
             SchemaStore["📋 Schema Store"]
         end
     end
 
-    PG[("🐘 PostgreSQL<br/>Source Database")]
-    
+    PG[("🐘 Postgres<br/>Source Database")]
+
     Destination[("🎯 Destination<br/>BigQuery, etc.")]
-    
+
     Pipeline --> ApplyWorker
-    
+
     ApplyWorker --> TSWorker1
     ApplyWorker --> TSWorkerN
-    
+
     ApplyWorker --> Destination
     TSWorker1 --> Destination
     TSWorkerN --> Destination

--- a/etl/src/conversions/bool.rs
+++ b/etl/src/conversions/bool.rs
@@ -2,9 +2,9 @@ use crate::bail;
 use crate::error::EtlResult;
 use crate::error::{ErrorKind, EtlError};
 
-/// Parses a PostgreSQL boolean value from its text format representation.
+/// Parses a Postgres boolean value from its text format representation.
 ///
-/// PostgreSQL represents boolean values in text format as single characters:
+/// Postgres represents boolean values in text format as single characters:
 /// - `"t"` → `true` (exactly one lowercase 't')
 /// - `"f"` → `false` (exactly one lowercase 'f')
 pub fn parse_bool(s: &str) -> EtlResult<bool> {

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -15,7 +15,7 @@ use crate::error::{ErrorKind, EtlResult};
 use crate::store::schema::SchemaStore;
 use crate::{bail, etl_error};
 
-/// Transaction begin event from PostgreSQL logical replication.
+/// Transaction begin event from Postgres logical replication.
 ///
 /// [`BeginEvent`] marks the start of a new transaction in the replication stream.
 /// It contains metadata about the transaction including LSN positions and timing
@@ -26,14 +26,14 @@ pub struct BeginEvent {
     pub start_lsn: PgLsn,
     /// LSN position where the transaction will commit.
     pub commit_lsn: PgLsn,
-    /// Transaction start timestamp in PostgreSQL format.
+    /// Transaction start timestamp in Postgres format.
     pub timestamp: i64,
     /// Transaction ID for tracking and coordination.
     pub xid: u32,
 }
 
 impl BeginEvent {
-    /// Creates a [`BeginEvent`] from PostgreSQL protocol data.
+    /// Creates a [`BeginEvent`] from Postgres protocol data.
     ///
     /// This method parses the replication protocol begin message and extracts
     /// transaction metadata for use in the ETL pipeline.
@@ -51,7 +51,7 @@ impl BeginEvent {
     }
 }
 
-/// Transaction commit event from PostgreSQL logical replication.
+/// Transaction commit event from Postgres logical replication.
 ///
 /// [`CommitEvent`] marks the successful completion of a transaction in the replication
 /// stream. It provides final metadata about the transaction including timing and
@@ -62,16 +62,16 @@ pub struct CommitEvent {
     pub start_lsn: PgLsn,
     /// LSN position where the transaction committed.
     pub commit_lsn: PgLsn,
-    /// Transaction commit flags from PostgreSQL.
+    /// Transaction commit flags from Postgres.
     pub flags: i8,
     /// Final LSN position after the transaction.
     pub end_lsn: u64,
-    /// Transaction commit timestamp in PostgreSQL format.
+    /// Transaction commit timestamp in Postgres format.
     pub timestamp: i64,
 }
 
 impl CommitEvent {
-    /// Creates a [`CommitEvent`] from PostgreSQL protocol data.
+    /// Creates a [`CommitEvent`] from Postgres protocol data.
     ///
     /// This method parses the replication protocol commit message and extracts
     /// transaction completion metadata for use in the ETL pipeline.
@@ -90,7 +90,7 @@ impl CommitEvent {
     }
 }
 
-/// Table schema definition event from PostgreSQL logical replication.
+/// Table schema definition event from Postgres logical replication.
 ///
 /// [`RelationEvent`] provides schema information for tables involved in replication.
 /// It contains complete column definitions and metadata needed to interpret
@@ -106,7 +106,7 @@ pub struct RelationEvent {
 }
 
 impl RelationEvent {
-    /// Creates a [`RelationEvent`] from PostgreSQL protocol data.
+    /// Creates a [`RelationEvent`] from Postgres protocol data.
     ///
     /// This method parses the replication protocol relation message and builds
     /// a complete table schema for use in interpreting subsequent data events.
@@ -137,7 +137,7 @@ impl RelationEvent {
         })
     }
 
-    /// Constructs a [`ColumnSchema`] from PostgreSQL protocol column data.
+    /// Constructs a [`ColumnSchema`] from Postgres protocol column data.
     ///
     /// This helper method extracts column metadata from the replication protocol
     /// and converts it into the internal column schema representation. Some fields
@@ -157,7 +157,7 @@ impl RelationEvent {
     }
 }
 
-/// Row insertion event from PostgreSQL logical replication.
+/// Row insertion event from Postgres logical replication.
 ///
 /// [`InsertEvent`] represents a new row being added to a table. It contains
 /// the complete row data for insertion into the destination system.
@@ -173,7 +173,7 @@ pub struct InsertEvent {
     pub table_row: TableRow,
 }
 
-/// Row update event from PostgreSQL logical replication.
+/// Row update event from Postgres logical replication.
 ///
 /// [`UpdateEvent`] represents an existing row being modified. It contains
 /// both the new row data and optionally the old row data for comparison
@@ -191,12 +191,12 @@ pub struct UpdateEvent {
     /// Previous row data before the update.
     ///
     /// The boolean indicates whether the row contains only key columns (`true`)
-    /// or the complete row data (`false`). This depends on the PostgreSQL
+    /// or the complete row data (`false`). This depends on the Postgres
     /// `REPLICA IDENTITY` setting for the table.
     pub old_table_row: Option<(bool, TableRow)>,
 }
 
-/// Row deletion event from PostgreSQL logical replication.
+/// Row deletion event from Postgres logical replication.
 ///
 /// [`DeleteEvent`] represents a row being removed from a table. It contains
 /// information about the deleted row for proper cleanup in the destination system.
@@ -211,12 +211,12 @@ pub struct DeleteEvent {
     /// Data from the deleted row.
     ///
     /// The boolean indicates whether the row contains only key columns (`true`)
-    /// or the complete row data (`false`). This depends on the PostgreSQL
+    /// or the complete row data (`false`). This depends on the Postgres
     /// `REPLICA IDENTITY` setting for the table.
     pub old_table_row: Option<(bool, TableRow)>,
 }
 
-/// Table truncation event from PostgreSQL logical replication.
+/// Table truncation event from Postgres logical replication.
 ///
 /// [`TruncateEvent`] represents one or more tables being truncated (all rows deleted).
 /// This is a bulk operation that clears entire tables and may affect multiple tables
@@ -227,14 +227,14 @@ pub struct TruncateEvent {
     pub start_lsn: PgLsn,
     /// LSN position where the event will commit.
     pub commit_lsn: PgLsn,
-    /// Truncate operation options from PostgreSQL.
+    /// Truncate operation options from Postgres.
     pub options: i8,
     /// List of table IDs that were truncated in this operation.
     pub rel_ids: Vec<u32>,
 }
 
 impl TruncateEvent {
-    /// Creates a [`TruncateEvent`] from PostgreSQL protocol data.
+    /// Creates a [`TruncateEvent`] from Postgres protocol data.
     ///
     /// This method parses the replication protocol truncate message and extracts
     /// information about which tables were truncated and with what options.
@@ -252,9 +252,9 @@ impl TruncateEvent {
     }
 }
 
-/// Represents a single replication event from PostgreSQL logical replication.
+/// Represents a single replication event from Postgres logical replication.
 ///
-/// [`Event`] encapsulates all possible events that can occur in a PostgreSQL replication
+/// [`Event`] encapsulates all possible events that can occur in a Postgres replication
 /// stream, including data modification events and transaction control events. Each event
 /// type corresponds to specific operations in the source database.
 #[derive(Debug, Clone, PartialEq)]
@@ -309,7 +309,7 @@ impl Event {
     }
 }
 
-/// Classification of PostgreSQL replication event types.
+/// Classification of Postgres replication event types.
 ///
 /// [`EventType`] provides a lightweight enumeration of possible replication events
 /// without carrying the associated data. This is useful for filtering, routing,
@@ -391,11 +391,11 @@ where
         })
 }
 
-/// Converts PostgreSQL tuple data into a [`TableRow`] using column schemas.
+/// Converts Postgres tuple data into a [`TableRow`] using column schemas.
 ///
 /// This function transforms raw tuple data from the replication protocol into
 /// a structured row representation. It handles null values, unchanged TOAST data,
-/// and binary data according to PostgreSQL semantics. For unchanged TOAST values,
+/// and binary data according to Postgres semantics. For unchanged TOAST values,
 /// it attempts to reuse data from the old row if available.
 ///
 /// # Panics
@@ -470,7 +470,7 @@ fn convert_tuple_to_row(
     Ok(TableRow { values })
 }
 
-/// Converts a PostgreSQL insert message into an [`InsertEvent`].
+/// Converts a Postgres insert message into an [`InsertEvent`].
 ///
 /// This function processes an insert operation from the replication stream,
 /// retrieves the table schema from the store, and constructs a complete
@@ -502,12 +502,12 @@ where
     })
 }
 
-/// Converts a PostgreSQL update message into an [`UpdateEvent`].
+/// Converts a Postgres update message into an [`UpdateEvent`].
 ///
 /// This function processes an update operation from the replication stream,
 /// handling both the old and new row data. The old row data may be either
 /// the complete row or just the key columns, depending on the table's
-/// `REPLICA IDENTITY` setting in PostgreSQL.
+/// `REPLICA IDENTITY` setting in Postgres.
 async fn convert_update_to_event<S>(
     schema_store: &S,
     start_lsn: PgLsn,
@@ -553,12 +553,12 @@ where
     })
 }
 
-/// Converts a PostgreSQL delete message into a [`DeleteEvent`].
+/// Converts a Postgres delete message into a [`DeleteEvent`].
 ///
 /// This function processes a delete operation from the replication stream,
 /// extracting the old row data that was deleted. The old row data may be
 /// either the complete row or just the key columns, depending on the table's
-/// `REPLICA IDENTITY` setting in PostgreSQL.
+/// `REPLICA IDENTITY` setting in Postgres.
 async fn convert_delete_to_event<S>(
     schema_store: &S,
     start_lsn: PgLsn,
@@ -594,7 +594,7 @@ where
     })
 }
 
-/// Converts a PostgreSQL logical replication message into an [`Event`].
+/// Converts a Postgres logical replication message into an [`Event`].
 ///
 /// This is the main entry point for converting raw replication protocol messages
 /// into strongly-typed events for ETL processing. It dispatches to specialized

--- a/etl/src/conversions/hex.rs
+++ b/etl/src/conversions/hex.rs
@@ -2,9 +2,9 @@ use crate::bail;
 use crate::error::EtlError;
 use crate::error::{ErrorKind, EtlResult};
 
-/// Converts a PostgreSQL bytea hex string to a byte array.
+/// Converts a Postgres bytea hex string to a byte array.
 ///
-/// This function parses PostgreSQL's hex-encoded bytea format, which uses
+/// This function parses Postgres's hex-encoded bytea format, which uses
 /// the `\x` prefix followed by hexadecimal digits. Each pair of hex digits
 /// represents one byte in the output array.
 pub fn from_bytea_hex(s: &str) -> EtlResult<Vec<u8>> {

--- a/etl/src/conversions/mod.rs
+++ b/etl/src/conversions/mod.rs
@@ -14,10 +14,10 @@ pub mod numeric;
 pub mod table_row;
 pub mod text;
 
-/// Represents a single database cell value with support for PostgreSQL types.
+/// Represents a single database cell value with support for Postgres types.
 ///
 /// [`Cell`] is the primary data container for individual values during ETL processing.
-/// It supports all common PostgreSQL data types including arrays, JSON, and temporal types.
+/// It supports all common Postgres data types including arrays, JSON, and temporal types.
 /// Each variant handles nullable data appropriately for the destination system.
 ///
 /// The enum is designed to preserve type information and enable efficient conversion
@@ -42,7 +42,7 @@ pub enum Cell {
     F32(f32),
     /// 64-bit floating point number
     F64(f64),
-    /// PostgreSQL NUMERIC/DECIMAL type with arbitrary precision
+    /// Postgres NUMERIC/DECIMAL type with arbitrary precision
     Numeric(PgNumeric),
     /// Date without time information
     Date(NaiveDate),
@@ -90,10 +90,10 @@ impl Cell {
     }
 }
 
-/// Represents array data from PostgreSQL with nullable elements.
+/// Represents array data from Postgres with nullable elements.
 ///
-/// [`ArrayCell`] handles PostgreSQL array types where individual elements can be NULL.
-/// Each variant corresponds to a PostgreSQL array type and maintains the nullable
+/// [`ArrayCell`] handles Postgres array types where individual elements can be NULL.
+/// Each variant corresponds to a Postgres array type and maintains the nullable
 /// nature of array elements as they exist in the source database.
 ///
 /// This type is used internally during data conversion and can be converted to
@@ -118,7 +118,7 @@ pub enum ArrayCell {
     F32(Vec<Option<f32>>),
     /// Array of nullable 64-bit floats
     F64(Vec<Option<f64>>),
-    /// Array of nullable PostgreSQL numeric values
+    /// Array of nullable Postgres numeric values
     Numeric(Vec<Option<PgNumeric>>),
     /// Array of nullable dates
     Date(Vec<Option<NaiveDate>>),

--- a/etl/src/conversions/numeric.rs
+++ b/etl/src/conversions/numeric.rs
@@ -12,10 +12,10 @@ const NAN_SIGN: u16 = 0xC000;
 const POSITIVE_INFINITY_SIGN: u16 = 0xC000;
 const NEGATIVE_INFINITY_SIGN: u16 = 0xF000;
 
-/// Sign indicator for PostgreSQL numeric values.
+/// Sign indicator for Postgres numeric values.
 ///
 /// [`Sign`] represents whether a numeric value is positive or negative,
-/// used internally in the PostgreSQL numeric wire format representation.
+/// used internally in the Postgres numeric wire format representation.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub enum Sign {
     /// Positive numeric value.
@@ -24,10 +24,10 @@ pub enum Sign {
     Negative,
 }
 
-/// Error indicating an invalid sign value in PostgreSQL numeric format.
+/// Error indicating an invalid sign value in Postgres numeric format.
 ///
 /// [`InvalidSign`] wraps the invalid sign value encountered when parsing
-/// numeric data from PostgreSQL's wire format.
+/// numeric data from Postgres's wire format.
 pub struct InvalidSign(u16);
 
 impl TryFrom<u16> for Sign {
@@ -51,10 +51,10 @@ impl From<Sign> for u16 {
     }
 }
 
-/// PostgreSQL NUMERIC/DECIMAL type with arbitrary precision.
+/// Postgres NUMERIC/DECIMAL type with arbitrary precision.
 ///
-/// [`PgNumeric`] represents PostgreSQL's NUMERIC and DECIMAL types, which support
-/// arbitrary precision arithmetic. This enum closely matches PostgreSQL's internal
+/// [`PgNumeric`] represents Postgres's NUMERIC and DECIMAL types, which support
+/// arbitrary precision arithmetic. This enum closely matches Postgres's internal
 /// wire format and can represent special values like NaN and infinity.
 ///
 /// The numeric format uses base-10000 digits internally for efficient storage
@@ -259,7 +259,7 @@ impl std::error::Error for ParseNumericError {}
 
 /// Parses special numeric values like NaN, Infinity, and -Infinity.
 ///
-/// This function handles PostgreSQL's special numeric values when they appear
+/// This function handles Postgres's special numeric values when they appear
 /// in string format. NaN cannot have a negative sign, while infinity values
 /// respect the sign parameter.
 fn parse_special_value(
@@ -408,9 +408,9 @@ fn parse_numeric_value(
     convert_to_base_10000(decimal_digits, dweight, dscale as u16, sign)
 }
 
-/// Converts decimal digits to PostgreSQL's base-10000 internal format.
+/// Converts decimal digits to Postgres's base-10000 internal format.
 ///
-/// This function transforms a sequence of decimal digits into PostgreSQL's
+/// This function transforms a sequence of decimal digits into Postgres's
 /// efficient base-10000 representation, where each internal digit represents
 /// up to 10000 in decimal. This format balances storage efficiency with
 /// calculation performance.

--- a/etl/src/conversions/table_row.rs
+++ b/etl/src/conversions/table_row.rs
@@ -30,16 +30,16 @@ impl TableRow {
 
 /// Utility for converting raw data into typed [`TableRow`] instances.
 ///
-/// [`TableRowConverter`] handles parsing of PostgreSQL's text format data
+/// [`TableRowConverter`] handles parsing of Postgres's text format data
 /// into strongly-typed table rows with proper error handling and type conversion.
 pub struct TableRowConverter;
 
 impl TableRowConverter {
-    /// Converts raw PostgreSQL COPY format data into a typed table row.
+    /// Converts raw Postgres COPY format data into a typed table row.
     ///
-    /// This method parses the text format data produced by PostgreSQL's COPY command
+    /// This method parses the text format data produced by Postgres's COPY command
     /// and converts it into strongly-typed [`Cell`] values according to the provided
-    /// column schemas. It handles PostgreSQL's specific escaping rules and type formats.
+    /// column schemas. It handles Postgres's specific escaping rules and type formats.
     ///
     /// # Panics
     ///
@@ -68,7 +68,7 @@ impl TableRowConverter {
                                 val_str.push('\\');
                                 val_str.push(c);
                             }
-                            // Standard PostgreSQL escape sequences
+                            // Standard Postgres escape sequences
                             else if c == 'b' {
                                 val_str.push(8 as char); // backspace
                             } else if c == 'f' {
@@ -135,13 +135,13 @@ impl TableRowConverter {
 
                 // Convert the parsed string value to appropriate Cell type
                 let value = if val_str == "\\N" {
-                    // PostgreSQL NULL marker: \N represents a NULL value
+                    // Postgres NULL marker: \N represents a NULL value
                     // We preserve this as Cell::Null rather than converting to a typed null
                     // so that downstream code can handle null semantics appropriately
                     Cell::Null
                 } else {
                     // Convert non-null field value to appropriate Cell type based on column schema
-                    // This delegates to TextFormatConverter which handles PostgreSQL text format
+                    // This delegates to TextFormatConverter which handles Postgres text format
                     // parsing for all supported data types (integers, floats, strings, booleans, etc.)
                     match TextFormatConverter::try_from_str(&column_schema.typ, &val_str) {
                         Ok(value) => value,
@@ -398,7 +398,7 @@ mod tests {
             ColumnSchema::new("col2".to_string(), Type::TEXT, -1, false, false),
         ];
 
-        // PostgreSQL escapes tab characters in data with \\t
+        // Postgres escapes tab characters in data with \\t
         let row_data = b"value\\twith\\ttabs\tnormal\\tvalue\n";
         let result = TableRowConverter::try_from(row_data, &schema).unwrap();
 
@@ -447,7 +447,7 @@ mod tests {
     fn try_from_postgres_escape_sequences() {
         let schema = create_single_column_schema("data", Type::TEXT);
 
-        // Comprehensive test of all escape sequences that PostgreSQL COPY TO produces
+        // Comprehensive test of all escape sequences that Postgres COPY TO produces
         let test_cases: Vec<(&[u8], &str)> = vec![
             // Control character escapes
             (b"\\b\n", "\u{0008}"), // backspace

--- a/etl/src/conversions/text.rs
+++ b/etl/src/conversions/text.rs
@@ -12,17 +12,17 @@ use crate::error::{ErrorKind, EtlError, EtlResult};
 
 use super::{ArrayCell, Cell, numeric::PgNumeric};
 
-/// Utilities for converting PostgreSQL text-format data to typed [`Cell`] values.
+/// Utilities for converting Postgres text-format data to typed [`Cell`] values.
 ///
-/// This helper struct provides methods for parsing PostgreSQL's text representation
-/// of various data types into strongly-typed [`Cell`] variants. It handles PostgreSQL's
+/// This helper struct provides methods for parsing Postgres's text representation
+/// of various data types into strongly-typed [`Cell`] variants. It handles Postgres's
 /// specific text formatting conventions and provides fallback behavior for unknown types.
 pub struct TextFormatConverter;
 
 impl TextFormatConverter {
-    /// Creates a default [`Cell`] value for the given PostgreSQL type.
+    /// Creates a default [`Cell`] value for the given Postgres type.
     ///
-    /// This helper method provides sensible default values for PostgreSQL types,
+    /// This helper method provides sensible default values for Postgres types,
     /// primarily used during cell initialization and error recovery scenarios.
     /// The defaults are chosen to be the zero/empty value for each type where possible.
     ///
@@ -91,13 +91,13 @@ impl TextFormatConverter {
         }
     }
 
-    /// Converts a PostgreSQL text-format string to a typed [`Cell`] value.
+    /// Converts a Postgres text-format string to a typed [`Cell`] value.
     ///
-    /// This method parses PostgreSQL's text representation of various data types
-    /// into strongly-typed [`Cell`] variants. It handles all major PostgreSQL types
+    /// This method parses Postgres's text representation of various data types
+    /// into strongly-typed [`Cell`] variants. It handles all major Postgres types
     /// including arrays, and provides comprehensive error handling for malformed input.
     ///
-    /// For array types, it delegates to [`parse_array`] which handles PostgreSQL's
+    /// For array types, it delegates to [`parse_array`] which handles Postgres's
     /// array literal syntax with proper escaping and null value support.
     pub fn try_from_str(typ: &Type, str: &str) -> EtlResult<Cell> {
         match *typ {
@@ -256,9 +256,9 @@ impl TextFormatConverter {
         }
     }
 
-    /// Parses PostgreSQL array literal syntax into a typed [`ArrayCell`].
+    /// Parses Postgres array literal syntax into a typed [`ArrayCell`].
     ///
-    /// This function handles PostgreSQL's array format with curly braces, comma
+    /// This function handles Postgres's array format with curly braces, comma
     /// separation, and proper quoting. It supports null values (unquoted "null"),
     /// escaped characters within quoted strings, and delegates element parsing
     /// to the provided closure.

--- a/etl/src/destination/base.rs
+++ b/etl/src/destination/base.rs
@@ -36,7 +36,7 @@ pub trait Destination {
 
     /// Writes streaming replication events to the destination.
     ///
-    /// This method handles real-time changes from the PostgreSQL replication stream.
+    /// This method handles real-time changes from the Postgres replication stream.
     /// Events include inserts, updates, deletes, and transaction boundaries. The
     /// destination should process events in order, this is required to maintain data consistency.
     ///

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -354,7 +354,7 @@ impl From<std::num::ParseFloatError> for EtlError {
 
 /// Converts [`tokio_postgres::Error`] to [`EtlError`] with the appropriate error kind.
 ///
-/// Maps errors based on PostgreSQL SQLSTATE codes to provide granular error classification
+/// Maps errors based on Postgres SQLSTATE codes to provide granular error classification
 /// for better error handling in ETL operations.
 impl From<tokio_postgres::Error> for EtlError {
     fn from(err: tokio_postgres::Error) -> EtlError {
@@ -370,13 +370,13 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION
                     | SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION => (
                         ErrorKind::SourceConnectionFailed,
-                        "PostgreSQL connection error",
+                        "Postgres connection error",
                     ),
 
                     // Authentication errors (28xxx)
                     SqlState::INVALID_AUTHORIZATION_SPECIFICATION | SqlState::INVALID_PASSWORD => (
                         ErrorKind::AuthenticationError,
-                        "PostgreSQL authentication failed",
+                        "Postgres authentication failed",
                     ),
 
                     // Data integrity violations (23xxx)
@@ -384,20 +384,18 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::NOT_NULL_VIOLATION
                     | SqlState::FOREIGN_KEY_VIOLATION
                     | SqlState::UNIQUE_VIOLATION
-                    | SqlState::CHECK_VIOLATION => (
-                        ErrorKind::ValidationError,
-                        "PostgreSQL constraint violation",
-                    ),
+                    | SqlState::CHECK_VIOLATION => {
+                        (ErrorKind::ValidationError, "Postgres constraint violation")
+                    }
 
                     // Data conversion errors (22xxx)
                     SqlState::DATA_EXCEPTION
                     | SqlState::INVALID_TEXT_REPRESENTATION
                     | SqlState::INVALID_DATETIME_FORMAT
                     | SqlState::NUMERIC_VALUE_OUT_OF_RANGE
-                    | SqlState::DIVISION_BY_ZERO => (
-                        ErrorKind::ConversionError,
-                        "PostgreSQL data conversion error",
-                    ),
+                    | SqlState::DIVISION_BY_ZERO => {
+                        (ErrorKind::ConversionError, "Postgres data conversion error")
+                    }
 
                     // Schema/object not found errors (42xxx)
                     SqlState::UNDEFINED_TABLE
@@ -405,7 +403,7 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::UNDEFINED_FUNCTION
                     | SqlState::UNDEFINED_SCHEMA => (
                         ErrorKind::SourceSchemaError,
-                        "PostgreSQL schema object not found",
+                        "Postgres schema object not found",
                     ),
 
                     // Syntax and access errors (42xxx)
@@ -413,7 +411,7 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::SYNTAX_ERROR_OR_ACCESS_RULE_VIOLATION
                     | SqlState::INSUFFICIENT_PRIVILEGE => (
                         ErrorKind::SourceQueryFailed,
-                        "PostgreSQL syntax or access error",
+                        "Postgres syntax or access error",
                     ),
 
                     // Resource errors (53xxx)
@@ -421,7 +419,7 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::OUT_OF_MEMORY
                     | SqlState::TOO_MANY_CONNECTIONS => (
                         ErrorKind::SourceConnectionFailed,
-                        "PostgreSQL resource limitation",
+                        "Postgres resource limitation",
                     ),
 
                     // Transaction errors (40xxx, 25xxx)
@@ -429,56 +427,51 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::T_R_SERIALIZATION_FAILURE
                     | SqlState::T_R_DEADLOCK_DETECTED
                     | SqlState::INVALID_TRANSACTION_STATE => {
-                        (ErrorKind::InvalidState, "PostgreSQL transaction error")
+                        (ErrorKind::InvalidState, "Postgres transaction error")
                     }
 
                     // System errors (58xxx, XX xxx)
                     SqlState::SYSTEM_ERROR | SqlState::INTERNAL_ERROR => {
-                        (ErrorKind::SourceQueryFailed, "PostgreSQL system error")
+                        (ErrorKind::SourceQueryFailed, "Postgres system error")
                     }
-                    SqlState::IO_ERROR => (ErrorKind::SourceIoError, "PostgreSQL I/O error"),
+                    SqlState::IO_ERROR => (ErrorKind::SourceIoError, "Postgres I/O error"),
 
                     // Operator intervention errors (57xxx)
                     SqlState::OPERATOR_INTERVENTION => (
                         ErrorKind::SourceOperationCanceled,
-                        "PostgreSQL operation canceled",
+                        "Postgres operation canceled",
                     ),
                     SqlState::QUERY_CANCELED => (
                         ErrorKind::SourceOperationCanceled,
-                        "PostgreSQL query canceled",
+                        "Postgres query canceled",
                     ),
-                    SqlState::ADMIN_SHUTDOWN => (
-                        ErrorKind::SourceDatabaseShutdown,
-                        "PostgreSQL admin shutdown",
-                    ),
-                    SqlState::CRASH_SHUTDOWN => (
-                        ErrorKind::SourceDatabaseShutdown,
-                        "PostgreSQL crash shutdown",
-                    ),
+                    SqlState::ADMIN_SHUTDOWN => {
+                        (ErrorKind::SourceDatabaseShutdown, "Postgres admin shutdown")
+                    }
+                    SqlState::CRASH_SHUTDOWN => {
+                        (ErrorKind::SourceDatabaseShutdown, "Postgres crash shutdown")
+                    }
                     SqlState::CANNOT_CONNECT_NOW => (
                         ErrorKind::SourceDatabaseInRecovery,
-                        "PostgreSQL database in recovery",
+                        "Postgres database in recovery",
                     ),
                     SqlState::DATABASE_DROPPED => {
-                        (ErrorKind::SourceSchemaError, "PostgreSQL database dropped")
+                        (ErrorKind::SourceSchemaError, "Postgres database dropped")
                     }
                     SqlState::IDLE_SESSION_TIMEOUT => (
                         ErrorKind::SourceConnectionFailed,
-                        "PostgreSQL idle session timeout",
+                        "Postgres idle session timeout",
                     ),
 
                     // Object state errors (55xxx)
                     SqlState::OBJECT_NOT_IN_PREREQUISITE_STATE => (
                         ErrorKind::InvalidState,
-                        "PostgreSQL object not in prerequisite state",
+                        "Postgres object not in prerequisite state",
                     ),
-                    SqlState::OBJECT_IN_USE => {
-                        (ErrorKind::InvalidState, "PostgreSQL object in use")
+                    SqlState::OBJECT_IN_USE => (ErrorKind::InvalidState, "Postgres object in use"),
+                    SqlState::LOCK_NOT_AVAILABLE => {
+                        (ErrorKind::SourceLockTimeout, "Postgres lock not available")
                     }
-                    SqlState::LOCK_NOT_AVAILABLE => (
-                        ErrorKind::SourceLockTimeout,
-                        "PostgreSQL lock not available",
-                    ),
 
                     // Program limit errors (54xxx)
                     SqlState::PROGRAM_LIMIT_EXCEEDED
@@ -486,58 +479,56 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::TOO_MANY_COLUMNS
                     | SqlState::TOO_MANY_ARGUMENTS => (
                         ErrorKind::SourceQueryFailed,
-                        "PostgreSQL program limit exceeded",
+                        "Postgres program limit exceeded",
                     ),
 
                     // Configuration errors (53xxx)
-                    SqlState::DISK_FULL => (ErrorKind::SourceIoError, "PostgreSQL disk full"),
+                    SqlState::DISK_FULL => (ErrorKind::SourceIoError, "Postgres disk full"),
                     SqlState::CONFIGURATION_LIMIT_EXCEEDED => (
                         ErrorKind::SourceConfigurationLimitExceeded,
-                        "PostgreSQL configuration limit exceeded",
+                        "Postgres configuration limit exceeded",
                     ),
 
                     // Transaction state errors (25xxx)
                     SqlState::ACTIVE_SQL_TRANSACTION
                     | SqlState::NO_ACTIVE_SQL_TRANSACTION
                     | SqlState::IN_FAILED_SQL_TRANSACTION
-                    | SqlState::IDLE_IN_TRANSACTION_SESSION_TIMEOUT => (
-                        ErrorKind::InvalidState,
-                        "PostgreSQL transaction state error",
-                    ),
+                    | SqlState::IDLE_IN_TRANSACTION_SESSION_TIMEOUT => {
+                        (ErrorKind::InvalidState, "Postgres transaction state error")
+                    }
 
                     // Cursor errors (24xxx, 34xxx)
                     SqlState::INVALID_CURSOR_STATE | SqlState::INVALID_CURSOR_NAME => {
-                        (ErrorKind::InvalidState, "PostgreSQL cursor error")
+                        (ErrorKind::InvalidState, "Postgres cursor error")
                     }
 
                     // Data corruption errors (XX xxx)
                     SqlState::DATA_CORRUPTED | SqlState::INDEX_CORRUPTED => {
-                        (ErrorKind::SourceIoError, "PostgreSQL data corruption")
+                        (ErrorKind::SourceIoError, "Postgres data corruption")
                     }
 
                     // Configuration file errors (F0xxx)
                     SqlState::CONFIG_FILE_ERROR | SqlState::LOCK_FILE_EXISTS => {
-                        (ErrorKind::ConfigError, "PostgreSQL configuration error")
+                        (ErrorKind::ConfigError, "Postgres configuration error")
                     }
 
                     // Feature not supported (0Axxx)
                     SqlState::FEATURE_NOT_SUPPORTED => (
                         ErrorKind::SourceSchemaError,
-                        "PostgreSQL feature not supported",
+                        "Postgres feature not supported",
                     ),
 
                     // Invalid transaction initiation (0Bxxx)
                     SqlState::INVALID_TRANSACTION_INITIATION => (
                         ErrorKind::InvalidState,
-                        "PostgreSQL invalid transaction initiation",
+                        "Postgres invalid transaction initiation",
                     ),
 
                     // Dependent objects errors (2Bxxx)
                     SqlState::DEPENDENT_PRIVILEGE_DESCRIPTORS_STILL_EXIST
-                    | SqlState::DEPENDENT_OBJECTS_STILL_EXIST => (
-                        ErrorKind::InvalidState,
-                        "PostgreSQL dependent objects exist",
-                    ),
+                    | SqlState::DEPENDENT_OBJECTS_STILL_EXIST => {
+                        (ErrorKind::InvalidState, "Postgres dependent objects exist")
+                    }
 
                     // SQL routine errors (2Fxxx)
                     SqlState::SQL_ROUTINE_EXCEPTION
@@ -545,7 +536,7 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::S_R_E_MODIFYING_SQL_DATA_NOT_PERMITTED
                     | SqlState::S_R_E_PROHIBITED_SQL_STATEMENT_ATTEMPTED
                     | SqlState::S_R_E_READING_SQL_DATA_NOT_PERMITTED => {
-                        (ErrorKind::SourceQueryFailed, "PostgreSQL routine exception")
+                        (ErrorKind::SourceQueryFailed, "Postgres routine exception")
                     }
 
                     // External routine errors (38xxx, 39xxx)
@@ -561,7 +552,7 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::E_R_I_E_SRF_PROTOCOL_VIOLATED
                     | SqlState::E_R_I_E_EVENT_TRIGGER_PROTOCOL_VIOLATED => (
                         ErrorKind::SourceQueryFailed,
-                        "PostgreSQL external routine error",
+                        "Postgres external routine error",
                     ),
 
                     // PL/pgSQL errors (P0xxx)
@@ -570,29 +561,29 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::NO_DATA_FOUND
                     | SqlState::TOO_MANY_ROWS
                     | SqlState::ASSERT_FAILURE => {
-                        (ErrorKind::SourceQueryFailed, "PostgreSQL PL/pgSQL error")
+                        (ErrorKind::SourceQueryFailed, "Postgres PL/pgSQL error")
                     }
 
                     // Foreign Data Wrapper errors (HVxxx) - connection/schema related
                     SqlState::FDW_ERROR | SqlState::FDW_UNABLE_TO_ESTABLISH_CONNECTION => (
                         ErrorKind::SourceConnectionFailed,
-                        "PostgreSQL FDW connection error",
+                        "Postgres FDW connection error",
                     ),
                     SqlState::FDW_SCHEMA_NOT_FOUND
                     | SqlState::FDW_TABLE_NOT_FOUND
                     | SqlState::FDW_COLUMN_NAME_NOT_FOUND
                     | SqlState::FDW_INVALID_COLUMN_NAME
                     | SqlState::FDW_NO_SCHEMAS => {
-                        (ErrorKind::SourceSchemaError, "PostgreSQL FDW schema error")
+                        (ErrorKind::SourceSchemaError, "Postgres FDW schema error")
                     }
                     SqlState::FDW_INVALID_DATA_TYPE
                     | SqlState::FDW_INVALID_DATA_TYPE_DESCRIPTORS
                     | SqlState::FDW_INVALID_STRING_FORMAT => {
-                        (ErrorKind::ConversionError, "PostgreSQL FDW data type error")
+                        (ErrorKind::ConversionError, "Postgres FDW data type error")
                     }
                     SqlState::FDW_OUT_OF_MEMORY => (
                         ErrorKind::SourceConnectionFailed,
-                        "PostgreSQL FDW out of memory",
+                        "Postgres FDW out of memory",
                     ),
                     SqlState::FDW_DYNAMIC_PARAMETER_VALUE_NEEDED
                     | SqlState::FDW_FUNCTION_SEQUENCE_ERROR
@@ -609,20 +600,18 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::FDW_OPTION_NAME_NOT_FOUND
                     | SqlState::FDW_REPLY_HANDLE
                     | SqlState::FDW_UNABLE_TO_CREATE_EXECUTION
-                    | SqlState::FDW_UNABLE_TO_CREATE_REPLY => (
-                        ErrorKind::SourceQueryFailed,
-                        "PostgreSQL FDW operation error",
-                    ),
+                    | SqlState::FDW_UNABLE_TO_CREATE_REPLY => {
+                        (ErrorKind::SourceQueryFailed, "Postgres FDW operation error")
+                    }
 
                     // Snapshot errors (72xxx) - important for replication consistency
-                    SqlState::SNAPSHOT_TOO_OLD => (
-                        ErrorKind::SourceSnapshotTooOld,
-                        "PostgreSQL snapshot too old",
-                    ),
+                    SqlState::SNAPSHOT_TOO_OLD => {
+                        (ErrorKind::SourceSnapshotTooOld, "Postgres snapshot too old")
+                    }
 
                     // Array errors - relevant for replication data handling
                     SqlState::ARRAY_ELEMENT_ERROR => {
-                        (ErrorKind::ConversionError, "PostgreSQL array error")
+                        (ErrorKind::ConversionError, "Postgres array error")
                     }
 
                     // XML/JSON errors that could occur during replication
@@ -648,17 +637,17 @@ impl From<tokio_postgres::Error> for EtlError {
                     | SqlState::TOO_MANY_JSON_OBJECT_MEMBERS
                     | SqlState::SQL_JSON_SCALAR_REQUIRED
                     | SqlState::SQL_JSON_ITEM_CANNOT_BE_CAST_TO_TARGET_TYPE => {
-                        (ErrorKind::ConversionError, "PostgreSQL XML/JSON error")
+                        (ErrorKind::ConversionError, "Postgres XML/JSON error")
                     }
 
                     // Default for other SQL states
-                    _ => (ErrorKind::SourceError, "PostgreSQL error"),
+                    _ => (ErrorKind::SourceError, "Postgres error"),
                 }
             }
             // No SQL state means connection issue
             None => (
                 ErrorKind::SourceConnectionFailed,
-                "PostgreSQL connection failed",
+                "Postgres connection failed",
             ),
         };
 

--- a/etl/src/lib.rs
+++ b/etl/src/lib.rs
@@ -5,13 +5,13 @@
 //! ⚠️ **Warning:** These docs are a work in progress, for this reason they may be incomplete.
 //!
 //! This crate provides a high-performance, streaming ETL (Extract, Transform, Load) system
-//! built on PostgreSQL logical replication. It enables real-time data synchronization
-//! from PostgreSQL databases to various destinations with configurable transformations
+//! built on Postgres logical replication. It enables real-time data synchronization
+//! from Postgres databases to various destinations with configurable transformations
 //! and robust error handling.
 //!
 //! # Key Features
 //!
-//! - **Real-time streaming**: Uses PostgreSQL logical replication for minimal latency
+//! - **Real-time streaming**: Uses Postgres logical replication for minimal latency
 //! - **Destination agnostic**: Implement your own custom destinations to which data will be sent
 //! - **Robust error handling**: Comprehensive error classification with retry strategies
 //! - **Concurrent processing**: Parallel table synchronization and event application for increased throughput
@@ -20,7 +20,7 @@
 //! # Core Concepts
 //!
 //! ## Pipeline
-//! A [`pipeline::Pipeline`] represents a complete ETL workflow that connects a PostgreSQL publication
+//! A [`pipeline::Pipeline`] represents a complete ETL workflow that connects a Postgres publication
 //! to a destination. It manages the replication stream, applies transformations,
 //! and handles failures gracefully.
 //!
@@ -38,7 +38,7 @@
 //!
 //! **Note:** To pause and resume a pipeline after the process is stopped, it must be able to
 //! persist data durably. The crate itself provides no durability guarantees as it only transfers
-//! data between PostgreSQL and the destination relying on the store traits to provide the required
+//! data between Postgres and the destination relying on the store traits to provide the required
 //! data when needed.
 //!
 //! ## Error Handling
@@ -57,7 +57,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     // Configure PostgreSQL connection
+//!     // Configure Postgres connection
 //!     let pg_config = PgConnectionConfig {
 //!         host: "localhost".to_string(),
 //!         port: 5432,
@@ -94,7 +94,7 @@
 //!
 //! # Feature Flags
 //!
-//! - `unknown-types-to-bytes`: Convert unknown PostgreSQL types to byte arrays (default)
+//! - `unknown-types-to-bytes`: Convert unknown Postgres types to byte arrays (default)
 //! - `test-utils`: Enable testing utilities and mock implementations  
 //! - `failpoints`: Enable fault injection for testing error scenarios
 

--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -1,6 +1,6 @@
 //! Core pipeline orchestration and execution.
 //!
-//! Contains the main [`Pipeline`] struct that coordinates PostgreSQL logical replication
+//! Contains the main [`Pipeline`] struct that coordinates Postgres logical replication
 //! with destination systems. Manages worker lifecycles, shutdown coordination, and error handling.
 
 use etl_config::shared::PipelineConfig;
@@ -39,9 +39,9 @@ enum PipelineState {
     },
 }
 
-/// Core ETL pipeline that orchestrates PostgreSQL logical replication.
+/// Core ETL pipeline that orchestrates Postgres logical replication.
 ///
-/// A [`Pipeline`] represents a complete ETL workflow connecting a PostgreSQL publication
+/// A [`Pipeline`] represents a complete ETL workflow connecting a Postgres publication
 /// to a destination through configurable transformations. It manages the replication
 /// stream, coordinates worker processes, and handles failures gracefully.
 ///
@@ -109,7 +109,7 @@ where
 
     /// Starts the pipeline and begins replication processing.
     ///
-    /// This method initializes the connection to PostgreSQL, sets up table mappings and schemas,
+    /// This method initializes the connection to Postgres, sets up table mappings and schemas,
     /// creates the worker pool for table synchronization, and starts the apply worker for
     /// processing replication stream events.
     pub async fn start(&mut self) -> EtlResult<()> {
@@ -254,7 +254,7 @@ where
 
     /// Initializes table replication states for all tables in the publication.
     ///
-    /// This private method ensures that each table in the PostgreSQL publication has
+    /// This private method ensures that each table in the Postgres publication has
     /// a corresponding replication state record. Tables without existing states are
     /// initialized to the [`TableReplicationPhase::Init`] phase.
     async fn initialize_table_states(

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -19,7 +19,7 @@ use tokio_postgres::{
 };
 use tracing::{Instrument, error, info, warn};
 
-/// Spawns a background task to monitor a PostgreSQL connection until it terminates.
+/// Spawns a background task to monitor a Postgres connection until it terminates.
 ///
 /// The task will log when the connection terminates, either successfully or with an error.
 fn spawn_postgres_connection<T>(connection: Connection<Socket, T::Stream>)
@@ -156,7 +156,7 @@ impl PgReplicationSlotTransaction {
     }
 }
 
-/// A client for interacting with PostgreSQL's logical replication features.
+/// A client for interacting with Postgres's logical replication features.
 ///
 /// This client provides methods for creating replication slots, managing transactions,
 /// and streaming changes from the database.
@@ -166,7 +166,7 @@ pub struct PgReplicationClient {
 }
 
 impl PgReplicationClient {
-    /// Establishes a connection to PostgreSQL. The connection uses TLS if configured in the
+    /// Establishes a connection to Postgres. The connection uses TLS if configured in the
     /// supplied [`PgConnectionConfig`].
     ///
     /// The connection is configured for logical replication mode
@@ -177,7 +177,7 @@ impl PgReplicationClient {
         }
     }
 
-    /// Establishes a connection to PostgreSQL without TLS encryption.
+    /// Establishes a connection to Postgres without TLS encryption.
     ///
     /// The connection is configured for logical replication mode.
     async fn connect_no_tls(pg_connection_config: PgConnectionConfig) -> EtlResult<Self> {
@@ -194,7 +194,7 @@ impl PgReplicationClient {
         })
     }
 
-    /// Establishes a TLS-encrypted connection to PostgreSQL.
+    /// Establishes a TLS-encrypted connection to Postgres.
     ///
     /// The connection is configured for logical replication mode
     async fn connect_tls(pg_connection_config: PgConnectionConfig) -> EtlResult<Self> {

--- a/etl/src/replication/mod.rs
+++ b/etl/src/replication/mod.rs
@@ -1,6 +1,6 @@
-//! PostgreSQL logical replication protocol implementation.
+//! Postgres logical replication protocol implementation.
 //!
-//! Handles the PostgreSQL logical replication protocol including slot management,
+//! Handles the Postgres logical replication protocol including slot management,
 //! streaming changes, and maintaining replication consistency.
 
 pub mod apply;

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -21,7 +21,7 @@ use crate::etl_error;
 const STATUS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 
 pin_project! {
-    /// A stream that yields rows from a PostgreSQL COPY operation.
+    /// A stream that yields rows from a Postgres COPY operation.
     ///
     /// This stream wraps a [`CopyOutStream`] and converts each row into a [`TableRow`]
     /// using the provided column schemas. The conversion process handles both text and
@@ -37,7 +37,7 @@ pin_project! {
 impl<'a> TableCopyStream<'a> {
     /// Creates a new [`TableCopyStream`] from a [`CopyOutStream`] and column schemas.
     ///
-    /// The column schemas are used to convert the raw PostgreSQL data into [`TableRow`]s.
+    /// The column schemas are used to convert the raw Postgres data into [`TableRow`]s.
     pub fn wrap(stream: CopyOutStream, column_schemas: &'a [ColumnSchema]) -> Self {
         Self {
             stream,
@@ -51,7 +51,7 @@ impl<'a> Stream for TableCopyStream<'a> {
 
     /// Polls the stream for the next converted table row with comprehensive error handling.
     ///
-    /// This method handles the complex process of converting raw PostgreSQL COPY data into
+    /// This method handles the complex process of converting raw Postgres COPY data into
     /// structured [`TableRow`] objects, with detailed error reporting for various failure modes.
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
@@ -70,7 +70,7 @@ impl<'a> Stream for TableCopyStream<'a> {
                 }
             }
             Some(Err(err)) => {
-                // PROTOCOL ERROR: PostgreSQL connection or protocol-level failure
+                // PROTOCOL ERROR: Postgres connection or protocol-level failure
                 // Convert tokio-postgres errors to ETL errors with additional context
                 Poll::Ready(Some(Err(err.into())))
             }
@@ -104,9 +104,9 @@ impl EventsStream {
         }
     }
 
-    /// Sends a status update to the PostgreSQL server.
+    /// Sends a status update to the Postgres server.
     ///
-    /// This method implements a status update logic that balances PostgreSQL's need for
+    /// This method implements a status update logic that balances Postgres's need for
     /// progress information with network efficiency and system performance. It handles multiple
     /// error scenarios and edge cases related to time synchronization and network communication.
     pub async fn send_status_update(

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -52,7 +52,7 @@ pub enum TableSyncResult {
 /// Starts table synchronization for a specific table.
 ///
 /// This function performs the initial data copy for a table from the source
-/// PostgreSQL database to the destination. It handles the complete sync process
+/// Postgres database to the destination. It handles the complete sync process
 /// including data copying, state management, and coordination with the apply worker.
 #[expect(clippy::too_many_arguments)]
 pub async fn start_table_sync<S, D>(

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -20,7 +20,7 @@ struct Inner {
     /// table state evolution. Entries are chronologically ordered.
     table_state_history: HashMap<TableId, Vec<TableReplicationPhase>>,
     /// Cached table schema definitions, reference-counted for efficient sharing.
-    /// Schemas are expensive to fetch from PostgreSQL, so they're cached here
+    /// Schemas are expensive to fetch from Postgres, so they're cached here
     /// once retrieved and shared via Arc across the application.
     table_schemas: HashMap<TableId, Arc<TableSchema>>,
     /// Mapping from table IDs to human-readable table names for easier debugging

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -18,10 +18,10 @@ use crate::{bail, etl_error};
 
 const NUM_POOL_CONNECTIONS: u32 = 1;
 
-/// Converts ETL table replication phases to PostgreSQL database state format.
+/// Converts ETL table replication phases to Postgres database state format.
 ///
 /// This conversion transforms internal ETL replication states into the format
-/// used by the PostgreSQL state store for persistence. It handles all phase
+/// used by the Postgres state store for persistence. It handles all phase
 /// types except in-memory phases that cannot be persisted.
 impl TryFrom<TableReplicationPhase> for state::TableReplicationState {
     type Error = EtlError;
@@ -66,7 +66,7 @@ impl TryFrom<TableReplicationPhase> for state::TableReplicationState {
     }
 }
 
-/// Converts PostgreSQL state rows back to ETL table replication phases.
+/// Converts Postgres state rows back to ETL table replication phases.
 ///
 /// This conversion transforms persisted database state into internal ETL
 /// replication phase representations. It deserializes metadata from the
@@ -152,11 +152,11 @@ impl Inner {
     }
 }
 
-/// PostgreSQL-backed storage for ETL pipeline state and schema information.
+/// Postgres-backed storage for ETL pipeline state and schema information.
 ///
 /// [`PostgresStore`] implements both [`StateStore`] and [`SchemaStore`] traits,
 /// providing persistent storage of replication state and schema information
-/// directly in the source PostgreSQL database. This ensures durability and
+/// directly in the source Postgres database. This ensures durability and
 /// consistency of the pipeline state across restarts.
 ///
 /// The store maintains both in-memory cache and persistent database storage,
@@ -170,10 +170,10 @@ pub struct PostgresStore {
 }
 
 impl PostgresStore {
-    /// Creates a new PostgreSQL-backed store for the given pipeline.
+    /// Creates a new Postgres-backed store for the given pipeline.
     ///
     /// The store will use the provided connection configuration to access
-    /// the source PostgreSQL database for persistent storage operations.
+    /// the source Postgres database for persistent storage operations.
     /// The pipeline ID ensures isolation between different pipeline instances.
     pub fn new(pipeline_id: PipelineId, source_config: PgConnectionConfig) -> Self {
         let inner = Inner {
@@ -190,7 +190,7 @@ impl PostgresStore {
         }
     }
 
-    /// Establishes a connection to the source PostgreSQL database.
+    /// Establishes a connection to the source Postgres database.
     ///
     /// This method creates a new connection pool each time it's called rather
     /// than maintaining persistent connections. This approach trades connection
@@ -247,7 +247,7 @@ impl StateStore for PostgresStore {
         Ok(inner.table_states.clone())
     }
 
-    /// Loads table replication states from PostgreSQL into memory cache.
+    /// Loads table replication states from Postgres into memory cache.
     ///
     /// This method connects to the source database, retrieves all table
     /// replication state rows for this pipeline, deserializes the state
@@ -401,7 +401,7 @@ impl StateStore for PostgresStore {
         Ok(inner.table_mappings.clone())
     }
 
-    /// Loads table mappings from PostgreSQL into memory cache.
+    /// Loads table mappings from Postgres into memory cache.
     ///
     /// This method connects to the source database, retrieves all table mapping
     /// definitions for this pipeline, and populates the in-memory cache.
@@ -498,7 +498,7 @@ impl SchemaStore for PostgresStore {
         Ok(inner.table_schemas.values().cloned().collect())
     }
 
-    /// Loads table schemas from PostgreSQL into memory cache.
+    /// Loads table schemas from Postgres into memory cache.
     ///
     /// This method connects to the source database, retrieves schema information
     /// for all tables in this pipeline, and populates the in-memory cache.

--- a/etl/src/test_utils/database.rs
+++ b/etl/src/test_utils/database.rs
@@ -23,9 +23,9 @@ pub fn test_table_name(name: &str) -> TableName {
     }
 }
 
-/// Generates PostgreSQL connection configuration for isolated test databases.
+/// Generates Postgres connection configuration for isolated test databases.
 ///
-/// This function creates connection parameters for a local PostgreSQL instance with
+/// This function creates connection parameters for a local Postgres instance with
 /// test-specific settings designed for isolation, reproducibility, and ease of debugging.
 /// Each invocation creates a unique database name to prevent test interference.
 fn local_pg_connection_config() -> PgConnectionConfig {
@@ -46,7 +46,7 @@ fn local_pg_connection_config() -> PgConnectionConfig {
 
 /// Creates a new test database instance with a unique name.
 ///
-/// This function spawns a new PostgreSQL database with a random UUID as its name,
+/// This function spawns a new Postgres database with a random UUID as its name,
 /// using default credentials and disabled SSL. It automatically creates the test schema
 /// for organizing test tables.
 ///
@@ -72,7 +72,7 @@ pub async fn spawn_source_database() -> PgDatabase<Client> {
 
 /// Creates a new test database instance with a unique name and all the ETL migrations run.
 ///
-/// This function spawns a new PostgreSQL database with a random UUID as its name,
+/// This function spawns a new Postgres database with a random UUID as its name,
 /// using default credentials and disabled SSL. It automatically creates the test schema
 /// for organizing test tables.
 ///

--- a/etl/src/test_utils/mod.rs
+++ b/etl/src/test_utils/mod.rs
@@ -1,6 +1,6 @@
-//! Testing utilities for PostgreSQL logical replication systems.
+//! Testing utilities for Postgres logical replication systems.
 //!
-//! Provides a complete testing framework for complex ETL scenarios involving PostgreSQL logical replication,
+//! Provides a complete testing framework for complex ETL scenarios involving Postgres logical replication,
 //! multiple workers, and various destination systems. Handles test database setup, replication slot management,
 //! worker lifecycle coordination, and data consistency validation.
 

--- a/etl/src/types/mod.rs
+++ b/etl/src/types/mod.rs
@@ -1,7 +1,7 @@
 //! Common types used throughout the ETL system.
 //!
 //! Re-exports core data types, event types, and schema definitions used across the ETL pipeline.
-//! Includes PostgreSQL-specific types, replication events, and table structures.
+//! Includes Postgres-specific types, replication events, and table structures.
 
 mod pipeline;
 

--- a/etl/src/utils/tokio.rs
+++ b/etl/src/utils/tokio.rs
@@ -1,6 +1,6 @@
 // This code is copied from the tokio-postgres-rustls library (https://github.com/jbg/tokio-postgres-rustls),
 // available under the MIT License, which provides Rustls-based TLS support for secure asynchronous
-// PostgreSQL connections using the tokio-postgres client.
+// Postgres connections using the tokio-postgres client.
 
 use const_oid::db::{
     rfc5912::{
@@ -24,7 +24,7 @@ use x509_cert::{TbsCertificate, der::Decode};
 
 /// A `MakeTlsConnect` implementation using `rustls`.
 ///
-/// That way you can connect to PostgreSQL using `rustls` as the TLS stack.
+/// That way you can connect to Postgres using `rustls` as the TLS stack.
 #[derive(Clone)]
 pub struct MakeRustlsConnect {
     config: Arc<ClientConfig>,

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -68,7 +68,7 @@ impl WorkerHandle<()> for ApplyWorkerHandle {
 
 /// Worker that applies replication stream events to destinations.
 ///
-/// [`ApplyWorker`] is the core worker responsible for processing PostgreSQL logical
+/// [`ApplyWorker`] is the core worker responsible for processing Postgres logical
 /// replication events and applying them to the configured destination. It coordinates
 /// with table sync workers during initial synchronization and handles the continuous
 /// replication stream during normal operation.
@@ -90,7 +90,7 @@ pub struct ApplyWorker<S, D> {
 impl<S, D> ApplyWorker<S, D> {
     /// Creates a new apply worker with the given configuration and dependencies.
     ///
-    /// The worker will use the provided replication client to read the PostgreSQL
+    /// The worker will use the provided replication client to read the Postgres
     /// replication stream and coordinate with the table sync worker pool for
     /// initial synchronization operations.
     #[expect(clippy::too_many_arguments)]
@@ -182,7 +182,7 @@ where
 /// Determines the LSN position from which the apply worker should start reading the replication stream.
 ///
 /// This function implements critical replication consistency logic by managing the apply worker's
-/// replication slot. The slot serves as a persistent marker in PostgreSQL's WAL (Write-Ahead Log)
+/// replication slot. The slot serves as a persistent marker in Postgres's WAL (Write-Ahead Log)
 /// that tracks the apply worker's progress and prevents WAL deletion of unreplicated data.
 async fn get_start_lsn(
     pipeline_id: PipelineId,

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -327,7 +327,7 @@ impl WorkerHandle<TableSyncWorkerState> for TableSyncWorkerHandle {
     }
 }
 
-/// Worker responsible for synchronizing individual tables from PostgreSQL to destinations.
+/// Worker responsible for synchronizing individual tables from Postgres to destinations.
 ///
 /// [`TableSyncWorker`] handles the complete lifecycle of table synchronization, including
 /// initial data copying, incremental catchup, and coordination with apply workers. Each

--- a/etl/tests/integration/replica_identity.rs
+++ b/etl/tests/integration/replica_identity.rs
@@ -68,7 +68,7 @@ impl FromTableRow for ToastTable {
 
 /// Generates a string of random ASCII printable characters of the specified length.
 /// This is useful for creating large text values that won't compress well,
-/// ensuring they trigger PostgreSQL's TOAST storage mechanism.
+/// ensuring they trigger Postgres's TOAST storage mechanism.
 fn generate_random_ascii_string(length: usize) -> String {
     let rng = rand::rng();
     rng.sample_iter(Alphanumeric)
@@ -81,7 +81,7 @@ const LARGE_TEXT_SIZE_BYTES: usize = 8192;
 
 /// Tests that TOAST values are replaced with default values when updating non-TOAST columns
 /// with default replica identity. When a table uses default replica identity (primary key)
-/// and non-TOAST columns are updated, PostgreSQL sends UnchangedToast for TOAST values.
+/// and non-TOAST columns are updated, Postgres sends UnchangedToast for TOAST values.
 /// We send a default to the destination for the missing values .
 #[tokio::test(flavor = "multi_thread")]
 async fn update_non_toast_values_with_default_replica_identity() {
@@ -147,7 +147,7 @@ async fn update_non_toast_values_with_default_replica_identity() {
     table_sync_done_notification.notified().await;
 
     // Insert a row with a large text value that will be TOASTed
-    // PostgreSQL typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
+    // Postgres typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
     let large_text_value = generate_random_ascii_string(LARGE_TEXT_SIZE_BYTES);
     let initial_int_value = 100;
 
@@ -175,7 +175,7 @@ async fn update_non_toast_values_with_default_replica_identity() {
     assert_eq!(parsed_table_rows, vec![expected_initial_row]);
 
     // Now update only the small_int column, leaving the large_text unchanged
-    // This should trigger TOAST behavior where PostgreSQL sends UnchangedToast
+    // This should trigger TOAST behavior where Postgres sends UnchangedToast
     // for the large_text column
     let updated_int_value = 200;
 
@@ -203,7 +203,7 @@ async fn update_non_toast_values_with_default_replica_identity() {
 }
 
 /// Tests that TOAST values are preserved when updating non-TOAST columns with full replica identity.
-/// When a table uses full replica identity and non-TOAST columns are updated, PostgreSQL includes
+/// When a table uses full replica identity and non-TOAST columns are updated, Postgres includes
 /// all column values in the update event. We send these values to the destination.
 #[tokio::test(flavor = "multi_thread")]
 async fn update_non_toast_values_with_full_replica_identity() {
@@ -279,7 +279,7 @@ async fn update_non_toast_values_with_full_replica_identity() {
     table_sync_done_notification.notified().await;
 
     // Insert a row with a large text value that will be TOASTed
-    // PostgreSQL typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
+    // Postgres typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
     let large_text_value = generate_random_ascii_string(LARGE_TEXT_SIZE_BYTES);
     let initial_int_value = 100;
 
@@ -307,7 +307,7 @@ async fn update_non_toast_values_with_full_replica_identity() {
     assert_eq!(parsed_table_rows, vec![expected_initial_row]);
 
     // Now update only the small_int column, leaving the large_text unchanged
-    // This should trigger TOAST behavior where PostgreSQL sends UnchangedToast
+    // This should trigger TOAST behavior where Postgres sends UnchangedToast
     // for the large_text column
     let updated_int_value = 200;
 
@@ -335,7 +335,7 @@ async fn update_non_toast_values_with_full_replica_identity() {
 }
 
 /// Tests that TOAST values are correctly updated when directly modifying TOAST columns
-/// with default replica identity. When updating the TOAST column itself, PostgreSQL
+/// with default replica identity. When updating the TOAST column itself, Postgres
 /// sends the new value regardless of replica identity settings, ensuring the destination
 /// receives and applies the updated TOAST data correctly.
 #[tokio::test(flavor = "multi_thread")]
@@ -402,7 +402,7 @@ async fn update_toast_values_with_default_replica_identity() {
     table_sync_done_notification.notified().await;
 
     // Insert a row with a large text value that will be TOASTed
-    // PostgreSQL typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
+    // Postgres typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
     let large_text_value = generate_random_ascii_string(LARGE_TEXT_SIZE_BYTES);
     let initial_int_value = 100;
 
@@ -457,9 +457,9 @@ async fn update_toast_values_with_default_replica_identity() {
     pipeline.shutdown_and_wait().await.unwrap();
 }
 
-/// Tests that PostgreSQL rejects update operations when replica identity is set to none.
+/// Tests that Postgres rejects update operations when replica identity is set to none.
 /// When a table has replica identity none and is part of a publication that publishes updates,
-/// PostgreSQL will reject update operations because it cannot identify which row to update
+/// Postgres will reject update operations because it cannot identify which row to update
 /// without sufficient replica identity information.
 #[tokio::test(flavor = "multi_thread")]
 async fn update_non_toast_values_with_none_replica_identity() {
@@ -497,7 +497,7 @@ async fn update_non_toast_values_with_none_replica_identity() {
         .await
         .unwrap();
 
-    // Set replica identity on the table to none to test that PostgreSQL rejects
+    // Set replica identity on the table to none to test that Postgres rejects
     // update operations when there's insufficient replica identity information
     database
         .alter_table(
@@ -535,7 +535,7 @@ async fn update_non_toast_values_with_none_replica_identity() {
     table_sync_done_notification.notified().await;
 
     // Insert a row with a large text value that will be TOASTed
-    // PostgreSQL typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
+    // Postgres typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
     let large_text_value = generate_random_ascii_string(LARGE_TEXT_SIZE_BYTES);
     let initial_int_value = 100;
 
@@ -563,7 +563,7 @@ async fn update_non_toast_values_with_none_replica_identity() {
     assert_eq!(parsed_table_rows, vec![expected_initial_row]);
 
     // Now attempt to update only the small_int column
-    // With replica identity NONE, PostgreSQL should reject the update operation
+    // With replica identity NONE, Postgres should reject the update operation
     // because the table does not have sufficient replica identity information for updates
     let updated_int_value = 200;
 
@@ -595,7 +595,7 @@ async fn update_non_toast_values_with_none_replica_identity() {
 
 /// Tests that TOAST values are replaced with default values when the table uses
 /// replica identity with a unique index that includes columns being updated.
-/// When updating columns that are part of the replica identity index, PostgreSQL sends
+/// When updating columns that are part of the replica identity index, Postgres sends
 /// UnchangedToast for large TOAST values. We send a default to the destination for the
 /// missing values .
 #[tokio::test(flavor = "multi_thread")]
@@ -681,7 +681,7 @@ async fn update_non_toast_values_with_unique_index_replica_identity() {
     table_sync_done_notification.notified().await;
 
     // Insert a row with a large text value that will be TOASTed
-    // PostgreSQL typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
+    // Postgres typically TOASTs values larger than ~2KB (TOAST_TUPLE_THRESHOLD)
     let large_text_size_bytes = 8192;
     let large_text_value = generate_random_ascii_string(large_text_size_bytes);
     let initial_int_value = 100;
@@ -710,7 +710,7 @@ async fn update_non_toast_values_with_unique_index_replica_identity() {
     assert_eq!(parsed_table_rows[0], expected_initial_row);
 
     // Now update the small_int column, which is part of the unique index used for replica identity
-    // This should trigger TOAST behavior where PostgreSQL sends UnchangedToast
+    // This should trigger TOAST behavior where Postgres sends UnchangedToast
     // for the large_text column, since the replica identity includes the column being updated
     let updated_int_value = 200;
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -14,7 +14,7 @@ nav:
       - Custom Stores and Destinations: tutorials/custom-implementations.md
   - How-to Guides:
       - Overview: how-to/index.md
-      - Configure PostgreSQL: how-to/configure-postgres.md
+      - Configure Postgres: how-to/configure-postgres.md
   - Reference:
       - Overview: reference/index.md
   - Explanation:

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -52,7 +52,7 @@ fi
 
 # Check if psql is installed
 if ! [ -x "$(command -v psql)" ]; then
-  echo >&2 "❌ Error: PostgreSQL client (psql) is not installed."
+  echo >&2 "❌ Error: Postgres client (psql) is not installed."
   echo >&2 "Please install it using your system's package manager."
   exit 1
 fi

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -8,7 +8,7 @@ if [ ! -d "etl-api/migrations" ]; then
 fi
 
 if ! [ -x "$(command -v psql)" ]; then
-  echo >&2 "❌ Error: PostgreSQL client (psql) is not installed."
+  echo >&2 "❌ Error: Postgres client (psql) is not installed."
   echo >&2 "Please install it using your system's package manager."
   exit 1
 fi
@@ -37,9 +37,9 @@ then
   echo "🐳 Checking Docker container status..."
   RUNNING_POSTGRES_CONTAINER_ID=$(docker ps --filter 'name=postgres' --format '{{.ID}}')
   if [[ -n $RUNNING_POSTGRES_CONTAINER_ID ]]; then
-    echo "✅ PostgreSQL container is already running"
+    echo "✅ Postgres container is already running"
   else
-    echo "🚀 Starting new PostgreSQL container..."
+    echo "🚀 Starting new Postgres container..."
     
     # Prepare docker run command
     DOCKER_RUN_CMD="docker run \
@@ -54,13 +54,13 @@ then
       echo "📁 Setting up persistent storage at ${POSTGRES_DATA_VOLUME}"
       mkdir -p "${POSTGRES_DATA_VOLUME}"
       DOCKER_RUN_CMD="${DOCKER_RUN_CMD} \
-        -v "${POSTGRES_DATA_VOLUME}":/var/lib/postgresql/data"
+        -v "${POSTGRES_DATA_VOLUME}":/var/lib/Postgres/data"
     else
       echo "📁 No storage path specified, using default Docker volume"
     fi
 
     # Complete the docker run command
-    # Increased PostgreSQL settings for logical replication for tests to run smoothly
+    # Increased Postgres settings for logical replication for tests to run smoothly
     DOCKER_RUN_CMD="${DOCKER_RUN_CMD} \
         --name "postgres_$(date '+%s')" \
         postgres:15 -N 1000 \
@@ -70,18 +70,18 @@ then
 
     # Start the container
     eval "${DOCKER_RUN_CMD}"
-    echo "✅ PostgreSQL container started"
+    echo "✅ Postgres container started"
   fi
 fi
 
-# Wait for PostgreSQL to be ready
-echo "⏳ Waiting for PostgreSQL to be ready..."
+# Wait for Postgres to be ready
+echo "⏳ Waiting for Postgres to be ready..."
 until PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -U "${DB_USER}" -p "${DB_PORT}" -d "postgres" -c '\q'; do
-  echo "⏳ PostgreSQL is still starting up... waiting"
+  echo "⏳ Postgres is still starting up... waiting"
   sleep 1
 done
 
-echo "✅ PostgreSQL is up and running on port ${DB_PORT}"
+echo "✅ Postgres is up and running on port ${DB_PORT}"
 
 # Set up the database
 echo "🔄 Setting up the database..."

--- a/scripts/prepare_tpcc.sh
+++ b/scripts/prepare_tpcc.sh
@@ -11,7 +11,7 @@ fi
 
 # Check if psql is installed
 if ! [ -x "$(command -v psql)" ]; then
-  echo >&2 "❌ Error: PostgreSQL client (psql) is not installed."
+  echo >&2 "❌ Error: Postgres client (psql) is not installed."
   echo >&2 "Please install it using your system's package manager."
   exit 1
 fi
@@ -32,14 +32,14 @@ echo "   User: ${DB_USER}"
 echo "   Warehouses: ${WAREHOUSES}"
 echo "   Threads: ${THREADS}"
 
-# Wait for PostgreSQL to be ready
-echo "⏳ Waiting for PostgreSQL to be ready..."
+# Wait for Postgres to be ready
+echo "⏳ Waiting for Postgres to be ready..."
 until PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -U "${DB_USER}" -p "${DB_PORT}" -d "postgres" -c '\q'; do
-  echo "⏳ PostgreSQL is still starting up... waiting"
+  echo "⏳ Postgres is still starting up... waiting"
   sleep 1
 done
 
-echo "✅ PostgreSQL is up and running on port ${DB_PORT}"
+echo "✅ Postgres is up and running on port ${DB_PORT}"
 
 # Create the database if it doesn't exist
 echo "🔄 Ensuring database '${DB_NAME}' exists..."


### PR DESCRIPTION
Supabase uses `Postgres` instead of `PostgreSQL` in docs (see [this](https://supabase.com/docs/guides/database/overview#postgres-or-postgresql)). This PR replaces the former with the latter.