### PR TITLE
feat(k8s): Add taint toleration for the replicator statefulset

### DIFF
--- a/etl-api/src/k8s_client.rs
+++ b/etl-api/src/k8s_client.rs
@@ -369,6 +369,10 @@ impl K8sClient for HttpK8sClient {
                     "effect": "NoSchedule"
                   }
                 ],
+                // Pin pods to nodes labeled with `nodeType=workloads`.
+                "nodeSelector": {
+                  "nodeType": "workloads"
+                },
                 // We want to wait at most 60 seconds before K8S sends a `SIGKILL` to the containers.
                 "terminationGracePeriodSeconds": 60,
                 "initContainers": [


### PR DESCRIPTION
This PR adds a new toleration for the taint `nodeType: workloads` and a selector for the same values.