### PR TITLE
fix: export metrics port from replicators

### DIFF
--- a/etl-api/src/k8s_client.rs
+++ b/etl-api/src/k8s_client.rs
@@ -403,6 +403,13 @@ impl K8sClient for HttpK8sClient {
                   {
                     "name": replicator_container_name,
                     "image": replicator_image,
+                    "ports": [
+                      {
+                        "name": "metrics",
+                        "containerPort": 9000,
+                        "protocol": "TCP"
+                      }
+                    ],
                     "env": [
                       {
                         "name": "APP_ENVIRONMENT",


### PR DESCRIPTION
Metrics are not being scraped from replicators because the metrics port was not exposed.