### PR TITLE
ref(k8s): Increase the timeout for the sigterm

### DIFF
--- a/etl-api/src/k8s/http.rs
+++ b/etl-api/src/k8s/http.rs
@@ -362,8 +362,9 @@ impl K8sClient for HttpK8sClient {
                 "nodeSelector": {
                   "nodeType": "workloads"
                 },
-                // We want to wait at most 60 seconds before K8S sends a `SIGKILL` to the containers.
-                "terminationGracePeriodSeconds": 60,
+                // We want to wait at most 5 minutes before K8S sends a `SIGKILL` to the containers,
+                // this way we let the system finish any in-flight transaction, if there are any.
+                "terminationGracePeriodSeconds": 300,
                 "initContainers": [
                   {
                     "name": vector_container_name,

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -338,7 +338,7 @@ struct ApplyLoopState {
     ///
     /// When a shutdown has been discarded, the apply loop will continue processing events until a
     /// transaction boundary is found. If not found, the process will continue until it is killed via
-    /// a `SIGTERM`.
+    /// a `SIGKILL`.
     shutdown_discarded: bool,
 }
 


### PR DESCRIPTION
This PR increases the timeout to 5 minutes before K8S sends a `SIGKILL` to the replicator container.