### PR TITLE
fix(rollback): Do not delete table mappings on rollback

### DIFF
--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -1198,7 +1198,7 @@ async fn rollback_tables_with_full_reset_succeeds() {
     .unwrap();
     assert_eq!(schema_count_after, 0);
 
-    // Verify table mapping was deleted
+    // Verify table mapping was NOT deleted (kept for truncation on restart)
     let mapping_count_after: i64 = sqlx::query_scalar(
         "select count(*) from etl.table_mappings where pipeline_id = $1 and source_table_id = $2",
     )
@@ -1207,13 +1207,13 @@ async fn rollback_tables_with_full_reset_succeeds() {
     .fetch_one(&source_db_pool)
     .await
     .unwrap();
-    assert_eq!(mapping_count_after, 0);
+    assert_eq!(mapping_count_after, 1);
 
     drop_pg_database(&source_db_config).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn rollback_to_init_cleans_up_schemas_and_mappings() {
+async fn rollback_to_init_cleans_up_schemas_but_keeps_mappings() {
     init_test_tracing();
     let (app, tenant_id, pipeline_id, source_db_pool, source_db_config) =
         setup_pipeline_with_source_db().await;
@@ -1285,7 +1285,7 @@ async fn rollback_to_init_cleans_up_schemas_and_mappings() {
     .unwrap();
     assert_eq!(schema_count, 0);
 
-    // Verify table mapping was deleted
+    // Verify table mapping was NOT deleted (kept for truncation on restart)
     let mapping_count: i64 = sqlx::query_scalar(
         "select count(*) from etl.table_mappings where pipeline_id = $1 and source_table_id = $2",
     )
@@ -1294,7 +1294,7 @@ async fn rollback_to_init_cleans_up_schemas_and_mappings() {
     .fetch_one(&source_db_pool)
     .await
     .unwrap();
-    assert_eq!(mapping_count, 0);
+    assert_eq!(mapping_count, 1);
 
     drop_pg_database(&source_db_config).await;
 }

--- a/etl-postgres/src/replication/state.rs
+++ b/etl-postgres/src/replication/state.rs
@@ -4,7 +4,6 @@ use sqlx::{PgExecutor, PgPool, Type, postgres::types::Oid as SqlxTableId, prelud
 use tokio_postgres::types::PgLsn;
 
 use crate::replication::schema::delete_table_schema_for_table;
-use crate::replication::table_mappings::delete_table_mappings_for_table;
 use crate::types::TableId;
 
 /// Replication state of a table during the ETL process.
@@ -294,9 +293,9 @@ pub async fn rollback_replication_state(
 
 /// Resets table replication state to initial state.
 ///
-/// Removes all existing state entries for the table, clears the table mapping
-/// and table schema, and creates a new [`TableReplicationState::Init`] entry,
-/// effectively restarting replication.
+/// Removes all existing state entries for the table, clears the table schema,
+/// and creates a new [`TableReplicationState::Init`] entry, effectively
+/// restarting replication. Table mappings are preserved for truncation on restart.
 pub async fn reset_replication_state(
     conn: &mut sqlx::PgConnection,
     pipeline_id: i64,


### PR DESCRIPTION
This PR removes the deletion of table mappings on reset/rollback. This was a bug, since some destinations rely on table mappings to properly perform table truncations (e.g. BigQuery).