### PR TITLE
feat(ci): Add experimental image building

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,7 +32,7 @@ on:
         type: string
         required: false
       experimental:
-        description: "Build experimental image (tagged as commithash-experimental only)"
+        description: "Build experimental image (main branch excluded)"
         type: boolean
         default: false
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -10,7 +10,7 @@ on:
         type: string
         required: false
       experimental:
-        description: "Build experimental image (tagged as commithash-experimental only)"
+        description: "Build experimental image (main branch excluded)"
         type: boolean
         required: false
         default: false


### PR DESCRIPTION
This PR implements the possibility to create an experimental docker image, this way we are able to release images and clearly mark them as experimental. This applies for images that come from branches that are not main.