### PR TITLE
chore: [github/codeowners] adding srcCraftsman as a part of CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @supabase/etl
+* @srcCraftsman


### PR DESCRIPTION
Adding srcCraftsman as a part of codeowners to aid team with review for period of time. 