### PR TITLE
feat(db): Add Postgres function to atomically update default image

### DIFF
--- a/etl-api/migrations/20250905100000_update_default_image_function.sql
+++ b/etl-api/migrations/20250905100000_update_default_image_function.sql
@@ -1,0 +1,36 @@
+-- Function to atomically create (if needed) and set the default image by name.
+-- Usage: select app.update_default_image('supabase/etl-replicator:1.2.3');
+
+create or replace function app.update_default_image(new_image_name text)
+returns void
+language plpgsql
+as $$
+declare
+  new_image_id bigint;
+begin
+  -- Serialize concurrent default switches using an advisory transaction lock.
+  perform pg_advisory_xact_lock(hashtext('app.images:default')::bigint);
+
+  -- Insert if missing; don't set default yet to respect the partial unique index.
+  insert into app.images(name, is_default)
+  values (new_image_name, false)
+  on conflict (name) do nothing
+  returning id into new_image_id;
+
+  -- If the image already existed, fetch its id.
+  if new_image_id is null then
+    select id into new_image_id from app.images where name = new_image_name;
+  end if;
+
+  -- Unset any existing default that is not the requested image.
+  update app.images
+     set is_default = false, updated_at = now()
+   where is_default = true
+     and id <> new_image_id;
+
+  -- Set the requested image as default.
+  update app.images
+     set is_default = true, updated_at = now()
+   where id = new_image_id;
+end
+$$;

--- a/etl-api/migrations/20250905100000_update_default_image_function.sql
+++ b/etl-api/migrations/20250905100000_update_default_image_function.sql
@@ -9,7 +9,7 @@ declare
   new_image_id bigint;
 begin
   -- Serialize concurrent default switches using an advisory transaction lock.
-  perform pg_advisory_xact_lock(hashtext('app.images:default')::bigint);
+  perform pg_advisory_xact_lock('app.images'::regclass::oid, 1);
 
   -- Insert if missing; don't set default yet to respect the partial unique index.
   insert into app.images(name, is_default)

--- a/etl-api/migrations/20250905100000_update_default_image_function.sql
+++ b/etl-api/migrations/20250905100000_update_default_image_function.sql
@@ -9,7 +9,7 @@ declare
   new_image_id bigint;
 begin
   -- Serialize concurrent default switches using an advisory transaction lock.
-  perform pg_advisory_xact_lock('app.images'::regclass::oid, 1);
+  perform pg_advisory_xact_lock('app.images'::regclass::oid::int, 1);
 
   -- Insert if missing; don't set default yet to respect the partial unique index.
   insert into app.images(name, is_default)

--- a/etl-api/migrations/20250905100000_update_default_image_function.sql
+++ b/etl-api/migrations/20250905100000_update_default_image_function.sql
@@ -9,7 +9,7 @@ declare
   new_image_id bigint;
 begin
   -- Serialize concurrent default switches using an advisory transaction lock.
-  perform pg_advisory_xact_lock('app.images'::regclass::oid::int, 1);
+  perform pg_advisory_xact_lock(('app.images'::regclass::oid)::bigint);
 
   -- Insert if missing; don't set default yet to respect the partial unique index.
   insert into app.images(name, is_default)


### PR DESCRIPTION
This PR introduces a new database function that atomically sets an image as the default:
* If the image already exists, it is promoted to default.
* If it does not exist, a new record is created and marked as default.

To prevent race conditions, the function acquires a transaction-scoped advisory lock, ensuring that only one default-switch operation can run at a time.

The rationale for adopting a function is to make the update process flexible and usable from multiple places. Python scripts, PSQL, etc... This will be useful when we want to implement automatic image update via registry callbacks when new images are uploaded to a registry.