### PR TITLE
fix: failing compilation in iceberg destination tests

### DIFF
--- a/etl-destinations/Cargo.toml
+++ b/etl-destinations/Cargo.toml
@@ -26,6 +26,7 @@ iceberg = [
     "dep:tokio",
     "dep:reqwest",
     "dep:async-trait",
+    "dep:rustls",
     "dep:serde",
     "dep:serde_json",
 ]


### PR DESCRIPTION
The failure was at this line: https://github.com/supabase/etl/blob/a9e4cb49ac81c68ed3a5e56653504358c3789392/etl-destinations/src/encryption.rs#L12 when running iceberg tests. This PR fixes the compiler error by adding `rustls` dependency to iceberg feature.