### PR TITLE
feat(iceberg): More flexible IcebergClient constructor. 

### DIFF
--- a/etl-destinations/src/iceberg/client.rs
+++ b/etl-destinations/src/iceberg/client.rs
@@ -55,6 +55,11 @@ pub struct IcebergClient {
 }
 
 impl IcebergClient {
+    /// Creates a new [`IcebergClient`] with the specified catalog.
+    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
+        IcebergClient { catalog }
+    }
+
     /// Creates a new [`IcebergClient`] using a REST catalog configuration.
     ///
     /// This constructor initializes a client that connects to an Iceberg catalog
@@ -71,9 +76,7 @@ impl IcebergClient {
         let builder = RestCatalogBuilder::default();
         let catalog = builder.load("RestCatalog", props).await?;
 
-        Ok(IcebergClient {
-            catalog: Arc::new(catalog),
-        })
+        Ok(IcebergClient::new(Arc::new(catalog)))
     }
 
     /// Creates a new [`IcebergClient`] configured for Supabase storage integration.
@@ -116,9 +119,7 @@ impl IcebergClient {
         let client = SupabaseClient::new(catalog_uri, warehouse_name, catalog_token);
         let catalog = SupabaseCatalog::new(inner, client);
 
-        Ok(IcebergClient {
-            catalog: Arc::new(catalog),
-        })
+        Ok(IcebergClient::new(Arc::new(catalog)))
     }
 
     /// Creates a namespace if it does not already exist.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## Additional context

The existing `IcebergClient` constructors are not flexible enough for all use cases. 

This changes introduces a less opinionated constructor `IcebergClient::new: fn(Arc<dyn Catalog>) -> Self`.

I've omitted creating an issue as it's a very small change. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal initialization of the Iceberg catalog to reduce duplication and unify creation across different catalog implementations. This enhances maintainability and consistency of catalog handling with no user-facing behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->