### PR TITLE
fix: show table from user created schemas but omit Supabase managed s…

### DIFF
--- a/etl-api/src/db/tables.rs
+++ b/etl-api/src/db/tables.rs
@@ -25,10 +25,8 @@ pub async fn get_tables(pool: &PgPool) -> Result<Vec<Table>, TablesDbError> {
             left join pg_catalog.pg_am am on am.oid = c.relam
         where
            	c.relkind = 'r'
-           	and n.nspname <> 'pg_catalog'
+           	and n.nspname not in ('pg_catalog', 'information_schema', 'auth', 'etl', 'extensions', 'graphql', 'pgtle', 'pgsodium', 'relatime', 'storage', 'vault')
             and n.nspname !~ '^pg_toast'
-            and n.nspname <> 'information_schema'
-           	and pg_catalog.pg_table_is_visible(c.oid)
         order by schema, name;
         "#;
 


### PR DESCRIPTION
The old query only showed tables from the current search path, which omitted tables from schemas other than `public`. We now return tables from all tables irrespective of the search path but still filter out schemas which the user is unlikely to be interested in, like Postgres and Supabase internal schemas.