### PR TITLE
fix(core): Fix pipeline stalling

### DIFF
--- a/etl/src/replication/table_sync.rs
+++ b/etl/src/replication/table_sync.rs
@@ -362,7 +362,7 @@ where
 
     // We also wait to be signaled to catch up with the main apply worker up to a specific lsn.
     let result = table_sync_worker_state
-        .wait_for_phase_type(TableReplicationPhaseType::Catchup, shutdown_rx.clone())
+        .wait_for_phase_type(&[TableReplicationPhaseType::Catchup], shutdown_rx.clone())
         .await;
 
     // If we are told to shut down while waiting for a phase change, we will signal this to

--- a/etl/src/workers/table_sync.rs
+++ b/etl/src/workers/table_sync.rs
@@ -213,7 +213,7 @@ impl TableSyncWorkerState {
 
     /// Waits for the table to reach a specific replication phase type.
     ///
-    /// This method blocks until either the table reaches the desired phase or
+    /// This method blocks until either the table reaches one of the desired phases or
     /// a shutdown signal is received. It uses an efficient notification system
     /// to avoid polling and provides immediate response to state changes.
     ///
@@ -221,7 +221,7 @@ impl TableSyncWorkerState {
     /// completed successfully or was interrupted by shutdown.
     pub async fn wait_for_phase_type(
         &self,
-        phase_type: TableReplicationPhaseType,
+        phase_types: &[TableReplicationPhaseType],
         mut shutdown_rx: ShutdownRx,
     ) -> ShutdownResult<MutexGuard<'_, TableSyncWorkerStateInner>, ()> {
         let table_id = {
@@ -230,7 +230,7 @@ impl TableSyncWorkerState {
         };
         info!(
             "waiting for table replication phase '{:?}' for table {:?}",
-            phase_type, table_id
+            phase_types, table_id
         );
 
         loop {
@@ -239,13 +239,13 @@ impl TableSyncWorkerState {
 
                 // Shutdown signal received, exit loop.
                 _ = shutdown_rx.changed() => {
-                    info!("shutdown signal received, cancelling the wait for phase type {:?}", phase_type);
+                    info!("shutdown signal received, cancelling the wait for phase types {:?}", phase_types);
 
                     return ShutdownResult::Shutdown(());
                 }
 
                 // Try to wait for the phase type.
-                acquired = self.wait(phase_type) => {
+                acquired = self.wait(phase_types) => {
                     if let Some(acquired) = acquired {
                         return ShutdownResult::Ok(acquired);
                     }
@@ -262,16 +262,17 @@ impl TableSyncWorkerState {
     /// transition detection.
     async fn wait(
         &self,
-        phase_type: TableReplicationPhaseType,
+        phase_types: &[TableReplicationPhaseType],
     ) -> Option<MutexGuard<'_, TableSyncWorkerStateInner>> {
         // We grab hold of the phase change notify in case we don't immediately have the state
         // that we want.
         let phase_change = {
             let inner = self.inner.lock().await;
-            if inner.table_replication_phase.as_type() == phase_type {
+            let current_phase = inner.table_replication_phase.as_type();
+            if phase_types.contains(&current_phase) {
                 info!(
                     "table replication phase '{:?}' was already set, no need to wait",
-                    phase_type
+                    current_phase
                 );
                 return Some(inner);
             }
@@ -285,10 +286,11 @@ impl TableSyncWorkerState {
 
         // We read the state and return the lock to the state.
         let inner = self.inner.lock().await;
-        if inner.table_replication_phase.as_type() == phase_type {
+        let current_phase = inner.table_replication_phase.as_type();
+        if phase_types.contains(&current_phase) {
             info!(
                 "table replication phase '{:?}' was reached for table {:?}",
-                phase_type, inner.table_id
+                current_phase, inner.table_id
             );
             return Some(inner);
         }


### PR DESCRIPTION
This PR fixes a pipeline stall that could occur in an edge case during catch-up processing. If an error happened while a table sync worker was catching up, the system could stall when the table failed, because it was waiting exclusively for a `SyncDone` state that would never happen.

This behavior has now been corrected, ensuring the pipeline can make progress even when a table errors during catch-up.

We were not able to cover this scenario with tests. At the moment, the test suite does not provide a reliable way to drive the table sync worker’s streaming behavior in a controlled manner. Such a setup would have been necessary to reproduce and catch this issue in tests.