### PR TITLE
feat(ci): switch to `cargo-nextest`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,5 @@
+[profile.default]
+retries = 2
+
 [profile.no-bigquery]
 default-filter = "not (package(etl-destinations) and binary(/bigquery_pipeline/))"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,6 @@
 [profile.default]
 retries = 2
+slow-timeout = { period = "15s", terminate-after = 4 }
 
 [profile.no-bigquery]
 default-filter = "not (package(etl-destinations) and binary(/bigquery_pipeline/))"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.no-bigquery]
+default-filter = "not (package(etl-destinations) and binary(/bigquery_pipeline/))"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,19 +86,14 @@ jobs:
           sudo apt-get install libpq-dev -y
           ./etl-api/scripts/run_migrations.sh
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Run Tests
         run: |
-          cargo test \
-            --workspace \
-            --all-features \
-            --no-fail-fast \
-            --exclude etl-destinations \
-          && \
-          cargo test \
-            -p etl-destinations \
-            --no-default-features \
-            --no-fail-fast \
-            --features iceberg
+          cargo nextest run --all-features --no-fail-fast --profile no-bigquery
 
   test-full:
     name: Tests (Full)
@@ -117,6 +112,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@1.88.0
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -145,8 +142,10 @@ jobs:
           sudo apt-get install libpq-dev -y
           ./etl-api/scripts/run_migrations.sh
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov and cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
 
       - name: Set up BigQuery Credentials
         run: |
@@ -157,10 +156,8 @@ jobs:
       - name: Generate Code Coverage
         id: coverage
         run: |
-          cargo llvm-cov test \
-            --workspace --no-fail-fast \
-            --all-features \
-            --lcov --output-path lcov.info
+          cargo llvm-cov nextest --no-fail-fast \
+            --all-features --lcov --output-path lcov.info
 
       - name: Upload Coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@
 - Tests live per crate (`src` unit tests, `tests` integration); benches in `etl-benchmarks/benches/`.
 
 ## Build and Test
-- Build: `cargo build --workspace --all-targets --all-features`.
-- Lint/format: `cargo fmt`; `cargo clippy --all-targets --all-features -- -D warnings`.
+- Build: `just build`.
+- Lint/format: `just fmt; just lint`.
 - Use `ENABLE_TRACING=1` when running integration tests to see the logs.
 - Use `RUST_LOG=[log-level]` if you need to see the logs with a specific log level.
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,18 @@
+build:
+	cargo build --workspace --all-targets --all-features
+
+fmt:
+	cargo fmt
+
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+test:
+	cargo nextest run --all-features
+
+test-nobigquery:
+	cargo nextest run --all-features --profile no-bigquery
+
+install-tools:
+	cargo install cargo-nextest --locked
+	cargo install just --locked


### PR DESCRIPTION
## What kind of change does this PR introduce?

A few cherry-picked commits from my delta branch to speedup CI/CD. Seems to make tests from running at around ~3:30 to ~2:30. Also adds a filter for avoiding bigquery integration tests.

## What is the current behavior?

Uses traditional cargo harness.

## What is the new behavior?

Uses `cargo-nextest` for faster CI.

## Additional context

I added a `justfile` to automate the commands, but it can be removed of the maintainers would prefer something else.