### PR TITLE
chore: update deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,5 @@
 [advisories]
 version = 2
 ignore = [
-    { id = "RUSTSEC-2024-0370", reason = "Disabling because it is not a real vulnerability. The crate proc-macro-error is just unmaintained." },
-    { id = "RUSTSEC-2024-0384", reason = "Disabling because it is not a real vulnerability. The crate instant is just unmaintained." },
-    { id = "RUSTSEC-2025-0012", reason = "Disabling because it is not a real vulnerability. The crate backoff is just unmaintained." },
     { id = "RUSTSEC-2024-0436", reason = "Disabling because it is not a real vulnerability. The crate paste is just unmaintained." },
 ]


### PR DESCRIPTION
Removed ignored advisories which are not applicable any longer.