### PR TITLE
chore: add additional metadata to cargo.toml and pin to rust to 1.88.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
         with:
           components: ${{ matrix.check == 'fmt' && 'rustfmt' || 'clippy' }}
 
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "etl",
     "etl-api",
@@ -11,6 +11,13 @@ members = [
     "etl-replicator",
     "etl-telemetry",
 ]
+
+[workspace.package]
+license = "Apache-2.0"
+edition = "2024"
+rust-version = "1.88.0"
+repository = "https://github.com/supabase/etl"
+homepage = "https://supabase.github.io/etl/"
 
 [workspace.dependencies]
 etl = { path = "etl", default-features = false }

--- a/etl-api/Cargo.toml
+++ b/etl-api/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-api"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/etl-benchmarks/Cargo.toml
+++ b/etl-benchmarks/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-benchmarks"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dev-dependencies]
 etl = { workspace = true, features = ["test-utils"] }

--- a/etl-config/Cargo.toml
+++ b/etl-config/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-config"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 utoipa = ["dep:utoipa"]

--- a/etl-destinations/Cargo.toml
+++ b/etl-destinations/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-destinations"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 bigquery = [

--- a/etl-examples/Cargo.toml
+++ b/etl-examples/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-examples"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 etl = { workspace = true }

--- a/etl-postgres/Cargo.toml
+++ b/etl-postgres/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-postgres"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 test-utils = []

--- a/etl-replicator/Cargo.toml
+++ b/etl-replicator/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-replicator"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 etl = { workspace = true, features = ["unknown-types-to-bytes"] }

--- a/etl-telemetry/Cargo.toml
+++ b/etl-telemetry/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl-telemetry"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 etl-config = { workspace = true }

--- a/etl/Cargo.toml
+++ b/etl/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "etl"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 unknown-types-to-bytes = []


### PR DESCRIPTION
## What kind of change does this PR introduce?

This pins `rust-version` to 1.88 and updates CI/CD to target it. At my company, the internal tooling we're developing around etl failed to compile due to our internal base images being based on 1.87. This could've been caught if `rust-version` was specified, as cargo with edition 2024 warns if a package is incompatible based on their stated MSRV.

Additionally, tools like `cargo-deny` fail to work as none of the licenses were specified, so this updates that. I did some house cleaning and added additional metadata to the cargo.toml as well (such as repository information, a link to the docs, etc).

## What is the current behavior?

Fixes #322, the license field was added to fix cargo-deny issues from internal tooling
 
## What is the new behavior?

Not much, edition=2024 already implies resolver 3, so moving it to resolver 2 is cosmetic. 

## Additional context

