### PR TITLE
chore: improve logging when a table sync worker is in error

### DIFF
--- a/etl/src/replication/common.rs
+++ b/etl/src/replication/common.rs
@@ -5,22 +5,18 @@ use crate::error::EtlResult;
 use crate::state::table::TableReplicationPhase;
 use crate::store::state::StateStore;
 
-/// Returns the table replication states that are either done or in active state.
+/// Returns the table replication states that are not yet done.
 ///
 /// A table is considered in done state when the apply worker doesn't need to start/restart a table
 /// sync worker to make that table progress.
-pub async fn get_table_replication_states<S>(
+pub async fn get_active_table_replication_states<S>(
     state_store: &S,
-    done: bool,
 ) -> EtlResult<HashMap<TableId, TableReplicationPhase>>
 where
     S: StateStore + Clone + Send + Sync + 'static,
 {
     let mut table_replication_states = state_store.get_table_replication_states().await?;
-    table_replication_states.retain(|_table_id, state| match done {
-        true => state.as_type().is_done(),
-        false => !state.as_type().is_done(),
-    });
+    table_replication_states.retain(|_table_id, state| !state.as_type().is_done());
 
     Ok(table_replication_states)
 }

--- a/etl/src/state/table.rs
+++ b/etl/src/state/table.rs
@@ -314,6 +314,11 @@ impl TableReplicationPhaseType {
         }
     }
 
+    /// Return `true` if a table with this phase is in error, `false` otherwise.
+    pub fn is_errored(&self) -> bool {
+        matches!(self, Self::Errored)
+    }
+
     pub fn as_static_str(&self) -> &'static str {
         match self {
             TableReplicationPhaseType::Init => "init",


### PR DESCRIPTION
This PR:

* Logs a warning in the logs when a table sync worker won't start because the table is in an error state. This helps debugging when running the replicator locally.
* Renames the method `get_table_replication_states` to `get_active_table_replication_states` and removes the `done` argument and simplifies it because it was always being called with `done` set to false.