### PR TITLE
chore: make postgres team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @supabase/etl
+* @supabase/postgres


### PR DESCRIPTION
This PR makes postgres team as codeowners temporarily until Riccardo is back from vacation.