### PR TITLE
fix: reduce sentry txn sample rate & fix middleware ordering

### DIFF
--- a/etl-api/src/main.rs
+++ b/etl-api/src/main.rs
@@ -77,7 +77,7 @@ fn init_sentry() -> anyhow::Result<Option<sentry::ClientInitGuard>> {
         let guard = sentry::init(sentry::ClientOptions {
             dsn: Some(sentry_config.dsn.parse()?),
             environment: Some(environment.to_string().into()),
-            traces_sample_rate: 1.0,
+            traces_sample_rate: 0.01,
             max_request_body_size: sentry::MaxRequestBodySize::Always,
             integrations: vec![Arc::new(
                 sentry::integrations::panic::PanicIntegration::new(),

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -274,14 +274,14 @@ pub async fn run(
         let tracing_logger = TracingLogger::<ApiRootSpanBuilder>::new();
         let authentication = HttpAuthentication::bearer(auth_validator);
         let app = App::new()
+            .wrap(actix_metrics.clone())
+            .wrap(tracing_logger)
             .wrap(
                 sentry::integrations::actix::Sentry::builder()
                     .capture_server_errors(true)
                     .start_transaction(true)
                     .finish(),
             )
-            .wrap(actix_metrics.clone())
-            .wrap(tracing_logger)
             .service(health_check)
             .service(metrics)
             .service(


### PR DESCRIPTION
This PR:

* Corrects the order in which actix middleware are wrapped. The sentry middleware should wrap all others.
* Reduces the sentry transaction sample rate to 1% to avoid sending too many transactions to sentry ([context](https://supabase.slack.com/archives/C01D6TWFFFW/p1760373821935849))