### PR TITLE
ref(api): Improve performance of the replication status endpoint

### DIFF
--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -4,7 +4,9 @@ use actix_web::{
     post,
     web::{Data, Json, Path},
 };
-use etl_postgres::replication::{TableLookupError, get_table_names_from_oids, health, lag, state};
+use etl_postgres::replication::{
+    TableLookupError, get_table_names_from_table_ids, health, lag, state,
+};
 use etl_postgres::types::TableId;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
@@ -954,8 +956,11 @@ pub async fn get_pipeline_replication_status(
     let apply_lag = lag_metrics.apply.map(Into::into);
 
     // Collect all table IDs and fetch their names in a single batch query
-    let table_ids: Vec<TableId> = state_rows.iter().map(|row| TableId::new(row.table_id.0)).collect();
-    let table_names = get_table_names_from_oids(&source_pool, &table_ids).await?;
+    let table_ids: Vec<TableId> = state_rows
+        .iter()
+        .map(|row| TableId::new(row.table_id.0))
+        .collect();
+    let table_names = get_table_names_from_table_ids(&source_pool, &table_ids).await?;
 
     // Convert database states to UI-friendly format
     let mut tables: Vec<TableReplicationStatus> = Vec::new();

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -1022,7 +1022,6 @@ async fn pipeline_replication_status_returns_table_states_and_names() {
     let response = app
         .get_pipeline_replication_status(&tenant_id, pipeline_id)
         .await;
-    println!("{:?}", response);
     let response: GetPipelineReplicationStatusResponse = response.json().await.unwrap();
 
     assert_eq!(response.pipeline_id, pipeline_id);


### PR DESCRIPTION
This PR improves the performance of the replication status endpoint by removing the `N + 1` query.