### PR TITLE
fix: always map unknown types to strings

### DIFF
--- a/etl-postgres/src/types/utils.rs
+++ b/etl-postgres/src/types/utils.rs
@@ -1,16 +1,11 @@
-use tokio_postgres::types::{Kind, PgLsn, Type};
+use tokio_postgres::types::{PgLsn, Type};
 
 /// Converts a Postgres type OID to a [`Type`] instance.
 ///
-/// Returns a properly constructed [`Type`] for the given OID, or creates an unnamed
+/// Returns a properly constructed [`Type`] for the given OID, or return TEXT
 /// type as fallback if the OID lookup fails.
 pub fn convert_type_oid_to_type(type_oid: u32) -> Type {
-    Type::from_oid(type_oid).unwrap_or(Type::new(
-        format!("unnamed_type({type_oid})"),
-        type_oid,
-        Kind::Simple,
-        "pg_catalog".to_string(),
-    ))
+    Type::from_oid(type_oid).unwrap_or(Type::TEXT)
 }
 
 /// Returns whether the Postgres type is an array type.

--- a/etl-replicator/Cargo.toml
+++ b/etl-replicator/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-etl = { workspace = true, features = ["unknown-types-to-bytes"] }
+etl = { workspace = true }
 etl-config = { workspace = true }
 etl-destinations = { workspace = true, features = ["bigquery", "iceberg"] }
 etl-telemetry = { workspace = true }

--- a/etl/Cargo.toml
+++ b/etl/Cargo.toml
@@ -8,10 +8,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-unknown-types-to-bytes = []
 test-utils = ["etl-postgres/test-utils"]
 failpoints = ["fail/failpoints"]
-default = ["unknown-types-to-bytes"]
+default = []
 
 [dependencies]
 etl-config = { workspace = true }

--- a/etl/README.md
+++ b/etl/README.md
@@ -6,7 +6,6 @@ This is the main crate of the ETL system, providing the core functionality for P
 
 | Feature                  | Description                                                   |
 | ------------------------ | ------------------------------------------------------------- |
-| `unknown-types-to-bytes` | Converts unknown Postgres types to bytes (enabled by default) |
 | `test-utils`             | Enables testing utilities and helpers                         |
 | `failpoints`             | Enables failure injection for testing                         |
 

--- a/etl/src/conversions/text.rs
+++ b/etl/src/conversions/text.rs
@@ -65,19 +65,7 @@ pub fn default_value_for_type(typ: &Type) -> EtlResult<Cell> {
         Type::JSON_ARRAY | Type::JSONB_ARRAY => Ok(Cell::Array(ArrayCell::Json(Vec::default()))),
         Type::OID => Ok(Cell::U32(u32::default())),
         Type::OID_ARRAY => Ok(Cell::Array(ArrayCell::U32(Vec::default()))),
-        #[cfg(feature = "unknown-types-to-bytes")]
         _ => Ok(Cell::String(String::default())),
-        #[cfg(not(feature = "unknown-types-to-bytes"))]
-        _ => {
-            bail!(
-                ErrorKind::ConversionError,
-                "Unsupported type",
-                format!(
-                    "The type {} is not supported, enable 'unknown-types-to-bytes' if you want to treat it as 'string'",
-                    typ.name()
-                )
-            )
-        }
     }
 }
 
@@ -224,19 +212,7 @@ pub fn parse_cell_from_postgres_text(typ: &Type, str: &str) -> EtlResult<Cell> {
         Type::OID_ARRAY => {
             parse_cell_from_postgres_text_array(str, |str| Ok(Some(str.parse()?)), ArrayCell::U32)
         }
-        #[cfg(feature = "unknown-types-to-bytes")]
         _ => Ok(Cell::String(str.to_string())),
-        #[cfg(not(feature = "unknown-types-to-bytes"))]
-        _ => {
-            bail!(
-                ErrorKind::ConversionError,
-                "Unsupported type",
-                format!(
-                    "The type {} is not supported, enable 'unknown-types-to-bytes' if you want to treat it as 'string'",
-                    typ.name()
-                )
-            )
-        }
     }
 }
 
@@ -643,7 +619,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "unknown-types-to-bytes")]
     #[test]
     fn unknown_types_to_string() {
         use tokio_postgres::types::Type;

--- a/etl/src/lib.rs
+++ b/etl/src/lib.rs
@@ -95,7 +95,6 @@
 //!
 //! # Feature Flags
 //!
-//! - `unknown-types-to-bytes`: Convert unknown Postgres types to byte arrays (default)
 //! - `test-utils`: Enable testing utilities and mock implementations  
 //! - `failpoints`: Enable fault injection for testing error scenarios
 


### PR DESCRIPTION
This PR:

* Always maps unknown types to strings in the `convert_type_oid_to_type` function.
* Removes the `unknown-types-to-bytes` as we currently always use the text format in the Postgres protocol.