### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/etl-postgres/src/tokio/test_utils.rs
+++ b/etl-postgres/src/tokio/test_utils.rs
@@ -479,10 +479,10 @@ impl PgDatabase<Transaction<'_>> {
     /// This function will not panic on errors - it logs them and continues.
     /// This ensures transaction cleanup doesn't fail unexpectedly.
     pub async fn commit_transaction(mut self) {
-        if let Some(client) = self.client.take() {
-            if let Err(e) = client.commit().await {
-                eprintln!("warning: failed to commit transaction: {e}");
-            }
+        if let Some(client) = self.client.take()
+            && let Err(e) = client.commit().await
+        {
+            eprintln!("warning: failed to commit transaction: {e}");
         }
     }
 }

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -61,9 +61,10 @@ pub enum ApplyLoopResult {
 /// Action that should be taken during the apply loop.
 ///
 /// An action defines what to do after one iteration of the apply loop.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub enum ApplyLoopAction {
     /// The apply loop can continue on the next element.
+    #[default]
     Continue,
     /// The apply loop should pause processing.
     Pause,
@@ -126,12 +127,6 @@ impl ApplyLoopAction {
                 }
             }
         }
-    }
-}
-
-impl Default for ApplyLoopAction {
-    fn default() -> Self {
-        Self::Continue
     }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

I have fixed some clippy warnings that clippy 0.1.91 returns. Since CI uses `rust-toolchain@1.88.0`, those warnings probably won’t appear there, but I still think it’s worth addressing those warnings, and it's necessary to fix them eventually anyway.

If it's better to bump up Rust to 1.91.1, please let me know.

https://github.com/supabase/etl/blob/12c45fe8c3fd514f4769075df3b9c7adb2f0ec2b/.github/workflows/ci.yml#L32

## What is the current behavior?

Clippy 0.1.91 returns two clippy warnings.

## What is the new behavior?

No clippy warnings.

## Additional context

clippy 0.1.91 (ed61e7d7e2 2025-11-07)
