### PR TITLE
ref(errors): Do not create Many variant if vector has 1 element

### DIFF
--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -455,6 +455,9 @@ where
 }
 
 /// Creates an [`EtlError`] from a vector of errors for aggregation.
+///
+/// If the vector contains exactly one error, returns that error directly without wrapping
+/// it in the [`ErrorRepr::Many`] variant.
 impl<E> From<Vec<E>> for EtlError
 where
     E: Into<EtlError>,
@@ -463,7 +466,11 @@ where
     fn from(errors: Vec<E>) -> EtlError {
         let location = Location::caller();
 
-        let errors = errors.into_iter().map(Into::into).collect();
+        let mut errors: Vec<EtlError> = errors.into_iter().map(Into::into).collect();
+
+        if errors.len() == 1 {
+            return errors.pop().expect("just checked length is 1");
+        }
 
         EtlError {
             repr: ErrorRepr::Many { errors, location },
@@ -1098,6 +1105,17 @@ mod tests {
         ];
         let multi_err = EtlError::from(errors);
         assert_eq!(multi_err.kinds().len(), 2);
+    }
+
+    #[test]
+    fn test_from_vector_single_error_not_wrapped() {
+        let error = EtlError::from((ErrorKind::ValidationError, "Single error"));
+        let errors = vec![error];
+        let result = EtlError::from(errors);
+
+        // Single error should not be wrapped in Many variant.
+        assert_eq!(result.kinds().len(), 1);
+        assert_eq!(result.kind(), ErrorKind::ValidationError);
     }
 
     #[test]


### PR DESCRIPTION
This PR improves error handling by not creating the `Many` variant if the `Vec<T>` has length 1.