### PR TITLE
Remove warnings when compiling without egress feature

### DIFF
--- a/etl-destinations/src/iceberg/core.rs
+++ b/etl-destinations/src/iceberg/core.rs
@@ -381,8 +381,9 @@ where
                     });
                 }
 
-                #[allow(unused_mut, unused_variables)]
+                #[cfg_attr(not(feature = "egress"), allow(unused_mut, unused_variables))]
                 let mut bytes_sent = 0;
+                #[cfg_attr(not(feature = "egress"), allow(unused_assignments))]
                 while let Some(insert_result) = join_set.join_next().await {
                     bytes_sent += insert_result
                         .map_err(|_| etl_error!(ErrorKind::Unknown, "Failed to join future"))??;


### PR DESCRIPTION
This PR will remove useless warning we have when executing `cargo check` globally without any features.

```
warning: value assigned to `bytes_sent` is never read
   --> etl-destinations/src/iceberg/core.rs:390:21
    |
390 | /                     bytes_sent += insert_result
391 | |                         .map_err(|_| etl_error!(ErrorKind::Unknown, "Failed to join future"))??;
    | |_______________________________________________________________________________________________^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
```