### PR TITLE
fix(tests): Fix flaky test

### DIFF
--- a/etl-postgres/src/tokio/test_utils.rs
+++ b/etl-postgres/src/tokio/test_utils.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroI32;
 
 use etl_config::shared::{IntoConnectOptions, PgConnectionConfig};
 use tokio::runtime::Handle;
-use tokio_postgres::types::{ToSql, Type};
+use tokio_postgres::types::{FromSql, ToSql, Type};
 use tokio_postgres::{Client, GenericClient, NoTls, Transaction};
 use tracing::info;
 
@@ -240,7 +240,7 @@ impl<G: GenericClient> PgDatabase<G> {
         &self,
         table_name: TableName,
         columns: &[&str],
-        values: &[&(dyn tokio_postgres::types::ToSql + Sync)],
+        values: &[&(dyn ToSql + Sync)],
     ) -> Result<u64, tokio_postgres::Error> {
         let columns_str = columns.join(", ");
         let placeholders: Vec<String> = (1..=values.len()).map(|i| format!("${i}")).collect();
@@ -362,7 +362,7 @@ impl<G: GenericClient> PgDatabase<G> {
         where_clause: Option<&str>,
     ) -> Result<Vec<T>, tokio_postgres::Error>
     where
-        T: for<'a> tokio_postgres::types::FromSql<'a>,
+        T: for<'a> FromSql<'a>,
     {
         let where_str = where_clause.map_or(String::new(), |w| format!("where {w}"));
         let query = format!(

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -985,9 +985,11 @@ async fn table_without_primary_key_is_errored() {
     assert_eq!(err.kinds().len(), 1);
     assert_eq!(err.kinds()[0], ErrorKind::SourceSchemaError);
 
-    // We expect no events to be saved.
+    // We expect the insert events to not be saved.
     let events = destination.get_events().await;
-    assert!(events.is_empty());
+    let grouped_events = group_events_by_type_and_table_id(&events);
+    let insert_events = grouped_events.get(&(EventType::Insert, table_id));
+    assert!(insert_events.is_none());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR fixes a flaky test which had the incorrect assertion. It can happen that non-table bound events are going through the apply worker before we reach the assertion, so we want to only assert the invariant, that is, no `INSERT` events are going through.