### PR TITLE
feat: encrypt s3_access_key_id as well

### DIFF
--- a/etl-api/tests/snapshots/destinations__an_existing_iceberg_supabase_destination_can_be_updated.snap
+++ b/etl-api/tests/snapshots/destinations__an_existing_iceberg_supabase_destination_can_be_updated.snap
@@ -10,7 +10,9 @@ Iceberg {
         catalog_token: SerializableSecretString(
             SecretBox<str>([REDACTED]),
         ),
-        s3_access_key_id: "updated9156667efc2c70d89af6588da86d2924",
+        s3_access_key_id: SerializableSecretString(
+            SecretBox<str>([REDACTED]),
+        ),
         s3_secret_access_key: SerializableSecretString(
             SecretBox<str>([REDACTED]),
         ),

--- a/etl-api/tests/snapshots/destinations_pipelines__an_existing_iceberg_supabase_destination_and_pipeline_can_be_updated.snap
+++ b/etl-api/tests/snapshots/destinations_pipelines__an_existing_iceberg_supabase_destination_and_pipeline_can_be_updated.snap
@@ -10,7 +10,9 @@ Iceberg {
         catalog_token: SerializableSecretString(
             SecretBox<str>([REDACTED]),
         ),
-        s3_access_key_id: "updated9156667efc2c70d89af6588da86d2924",
+        s3_access_key_id: SerializableSecretString(
+            SecretBox<str>([REDACTED]),
+        ),
         s3_secret_access_key: SerializableSecretString(
             SecretBox<str>([REDACTED]),
         ),

--- a/etl-api/tests/snapshots/destinations_pipelines__iceberg_supabase_destination_and_pipeline_can_be_created.snap
+++ b/etl-api/tests/snapshots/destinations_pipelines__iceberg_supabase_destination_and_pipeline_can_be_created.snap
@@ -10,7 +10,9 @@ Iceberg {
         catalog_token: SerializableSecretString(
             SecretBox<str>([REDACTED]),
         ),
-        s3_access_key_id: "9156667efc2c70d89af6588da86d2924",
+        s3_access_key_id: SerializableSecretString(
+            SecretBox<str>([REDACTED]),
+        ),
         s3_secret_access_key: SerializableSecretString(
             SecretBox<str>([REDACTED]),
         ),

--- a/etl-api/tests/support/mocks.rs
+++ b/etl-api/tests/support/mocks.rs
@@ -78,7 +78,7 @@ pub mod destinations {
                 catalog_token: SerializableSecretString::from(
                     "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjFkNzFjMGEyNmIxMDFjODQ5ZTkxZmQ1NjdjYjA5NTJmIn0.eyJleHAiOjIwNzA3MTcxNjAsImlhdCI6MTc1NjE0NTE1MCwiaXNzIjoic3VwYWJhc2UiLCJyZWYiOiJhYmNkZWZnaGlqbGttbm9wcXJzdCIsInJvbGUiOiJzZXJ2aWNlX3JvbGUifQ.YdTWkkIvwjSkXot3NC07xyjPjGWQMNzLq5EPzumzrdLzuHrj-zuzI-nlyQtQ5V7gZauysm-wGwmpztRXfPc3AQ".to_string()
                 ),
-                s3_access_key_id: "9156667efc2c70d89af6588da86d2924".to_string(),
+                s3_access_key_id: SerializableSecretString::from("9156667efc2c70d89af6588da86d2924".to_string()),
                 s3_secret_access_key: SerializableSecretString::from(
                     "ca833e890916d848c69135924bcd75e5909184814a0ebc6c988937ee094120d4".to_string()
                 ),
@@ -99,7 +99,7 @@ pub mod destinations {
                 catalog_token: SerializableSecretString::from(
                     "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IjJlOGQxZDNjN2MyMTJkOTU4ZmEyOGU2ZDhjZDEwYTMzIn0.eyJleHAiOjIwNzA3MTcxNjAsImlhdCI6MTc1NjE0NTE1MCwiaXNzIjoic3VwYWJhc2UiLCJyZWYiOiJ0c3JxcG9ubWxramloZ2ZlZGNiYSIsInJvbGUiOiJzZXJ2aWNlX3JvbGUifQ.UpdatedTokenSignatureForTesting".to_string()
                 ),
-                s3_access_key_id: "updated9156667efc2c70d89af6588da86d2924".to_string(),
+                s3_access_key_id: SerializableSecretString::from("updated9156667efc2c70d89af6588da86d2924".to_string()),
                 s3_secret_access_key: SerializableSecretString::from(
                     "updatedca833e890916d848c69135924bcd75e5909184814a0ebc6c988937ee094120d4".to_string()
                 ),

--- a/etl-config/src/shared/destination.rs
+++ b/etl-config/src/shared/destination.rs
@@ -59,7 +59,7 @@ pub enum IcebergConfig {
         /// Catalog authentication token
         catalog_token: SerializableSecretString,
         /// The S3 access key id
-        s3_access_key_id: String,
+        s3_access_key_id: SerializableSecretString,
         /// The S3 secret access key
         s3_secret_access_key: SerializableSecretString,
         /// The S3 region

--- a/etl-replicator/src/core.rs
+++ b/etl-replicator/src/core.rs
@@ -92,7 +92,7 @@ pub async fn start_replicator_with_config(
                 supabase_domain,
                 catalog_token.expose_secret().to_string(),
                 warehouse_name.clone(),
-                s3_access_key_id.clone(),
+                s3_access_key_id.expose_secret().to_string(),
                 s3_secret_access_key.expose_secret().to_string(),
                 s3_region.clone(),
             );
@@ -160,18 +160,14 @@ fn log_destination_config(config: &DestinationConfig) {
                     project_ref,
                     catalog_token: _,
                     warehouse_name,
-                    s3_access_key_id,
+                    s3_access_key_id: _,
                     s3_secret_access_key: _,
                     s3_region,
                 },
         } => {
             debug!(
                 namespace,
-                project_ref,
-                warehouse_name,
-                s3_access_key_id,
-                s3_region,
-                "using Supabase iceberg destination config"
+                project_ref, warehouse_name, s3_region, "using Supabase iceberg destination config"
             )
         }
         DestinationConfig::Iceberg {


### PR DESCRIPTION
To be consistent with the UI whe s3 access key is shown as an obscured value because it is sensitive, etl api also now stores it as encrypted.