### PR TITLE
chore(ci): fix partial CI/CD

### DIFF
--- a/etl-destinations/Cargo.toml
+++ b/etl-destinations/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [features]
 bigquery = [
-    "dep:futures",
     "dep:gcp-bigquery-client",
     "dep:prost",
     "dep:rustls",
@@ -18,7 +17,6 @@ iceberg = ["dep:iceberg", "dep:iceberg-catalog-rest"]
 etl = { workspace = true }
 chrono = { workspace = true }
 
-futures = { workspace = true, optional = true }
 gcp-bigquery-client = { workspace = true, optional = true, features = [
     "rust-tls",
     "aws-lc-rs",
@@ -44,4 +42,5 @@ rand = { workspace = true, features = ["thread_rng"] }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/etl-destinations/tests/support/bigquery.rs
+++ b/etl-destinations/tests/support/bigquery.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![cfg(feature = "bigquery")]
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;

--- a/etl-destinations/tests/support/lakekeeper.rs
+++ b/etl-destinations/tests/support/lakekeeper.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![cfg(feature = "iceberg")]
 
 use uuid::Uuid;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the partial CI/CD workflow, which has been broken due to an indirect dependency not being included. Solves it by including tokio as a dev dependency used across all the features.

## What is the current behavior?

Partial CI/CD workflow fails.

## What is the new behavior?

It doesn't fail.

## Additional context

Drive-by fix included of removing `futures` from the bigquery feature, as I noticed it wasn't getting used for anything (as I audited the dependencies via `cargo-udeps`. 