### PR TITLE
feat(config): Add version configuration for the replicator

### DIFF
--- a/etl-api/src/k8s/http.rs
+++ b/etl-api/src/k8s/http.rs
@@ -48,10 +48,6 @@ const LOGS_VOLUME_NAME: &str = "logs";
 pub const TRUSTED_ROOT_CERT_CONFIG_MAP_NAME: &str = "trusted-root-certs-config";
 /// Key inside the trusted root certificates ConfigMap.
 pub const TRUSTED_ROOT_CERT_KEY_NAME: &str = "trusted_root_certs";
-/// Environment variable for the Postgres password.
-const PG_PASSWORD_ENV_VAR_NAME: &str = "APP_PIPELINE__PG_CONNECTION__PASSWORD";
-/// Environment variable for the BigQuery service account key.
-const BIG_QUERY_SA_KEY_ENV_VAR_NAME: &str = "APP_DESTINATION__BIG_QUERY__SERVICE_ACCOUNT_KEY";
 /// Pod template annotation used to trigger rolling restarts.
 pub const RESTARTED_AT_ANNOTATION_KEY: &str = "etl.supabase.com/restarted-at";
 /// Label used to identify replicator pods.
@@ -421,6 +417,10 @@ impl K8sClient for HttpK8sClient {
                         "value": environment.to_string()
                       },
                       {
+                          "name": "APP_VERSION",
+                          "value": replicator_image
+                      },
+                      {
                         "name": "APP_SENTRY__DSN",
                         "valueFrom": {
                           "secretKeyRef": {
@@ -430,7 +430,7 @@ impl K8sClient for HttpK8sClient {
                         }
                       },
                       {
-                        "name": PG_PASSWORD_ENV_VAR_NAME,
+                        "name": "APP_PIPELINE__PG_CONNECTION__PASSWORD",
                         "valueFrom": {
                           "secretKeyRef": {
                             "name": postgres_secret_name,
@@ -439,7 +439,7 @@ impl K8sClient for HttpK8sClient {
                         }
                       },
                       {
-                        "name": BIG_QUERY_SA_KEY_ENV_VAR_NAME,
+                        "name": "APP_DESTINATION__BIG_QUERY__SERVICE_ACCOUNT_KEY",
                         "valueFrom": {
                           "secretKeyRef": {
                             "name": bq_secret_name,

--- a/etl-replicator/src/main.rs
+++ b/etl-replicator/src/main.rs
@@ -18,6 +18,9 @@ mod config;
 mod core;
 mod migrations;
 
+/// The name of the environment variable which contains version information for this replicator.
+const APP_VERSION_ENV_NAME: &str = "APP_VERSION";
+
 /// Entry point for the replicator service.
 ///
 /// Loads configuration, initializes tracing and Sentry, starts the async runtime,
@@ -92,9 +95,15 @@ fn init_sentry() -> anyhow::Result<Option<sentry::ClientInitGuard>> {
             ..Default::default()
         });
 
+        // We load the version of the replicator which is specified via environment variable.
+        let version = std::env::var(APP_VERSION_ENV_NAME);
+
         // Set service tag to differentiate replicator from other services
         sentry::configure_scope(|scope| {
             scope.set_tag("service", "replicator");
+            if let Ok(version) = version {
+                scope.set_tag("version", version);
+            }
         });
 
         return Ok(Some(guard));


### PR DESCRIPTION
This PR adds the version configuration in the replicator, this way we can have more details on which version is currently running when an error happens.