### PR TITLE
ref(deps): Remove time feature from sqlx

### DIFF
--- a/etl-postgres/Cargo.toml
+++ b/etl-postgres/Cargo.toml
@@ -28,7 +28,6 @@ sqlx = { workspace = true, features = [
     "postgres",
     "json",
     "migrate",
-    "time",
 ] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
This PR removes the `time` feature from `sqlx` since it's not used.