### PR TITLE
fix(bigquery): Allow missing table schema when truncate is issued

### DIFF
--- a/etl/src/failpoints.rs
+++ b/etl/src/failpoints.rs
@@ -8,7 +8,8 @@ use fail::fail_point;
 use crate::bail;
 use crate::error::{ErrorKind, EtlError, EtlResult};
 
-pub const START_TABLE_SYNC__AFTER_DATA_SYNC: &str = "start_table_sync.after_data_sync";
+pub const START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION: &str =
+    "start_table_sync.befor_data_sync_slot_creation";
 pub const START_TABLE_SYNC__DURING_DATA_SYNC: &str = "start_table_sync.during_data_sync";
 
 /// Executes a configurable failpoint for testing error scenarios.

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -18,7 +18,8 @@ use crate::destination::Destination;
 use crate::error::{ErrorKind, EtlError, EtlResult};
 #[cfg(feature = "failpoints")]
 use crate::failpoints::{
-    START_TABLE_SYNC__AFTER_DATA_SYNC, START_TABLE_SYNC__DURING_DATA_SYNC, etl_fail_point,
+    START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION, START_TABLE_SYNC__DURING_DATA_SYNC,
+    etl_fail_point,
 };
 use crate::metrics::{
     ETL_BATCH_SEND_MILLISECONDS_TOTAL, ETL_BATCH_SIZE, ETL_TABLE_SYNC_ROWS_COPIED_TOTAL,
@@ -165,7 +166,7 @@ where
 
             // Fail point to test when the table sync fails before copying data.
             #[cfg(feature = "failpoints")]
-            etl_fail_point(START_TABLE_SYNC__AFTER_DATA_SYNC)?;
+            etl_fail_point(START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION)?;
 
             // We create the slot with a transaction, since we need to have a consistent snapshot of the database
             // before copying the schema and tables.

--- a/etl/tests/failpoints/pipeline_test.rs
+++ b/etl/tests/failpoints/pipeline_test.rs
@@ -1,6 +1,8 @@
 use etl::destination::memory::MemoryDestination;
 use etl::error::ErrorKind;
-use etl::failpoints::{START_TABLE_SYNC__AFTER_DATA_SYNC, START_TABLE_SYNC__DURING_DATA_SYNC};
+use etl::failpoints::{
+    START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION, START_TABLE_SYNC__DURING_DATA_SYNC,
+};
 use etl::state::table::TableReplicationPhaseType;
 use etl::test_utils::database::spawn_source_database;
 use etl::test_utils::notify::NotifyingStore;
@@ -15,7 +17,11 @@ use rand::random;
 #[tokio::test(flavor = "multi_thread")]
 async fn table_copy_fails_after_data_sync_threw_an_error_with_no_retry() {
     let _scenario = FailScenario::setup();
-    fail::cfg(START_TABLE_SYNC__AFTER_DATA_SYNC, "1*return(no_retry)").unwrap();
+    fail::cfg(
+        START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION,
+        "1*return(no_retry)",
+    )
+    .unwrap();
 
     init_test_tracing();
 
@@ -73,7 +79,11 @@ async fn table_copy_fails_after_data_sync_threw_an_error_with_no_retry() {
 #[tokio::test(flavor = "multi_thread")]
 async fn table_copy_is_consistent_after_data_sync_threw_an_error_with_timed_retry() {
     let _scenario = FailScenario::setup();
-    fail::cfg(START_TABLE_SYNC__AFTER_DATA_SYNC, "1*return(timed_retry)").unwrap();
+    fail::cfg(
+        START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION,
+        "1*return(timed_retry)",
+    )
+    .unwrap();
 
     init_test_tracing();
 


### PR DESCRIPTION
This PR implements a fix for the BigQuery destination in which the system was throwing an error during truncation of a single table when a failure occurred during table copy but before the schema of a table was actually loaded.