### PR TITLE
 feat(retry): Add bounded retries across etl

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         pg_connection: pg,
         batch: BatchConfig { max_size: 1000, max_fill_ms: 5000 },
         table_error_retry_delay_ms: 10_000,
+        table_error_retry_max_attempts: 5,
         max_table_sync_workers: 4,
     };
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         pg_connection: pg_config,
         batch: BatchConfig { max_size: 1000, max_fill_ms: 5000 },
         table_error_retry_delay_ms: 10000,
+        table_error_retry_max_attempts: 5,
         max_table_sync_workers: 4,
     };
 

--- a/docs/tutorials/custom-implementations.md
+++ b/docs/tutorials/custom-implementations.md
@@ -621,6 +621,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Error handling configuration
         table_error_retry_delay_ms: 10000,  // Wait 10s before retrying failed tables
+        table_error_retry_max_attempts: 5,  // Stop automatic retries after 5 attempts
         max_table_sync_workers: 2,          // Use 2 workers for parallel table syncing
     };
 

--- a/docs/tutorials/first-pipeline.md
+++ b/docs/tutorials/first-pipeline.md
@@ -116,6 +116,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             max_fill_ms: 5000,
         },
         table_error_retry_delay_ms: 10000,
+        table_error_retry_max_attempts: 5,
         max_table_sync_workers: 4,
     };
 

--- a/etl-api/src/configs/pipeline.rs
+++ b/etl-api/src/configs/pipeline.rs
@@ -10,6 +10,10 @@ const DEFAULT_TABLE_ERROR_RETRY_DELAY_MS: u64 = 10000;
 const DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS: u32 = 5;
 const DEFAULT_MAX_TABLE_SYNC_WORKERS: u16 = 4;
 
+const fn default_table_error_retry_max_attempts() -> u32 {
+    DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS
+}
+
 /// Batch processing configuration for pipelines.
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -78,7 +82,7 @@ pub struct StoredPipelineConfig {
     pub publication_name: String,
     pub batch: BatchConfig,
     pub table_error_retry_delay_ms: u64,
-    #[serde(default = "DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS")]
+    #[serde(default = "default_table_error_retry_max_attempts")]
     pub table_error_retry_max_attempts: u32,
     pub max_table_sync_workers: u16,
 }

--- a/etl-api/src/configs/pipeline.rs
+++ b/etl-api/src/configs/pipeline.rs
@@ -10,10 +10,6 @@ const DEFAULT_TABLE_ERROR_RETRY_DELAY_MS: u64 = 10000;
 const DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS: u32 = 5;
 const DEFAULT_MAX_TABLE_SYNC_WORKERS: u16 = 4;
 
-const fn default_table_error_retry_max_attempts() -> u32 {
-    DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS
-}
-
 /// Batch processing configuration for pipelines.
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -82,7 +78,6 @@ pub struct StoredPipelineConfig {
     pub publication_name: String,
     pub batch: BatchConfig,
     pub table_error_retry_delay_ms: u64,
-    #[serde(default = "default_table_error_retry_max_attempts")]
     pub table_error_retry_max_attempts: u32,
     pub max_table_sync_workers: u16,
 }

--- a/etl-api/src/configs/pipeline.rs
+++ b/etl-api/src/configs/pipeline.rs
@@ -78,6 +78,7 @@ pub struct StoredPipelineConfig {
     pub publication_name: String,
     pub batch: BatchConfig,
     pub table_error_retry_delay_ms: u64,
+    #[serde(default = "DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS")]
     pub table_error_retry_max_attempts: u32,
     pub max_table_sync_workers: u16,
 }

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -795,6 +795,24 @@ async fn pipeline_config_can_be_updated() {
 
     // Act
     let update_request = UpdatePipelineConfigRequest {
+        config: partially_updated_optional_pipeline_config(
+            ConfigUpdateType::TableErrorRetryMaxAttempts(12),
+        ),
+    };
+    let response = app
+        .update_pipeline_config(&tenant_id, pipeline_id, &update_request)
+        .await;
+
+    // Assert
+    assert!(response.status().is_success());
+    let response: UpdatePipelineConfigResponse = response
+        .json()
+        .await
+        .expect("failed to deserialize response");
+    insta::assert_debug_snapshot!(response.config);
+
+    // Act
+    let update_request = UpdatePipelineConfigRequest {
         config: partially_updated_optional_pipeline_config(ConfigUpdateType::MaxTableSyncWorkers(
             8,
         )),

--- a/etl-api/tests/snapshots/destinations_pipelines__an_existing_destination_and_pipeline_can_be_updated-2.snap
+++ b/etl-api/tests/snapshots/destinations_pipelines__an_existing_destination_and_pipeline_can_be_updated-2.snap
@@ -17,6 +17,9 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         20000,
     ),
+    table_error_retry_max_attempts: Some(
+        10,
+    ),
     max_table_sync_workers: Some(
         4,
     ),

--- a/etl-api/tests/snapshots/destinations_pipelines__destination_and_pipeline_can_be_created-2.snap
+++ b/etl-api/tests/snapshots/destinations_pipelines__destination_and_pipeline_can_be_created-2.snap
@@ -17,6 +17,9 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         10000,
     ),
+    table_error_retry_max_attempts: Some(
+        5,
+    ),
     max_table_sync_workers: Some(
         2,
     ),

--- a/etl-api/tests/snapshots/pipelines__all_pipelines_can_be_read-2.snap
+++ b/etl-api/tests/snapshots/pipelines__all_pipelines_can_be_read-2.snap
@@ -17,6 +17,9 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         20000,
     ),
+    table_error_retry_max_attempts: Some(
+        10,
+    ),
     max_table_sync_workers: Some(
         4,
     ),

--- a/etl-api/tests/snapshots/pipelines__all_pipelines_can_be_read.snap
+++ b/etl-api/tests/snapshots/pipelines__all_pipelines_can_be_read.snap
@@ -17,6 +17,9 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         10000,
     ),
+    table_error_retry_max_attempts: Some(
+        5,
+    ),
     max_table_sync_workers: Some(
         2,
     ),

--- a/etl-api/tests/snapshots/pipelines__an_existing_pipeline_can_be_read.snap
+++ b/etl-api/tests/snapshots/pipelines__an_existing_pipeline_can_be_read.snap
@@ -17,6 +17,9 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         10000,
     ),
+    table_error_retry_max_attempts: Some(
+        5,
+    ),
     max_table_sync_workers: Some(
         2,
     ),

--- a/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated-2.snap
+++ b/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated-2.snap
@@ -17,6 +17,9 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         20000,
     ),
+    table_error_retry_max_attempts: Some(
+        5,
+    ),
     max_table_sync_workers: Some(
         2,
     ),

--- a/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated-3.snap
+++ b/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated-3.snap
@@ -17,7 +17,10 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         20000,
     ),
+    table_error_retry_max_attempts: Some(
+        12,
+    ),
     max_table_sync_workers: Some(
-        8,
+        2,
     ),
 }

--- a/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated-4.snap
+++ b/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated-4.snap
@@ -3,14 +3,14 @@ source: etl-api/tests/pipelines.rs
 expression: response.config
 ---
 FullApiPipelineConfig {
-    publication_name: "updated_publication",
+    publication_name: "publication",
     batch: Some(
         ApiBatchConfig {
             max_size: Some(
-                2000,
+                10000,
             ),
             max_fill_ms: Some(
-                10,
+                100,
             ),
         },
     ),
@@ -18,9 +18,9 @@ FullApiPipelineConfig {
         20000,
     ),
     table_error_retry_max_attempts: Some(
-        10,
+        12,
     ),
     max_table_sync_workers: Some(
-        4,
+        8,
     ),
 }

--- a/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated.snap
+++ b/etl-api/tests/snapshots/pipelines__pipeline_config_can_be_updated.snap
@@ -17,6 +17,9 @@ FullApiPipelineConfig {
     table_error_retry_delay_ms: Some(
         10000,
     ),
+    table_error_retry_max_attempts: Some(
+        5,
+    ),
     max_table_sync_workers: Some(
         2,
     ),

--- a/etl-api/tests/support/mocks.rs
+++ b/etl-api/tests/support/mocks.rs
@@ -187,6 +187,7 @@ pub mod pipelines {
                 max_fill_ms: Some(5),
             }),
             table_error_retry_delay_ms: Some(10000),
+            table_error_retry_max_attempts: Some(5),
             max_table_sync_workers: Some(2),
         }
     }
@@ -200,6 +201,7 @@ pub mod pipelines {
                 max_fill_ms: Some(10),
             }),
             table_error_retry_delay_ms: Some(20000),
+            table_error_retry_max_attempts: Some(10),
             max_table_sync_workers: Some(4),
         }
     }
@@ -208,6 +210,7 @@ pub mod pipelines {
     pub enum ConfigUpdateType {
         Batch(ApiBatchConfig),
         TableErrorRetryDelayMs(u64),
+        TableErrorRetryMaxAttempts(u32),
         MaxTableSyncWorkers(u16),
     }
 
@@ -220,6 +223,7 @@ pub mod pipelines {
                 publication_name: None,
                 batch: Some(batch_config),
                 table_error_retry_delay_ms: None,
+                table_error_retry_max_attempts: None,
                 max_table_sync_workers: None,
             },
             ConfigUpdateType::TableErrorRetryDelayMs(table_error_retry_delay_ms) => {
@@ -227,6 +231,16 @@ pub mod pipelines {
                     publication_name: None,
                     batch: None,
                     table_error_retry_delay_ms: Some(table_error_retry_delay_ms),
+                    table_error_retry_max_attempts: None,
+                    max_table_sync_workers: None,
+                }
+            }
+            ConfigUpdateType::TableErrorRetryMaxAttempts(max_attempts) => {
+                PartialApiPipelineConfig {
+                    publication_name: None,
+                    batch: None,
+                    table_error_retry_delay_ms: None,
+                    table_error_retry_max_attempts: Some(max_attempts),
                     max_table_sync_workers: None,
                 }
             }
@@ -234,6 +248,7 @@ pub mod pipelines {
                 publication_name: None,
                 batch: None,
                 table_error_retry_delay_ms: None,
+                table_error_retry_max_attempts: None,
                 max_table_sync_workers: Some(n),
             },
         }
@@ -248,6 +263,7 @@ pub mod pipelines {
                 max_fill_ms: Some(100),
             }),
             table_error_retry_delay_ms: Some(10000),
+            table_error_retry_max_attempts: Some(6),
             max_table_sync_workers: Some(8),
         }
     }

--- a/etl-benchmarks/benches/table_copies.rs
+++ b/etl-benchmarks/benches/table_copies.rs
@@ -331,6 +331,7 @@ async fn start_pipeline(args: RunArgs) -> Result<(), Box<dyn Error>> {
             max_fill_ms: args.batch_max_fill_ms,
         },
         table_error_retry_delay_ms: 10000,
+        table_error_retry_max_attempts: 5,
         max_table_sync_workers: args.max_table_sync_workers,
     };
 

--- a/etl-benchmarks/benches/table_copies.rs
+++ b/etl-benchmarks/benches/table_copies.rs
@@ -369,7 +369,7 @@ async fn start_pipeline(args: RunArgs) -> Result<(), Box<dyn Error>> {
     let mut table_copied_notifications = vec![];
     for table_id in &args.table_ids {
         let table_copied = store
-            .notify_on_table_state(
+            .notify_on_table_state_type(
                 TableId::new(*table_id),
                 TableReplicationPhaseType::FinishedCopy,
             )

--- a/etl-config/src/shared/base.rs
+++ b/etl-config/src/shared/base.rs
@@ -6,6 +6,9 @@ pub enum ValidationError {
     /// Maximum table sync workers cannot be zero.
     #[error("`max_table_sync_workers` cannot be zero")]
     MaxTableSyncWorkersZero,
+    /// Maximum retry attempts for table errors cannot be zero.
+    #[error("`table_error_retry_max_attempts` cannot be zero")]
+    TableErrorRetryMaxAttemptsZero,
     /// TLS is enabled but no trusted root certificates are provided.
     #[error("Invalid TLS config: `trusted_root_certs` must be set when `enabled` is true")]
     MissingTrustedRootCerts,

--- a/etl-config/src/shared/pipeline.rs
+++ b/etl-config/src/shared/pipeline.rs
@@ -20,8 +20,10 @@ pub struct PipelineConfig {
     pub pg_connection: PgConnectionConfig,
     /// Batch processing configuration.
     pub batch: BatchConfig,
-    /// Number of ms between one retry and another when a table error occurs.
+    /// Number of milliseconds between one retry and another when a table error occurs.
     pub table_error_retry_delay_ms: u64,
+    /// Maximum number of automatic retry attempts before requiring manual intervention.
+    pub table_error_retry_max_attempts: u32,
     /// Maximum number of table sync workers that can run at a time
     pub max_table_sync_workers: u16,
 }
@@ -35,6 +37,10 @@ impl PipelineConfig {
 
         if self.max_table_sync_workers == 0 {
             return Err(ValidationError::MaxTableSyncWorkersZero);
+        }
+
+        if self.table_error_retry_max_attempts == 0 {
+            return Err(ValidationError::TableErrorRetryMaxAttemptsZero);
         }
 
         Ok(())

--- a/etl-destinations/tests/bigquery_pipeline.rs
+++ b/etl-destinations/tests/bigquery_pipeline.rs
@@ -61,13 +61,13 @@ async fn table_copy_and_streaming_with_restart() {
 
     // Register notifications for table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
         .await;
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -194,7 +194,7 @@ async fn table_insert_update_delete() {
 
     // Register notifications for table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -311,7 +311,7 @@ async fn table_subsequent_updates() {
 
     // Register notifications for table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -410,13 +410,13 @@ async fn table_truncate_with_batching() {
 
     // Register notifications for table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
         .await;
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -549,7 +549,7 @@ async fn table_nullable_scalar_columns() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -758,7 +758,7 @@ async fn table_nullable_array_columns() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -993,7 +993,7 @@ async fn table_non_nullable_scalar_columns() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -1243,7 +1243,7 @@ async fn table_non_nullable_array_columns() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -1527,7 +1527,7 @@ async fn table_array_with_null_values() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -1594,7 +1594,7 @@ async fn table_array_with_null_values() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -1748,15 +1748,15 @@ async fn table_validation_out_of_bounds_values() {
 
     // Register notifications for errored replication phase
     let huge_numeric_error_notify = store
-        .notify_on_table_state(huge_numeric_table_id, TableReplicationPhaseType::Errored)
+        .notify_on_table_state_type(huge_numeric_table_id, TableReplicationPhaseType::Errored)
         .await;
 
     let old_date_error_notify = store
-        .notify_on_table_state(old_date_table_id, TableReplicationPhaseType::Errored)
+        .notify_on_table_state_type(old_date_table_id, TableReplicationPhaseType::Errored)
         .await;
 
     let nan_array_error_notify = store
-        .notify_on_table_state(nan_array_table_id, TableReplicationPhaseType::Errored)
+        .notify_on_table_state_type(nan_array_table_id, TableReplicationPhaseType::Errored)
         .await;
 
     pipeline.start().await.unwrap();

--- a/etl-examples/src/main.rs
+++ b/etl-examples/src/main.rs
@@ -170,6 +170,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
             max_fill_ms: args.bq_args.max_batch_fill_duration_ms,
         },
         table_error_retry_delay_ms: 10000,
+        table_error_retry_max_attempts: 5,
         max_table_sync_workers: args.bq_args.max_table_sync_workers,
     };
 

--- a/etl-replicator/configuration/base.yaml
+++ b/etl-replicator/configuration/base.yaml
@@ -6,5 +6,6 @@ pipeline:
     max_fill_ms: 1000
   max_table_sync_workers: 10
   table_error_retry_delay_ms: 1000
+  table_error_retry_max_attempts: 5
 supabase:
   project_ref: "abcdefghijklmnopqrst"

--- a/etl/src/lib.rs
+++ b/etl/src/lib.rs
@@ -78,6 +78,7 @@
 //!         pg_connection: pg_config,
 //!         batch: BatchConfig { max_size: 1000, max_fill_ms: 5000 },
 //!         table_error_retry_delay_ms: 10000,
+//!         table_error_retry_max_attempts: 5,
 //!         max_table_sync_workers: 4,
 //!     };
 //!

--- a/etl/src/state/table.rs
+++ b/etl/src/state/table.rs
@@ -58,6 +58,12 @@ impl TableReplicationError {
         &self.retry_policy
     }
 
+    /// Returns a copy of the error with the provided retry policy.
+    pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy;
+        self
+    }
+
     /// Converts an [`EtlError`] to a [`TableReplicationError`] for a specific table.
     ///
     /// Determines appropriate retry policies based on the error kind.

--- a/etl/src/test_utils/notify.rs
+++ b/etl/src/test_utils/notify.rs
@@ -19,17 +19,20 @@ pub enum StateStoreMethod {
     RollbackTableReplicationState,
 }
 
+type TableStateTypeCondition = (TableId, TableReplicationPhaseType, Arc<Notify>);
+type TableStateCondition = (
+    TableId,
+    Arc<Notify>,
+    Box<dyn Fn(&TableReplicationPhase) -> bool + Send + Sync>,
+);
+
 struct Inner {
     table_replication_states: HashMap<TableId, TableReplicationPhase>,
     table_state_history: HashMap<TableId, Vec<TableReplicationPhase>>,
     table_schemas: HashMap<TableId, Arc<TableSchema>>,
     table_mappings: HashMap<TableId, String>,
-    table_state_type_conditions: Vec<(TableId, TableReplicationPhaseType, Arc<Notify>)>,
-    table_state_conditions: Vec<(
-        TableId,
-        Arc<Notify>,
-        Box<dyn Fn(&TableReplicationPhase) -> bool + Send + Sync>,
-    )>,
+    table_state_type_conditions: Vec<TableStateTypeCondition>,
+    table_state_conditions: Vec<TableStateCondition>,
     method_call_notifiers: HashMap<StateStoreMethod, Vec<Arc<Notify>>>,
 }
 

--- a/etl/src/test_utils/pipeline.rs
+++ b/etl/src/test_utils/pipeline.rs
@@ -37,7 +37,7 @@ where
             max_fill_ms: 1000,
         },
         table_error_retry_delay_ms: 1000,
-        table_error_retry_max_attempts: 5,
+        table_error_retry_max_attempts: 2,
         max_table_sync_workers: 1,
     };
 

--- a/etl/src/test_utils/pipeline.rs
+++ b/etl/src/test_utils/pipeline.rs
@@ -37,6 +37,7 @@ where
             max_fill_ms: 1000,
         },
         table_error_retry_delay_ms: 1000,
+        table_error_retry_max_attempts: 5,
         max_table_sync_workers: 1,
     };
 
@@ -66,6 +67,7 @@ where
         pg_connection: pg_connection_config.clone(),
         batch,
         table_error_retry_delay_ms: 1000,
+        table_error_retry_max_attempts: 5,
         max_table_sync_workers: 1,
     };
 

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -486,7 +486,8 @@ where
                         );
 
                         table_error = table_error.with_retry_policy(RetryPolicy::ManualRetry);
-                        retry_policy = RetryPolicy::ManualRetry;
+                        retry_policy = table_error.retry_policy().clone();
+
                         state_guard.reset_retry_attempts();
                     }
 

--- a/etl/tests/failpoints_pipeline.rs
+++ b/etl/tests/failpoints_pipeline.rs
@@ -119,12 +119,15 @@ async fn table_copy_fails_after_timed_retry_exceeded_max_attempts() {
     // Register notifications for waiting on the manual retry which is expected to be flipped by the
     // max attempts handling.
     let users_state_notify = store
-        .notify_on_table_state(
-            database_schema.users_schema().id,
-            |phase| {
-                matches!(phase, TableReplicationPhase::Errored { retry_policy: RetryPolicy::ManualRetry, .. })
-            },
-        )
+        .notify_on_table_state(database_schema.users_schema().id, |phase| {
+            matches!(
+                phase,
+                TableReplicationPhase::Errored {
+                    retry_policy: RetryPolicy::ManualRetry,
+                    ..
+                }
+            )
+        })
         .await;
 
     pipeline.start().await.unwrap();

--- a/etl/tests/failpoints_pipeline.rs
+++ b/etl/tests/failpoints_pipeline.rs
@@ -134,10 +134,10 @@ async fn table_copy_fails_after_timed_retry_exceeded_max_attempts() {
 
     users_state_notify.notified().await;
 
-    // We expect to have a manul retry error which was used after the max attempts have been reached.
+    // We expect to still have the timed retry kind since this is the kind of error that we triggered.
     let err = pipeline.shutdown_and_wait().await.err().unwrap();
     assert_eq!(err.kinds().len(), 1);
-    assert_eq!(err.kinds()[0], ErrorKind::WithManualRetry);
+    assert_eq!(err.kinds()[0], ErrorKind::WithTimedRetry);
 
     // Verify no data is there.
     let table_rows = destination.get_table_rows().await;

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -44,13 +44,13 @@ async fn table_schema_copy_survives_pipeline_restarts() {
 
     // We wait for both table states to be in sync done.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
         .await;
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -190,10 +190,10 @@ async fn publication_changes_are_correctly_handled() {
 
     // Wait for initial copy completion (SyncDone) for both tables.
     let table_1_done = store
-        .notify_on_table_state(table_1_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_1_id, TableReplicationPhaseType::SyncDone)
         .await;
     let table_2_done = store
-        .notify_on_table_state(table_2_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_2_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -249,7 +249,7 @@ async fn publication_changes_are_correctly_handled() {
 
     // Wait for the table_3 to be done.
     let table_3_done = store
-        .notify_on_table_state(table_3_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_3_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -346,7 +346,7 @@ async fn publication_for_all_tables_in_schema_ignores_new_tables_until_restart()
     );
 
     let sync_done = store
-        .notify_on_table_state(table_1_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_1_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -386,7 +386,7 @@ async fn publication_for_all_tables_in_schema_ignores_new_tables_until_restart()
     );
 
     let sync_done = store
-        .notify_on_table_state(table_2_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_2_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -435,13 +435,13 @@ async fn table_copy_replicates_existing_data() {
 
     // Register notifications for table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
         .await;
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -528,13 +528,13 @@ async fn table_copy_and_sync_streams_new_data() {
 
     // Register notifications for initial table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
         .await;
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -557,13 +557,13 @@ async fn table_copy_and_sync_streams_new_data() {
 
     // Register notifications for ready state.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::Ready,
         )
         .await;
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::Ready,
         )
@@ -698,7 +698,7 @@ async fn table_sync_streams_new_data_with_batch_timeout_expired() {
 
     // Register notifications for initial table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -783,7 +783,7 @@ async fn table_processing_converges_to_apply_loop_with_no_events_coming() {
 
     // Register notifications for initial table copy completion.
     let users_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.users_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -838,7 +838,7 @@ async fn table_processing_with_schema_change_errors_table() {
 
     // Register notifications for initial table copy completion.
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::FinishedCopy,
         )
@@ -850,7 +850,7 @@ async fn table_processing_with_schema_change_errors_table() {
 
     // Register notification for the sync done state.
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::SyncDone,
         )
@@ -870,7 +870,7 @@ async fn table_processing_with_schema_change_errors_table() {
 
     // Register notification for the ready state.
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::Ready,
         )
@@ -890,7 +890,7 @@ async fn table_processing_with_schema_change_errors_table() {
 
     // Register notification for the errored state.
     let orders_state_notify = store
-        .notify_on_table_state(
+        .notify_on_table_state_type(
             database_schema.orders_schema().id,
             TableReplicationPhaseType::Errored,
         )
@@ -984,7 +984,7 @@ async fn table_without_primary_key_is_errored() {
 
     // We wait for the table to be errored.
     let errored_state = state_store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::Errored)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::Errored)
         .await;
 
     pipeline.start().await.unwrap();

--- a/etl/tests/replica_identity.rs
+++ b/etl/tests/replica_identity.rs
@@ -141,7 +141,7 @@ async fn update_non_toast_values_with_default_replica_identity() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -273,7 +273,7 @@ async fn update_non_toast_values_with_full_replica_identity() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -396,7 +396,7 @@ async fn update_toast_values_with_default_replica_identity() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -529,7 +529,7 @@ async fn update_non_toast_values_with_none_replica_identity() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();
@@ -675,7 +675,7 @@ async fn update_non_toast_values_with_unique_index_replica_identity() {
     );
 
     let table_sync_done_notification = store
-        .notify_on_table_state(table_id, TableReplicationPhaseType::SyncDone)
+        .notify_on_table_state_type(table_id, TableReplicationPhaseType::SyncDone)
         .await;
 
     pipeline.start().await.unwrap();


### PR DESCRIPTION
This PR adds a `max_attempts` mechanism to timed retires to avoid the worker continuing retrying errors indefinitely which could exhaust resources.