### PR TITLE
fix(replication): Fix apply loop event conversion ordering

### DIFF
--- a/etl-postgres/src/tokio/test_utils.rs
+++ b/etl-postgres/src/tokio/test_utils.rs
@@ -74,13 +74,9 @@ impl<G: GenericClient> PgDatabase<G> {
         let create_publication_query = match schema {
             Some(schema_name) => format!(
                 "create publication {} for tables in schema {}",
-                publication_name,
-                schema_name
+                publication_name, schema_name
             ),
-            None => format!(
-                "create publication {} for all tables",
-                publication_name
-            ),
+            None => format!("create publication {} for all tables", publication_name),
         };
 
         self.client

--- a/etl-postgres/src/tokio/test_utils.rs
+++ b/etl-postgres/src/tokio/test_utils.rs
@@ -66,6 +66,32 @@ impl<G: GenericClient> PgDatabase<G> {
         Ok(())
     }
 
+    pub async fn create_publication_for_all(
+        &self,
+        publication_name: &str,
+        schema: Option<&str>,
+    ) -> Result<(), tokio_postgres::Error> {
+        let create_publication_query = match schema {
+            Some(schema_name) => format!(
+                "create publication {} for tables in schema {}",
+                publication_name,
+                schema_name
+            ),
+            None => format!(
+                "create publication {} for all tables",
+                publication_name
+            ),
+        };
+
+        self.client
+            .as_ref()
+            .unwrap()
+            .execute(&create_publication_query, &[])
+            .await?;
+
+        Ok(())
+    }
+
     /// Creates a new table with the given name and column definitions.
     ///
     /// Optionally adds a primary key column named `id` of type `bigserial`.

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -3,7 +3,6 @@ use etl_postgres::types::{
     ColumnSchema, TableId, TableName, TableSchema, convert_type_oid_to_type,
 };
 use postgres_replication::protocol;
-use postgres_replication::protocol::LogicalReplicationMessage;
 use std::sync::Arc;
 use tokio_postgres::types::PgLsn;
 
@@ -12,37 +11,16 @@ use crate::error::EtlError;
 use crate::error::{ErrorKind, EtlResult};
 use crate::store::schema::SchemaStore;
 use crate::types::{
-    BeginEvent, Cell, CommitEvent, DeleteEvent, Event, InsertEvent, RelationEvent, TableRow,
+    BeginEvent, Cell, CommitEvent, DeleteEvent, InsertEvent, RelationEvent, TableRow,
     TruncateEvent, UpdateEvent,
 };
 use crate::{bail, etl_error};
-
-/// Retrieves a table schema from the schema store by table ID.
-///
-/// This function looks up the table schema for the specified table ID in the
-/// schema store. If the schema is not found, it returns an error indicating
-/// that the table is missing from the cache.
-async fn get_table_schema<S>(schema_store: &S, table_id: TableId) -> EtlResult<Arc<TableSchema>>
-where
-    S: SchemaStore,
-{
-    schema_store
-        .get_table_schema(&table_id)
-        .await?
-        .ok_or_else(|| {
-            etl_error!(
-                ErrorKind::MissingTableSchema,
-                "Table not found in the schema cache",
-                format!("The table schema for table {table_id} was not found in the cache")
-            )
-        })
-}
 
 /// Creates a [`BeginEvent`] from Postgres protocol data.
 ///
 /// This method parses the replication protocol begin message and extracts
 /// transaction metadata for use in the ETL pipeline.
-fn begin_event_from_protocol(
+pub fn begin_event_from_protocol(
     start_lsn: PgLsn,
     commit_lsn: PgLsn,
     begin_body: &protocol::BeginBody,
@@ -59,7 +37,7 @@ fn begin_event_from_protocol(
 ///
 /// This method parses the replication protocol commit message and extracts
 /// transaction completion metadata for use in the ETL pipeline.
-fn commit_event_from_protocol(
+pub fn commit_event_from_protocol(
     start_lsn: PgLsn,
     commit_lsn: PgLsn,
     commit_body: &protocol::CommitBody,
@@ -104,6 +82,169 @@ pub fn relation_event_from_protocol(
     })
 }
 
+/// Creates a [`TruncateEvent`] from Postgres protocol data.
+///
+/// This method parses the replication protocol truncate message and extracts
+/// information about which tables were truncated and with what options.
+pub fn truncate_event_from_protocol(
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
+    truncate_body: &protocol::TruncateBody,
+    overridden_rel_ids: Vec<u32>,
+) -> TruncateEvent {
+    TruncateEvent {
+        start_lsn,
+        commit_lsn,
+        options: truncate_body.options(),
+        rel_ids: overridden_rel_ids,
+    }
+}
+
+/// Converts a Postgres insert message into an [`InsertEvent`].
+///
+/// This function processes an insert operation from the replication stream,
+/// retrieves the table schema from the store, and constructs a complete
+/// insert event with the new row data ready for ETL processing.
+pub async fn insert_event_from_protocol<S>(
+    schema_store: &S,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
+    insert_body: &protocol::InsertBody,
+) -> EtlResult<InsertEvent>
+where
+    S: SchemaStore,
+{
+    let table_id = insert_body.rel_id();
+    let table_schema = get_table_schema(schema_store, TableId::new(table_id)).await?;
+
+    let table_row = convert_tuple_to_row(
+        &table_schema.column_schemas,
+        insert_body.tuple().tuple_data(),
+        &mut None,
+        false,
+    )?;
+
+    Ok(InsertEvent {
+        start_lsn,
+        commit_lsn,
+        table_id: TableId::new(table_id),
+        table_row,
+    })
+}
+
+/// Converts a Postgres update message into an [`UpdateEvent`].
+///
+/// This function processes an update operation from the replication stream,
+/// handling both the old and new row data. The old row data may be either
+/// the complete row or just the key columns, depending on the table's
+/// `REPLICA IDENTITY` setting in Postgres.
+pub async fn update_event_from_protocol<S>(
+    schema_store: &S,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
+    update_body: &protocol::UpdateBody,
+) -> EtlResult<UpdateEvent>
+where
+    S: SchemaStore,
+{
+    let table_id = update_body.rel_id();
+    let table_schema = get_table_schema(schema_store, TableId::new(table_id)).await?;
+
+    // We try to extract the old tuple by either taking the entire old tuple or the key of the old
+    // tuple.
+    let is_key = update_body.old_tuple().is_none();
+    let old_tuple = update_body.old_tuple().or(update_body.key_tuple());
+    let old_table_row = match old_tuple {
+        Some(identity) => Some(convert_tuple_to_row(
+            &table_schema.column_schemas,
+            identity.tuple_data(),
+            &mut None,
+            true,
+        )?),
+        None => None,
+    };
+
+    let mut old_table_row_mut = old_table_row;
+    let table_row = convert_tuple_to_row(
+        &table_schema.column_schemas,
+        update_body.new_tuple().tuple_data(),
+        &mut old_table_row_mut,
+        false,
+    )?;
+
+    let old_table_row = old_table_row_mut.map(|row| (is_key, row));
+
+    Ok(UpdateEvent {
+        start_lsn,
+        commit_lsn,
+        table_id: TableId::new(table_id),
+        table_row,
+        old_table_row,
+    })
+}
+
+/// Converts a Postgres delete message into a [`DeleteEvent`].
+///
+/// This function processes a delete operation from the replication stream,
+/// extracting the old row data that was deleted. The old row data may be
+/// either the complete row or just the key columns, depending on the table's
+/// `REPLICA IDENTITY` setting in Postgres.
+pub async fn delete_event_from_protocol<S>(
+    schema_store: &S,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
+    delete_body: &protocol::DeleteBody,
+) -> EtlResult<DeleteEvent>
+where
+    S: SchemaStore,
+{
+    let table_id = delete_body.rel_id();
+    let table_schema = get_table_schema(schema_store, TableId::new(table_id)).await?;
+
+    // We try to extract the old tuple by either taking the entire old tuple or the key of the old
+    // tuple.
+    let is_key = delete_body.old_tuple().is_none();
+    let old_tuple = delete_body.old_tuple().or(delete_body.key_tuple());
+    let old_table_row = match old_tuple {
+        Some(identity) => Some(convert_tuple_to_row(
+            &table_schema.column_schemas,
+            identity.tuple_data(),
+            &mut None,
+            true,
+        )?),
+        None => None,
+    }
+    .map(|row| (is_key, row));
+
+    Ok(DeleteEvent {
+        start_lsn,
+        commit_lsn,
+        table_id: TableId::new(table_id),
+        old_table_row,
+    })
+}
+
+/// Retrieves a table schema from the schema store by table ID.
+///
+/// This function looks up the table schema for the specified table ID in the
+/// schema store. If the schema is not found, it returns an error indicating
+/// that the table is missing from the cache.
+async fn get_table_schema<S>(schema_store: &S, table_id: TableId) -> EtlResult<Arc<TableSchema>>
+where
+    S: SchemaStore,
+{
+    schema_store
+        .get_table_schema(&table_id)
+        .await?
+        .ok_or_else(|| {
+            etl_error!(
+                ErrorKind::MissingTableSchema,
+                "Table not found in the schema cache",
+                format!("The table schema for table {table_id} was not found in the cache")
+            )
+        })
+}
+
 /// Constructs a [`ColumnSchema`] from Postgres protocol column data.
 ///
 /// This helper method extracts column metadata from the replication protocol
@@ -123,23 +264,6 @@ fn build_column_schema(column: &protocol::Column) -> EtlResult<ColumnSchema> {
     ))
 }
 
-/// Creates a [`TruncateEvent`] from Postgres protocol data.
-///
-/// This method parses the replication protocol truncate message and extracts
-/// information about which tables were truncated and with what options.
-pub fn truncate_event_from_protocol(
-    start_lsn: PgLsn,
-    commit_lsn: PgLsn,
-    truncate_body: &protocol::TruncateBody,
-) -> TruncateEvent {
-    TruncateEvent {
-        start_lsn,
-        commit_lsn,
-        options: truncate_body.options(),
-        rel_ids: truncate_body.rel_ids().to_vec(),
-    }
-}
-
 /// Converts Postgres tuple data into a [`TableRow`] using column schemas.
 ///
 /// This function transforms raw tuple data from the replication protocol into
@@ -152,7 +276,7 @@ pub fn truncate_event_from_protocol(
 /// Panics if a required (non-nullable) column receives null data and
 /// `use_default_for_missing_cols` is false, as this indicates protocol-level
 /// corruption that should not be handled gracefully.
-fn convert_tuple_to_row(
+pub fn convert_tuple_to_row(
     column_schemas: &[ColumnSchema],
     tuple_data: &[protocol::TupleData],
     old_table_row: &mut Option<TableRow>,
@@ -217,182 +341,4 @@ fn convert_tuple_to_row(
     }
 
     Ok(TableRow { values })
-}
-
-/// Converts a Postgres insert message into an [`InsertEvent`].
-///
-/// This function processes an insert operation from the replication stream,
-/// retrieves the table schema from the store, and constructs a complete
-/// insert event with the new row data ready for ETL processing.
-async fn convert_insert_to_event<S>(
-    schema_store: &S,
-    start_lsn: PgLsn,
-    commit_lsn: PgLsn,
-    insert_body: &protocol::InsertBody,
-) -> EtlResult<InsertEvent>
-where
-    S: SchemaStore,
-{
-    let table_id = insert_body.rel_id();
-    let table_schema = get_table_schema(schema_store, TableId::new(table_id)).await?;
-
-    let table_row = convert_tuple_to_row(
-        &table_schema.column_schemas,
-        insert_body.tuple().tuple_data(),
-        &mut None,
-        false,
-    )?;
-
-    Ok(InsertEvent {
-        start_lsn,
-        commit_lsn,
-        table_id: TableId::new(table_id),
-        table_row,
-    })
-}
-
-/// Converts a Postgres update message into an [`UpdateEvent`].
-///
-/// This function processes an update operation from the replication stream,
-/// handling both the old and new row data. The old row data may be either
-/// the complete row or just the key columns, depending on the table's
-/// `REPLICA IDENTITY` setting in Postgres.
-async fn convert_update_to_event<S>(
-    schema_store: &S,
-    start_lsn: PgLsn,
-    commit_lsn: PgLsn,
-    update_body: &protocol::UpdateBody,
-) -> EtlResult<UpdateEvent>
-where
-    S: SchemaStore,
-{
-    let table_id = update_body.rel_id();
-    let table_schema = get_table_schema(schema_store, TableId::new(table_id)).await?;
-
-    // We try to extract the old tuple by either taking the entire old tuple or the key of the old
-    // tuple.
-    let is_key = update_body.old_tuple().is_none();
-    let old_tuple = update_body.old_tuple().or(update_body.key_tuple());
-    let old_table_row = match old_tuple {
-        Some(identity) => Some(convert_tuple_to_row(
-            &table_schema.column_schemas,
-            identity.tuple_data(),
-            &mut None,
-            true,
-        )?),
-        None => None,
-    };
-
-    let mut old_table_row_mut = old_table_row;
-    let table_row = convert_tuple_to_row(
-        &table_schema.column_schemas,
-        update_body.new_tuple().tuple_data(),
-        &mut old_table_row_mut,
-        false,
-    )?;
-
-    let old_table_row = old_table_row_mut.map(|row| (is_key, row));
-
-    Ok(UpdateEvent {
-        start_lsn,
-        commit_lsn,
-        table_id: TableId::new(table_id),
-        table_row,
-        old_table_row,
-    })
-}
-
-/// Converts a Postgres delete message into a [`DeleteEvent`].
-///
-/// This function processes a delete operation from the replication stream,
-/// extracting the old row data that was deleted. The old row data may be
-/// either the complete row or just the key columns, depending on the table's
-/// `REPLICA IDENTITY` setting in Postgres.
-async fn convert_delete_to_event<S>(
-    schema_store: &S,
-    start_lsn: PgLsn,
-    commit_lsn: PgLsn,
-    delete_body: &protocol::DeleteBody,
-) -> EtlResult<DeleteEvent>
-where
-    S: SchemaStore,
-{
-    let table_id = delete_body.rel_id();
-    let table_schema = get_table_schema(schema_store, TableId::new(table_id)).await?;
-
-    // We try to extract the old tuple by either taking the entire old tuple or the key of the old
-    // tuple.
-    let is_key = delete_body.old_tuple().is_none();
-    let old_tuple = delete_body.old_tuple().or(delete_body.key_tuple());
-    let old_table_row = match old_tuple {
-        Some(identity) => Some(convert_tuple_to_row(
-            &table_schema.column_schemas,
-            identity.tuple_data(),
-            &mut None,
-            true,
-        )?),
-        None => None,
-    }
-    .map(|row| (is_key, row));
-
-    Ok(DeleteEvent {
-        start_lsn,
-        commit_lsn,
-        table_id: TableId::new(table_id),
-        old_table_row,
-    })
-}
-
-/// Converts a Postgres logical replication message into an [`Event`].
-///
-/// This is the main entry point for converting raw replication protocol messages
-/// into strongly-typed events for ETL processing. It dispatches to specialized
-/// conversion functions based on the message type and handles unsupported message
-/// types by returning [`Event::Unsupported`].
-pub async fn convert_message_to_event<S>(
-    schema_store: &S,
-    start_lsn: PgLsn,
-    commit_lsn: PgLsn,
-    message: &LogicalReplicationMessage,
-) -> EtlResult<Event>
-where
-    S: SchemaStore,
-{
-    match message {
-        LogicalReplicationMessage::Begin(begin_body) => Ok(Event::Begin(
-            begin_event_from_protocol(start_lsn, commit_lsn, begin_body),
-        )),
-        LogicalReplicationMessage::Commit(commit_body) => Ok(Event::Commit(
-            commit_event_from_protocol(start_lsn, commit_lsn, commit_body),
-        )),
-        LogicalReplicationMessage::Relation(relation_body) => Ok(Event::Relation(
-            relation_event_from_protocol(start_lsn, commit_lsn, relation_body)?,
-        )),
-        LogicalReplicationMessage::Insert(insert_body) => {
-            let insert_event =
-                convert_insert_to_event(schema_store, start_lsn, commit_lsn, insert_body).await?;
-            Ok(Event::Insert(insert_event))
-        }
-        LogicalReplicationMessage::Update(update_body) => {
-            let update_event =
-                convert_update_to_event(schema_store, start_lsn, commit_lsn, update_body).await?;
-            Ok(Event::Update(update_event))
-        }
-        LogicalReplicationMessage::Delete(delete_body) => {
-            let delete_event =
-                convert_delete_to_event(schema_store, start_lsn, commit_lsn, delete_body).await?;
-            Ok(Event::Delete(delete_event))
-        }
-        LogicalReplicationMessage::Truncate(truncate_body) => Ok(Event::Truncate(
-            truncate_event_from_protocol(start_lsn, commit_lsn, truncate_body),
-        )),
-        LogicalReplicationMessage::Origin(_) | LogicalReplicationMessage::Type(_) => {
-            Ok(Event::Unsupported)
-        }
-        _ => bail!(
-            ErrorKind::ConversionError,
-            "Replication message not supported",
-            format!("The replication message {:?} is not supported", message)
-        ),
-    }
 }

--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -285,6 +285,12 @@ where
             .get_publication_table_ids(&self.config.publication_name)
             .await?;
 
+        info!(
+            "the publication '{}' contains {} tables",
+            self.config.publication_name,
+            table_ids.len()
+        );
+
         self.store.load_table_replication_states().await?;
         let states = self.store.get_table_replication_states().await?;
         for table_id in table_ids {

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -16,7 +16,11 @@ use tracing::{debug, info};
 
 use crate::concurrency::shutdown::ShutdownRx;
 use crate::concurrency::signal::SignalRx;
-use crate::conversions::event::convert_message_to_event;
+use crate::conversions::event::{
+    begin_event_from_protocol, commit_event_from_protocol, delete_event_from_protocol,
+    insert_event_from_protocol, relation_event_from_protocol, truncate_event_from_protocol,
+    update_event_from_protocol,
+};
 use crate::destination::Destination;
 use crate::error::{ErrorKind, EtlError, EtlResult};
 use crate::metrics::{
@@ -26,7 +30,7 @@ use crate::replication::client::PgReplicationClient;
 use crate::replication::stream::EventsStream;
 use crate::state::table::{RetryPolicy, TableReplicationError};
 use crate::store::schema::SchemaStore;
-use crate::types::{Event, EventType, PipelineId};
+use crate::types::{Event, PipelineId};
 use crate::{bail, etl_error};
 
 /// The amount of milliseconds that pass between one refresh and the other of the system, in case no
@@ -659,41 +663,61 @@ where
     S: SchemaStore + Clone + Send + 'static,
     T: ApplyLoopHook,
 {
-    // We perform the conversion of the message to our own event format which is used downstream
-    // by the destination.
-    //
-    // It's important to note that we use the `start_lsn` and `commit_lsn` as LSNs for tracking the
-    // position of the event in the WAL. The `start_lsn` defines total order within the WAL but with
-    // `commit_lsn` we can also encode information about the transaction order since we might have
-    // an entry with `start_lsn` greater than another but because logical replication sends transactions
-    // in the order of commit, the actual insert could happen before.
     let commit_lsn = get_commit_lsn(state, &message)?;
-    let event = convert_message_to_event(schema_store, start_lsn, commit_lsn, &message).await?;
 
-    let event_type = EventType::from(&event);
-    debug!("message converted to event type {}", event_type);
-
-    match message {
-        LogicalReplicationMessage::Begin(message) => {
-            handle_begin_message(state, event, &message).await
+    match &message {
+        LogicalReplicationMessage::Begin(begin_body) => {
+            handle_begin_message(state, start_lsn, commit_lsn, begin_body).await
         }
-        LogicalReplicationMessage::Commit(message) => {
-            handle_commit_message(state, event, &message, hook).await
+        LogicalReplicationMessage::Commit(commit_body) => {
+            handle_commit_message(state, start_lsn, commit_lsn, commit_body, hook).await
         }
-        LogicalReplicationMessage::Relation(message) => {
-            handle_relation_message(state, event, &message, schema_store, hook).await
+        LogicalReplicationMessage::Relation(relation_body) => {
+            handle_relation_message(
+                state,
+                start_lsn,
+                commit_lsn,
+                relation_body,
+                schema_store,
+                hook,
+            )
+            .await
         }
-        LogicalReplicationMessage::Insert(message) => {
-            handle_insert_message(state, event, &message, hook).await
+        LogicalReplicationMessage::Insert(insert_body) => {
+            handle_insert_message(
+                state,
+                start_lsn,
+                commit_lsn,
+                insert_body,
+                hook,
+                schema_store,
+            )
+            .await
         }
-        LogicalReplicationMessage::Update(message) => {
-            handle_update_message(state, event, &message, hook).await
+        LogicalReplicationMessage::Update(update_body) => {
+            handle_update_message(
+                state,
+                start_lsn,
+                commit_lsn,
+                update_body,
+                hook,
+                schema_store,
+            )
+            .await
         }
-        LogicalReplicationMessage::Delete(message) => {
-            handle_delete_message(state, event, &message, hook).await
+        LogicalReplicationMessage::Delete(delete_body) => {
+            handle_delete_message(
+                state,
+                start_lsn,
+                commit_lsn,
+                delete_body,
+                hook,
+                schema_store,
+            )
+            .await
         }
-        LogicalReplicationMessage::Truncate(message) => {
-            handle_truncate_message(state, event, &message, hook).await
+        LogicalReplicationMessage::Truncate(truncate_body) => {
+            handle_truncate_message(state, start_lsn, commit_lsn, truncate_body, hook).await
         }
         LogicalReplicationMessage::Origin(_) => Ok(HandleMessageResult::default()),
         LogicalReplicationMessage::Type(_) => Ok(HandleMessageResult::default()),
@@ -735,27 +759,20 @@ fn get_commit_lsn(state: &ApplyLoopState, message: &LogicalReplicationMessage) -
 /// all events within the transaction share the same commit boundary identifier.
 async fn handle_begin_message(
     state: &mut ApplyLoopState,
-    event: Event,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
     message: &protocol::BeginBody,
 ) -> EtlResult<HandleMessageResult> {
-    let EventType::Begin = event.event_type() else {
-        bail!(
-            ErrorKind::ValidationError,
-            "Invalid event",
-            format!(
-                "An invalid event {event:?} was received (expected {:?})",
-                EventType::Begin
-            )
-        );
-    };
-
     // We track the final lsn of this transaction, which should be equal to the `commit_lsn` of the
     // `Commit` message.
     let final_lsn = PgLsn::from(message.final_lsn());
     state.remote_final_lsn = Some(final_lsn);
 
+    // Convert event from the protocol message.
+    let event = begin_event_from_protocol(start_lsn, commit_lsn, message);
+
     Ok(HandleMessageResult {
-        event: Some(event),
+        event: Some(Event::Begin(event)),
         end_lsn: None,
         end_batch: None,
         table_replication_error: None,
@@ -774,24 +791,14 @@ async fn handle_begin_message(
 /// sync workers reaching their target LSN).
 async fn handle_commit_message<T>(
     state: &mut ApplyLoopState,
-    event: Event,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
     message: &protocol::CommitBody,
     hook: &T,
 ) -> EtlResult<HandleMessageResult>
 where
     T: ApplyLoopHook,
 {
-    let EventType::Commit = event.event_type() else {
-        bail!(
-            ErrorKind::ValidationError,
-            "Invalid event",
-            format!(
-                "An invalid event {event:?} was received (expected {:?})",
-                EventType::Commit
-            )
-        );
-    };
-
     // We take the LSN that belongs to the current transaction, however, if there is no
     // LSN, it means that a `Begin` message was not received before this `Commit` which means
     // we are in an inconsistent state.
@@ -806,14 +813,14 @@ where
     // If the commit lsn of the message is different from the remote final lsn, it means that the
     // transaction that was started expect a different commit lsn in the commit message. In this case,
     // we want to bail assuming we are in an inconsistent state.
-    let commit_lsn = PgLsn::from(message.commit_lsn());
-    if commit_lsn != remote_final_lsn {
+    let commit_lsn_msg = PgLsn::from(message.commit_lsn());
+    if commit_lsn_msg != remote_final_lsn {
         bail!(
             ErrorKind::ValidationError,
             "Invalid commit LSN",
             format!(
                 "Incorrect commit LSN {} in COMMIT message (expected {})",
-                commit_lsn, remote_final_lsn
+                commit_lsn_msg, remote_final_lsn
             )
         );
     }
@@ -827,8 +834,11 @@ where
     // destination.
     let continue_loop = hook.process_syncing_tables(end_lsn, false).await?;
 
+    // Convert event from the protocol message.
+    let event = commit_event_from_protocol(start_lsn, commit_lsn, message);
+
     let mut result = HandleMessageResult {
-        event: Some(event),
+        event: Some(Event::Commit(event)),
         // We mark this as the last commit end LSN since we want to be able to track from the outside
         // what was the biggest transaction boundary LSN which was successfully applied.
         //
@@ -863,7 +873,8 @@ where
 /// by failing fast on incompatible schema evolution.
 async fn handle_relation_message<S, T>(
     state: &mut ApplyLoopState,
-    event: Event,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
     message: &protocol::RelationBody,
     schema_store: &S,
     hook: &T,
@@ -872,17 +883,6 @@ where
     S: SchemaStore + Clone + Send + 'static,
     T: ApplyLoopHook,
 {
-    let Event::Relation(event) = event else {
-        bail!(
-            ErrorKind::ValidationError,
-            "Invalid event",
-            format!(
-                "An invalid event {event:?} was received (expected {:?})",
-                EventType::Relation
-            )
-        );
-    };
-
     let Some(remote_final_lsn) = state.remote_final_lsn else {
         bail!(
             ErrorKind::InvalidState,
@@ -914,6 +914,9 @@ where
                 )
             })?;
 
+    // Convert event from the protocol message.
+    let event = relation_event_from_protocol(start_lsn, commit_lsn, message)?;
+
     // We compare the table schema from the relation message with the existing schema (if any).
     // The purpose of this comparison is that we want to throw an error and stop the processing
     // of any table that incurs in a schema change after the initial table sync is performed.
@@ -941,26 +944,18 @@ where
 }
 
 /// Handles Postgres INSERT messages for row insertion events.
-async fn handle_insert_message<T>(
+async fn handle_insert_message<S, T>(
     state: &mut ApplyLoopState,
-    event: Event,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
     message: &protocol::InsertBody,
     hook: &T,
+    schema_store: &S,
 ) -> EtlResult<HandleMessageResult>
 where
+    S: SchemaStore + Clone + Send + 'static,
     T: ApplyLoopHook,
 {
-    let Event::Insert(event) = event else {
-        bail!(
-            ErrorKind::ValidationError,
-            "Invalid event",
-            format!(
-                "An invalid event {event:?} was received (expected {:?})",
-                EventType::Insert
-            )
-        );
-    };
-
     let Some(remote_final_lsn) = state.remote_final_lsn else {
         bail!(
             ErrorKind::InvalidState,
@@ -976,6 +971,9 @@ where
         return Ok(HandleMessageResult::default());
     }
 
+    // Convert event from the protocol message.
+    let event = insert_event_from_protocol(schema_store, start_lsn, commit_lsn, message).await?;
+
     Ok(HandleMessageResult {
         event: Some(Event::Insert(event)),
         end_lsn: None,
@@ -985,26 +983,18 @@ where
 }
 
 /// Handles Postgres UPDATE messages for row modification events.
-async fn handle_update_message<T>(
+async fn handle_update_message<S, T>(
     state: &mut ApplyLoopState,
-    event: Event,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
     message: &protocol::UpdateBody,
     hook: &T,
+    schema_store: &S,
 ) -> EtlResult<HandleMessageResult>
 where
+    S: SchemaStore + Clone + Send + 'static,
     T: ApplyLoopHook,
 {
-    let Event::Update(event) = event else {
-        bail!(
-            ErrorKind::ValidationError,
-            "Invalid event",
-            format!(
-                "An invalid event {event:?} was received (expected {:?})",
-                EventType::Update
-            )
-        );
-    };
-
     let Some(remote_final_lsn) = state.remote_final_lsn else {
         bail!(
             ErrorKind::InvalidState,
@@ -1020,6 +1010,9 @@ where
         return Ok(HandleMessageResult::default());
     }
 
+    // Convert event from the protocol message.
+    let event = update_event_from_protocol(schema_store, start_lsn, commit_lsn, message).await?;
+
     Ok(HandleMessageResult {
         event: Some(Event::Update(event)),
         end_lsn: None,
@@ -1029,26 +1022,18 @@ where
 }
 
 /// Handles Postgres DELETE messages for row removal events.
-async fn handle_delete_message<T>(
+async fn handle_delete_message<S, T>(
     state: &mut ApplyLoopState,
-    event: Event,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
     message: &protocol::DeleteBody,
     hook: &T,
+    schema_store: &S,
 ) -> EtlResult<HandleMessageResult>
 where
+    S: SchemaStore + Clone + Send + 'static,
     T: ApplyLoopHook,
 {
-    let Event::Delete(event) = event else {
-        bail!(
-            ErrorKind::ValidationError,
-            "Invalid event",
-            format!(
-                "An invalid event {event:?} was received (expected {:?})",
-                EventType::Delete
-            )
-        );
-    };
-
     let Some(remote_final_lsn) = state.remote_final_lsn else {
         bail!(
             ErrorKind::InvalidState,
@@ -1063,6 +1048,9 @@ where
     {
         return Ok(HandleMessageResult::default());
     }
+
+    // Convert event from the protocol message.
+    let event = delete_event_from_protocol(schema_store, start_lsn, commit_lsn, message).await?;
 
     Ok(HandleMessageResult {
         event: Some(Event::Delete(event)),
@@ -1080,24 +1068,14 @@ where
 /// it evaluates each table individually.
 async fn handle_truncate_message<T>(
     state: &mut ApplyLoopState,
-    event: Event,
+    start_lsn: PgLsn,
+    commit_lsn: PgLsn,
     message: &protocol::TruncateBody,
     hook: &T,
 ) -> EtlResult<HandleMessageResult>
 where
     T: ApplyLoopHook,
 {
-    let Event::Truncate(mut event) = event else {
-        bail!(
-            ErrorKind::ValidationError,
-            "Invalid event",
-            format!(
-                "An invalid event {event:?} was received (expected {:?})",
-                EventType::Truncate
-            )
-        );
-    };
-
     let Some(remote_final_lsn) = state.remote_final_lsn else {
         bail!(
             ErrorKind::InvalidState,
@@ -1106,6 +1084,8 @@ where
         );
     };
 
+    // We collect only the relation ids for which we are allow to apply changes, thus in this case
+    // the truncation.
     let mut rel_ids = Vec::with_capacity(message.rel_ids().len());
     for &table_id in message.rel_ids().iter() {
         if hook
@@ -1115,7 +1095,13 @@ where
             rel_ids.push(table_id)
         }
     }
-    event.rel_ids = rel_ids;
+    // If nothing to apply, skip conversion entirely
+    if rel_ids.is_empty() {
+        return Ok(HandleMessageResult::default());
+    }
+
+    // Convert event from the protocol message.
+    let event = truncate_event_from_protocol(start_lsn, commit_lsn, message, rel_ids);
 
     Ok(HandleMessageResult {
         event: Some(Event::Truncate(event)),

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -524,6 +524,13 @@ where
             None => {
                 let Some(state) = self.store.get_table_replication_state(table_id).await? else {
                     // If we don't even find the state for this table, we skip the event entirely.
+                    debug!(
+                        "table {} should apply changes in {:?}: {}",
+                        table_id,
+                        self.worker_type(),
+                        false
+                    );
+
                     return Ok(false);
                 };
 

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -537,6 +537,13 @@ where
             _ => false,
         };
 
+        debug!(
+            "table {} should apply changes in {:?}: {}",
+            table_id,
+            self.worker_type(),
+            should_apply_changes
+        );
+
         Ok(should_apply_changes)
     }
 

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -852,6 +852,13 @@ where
 
         let should_apply_changes = !is_errored && self.table_id == table_id;
 
+        debug!(
+            "table {} should apply changes in {:?}: {}",
+            table_id,
+            self.worker_type(),
+            should_apply_changes
+        );
+
         Ok(should_apply_changes)
     }
 


### PR DESCRIPTION
This PR fixes the handling of unknown tables by correctly ordering event conversion only after an event is confirmed to be processed. This doesn't apply to `Begin` and `Commit` events.

By reordering conversions, the apply loop doesn't crash anymore since it only handles tables that are present in the state and skips the others correctly. As a side effect, this PR also improves the performance of the pipeline since event conversion is now performed only when there is the guarantee that the event will be forwarded.