### PR TITLE
Add more options for auth

### DIFF
--- a/etl-destinations/src/bigquery/client.rs
+++ b/etl-destinations/src/bigquery/client.rs
@@ -98,6 +98,33 @@ impl BigQueryClient {
         Ok(BigQueryClient { project_id, client })
     }
 
+    /// Creates a new [`BigQueryClient`] using Application Default Credentials.
+    ///
+    /// Authenticates with BigQuery using the environment's default credentials.
+    /// Returns an error if credentials are missing or invalid.
+    pub async fn new_with_adc(project_id: BigQueryProjectId) -> EtlResult<BigQueryClient> {
+        let client = Client::from_application_default_credentials()
+            .await
+            .map_err(bq_error_to_etl_error)?;
+
+        Ok(BigQueryClient { project_id, client })
+    }
+
+    /// Creates a new [`BigQueryClient`] using OAuth2 installed flow authentication.
+    ///
+    /// Authenticates with BigQuery using the OAuth2 installed flow.
+    pub async fn new_with_flow_authenticator<S: AsRef<[u8]>, P: Into<std::path::PathBuf>>(
+        project_id: BigQueryProjectId,
+        secret: S,
+        persistant_file_path: P,
+    ) -> EtlResult<BigQueryClient> {
+        let client = Client::from_installed_flow_authenticator(secret, persistant_file_path)
+            .await
+            .map_err(bq_error_to_etl_error)?;
+
+        Ok(BigQueryClient { project_id, client })
+    }
+
     /// Returns the fully qualified BigQuery table name.
     ///
     /// Formats the table name as `project_id.dataset_id.table_id` with proper quoting.


### PR DESCRIPTION
This pull request adds support for two new authentication methods when initializing BigQuery clients and destinations: Application Default Credentials (ADC) and OAuth2 installed flow authentication. This makes it easier to integrate with different authentication environments and improves flexibility for users.

**BigQuery client authentication enhancements:**

* Added `new_with_adc` to `BigQueryClient` for initializing using Application Default Credentials, simplifying authentication in cloud environments.
* Added `new_with_flow_authenticator` to `BigQueryClient` for OAuth2 installed flow authentication, supporting scenarios where interactive user authentication is needed.

**BigQuery destination initialization improvements:**

* Added `new_with_adc` to `BigQueryDestination` to allow creation using ADC, enabling seamless integration with GCP environments.
* Added `new_with_flow_authenticator` to `BigQueryDestination` to support initialization with an OAuth2 flow authenticator, providing more options for credential management and user authentication.