### PR TITLE
refactor: use fully qualified paths in exported macros

### DIFF
--- a/etl-destinations/src/bigquery/validation.rs
+++ b/etl-destinations/src/bigquery/validation.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
-use etl::error::{ErrorKind, EtlError, EtlResult};
+use etl::error::{ErrorKind, EtlResult};
 use etl::types::{ArrayCellNonOptional, CellNonOptional, PgNumeric};
 use etl::{bail, etl_error};
 use std::sync::LazyLock;

--- a/etl/src/conversions/bool.rs
+++ b/etl/src/conversions/bool.rs
@@ -1,6 +1,6 @@
 use crate::bail;
+use crate::error::ErrorKind;
 use crate::error::EtlResult;
-use crate::error::{ErrorKind, EtlError};
 
 /// Parses a Postgres boolean value from its text format representation.
 ///

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use tokio_postgres::types::PgLsn;
 
 use crate::conversions::text::{default_value_for_type, parse_cell_from_postgres_text};
-use crate::error::EtlError;
 use crate::error::{ErrorKind, EtlResult};
 use crate::store::schema::SchemaStore;
 use crate::types::{

--- a/etl/src/conversions/hex.rs
+++ b/etl/src/conversions/hex.rs
@@ -1,5 +1,4 @@
 use crate::bail;
-use crate::error::EtlError;
 use crate::error::{ErrorKind, EtlResult};
 
 /// Converts a Postgres bytea hex string to a byte array.

--- a/etl/src/conversions/table_row.rs
+++ b/etl/src/conversions/table_row.rs
@@ -4,7 +4,6 @@ use tracing::error;
 
 use crate::bail;
 use crate::conversions::text::parse_cell_from_postgres_text;
-use crate::error::EtlError;
 use crate::error::{ErrorKind, EtlResult};
 use crate::types::{Cell, TableRow};
 

--- a/etl/src/conversions/text.rs
+++ b/etl/src/conversions/text.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::bail;
 use crate::conversions::numeric::PgNumeric;
 use crate::conversions::{bool::parse_bool, hex};
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 use crate::types::{ArrayCell, Cell};
 
 /// Creates a default [`Cell`] value for the given Postgres type.

--- a/etl/src/failpoints.rs
+++ b/etl/src/failpoints.rs
@@ -6,11 +6,11 @@
 use fail::fail_point;
 
 use crate::bail;
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 
-pub const START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION: &str =
+pub const START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION: &str =
     "start_table_sync.before_data_sync_slot_creation";
-pub const START_TABLE_SYNC__DURING_DATA_SYNC: &str = "start_table_sync.during_data_sync";
+pub const START_TABLE_SYNC_DURING_DATA_SYNC: &str = "start_table_sync.during_data_sync";
 
 /// Executes a configurable failpoint for testing error scenarios.
 ///

--- a/etl/src/macros.rs
+++ b/etl/src/macros.rs
@@ -10,10 +10,10 @@
 #[macro_export]
 macro_rules! etl_error {
     ($kind:expr, $desc:expr) => {
-        EtlError::from(($kind, $desc))
+        $crate::error::EtlError::from(($kind, $desc))
     };
     ($kind:expr, $desc:expr, $detail:expr) => {
-        EtlError::from(($kind, $desc, $detail.to_string()))
+        $crate::error::EtlError::from(($kind, $desc, $detail.to_string()))
     };
 }
 
@@ -24,9 +24,9 @@ macro_rules! etl_error {
 #[macro_export]
 macro_rules! bail {
     ($kind:expr, $desc:expr) => {
-        return Err($crate::etl_error!($kind, $desc))
+        return ::core::result::Result::Err($crate::etl_error!($kind, $desc))
     };
     ($kind:expr, $desc:expr, $detail:expr) => {
-        return Err($crate::etl_error!($kind, $desc, $detail))
+        return ::core::result::Result::Err($crate::etl_error!($kind, $desc, $detail))
     };
 }

--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -6,7 +6,7 @@
 use crate::bail;
 use crate::concurrency::shutdown::{ShutdownTx, create_shutdown_channel};
 use crate::destination::Destination;
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 use crate::metrics::register_metrics;
 use crate::replication::client::PgReplicationClient;
 use crate::state::table::TableReplicationPhase;

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -24,7 +24,7 @@ use crate::conversions::event::{
     parse_event_from_update_message,
 };
 use crate::destination::Destination;
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 use crate::metrics::{
     APPLY, ETL_BATCH_SEND_DURATION_SECONDS, ETL_BATCH_SIZE, ETL_ITEMS_COPIED_TOTAL, MILLIS_PER_SEC,
     PHASE, PIPELINE_ID,

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -1,4 +1,4 @@
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 use crate::utils::tokio::MakeRustlsConnect;
 use crate::{bail, etl_error};
 use etl_config::shared::{IntoConnectOptions, PgConnectionConfig};

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -12,7 +12,6 @@ use tokio_postgres::types::PgLsn;
 use tracing::debug;
 
 use crate::conversions::table_row::parse_table_row_from_postgres_copy_bytes;
-use crate::error::EtlError;
 use crate::error::{ErrorKind, EtlResult};
 use crate::etl_error;
 use crate::types::TableRow;

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -15,10 +15,10 @@ use crate::concurrency::shutdown::{ShutdownResult, ShutdownRx};
 use crate::concurrency::signal::SignalTx;
 use crate::concurrency::stream::TimeoutBatchStream;
 use crate::destination::Destination;
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 #[cfg(feature = "failpoints")]
 use crate::failpoints::{
-    START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION, START_TABLE_SYNC__DURING_DATA_SYNC,
+    START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION, START_TABLE_SYNC_DURING_DATA_SYNC,
     etl_fail_point,
 };
 use crate::metrics::{
@@ -168,7 +168,7 @@ where
 
             // Fail point to test when the table sync fails before copying data.
             #[cfg(feature = "failpoints")]
-            etl_fail_point(START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION)?;
+            etl_fail_point(START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION)?;
 
             // We create the slot with a transaction, since we need to have a consistent snapshot of the database
             // before copying the schema and tables.
@@ -239,7 +239,7 @@ where
                             .record(send_duration_secs);
                         // Fail point to test when the table sync fails after copying one batch.
                         #[cfg(feature = "failpoints")]
-                        etl_fail_point(START_TABLE_SYNC__DURING_DATA_SYNC)?;
+                        etl_fail_point(START_TABLE_SYNC_DURING_DATA_SYNC)?;
                     }
                     ShutdownResult::Shutdown(_) => {
                         // If we received a shutdown in the middle of a table copy, we bail knowing

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 use crate::etl_error;
 use crate::state::table::TableReplicationPhase;
 use crate::store::cleanup::CleanupStore;

--- a/etl/src/test_utils/notify.rs
+++ b/etl/src/test_utils/notify.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use etl_postgres::types::{TableId, TableSchema};
 use tokio::sync::{Notify, RwLock};
 
-use crate::error::{ErrorKind, EtlError, EtlResult};
+use crate::error::{ErrorKind, EtlResult};
 use crate::etl_error;
 use crate::state::table::{TableReplicationPhase, TableReplicationPhaseType};
 use crate::store::cleanup::CleanupStore;

--- a/etl/tests/failpoints_pipeline.rs
+++ b/etl/tests/failpoints_pipeline.rs
@@ -3,7 +3,7 @@
 use etl::destination::memory::MemoryDestination;
 use etl::error::ErrorKind;
 use etl::failpoints::{
-    START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION, START_TABLE_SYNC__DURING_DATA_SYNC,
+    START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION, START_TABLE_SYNC_DURING_DATA_SYNC,
 };
 use etl::state::table::TableReplicationPhaseType;
 use etl::test_utils::database::spawn_source_database;
@@ -20,7 +20,7 @@ use rand::random;
 async fn table_copy_fails_after_data_sync_threw_an_error_with_no_retry() {
     let _scenario = FailScenario::setup();
     fail::cfg(
-        START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION,
+        START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION,
         "1*return(no_retry)",
     )
     .unwrap();
@@ -82,7 +82,7 @@ async fn table_copy_fails_after_data_sync_threw_an_error_with_no_retry() {
 async fn table_copy_is_consistent_after_data_sync_threw_an_error_with_timed_retry() {
     let _scenario = FailScenario::setup();
     fail::cfg(
-        START_TABLE_SYNC__BEFORE_DATA_SYNC_SLOT_CREATION,
+        START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION,
         "1*return(timed_retry)",
     )
     .unwrap();
@@ -148,7 +148,7 @@ async fn table_copy_is_consistent_after_data_sync_threw_an_error_with_timed_retr
 #[tokio::test(flavor = "multi_thread")]
 async fn table_copy_is_consistent_during_data_sync_threw_an_error_with_timed_retry() {
     let _scenario = FailScenario::setup();
-    fail::cfg(START_TABLE_SYNC__DURING_DATA_SYNC, "1*return(timed_retry)").unwrap();
+    fail::cfg(START_TABLE_SYNC_DURING_DATA_SYNC, "1*return(timed_retry)").unwrap();
 
     init_test_tracing();
 


### PR DESCRIPTION
To avoid issues with the meaning of types changing based on what is in scope at the call site this PR uses fully qualified names in the macros exported from the etl crate. Also fixed clippy warnings about const names.