### PR TITLE
fix: free disk space on GH action runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,19 @@ jobs:
       matrix:
         postgres_version: [17, 16, 15, 14]
     steps:
+      # Free some disk space based on this article: https://carlosbecker.com/posts/github-actions-disk-space/
+      - name: Print Free Disk Space
+        run: df -h
+
+      - name: Cleanup Disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a --force
+
+      - name: Print Free Disk Space
+        run: df -h
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Free up some disk space before running tests because actions were failing due to runners going out of disk space.