### PR TITLE
Fix typo in namespace exclusion list

### DIFF
--- a/etl-api/src/db/tables.rs
+++ b/etl-api/src/db/tables.rs
@@ -25,7 +25,7 @@ pub async fn get_tables(pool: &PgPool) -> Result<Vec<Table>, TablesDbError> {
             left join pg_catalog.pg_am am on am.oid = c.relam
         where
            	c.relkind = 'r'
-           	and n.nspname not in ('pg_catalog', 'information_schema', 'auth', 'etl', 'extensions', 'graphql', 'pgtle', 'pgsodium', 'relatime', 'storage', 'vault')
+           	and n.nspname not in ('pg_catalog', 'information_schema', 'auth', 'etl', 'extensions', 'graphql', 'pgtle', 'pgsodium', 'realtime', 'storage', 'vault')
             and n.nspname !~ '^pg_toast'
         order by schema, name;
         "#;


### PR DESCRIPTION
realtime vs relatime

i don't know the internal tables of supabase, but considering realtime is a product, the table name would also be `realtime`. 



## What kind of change does this PR introduce?

typo correction 

## What is the current behavior?

related PR: https://github.com/supabase/etl/pull/442/

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
