### PR TITLE
refactor(etl): simplify Event::has_table_id for Truncate variant

### DIFF
--- a/etl/src/types/event.rs
+++ b/etl/src/types/event.rs
@@ -176,13 +176,7 @@ impl Event {
             Event::Update(update_event) => update_event.table_id == *table_id,
             Event::Delete(delete_event) => delete_event.table_id == *table_id,
             Event::Relation(relation_event) => relation_event.table_schema.id == *table_id,
-            Event::Truncate(event) => {
-                let Some(_) = event.rel_ids.iter().find(|&&id| table_id.0 == id) else {
-                    return false;
-                };
-
-                true
-            }
+            Event::Truncate(event) => event.rel_ids.contains(&table_id.0),
             _ => false,
         }
     }


### PR DESCRIPTION

Simplifies `Event::has_table_id` for the `Truncate` variant by replacing a verbose let-else pattern with `contains()`.

**Before (7 lines)**:
```rust
Event::Truncate(event) => {
    let Some(_) = event.rel_ids.iter().find(|&&id| table_id.0 == id) else {
        return false;
    };
    true
}
```

**After (1 line)**:
```rust
Event::Truncate(event) => event.rel_ids.contains(&table_id.0),
```

## Changes
- More idiomatic Rust code
- Satisfies `clippy::manual-contains` lint
- Identical behavior, clearer intent

## Testing
- All tests pass
- Clippy clean with `-D warnings`