### PR TITLE
fix(postgres): ensure that table sync works with Postgres<=14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,15 @@ jobs:
         run: cargo clippy --all-targets --all-features --no-deps -- -D warnings
 
   test-partial:
-    name: Test Partial
+    name: Test Partial (Postgres ${{ matrix.postgres_version }})
     runs-on: ubuntu-latest
     # Run on forks.
     if: github.event.pull_request.head.repo.fork == true
     permissions:
       contents: read
+    strategy:
+      matrix:
+        postgres_version: [17, 16, 15, 14]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,7 +66,7 @@ jobs:
 
       - name: Start Docker Compose Environment
         run: |
-          docker compose -f ./scripts/docker-compose.yaml up -d
+          POSTGRES_VERSION=${{ matrix.postgres_version }} docker compose -f ./scripts/docker-compose.yaml up -d
 
       - name: Install sqlx-cli
         run: |
@@ -89,13 +92,16 @@ jobs:
             --all-features -- --skip integration::bigquery_test
 
   test-full:
-    name: Test Full
+    name: Test Full (Postgres ${{ matrix.postgres_version }})
     runs-on: ubuntu-latest
     # Run on non forks.
     if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       id-token: write
+    strategy:
+      matrix:
+        postgres_version: [17, 16, 15, 14]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -110,7 +116,7 @@ jobs:
 
       - name: Start Docker Compose Environment
         run: |
-          docker compose -f ./scripts/docker-compose.yaml up -d
+          POSTGRES_VERSION=${{ matrix.postgres_version }} docker compose -f ./scripts/docker-compose.yaml up -d
 
       - name: Install sqlx-cli
         run: |

--- a/etl-postgres/src/replication/db.rs
+++ b/etl-postgres/src/replication/db.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroI32;
+
 use etl_config::shared::{IntoConnectOptions, PgConnectionConfig};
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use thiserror::Error;
@@ -66,5 +68,109 @@ pub async fn get_table_name_from_oid(
             })
         }
         None => Err(TableLookupError::TableNotFound(table_id)),
+    }
+}
+
+/// Extracts the PostgreSQL server version from a version string.
+///
+/// This function parses version strings like "15.5 (Homebrew)" or "14.2"
+/// and converts them to the numeric format used by PostgreSQL.
+///
+/// Returns the version in the format: MAJOR * 10000 + MINOR * 100 + PATCH
+/// For example: PostgreSQL 14.2 = 140200, PostgreSQL 15.1 = 150100
+///
+/// Returns `None` if the version string cannot be parsed or results in zero.
+pub fn extract_server_version(server_version_str: impl AsRef<str>) -> Option<NonZeroI32> {
+    // Parse version string like "15.5 (Homebrew)" or "14.2"
+    let version_part = server_version_str
+        .as_ref()
+        .split_whitespace()
+        .next()
+        .unwrap_or("0.0");
+
+    let version_components: Vec<&str> = version_part.split('.').collect();
+
+    let major = version_components
+        .first()
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    let minor = version_components
+        .get(1)
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    let patch = version_components
+        .get(2)
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+
+    let version = major * 10000 + minor * 100 + patch;
+
+    NonZeroI32::new(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_server_version_basic_versions() {
+        assert_eq!(extract_server_version("15.5"), NonZeroI32::new(150500));
+        assert_eq!(extract_server_version("14.2"), NonZeroI32::new(140200));
+        assert_eq!(extract_server_version("13.0"), NonZeroI32::new(130000));
+        assert_eq!(extract_server_version("16.1"), NonZeroI32::new(160100));
+    }
+
+    #[test]
+    fn test_extract_server_version_with_suffixes() {
+        assert_eq!(
+            extract_server_version("15.5 (Homebrew)"),
+            NonZeroI32::new(150500)
+        );
+        assert_eq!(
+            extract_server_version("14.2 on x86_64-pc-linux-gnu"),
+            NonZeroI32::new(140200)
+        );
+        assert_eq!(
+            extract_server_version("13.7 (Ubuntu 13.7-1.pgdg20.04+1)"),
+            NonZeroI32::new(130700)
+        );
+        assert_eq!(
+            extract_server_version("16.0 devel"),
+            NonZeroI32::new(160000)
+        );
+    }
+
+    #[test]
+    fn test_extract_server_version_patch_versions() {
+        // Test versions with patch numbers
+        assert_eq!(extract_server_version("15.5.1"), NonZeroI32::new(150501));
+        assert_eq!(extract_server_version("14.10.3"), NonZeroI32::new(141003));
+        assert_eq!(extract_server_version("13.12.25"), NonZeroI32::new(131225));
+    }
+
+    #[test]
+    fn test_extract_server_version_invalid_inputs() {
+        // Test invalid inputs that should return None
+        assert_eq!(extract_server_version(""), None);
+        assert_eq!(extract_server_version("invalid"), None);
+        assert_eq!(extract_server_version("not.a.version"), None);
+        assert_eq!(extract_server_version("PostgreSQL"), None);
+        assert_eq!(extract_server_version("   "), None);
+    }
+
+    #[test]
+    fn test_extract_server_version_zero_versions() {
+        assert_eq!(extract_server_version("0.0.0"), None);
+        assert_eq!(extract_server_version("0.0"), None);
+    }
+
+    #[test]
+    fn test_extract_server_version_whitespace_handling() {
+        assert_eq!(extract_server_version("  15.5  "), NonZeroI32::new(150500));
+        assert_eq!(
+            extract_server_version("15.5\t(Homebrew)"),
+            NonZeroI32::new(150500)
+        );
+        assert_eq!(extract_server_version("15.5\n"), NonZeroI32::new(150500));
     }
 }

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -178,7 +178,6 @@ impl PgReplicationClient {
         }
     }
 
-
     // Convenience method to avoid having to access the client directly.
     async fn simple_query(
         &self,

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -642,7 +642,9 @@ impl PgReplicationClient {
         publication: Option<&str>,
     ) -> EtlResult<Vec<ColumnSchema>> {
         let (pub_cte, pub_pred) = if let Some(publication) = publication {
-            if let Some(server_version) = self.server_version && server_version.get() >= 150000 {
+            if let Some(server_version) = self.server_version
+                && server_version.get() >= 150000
+            {
                 (
                     format!(
                         "with pub_attrs as (

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -755,7 +755,7 @@ impl PgReplicationClient {
             let version_components: Vec<&str> = version_part.split('.').collect();
 
             let major = version_components
-                .get(0)
+                .first()
                 .and_then(|v| v.parse::<i32>().ok())
                 .unwrap_or(0);
             let minor = version_components

--- a/etl/tests/integration/pipeline_test.rs
+++ b/etl/tests/integration/pipeline_test.rs
@@ -193,7 +193,9 @@ async fn publication_changes_are_correctly_handled() {
     if let Some(server_version) = database.server_version()
         && server_version.get() <= 150000
     {
-        println!("Skipping test for PostgreSQL version <= 15");
+        println!(
+            "Skipping test for PostgreSQL version <= 15, CREATE PUBLICATION FOR TABLES IN SCHEMA is not supported"
+        );
         return;
     }
 
@@ -363,7 +365,9 @@ async fn publication_for_all_tables_in_schema_ignores_new_tables_until_restart()
     if let Some(server_version) = database.server_version()
         && server_version.get() <= 150000
     {
-        println!("Skipping test for PostgreSQL version <= 15");
+        println!(
+            "Skipping test for PostgreSQL version <= 15, CREATE PUBLICATION FOR TABLES IN SCHEMA is not supported"
+        );
         return;
     }
 

--- a/etl/tests/integration/pipeline_test.rs
+++ b/etl/tests/integration/pipeline_test.rs
@@ -190,6 +190,13 @@ async fn publication_changes_are_correctly_handled() {
     table_1_done.notified().await;
     table_2_done.notified().await;
 
+    if let Some(server_version) = database.server_version()
+        && server_version.get() <= 150000
+    {
+        println!("Skipping test for PostgreSQL version <= 15");
+        return;
+    }
+
     // Insert one row in each table and wait for two insert events.
     let inserts_notify = destination
         .wait_for_events_count(vec![(EventType::Insert, 2)])
@@ -352,6 +359,13 @@ async fn publication_for_all_tables_in_schema_ignores_new_tables_until_restart()
     assert_eq!(table_schemas.len(), 1);
     assert!(table_schemas.contains_key(&table_1_id));
     assert!(!table_schemas.contains_key(&table_2_id));
+
+    if let Some(server_version) = database.server_version()
+        && server_version.get() <= 150000
+    {
+        println!("Skipping test for PostgreSQL version <= 15");
+        return;
+    }
 
     // We restart the pipeline and verify that the new table is now processed.
     let mut pipeline = create_pipeline(

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -10,7 +10,7 @@ name: etl
 services:
   # Start Postgres
   postgres:
-    image: postgres:17
+    image: postgres:${POSTGRES_VERSION:-17}
     container_name: postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -1,17 +1,16 @@
 x-lakekeeper-env: &lakekeeper-env
   environment:
     - LAKEKEEPER__PG_ENCRYPTION_KEY=insecure-encryption-key
-    - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@postgres:5432/iceberg-catalog
-    - LAKEKEEPER__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@postgres:5432/iceberg-catalog
+    - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://lakekeeper-postgres:lakekeeper-postgres@lakekeeper-postgres:5432/iceberg-catalog
+    - LAKEKEEPER__PG_DATABASE_URL_WRITE=postgresql://lakekeeper-postgres:lakekeeper-postgres@lakekeeper-postgres:5432/iceberg-catalog
     - RUST_LOG=info
 
-name: etl
+name: etl-pg-${POSTGRES_VERSION:-17}
 
 services:
   # Start Postgres
   postgres:
     image: postgres:${POSTGRES_VERSION:-17}
-    container_name: postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
@@ -20,10 +19,6 @@ services:
       - "${POSTGRES_PORT:-5430}:5432"
     volumes:
       - ${POSTGRES_DATA_VOLUME:-postgres_data}:/var/lib/postgresql/data
-    configs:
-      - source: postgres_init
-        target: /docker-entrypoint-initdb.d/01-create-iceberg-catalog.sh
-        mode: 0755
     command: >
       postgres
       -N 1000
@@ -37,10 +32,24 @@ services:
       timeout: 5s
       retries: 5
 
+  lakekeeper-postgres:
+      image: postgres:17
+      environment:
+        POSTGRES_USER: ${LAKEKEEPER_POSTGRES_USER:-lakekeeper-postgres}
+        POSTGRES_PASSWORD: ${LAKEKEEPER_POSTGRES_PASSWORD:-lakekeeper-postgres}
+        POSTGRES_DB: ${LAKEKEEPER_POSTGRES_DB:-iceberg-catalog}
+      volumes:
+        - ${LAKEKEEPER_POSTGRES_DATA_VOLUME:-lakekeeper_postgres_data}:/var/lib/postgresql/data
+      restart: unless-stopped
+      healthcheck:
+        test: ["CMD-SHELL", "pg_isready -U ${LAKEKEEPER_POSTGRES_USER:-lakekeeper-postgres} -d ${LAKEKEEPER_POSTGRES_DB:-iceberg-catalog}"]
+        interval: 5s
+        timeout: 5s
+        retries: 5
+
   # Start MinIO for S3-compatible object storage
   minio:
     image: minio/minio:latest
-    container_name: minio
     environment:
       MINIO_ROOT_USER: minio-admin
       MINIO_ROOT_PASSWORD: minio-admin-password
@@ -59,7 +68,6 @@ services:
   # Create MinIO bucket
   create-bucket:
     image: minio/mc:latest
-    container_name: create-bucket
     depends_on:
       minio:
         condition: service_healthy
@@ -73,18 +81,16 @@ services:
   # Migrate lakekeeper database
   migrate-lakekeeper:
     image: quay.io/lakekeeper/catalog:latest-main
-    container_name: migrate-lakekeeper
     <<: *lakekeeper-env
     restart: "no"
     command: ["migrate"]
     depends_on:
-      postgres:
+      lakekeeper-postgres:
         condition: service_healthy
 
   # Start lakekeeper, an iceberg REST catalog
   lakekeeper:
     image: quay.io/lakekeeper/catalog:latest-main
-    container_name: lakekeeper
     depends_on:
       migrate-lakekeeper:
         condition: service_completed_successfully
@@ -104,7 +110,6 @@ services:
   # Bootstrap lakekeeper. After deployment, lakekeeper needs to be bootstrapped.
   bootstrap-lakekeeper:
     image: curlimages/curl
-    container_name: bootstrap-lakekeeper
     depends_on:
       lakekeeper:
         condition: service_healthy
@@ -127,7 +132,6 @@ services:
   # Create a warehouse for development and testing
   create-warehouse:
     image: curlimages/curl
-    container_name: create-warehouse
     depends_on:
       lakekeeper:
         condition: service_healthy
@@ -153,18 +157,10 @@ services:
     volumes:
       - ./warehouse.json:/home/curl_user/warehouse.json
 
-configs:
-  postgres_init:
-    content: |
-      #!/bin/bash
-      set -e
-      
-      psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER:-postgres}" --dbname "${POSTGRES_DB:-postgres}" <<-EOSQL
-        CREATE DATABASE "iceberg-catalog";
-      EOSQL
-
 volumes:
   postgres_data:
+    driver: local
+  lakekeeper_postgres_data:
     driver: local
   minio_data:
     driver: local

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -20,6 +20,10 @@ services:
       - "${POSTGRES_PORT:-5430}:5432"
     volumes:
       - ${POSTGRES_DATA_VOLUME:-postgres_data}:/var/lib/postgresql/data
+    configs:
+      - source: postgres_init
+        target: /docker-entrypoint-initdb.d/01-create-iceberg-catalog.sh
+        mode: 0755
     command: >
       postgres
       -N 1000
@@ -32,24 +36,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-
-  # Create database for iceberg catalog
-  create-catalog-db:
-    image: postgres:17
-    container_name: create-catalog-db
-    depends_on:
-      postgres:
-        condition: service_healthy
-    environment:
-      PGHOST: postgres
-      PGPORT: 5432
-      PGUSER: ${POSTGRES_USER:-postgres}
-      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
-    entrypoint: >
-      /bin/sh -c "
-      psql -c 'create database \"iceberg-catalog\";';
-      exit 0;
-      "
 
   # Start MinIO for S3-compatible object storage
   minio:
@@ -92,8 +78,8 @@ services:
     restart: "no"
     command: ["migrate"]
     depends_on:
-      create-catalog-db:
-        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
 
   # Start lakekeeper, an iceberg REST catalog
   lakekeeper:
@@ -166,6 +152,16 @@ services:
       # - "--fail-with-body"
     volumes:
       - ./warehouse.json:/home/curl_user/warehouse.json
+
+configs:
+  postgres_init:
+    content: |
+      #!/bin/bash
+      set -e
+      
+      psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER:-postgres}" --dbname "${POSTGRES_DB:-postgres}" <<-EOSQL
+        CREATE DATABASE "iceberg-catalog";
+      EOSQL
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #294 

## What is the current behavior?

It fails on postgres 14

## What is the new behavior?

Introduce a check on the postgres version that goes to a separate query that assumes all columns are included in the publication. Updates CI/Docker Compose to allow variable postgres versions for testing.

## Additional context

Wish we could upgrade :/ 