### PR TITLE
feat(api): Expose replication lag metrics from source Postgres

### DIFF
--- a/etl-api/src/db/pipelines.rs
+++ b/etl-api/src/db/pipelines.rs
@@ -47,7 +47,7 @@ pub enum PipelinesDbError {
     DestinationsDb(#[from] DestinationsDbError),
 
     #[error("Slot operation failed: {0}")]
-    SlotError(#[from] slots::SlotError),
+    SlotError(#[from] slots::EtlReplicationSlotError),
 }
 
 pub async fn count_pipelines_for_tenant<'c, E>(

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -978,10 +978,7 @@ pub async fn get_pipeline_replication_status(
             table_id: table_id.into_inner(),
             table_name: table_name.to_string(),
             state: table_replication_state.into(),
-            table_sync_lag: lag_metrics
-                .table_sync
-                .remove(&table_id)
-                .map(Into::into),
+            table_sync_lag: lag_metrics.table_sync.remove(&table_id).map(Into::into),
         });
     }
 

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -271,9 +271,7 @@ pub enum SimpleTableReplicationState {
     Queued,
     CopyingTable,
     CopiedTable,
-    FollowingWal {
-        lag: u64,
-    },
+    FollowingWal,
     Error {
         reason: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -301,13 +299,10 @@ impl From<state::TableReplicationState> for SimpleTableReplicationState {
             state::TableReplicationState::Init => SimpleTableReplicationState::Queued,
             state::TableReplicationState::DataSync => SimpleTableReplicationState::CopyingTable,
             state::TableReplicationState::FinishedCopy => SimpleTableReplicationState::CopiedTable,
-            // TODO: add lag metric when available.
             state::TableReplicationState::SyncDone { .. } => {
-                SimpleTableReplicationState::FollowingWal { lag: 0 }
+                SimpleTableReplicationState::FollowingWal
             }
-            state::TableReplicationState::Ready => {
-                SimpleTableReplicationState::FollowingWal { lag: 0 }
-            }
+            state::TableReplicationState::Ready => SimpleTableReplicationState::FollowingWal,
             state::TableReplicationState::Errored {
                 reason,
                 solution,

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -1027,7 +1027,7 @@ async fn pipeline_replication_status_returns_table_states_and_names() {
             )),
             "test.test_table_orders" => assert!(matches!(
                 table_status.state,
-                SimpleTableReplicationState::FollowingWal { .. }
+                SimpleTableReplicationState::FollowingWal
             )),
             _ => panic!("Unexpected table name: {table_name}"),
         }
@@ -1071,7 +1071,7 @@ async fn rollback_table_state_succeeds_for_manual_retry_errors() {
     assert_eq!(response.table_id, table_oid.0);
     assert!(matches!(
         response.new_state,
-        SimpleTableReplicationState::FollowingWal { .. }
+        SimpleTableReplicationState::FollowingWal
     ));
 
     drop_pg_database(&source_db_config).await;

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -1007,6 +1007,7 @@ async fn pipeline_replication_status_returns_table_states_and_names() {
 
     assert_eq!(response.pipeline_id, pipeline_id);
     assert_eq!(response.table_statuses.len(), 2);
+    assert!(response.apply_lag.is_none());
 
     // Verify table states
     for (table_oid, table_name) in &tables {
@@ -1017,6 +1018,7 @@ async fn pipeline_replication_status_returns_table_states_and_names() {
             .expect("Table not found in response");
 
         assert_eq!(table_status.table_id, table_oid.0);
+        assert!(table_status.table_sync_lag.is_none());
 
         match table_name.as_str() {
             "test.test_table_users" => assert!(matches!(

--- a/etl-postgres/Cargo.toml
+++ b/etl-postgres/Cargo.toml
@@ -28,6 +28,7 @@ sqlx = { workspace = true, features = [
     "postgres",
     "json",
     "migrate",
+    "time",
 ] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/etl-postgres/src/replication/lag.rs
+++ b/etl-postgres/src/replication/lag.rs
@@ -77,8 +77,6 @@ pub async fn get_pipeline_lag_metrics(
 
     let mut metrics = PipelineLagMetrics::default();
 
-    println!("rows {:?}", rows);
-
     for row in rows {
         let slot_lag_metrics = SlotLagMetrics {
             restart_lsn_bytes: row.restart_lsn_bytes,

--- a/etl-postgres/src/replication/lag.rs
+++ b/etl-postgres/src/replication/lag.rs
@@ -1,0 +1,115 @@
+use sqlx::{FromRow, PgPool};
+use std::collections::BTreeMap;
+
+use crate::replication::slots::EtlReplicationSlot;
+use crate::types::TableId;
+
+/// Lag metrics associated with a logical replication slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlotLagMetrics {
+    /// The number of bytes between the current WAL LSN and the slot restart LSN.
+    pub restart_lsn_bytes: i64,
+    /// The number of bytes between the current WAL LSN and the confirmed flush LSN.
+    pub confirmed_flush_lsn_bytes: i64,
+    /// How many bytes of WAL are still safe to build up before the limit of the slot is reached.
+    pub safe_wal_size_bytes: i64,
+    /// Write lag in milliseconds relative to the primary.
+    pub write_lag_ms: Option<i64>,
+    /// Flush lag in milliseconds relative to the primary.
+    pub flush_lag_ms: Option<i64>,
+}
+
+/// Lag metrics for pipeline apply and table sync workers.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PipelineLagMetrics {
+    /// Lag metrics for the apply worker slot.
+    pub apply: Option<SlotLagMetrics>,
+    /// Lag metrics keyed by table OID for table sync worker slots.
+    pub table_sync: BTreeMap<TableId, SlotLagMetrics>,
+}
+
+/// Database row returned by the replication slot lag query.
+#[derive(Debug, FromRow)]
+struct SlotLagRow {
+    slot_name: String,
+    restart_lsn_bytes: i64,
+    confirmed_flush_lsn_bytes: i64,
+    safe_wal_size_bytes: i64,
+    write_lag_milliseconds: Option<i64>,
+    flush_lag_milliseconds: Option<i64>,
+}
+
+/// Fetches replication lag metrics for the given pipeline by inspecting logical replication slots.
+///
+/// Returns aggregated lag metrics for the apply worker slot and each table sync slot associated
+/// with the pipeline. Slots that are not currently active in `pg_stat_replication` still report
+/// their WAL metrics, while the write and flush lag values remain `None`.
+pub async fn get_pipeline_lag_metrics(
+    pool: &PgPool,
+    pipeline_id: u64,
+) -> sqlx::Result<PipelineLagMetrics> {
+    let Ok(apply_prefix) = EtlReplicationSlot::apply_prefix(pipeline_id) else {
+        return Ok(PipelineLagMetrics::default());
+    };
+    let Ok(table_sync_prefix) = EtlReplicationSlot::table_sync_prefix(pipeline_id) else {
+        return Ok(PipelineLagMetrics::default());
+    };
+
+    let rows: Vec<SlotLagRow> = sqlx::query_as(
+        r#"
+        select
+            s.slot_name,
+            coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), s.restart_lsn), 0)::bigint as restart_lsn_bytes,
+            coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), s.confirmed_flush_lsn), 0)::bigint as confirmed_flush_lsn_bytes,
+            coalesce(s.safe_wal_size, 0) as safe_wal_size_bytes,
+            round(extract(epoch from r.write_lag) * 1000)::bigint as write_lag_milliseconds,
+            round(extract(epoch from r.flush_lag) * 1000)::bigint as flush_lag_milliseconds
+        from pg_replication_slots as s
+        left outer join pg_stat_replication as r on s.active_pid = r.pid
+        where s.slot_type = 'logical'
+          and (s.slot_name = $1 or s.slot_name like $2)
+        "#,
+    )
+    .bind(apply_prefix)
+    .bind(format!("{table_sync_prefix}%"))
+    .fetch_all(pool)
+    .await?;
+
+    let mut metrics = PipelineLagMetrics::default();
+
+    for row in rows {
+        let SlotLagRow {
+            slot_name,
+            restart_lsn_bytes,
+            confirmed_flush_lsn_bytes,
+            safe_wal_size_bytes,
+            write_lag_milliseconds: write_lag_ms,
+            flush_lag_milliseconds: flush_lag_ms,
+        } = row;
+
+        let slot_lag_metrics = SlotLagMetrics {
+            restart_lsn_bytes,
+            confirmed_flush_lsn_bytes,
+            safe_wal_size_bytes,
+            write_lag_ms,
+            flush_lag_ms,
+        };
+
+        match EtlReplicationSlot::try_from_string(&slot_name) {
+            Ok(EtlReplicationSlot::Apply {
+                pipeline_id: slot_pipeline_id,
+            }) if slot_pipeline_id == pipeline_id => {
+                metrics.apply = Some(slot_lag_metrics);
+            }
+            Ok(EtlReplicationSlot::TableSync {
+                pipeline_id: slot_pipeline_id,
+                table_id,
+            }) if slot_pipeline_id == pipeline_id => {
+                metrics.table_sync.insert(table_id, slot_lag_metrics);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(metrics)
+}

--- a/etl-postgres/src/replication/lag.rs
+++ b/etl-postgres/src/replication/lag.rs
@@ -5,7 +5,7 @@ use crate::replication::slots::EtlReplicationSlot;
 use crate::types::TableId;
 
 /// Lag metrics associated with a logical replication slot.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct SlotLagMetrics {
     /// The number of bytes between the current WAL LSN and the slot restart LSN.
     pub restart_lsn_bytes: i64,
@@ -20,7 +20,7 @@ pub struct SlotLagMetrics {
 }
 
 /// Lag metrics for pipeline apply and table sync workers.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct PipelineLagMetrics {
     /// Lag metrics for the apply worker slot.
     pub apply: Option<SlotLagMetrics>,

--- a/etl-postgres/src/replication/lag.rs
+++ b/etl-postgres/src/replication/lag.rs
@@ -35,8 +35,8 @@ struct SlotLagRow {
     restart_lsn_bytes: i64,
     confirmed_flush_lsn_bytes: i64,
     safe_wal_size_bytes: i64,
-    write_lag_milliseconds: Option<i64>,
-    flush_lag_milliseconds: Option<i64>,
+    write_lag_ms: Option<i64>,
+    flush_lag_ms: Option<i64>,
 }
 
 /// Fetches replication lag metrics for the given pipeline by inspecting logical replication slots.
@@ -78,24 +78,15 @@ pub async fn get_pipeline_lag_metrics(
     let mut metrics = PipelineLagMetrics::default();
 
     for row in rows {
-        let SlotLagRow {
-            slot_name,
-            restart_lsn_bytes,
-            confirmed_flush_lsn_bytes,
-            safe_wal_size_bytes,
-            write_lag_milliseconds: write_lag_ms,
-            flush_lag_milliseconds: flush_lag_ms,
-        } = row;
-
         let slot_lag_metrics = SlotLagMetrics {
-            restart_lsn_bytes,
-            confirmed_flush_lsn_bytes,
-            safe_wal_size_bytes,
-            write_lag_ms,
-            flush_lag_ms,
+            restart_lsn_bytes: row.restart_lsn_bytes,
+            confirmed_flush_lsn_bytes: row.confirmed_flush_lsn_bytes,
+            safe_wal_size_bytes: row.safe_wal_size_bytes,
+            write_lag_ms: row.write_lag_ms,
+            flush_lag_ms: row.flush_lag_ms,
         };
 
-        match EtlReplicationSlot::try_from_string(&slot_name) {
+        match EtlReplicationSlot::try_from_string(&row.slot_name) {
             Ok(EtlReplicationSlot::Apply {
                 pipeline_id: slot_pipeline_id,
             }) if slot_pipeline_id == pipeline_id => {

--- a/etl-postgres/src/replication/lag.rs
+++ b/etl-postgres/src/replication/lag.rs
@@ -62,8 +62,8 @@ pub async fn get_pipeline_lag_metrics(
             coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), s.restart_lsn), 0)::bigint as restart_lsn_bytes,
             coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), s.confirmed_flush_lsn), 0)::bigint as confirmed_flush_lsn_bytes,
             coalesce(s.safe_wal_size, 0) as safe_wal_size_bytes,
-            round(extract(epoch from r.write_lag) * 1000)::bigint as write_lag_milliseconds,
-            round(extract(epoch from r.flush_lag) * 1000)::bigint as flush_lag_milliseconds
+            round(extract(epoch from r.write_lag) * 1000)::bigint as write_lag_ms,
+            round(extract(epoch from r.flush_lag) * 1000)::bigint as flush_lag_ms
         from pg_replication_slots as s
         left outer join pg_stat_replication as r on s.active_pid = r.pid
         where s.slot_type = 'logical'
@@ -76,6 +76,8 @@ pub async fn get_pipeline_lag_metrics(
     .await?;
 
     let mut metrics = PipelineLagMetrics::default();
+
+    println!("rows {:?}", rows);
 
     for row in rows {
         let slot_lag_metrics = SlotLagMetrics {

--- a/etl-postgres/src/replication/lag.rs
+++ b/etl-postgres/src/replication/lag.rs
@@ -86,7 +86,7 @@ pub async fn get_pipeline_lag_metrics(
             flush_lag_ms: row.flush_lag_ms,
         };
 
-        match EtlReplicationSlot::try_from_string(&row.slot_name) {
+        match EtlReplicationSlot::try_from(row.slot_name.as_str()) {
             Ok(EtlReplicationSlot::Apply {
                 pipeline_id: slot_pipeline_id,
             }) if slot_pipeline_id == pipeline_id => {

--- a/etl-postgres/src/replication/mod.rs
+++ b/etl-postgres/src/replication/mod.rs
@@ -1,5 +1,6 @@
 mod db;
 pub mod health;
+pub mod lag;
 pub mod schema;
 pub mod slots;
 pub mod state;

--- a/etl-postgres/src/replication/slots.rs
+++ b/etl-postgres/src/replication/slots.rs
@@ -31,10 +31,12 @@ pub enum EtlReplicationSlot {
 }
 
 impl EtlReplicationSlot {
+    /// Creates a new [`EtlReplicationSlot`] for the apply worker.
     pub fn for_apply_worker(pipeline_id: u64) -> Self {
         Self::Apply { pipeline_id }
     }
 
+    /// Creates a new [`EtlReplicationSlot`] for the table sync worker.
     pub fn for_table_sync_worker(pipeline_id: u64, table_id: TableId) -> Self {
         Self::TableSync {
             pipeline_id,

--- a/etl-postgres/src/replication/slots.rs
+++ b/etl-postgres/src/replication/slots.rs
@@ -68,7 +68,6 @@ impl EtlReplicationSlot {
 }
 
 impl TryFrom<&str> for EtlReplicationSlot {
-
     type Error = EtlReplicationSlotError;
 
     fn try_from(slot_name: &str) -> Result<Self, Self::Error> {
@@ -116,7 +115,6 @@ impl TryFrom<&str> for EtlReplicationSlot {
 }
 
 impl TryFrom<EtlReplicationSlot> for String {
-
     type Error = EtlReplicationSlotError;
 
     fn try_from(slot: EtlReplicationSlot) -> Result<Self, Self::Error> {
@@ -203,9 +201,10 @@ mod tests {
     #[test]
     fn test_table_sync_slot_name() {
         let pipeline_id = 1;
-        let result: String = EtlReplicationSlot::for_table_sync_worker(pipeline_id, TableId::new(123))
-            .try_into()
-            .unwrap();
+        let result: String =
+            EtlReplicationSlot::for_table_sync_worker(pipeline_id, TableId::new(123))
+                .try_into()
+                .unwrap();
 
         assert!(result.starts_with(TABLE_SYNC_WORKER_PREFIX));
         assert!(result.len() <= MAX_SLOT_NAME_LENGTH);
@@ -254,8 +253,7 @@ mod tests {
 
     #[test]
     fn test_parse_table_sync_slot() {
-        let parsed =
-            EtlReplicationSlot::try_from("supabase_etl_table_sync_7_12345").unwrap();
+        let parsed = EtlReplicationSlot::try_from("supabase_etl_table_sync_7_12345").unwrap();
         assert_eq!(
             parsed,
             EtlReplicationSlot::TableSync {

--- a/etl-postgres/src/replication/worker.rs
+++ b/etl-postgres/src/replication/worker.rs
@@ -1,3 +1,4 @@
+use crate::replication::slots::EtlReplicationSlot;
 use crate::types::TableId;
 
 /// Enum representing the types of workers that can be involved with a replication task.
@@ -5,4 +6,16 @@ use crate::types::TableId;
 pub enum WorkerType {
     Apply,
     TableSync { table_id: TableId },
+}
+
+impl WorkerType {
+    pub fn build_etl_replication_slot(&self, pipeline_id: u64) -> EtlReplicationSlot {
+        match self {
+            Self::Apply => EtlReplicationSlot::Apply { pipeline_id },
+            Self::TableSync { table_id } => EtlReplicationSlot::TableSync {
+                pipeline_id,
+                table_id: *table_id,
+            },
+        }
+    }
 }

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -739,19 +739,28 @@ impl From<sqlx::Error> for EtlError {
     }
 }
 
-/// Converts [`etl_postgres::replication::slots::SlotError`] to [`EtlError`] with appropriate error kind.
-impl From<etl_postgres::replication::slots::SlotError> for EtlError {
-    fn from(err: etl_postgres::replication::slots::SlotError) -> EtlError {
+/// Converts [`etl_postgres::replication::slots::EtlReplicationSlotError`] to [`EtlError`] with appropriate error kind.
+impl From<etl_postgres::replication::slots::EtlReplicationSlotError> for EtlError {
+    fn from(err: etl_postgres::replication::slots::EtlReplicationSlotError) -> EtlError {
         match err {
-            etl_postgres::replication::slots::SlotError::InvalidSlotNameLength(slot_name) => {
-                EtlError {
-                    repr: ErrorRepr::WithDescriptionAndDetail(
-                        ErrorKind::ValidationError,
-                        "Replication slot name exceeds maximum length",
-                        slot_name,
-                    ),
-                }
-            }
+            etl_postgres::replication::slots::EtlReplicationSlotError::InvalidSlotNameLength(
+                slot_name,
+            ) => EtlError {
+                repr: ErrorRepr::WithDescriptionAndDetail(
+                    ErrorKind::ValidationError,
+                    "Replication slot name exceeds maximum length",
+                    slot_name,
+                ),
+            },
+            etl_postgres::replication::slots::EtlReplicationSlotError::InvalidSlotName(
+                slot_name,
+            ) => EtlError {
+                repr: ErrorRepr::WithDescriptionAndDetail(
+                    ErrorKind::ValidationError,
+                    "Replication slot name is invalid",
+                    slot_name,
+                ),
+            },
         }
     }
 }

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -463,10 +463,10 @@ where
 
     // We compute the slot name for the replication slot that we are going to use for the logical
     // replication. At this point we assume that the slot already exists.
-    let slot_name = hook
+    let slot_name: String = hook
         .worker_type()
         .build_etl_replication_slot(pipeline_id)
-        .try_to_string()?;
+        .try_into()?;
 
     // We start the logical replication stream with the supplied parameters at a given lsn. That
     // lsn is the last lsn from which we need to start fetching events.

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1,5 +1,4 @@
 use etl_config::shared::PipelineConfig;
-use etl_postgres::replication::slots::get_slot_name;
 use etl_postgres::replication::worker::WorkerType;
 use etl_postgres::types::TableId;
 use futures::StreamExt;
@@ -475,7 +474,10 @@ where
 
     // We compute the slot name for the replication slot that we are going to use for the logical
     // replication. At this point we assume that the slot already exists.
-    let slot_name = get_slot_name(pipeline_id, hook.worker_type())?;
+    let slot_name = hook
+        .worker_type()
+        .build_etl_replication_slot(pipeline_id)
+        .try_to_string()?;
 
     // We start the logical replication stream with the supplied parameters at a given lsn. That
     // lsn is the last lsn from which we need to start fetching events.

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -120,8 +120,8 @@ where
         phase_type
     };
 
-    let slot_name =
-        EtlReplicationSlot::for_table_sync_worker(pipeline_id, table_id).try_to_string()?;
+    let slot_name: String =
+        EtlReplicationSlot::for_table_sync_worker(pipeline_id, table_id).try_into()?;
 
     // There are three phases in which the table can be in:
     // - `Init` -> this means that the table sync was never done, so we just perform it.

--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -1,6 +1,5 @@
 use etl_config::shared::PipelineConfig;
-use etl_postgres::replication::slots::get_slot_name;
-use etl_postgres::replication::worker::WorkerType;
+use etl_postgres::replication::slots::EtlReplicationSlot;
 use etl_postgres::types::TableId;
 use futures::StreamExt;
 use metrics::{gauge, histogram};
@@ -121,7 +120,8 @@ where
         phase_type
     };
 
-    let slot_name = get_slot_name(pipeline_id, WorkerType::TableSync { table_id })?;
+    let slot_name =
+        EtlReplicationSlot::for_table_sync_worker(pipeline_id, table_id).try_to_string()?;
 
     // There are three phases in which the table can be in:
     // - `Init` -> this means that the table sync was never done, so we just perform it.

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -1,4 +1,6 @@
 use etl_config::shared::PipelineConfig;
+use etl_postgres::replication::slots::EtlReplicationSlot;
+use etl_postgres::replication::worker::WorkerType;
 use etl_postgres::types::TableId;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -25,8 +27,6 @@ use crate::types::PipelineId;
 use crate::workers::base::{Worker, WorkerHandle};
 use crate::workers::pool::TableSyncWorkerPool;
 use crate::workers::table_sync::{TableSyncWorker, TableSyncWorkerState};
-use etl_postgres::replication::slots::get_slot_name;
-use etl_postgres::replication::worker::WorkerType;
 
 /// Handle for monitoring and controlling the apply worker.
 ///
@@ -189,7 +189,7 @@ async fn get_start_lsn(
     pipeline_id: PipelineId,
     replication_client: &PgReplicationClient,
 ) -> EtlResult<PgLsn> {
-    let slot_name = get_slot_name(pipeline_id, WorkerType::Apply)?;
+    let slot_name = EtlReplicationSlot::Apply { pipeline_id }.try_to_string()?;
 
     // TODO: validate that we only create the slot when we first start replication which
     //  means when all tables are in the Init state. In any other case we should raise an

--- a/etl/src/workers/apply.rs
+++ b/etl/src/workers/apply.rs
@@ -189,7 +189,7 @@ async fn get_start_lsn(
     pipeline_id: PipelineId,
     replication_client: &PgReplicationClient,
 ) -> EtlResult<PgLsn> {
-    let slot_name = EtlReplicationSlot::Apply { pipeline_id }.try_to_string()?;
+    let slot_name: String = EtlReplicationSlot::for_apply_worker(pipeline_id).try_into()?;
 
     // TODO: validate that we only create the slot when we first start replication which
     //  means when all tables are in the Init state. In any other case we should raise an

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -658,9 +658,9 @@ where
             // removed later, so manual intervention will be required. The reason for not implementing
             // an automatic cleanup mechanism is that it would introduce performance overhead,
             // and we expect this call to fail only rarely.
-            let slot_name =
+            let slot_name: String =
                 EtlReplicationSlot::for_table_sync_worker(self.pipeline_id, self.table_id)
-                    .try_to_string()?;
+                    .try_into()?;
             let result = tokio::time::timeout(
                 MAX_DELETE_SLOT_WAIT,
                 replication_client.delete_slot(&slot_name),

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use etl_config::shared::PipelineConfig;
-use etl_postgres::replication::slots::get_slot_name;
+use etl_postgres::replication::slots::EtlReplicationSlot;
 use etl_postgres::replication::worker::WorkerType;
 use etl_postgres::types::TableId;
 use std::ops::Deref;
@@ -658,10 +658,9 @@ where
             // removed later, so manual intervention will be required. The reason for not implementing
             // an automatic cleanup mechanism is that it would introduce performance overhead,
             // and we expect this call to fail only rarely.
-            let worker_type = WorkerType::TableSync {
-                table_id: self.table_id,
-            };
-            let slot_name = get_slot_name(self.pipeline_id, worker_type)?;
+            let slot_name =
+                EtlReplicationSlot::for_table_sync_worker(self.pipeline_id, self.table_id)
+                    .try_to_string()?;
             let result = tokio::time::timeout(
                 MAX_DELETE_SLOT_WAIT,
                 replication_client.delete_slot(&slot_name),

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -467,13 +467,13 @@ async fn table_copy_replicates_existing_data() {
     assert_eq!(age_sum, expected_age_sum);
 
     // Check that the replication slots for the two tables have been removed.
-    let users_replication_slot =
+    let users_replication_slot: String =
         EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.users_schema().id)
-            .try_to_string()
+            .try_into()
             .unwrap();
-    let orders_replication_slot =
+    let orders_replication_slot: String =
         EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.orders_schema().id)
-            .try_to_string()
+            .try_into()
             .unwrap();
     assert!(
         !database
@@ -635,13 +635,13 @@ async fn table_copy_and_sync_streams_new_data() {
     assert_events_equal(orders_inserts, &expected_orders_inserts);
 
     // Check that the replication slots for the two tables have been removed.
-    let users_replication_slot =
+    let users_replication_slot: String =
         EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.users_schema().id)
-            .try_to_string()
+            .try_into()
             .unwrap();
-    let orders_replication_slot =
+    let orders_replication_slot: String =
         EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.orders_schema().id)
-            .try_to_string()
+            .try_into()
             .unwrap();
     assert!(
         !database

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -15,8 +15,7 @@ use etl::test_utils::test_schema::{
 };
 use etl::types::{EventType, PipelineId};
 use etl_config::shared::BatchConfig;
-use etl_postgres::replication::slots::get_slot_name;
-use etl_postgres::replication::worker::WorkerType;
+use etl_postgres::replication::slots::EtlReplicationSlot;
 use etl_postgres::tokio::test_utils::TableModification;
 use etl_telemetry::tracing::init_test_tracing;
 use rand::random;
@@ -468,20 +467,14 @@ async fn table_copy_replicates_existing_data() {
     assert_eq!(age_sum, expected_age_sum);
 
     // Check that the replication slots for the two tables have been removed.
-    let users_replication_slot = get_slot_name(
-        pipeline_id,
-        WorkerType::TableSync {
-            table_id: database_schema.users_schema().id,
-        },
-    )
-    .unwrap();
-    let orders_replication_slot = get_slot_name(
-        pipeline_id,
-        WorkerType::TableSync {
-            table_id: database_schema.orders_schema().id,
-        },
-    )
-    .unwrap();
+    let users_replication_slot =
+        EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.users_schema().id)
+            .try_to_string()
+            .unwrap();
+    let orders_replication_slot =
+        EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.orders_schema().id)
+            .try_to_string()
+            .unwrap();
     assert!(
         !database
             .replication_slot_exists(&users_replication_slot)
@@ -642,20 +635,14 @@ async fn table_copy_and_sync_streams_new_data() {
     assert_events_equal(orders_inserts, &expected_orders_inserts);
 
     // Check that the replication slots for the two tables have been removed.
-    let users_replication_slot = get_slot_name(
-        pipeline_id,
-        WorkerType::TableSync {
-            table_id: database_schema.users_schema().id,
-        },
-    )
-    .unwrap();
-    let orders_replication_slot = get_slot_name(
-        pipeline_id,
-        WorkerType::TableSync {
-            table_id: database_schema.orders_schema().id,
-        },
-    )
-    .unwrap();
+    let users_replication_slot =
+        EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.users_schema().id)
+            .try_to_string()
+            .unwrap();
+    let orders_replication_slot =
+        EtlReplicationSlot::for_table_sync_worker(pipeline_id, database_schema.orders_schema().id)
+            .try_to_string()
+            .unwrap();
     assert!(
         !database
             .replication_slot_exists(&users_replication_slot)


### PR DESCRIPTION
This PR exposes replication lag metrics for the apply worker and table sync worker by fetching metrics from Postgres itself.