### PR TITLE
fix(state): Reset slot and table also on Init

### DIFF
--- a/etl/src/destination/base.rs
+++ b/etl/src/destination/base.rs
@@ -19,6 +19,10 @@ pub trait Destination {
     /// This operation is called during initial table synchronization to ensure the
     /// destination table starts from a clean state before bulk loading. The operation
     /// should be atomic and handle cases where the table may not exist.
+    ///
+    /// The implementation should assume that when truncation is called, the table might not be
+    /// present since truncation could be called after a failure that happened before the table copy
+    /// was started.
     fn truncate_table(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send;
 
     /// Writes a batch of table rows to the destination.


### PR DESCRIPTION
This PR fixes a bug that was overlooked during the implementation of the rollback mechanism. Now, we can also go back in states, thus it could be that when in `Init` we also have to delete a slot and issue a truncate to the table. We unconditionally do this to simplify the implementation but technically we could avoid issuing the operation in certain cases (when the table has never been copied).