### PR TITLE
refactor: avoid cloning JSON metadata during deserialization

### DIFF
--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -1080,11 +1080,9 @@ pub async fn get_pipeline_replication_status(
         // Extract the metadata row from the database
         let phase: TableReplicationPhase = row
             .metadata
-            .as_ref()
             .ok_or(PipelineError::MissingTableReplicationState)
             .and_then(|m| {
-                serde_json::from_value(m.clone())
-                    .map_err(PipelineError::InvalidTableReplicationState)
+                serde_json::from_value(m).map_err(PipelineError::InvalidTableReplicationState)
             })?;
 
         tables.push(TableReplicationStatus {
@@ -1248,11 +1246,9 @@ pub async fn rollback_tables(
 
         let new_phase: TableReplicationPhase = new_state_row
             .metadata
-            .as_ref()
             .ok_or(PipelineError::MissingTableReplicationState)
             .and_then(|m| {
-                serde_json::from_value(m.clone())
-                    .map_err(PipelineError::InvalidTableReplicationState)
+                serde_json::from_value(m).map_err(PipelineError::InvalidTableReplicationState)
             })?;
 
         rolled_back_tables.push(RolledBackTable {

--- a/etl/src/state/table.rs
+++ b/etl/src/state/table.rs
@@ -246,8 +246,8 @@ impl TableReplicationPhase {
     }
 
     /// Deserializes a [`TableReplicationPhase`] from a state store row's metadata.
-    pub fn from_state_row(row: &state::TableReplicationStateRow) -> EtlResult<Self> {
-        let Some(metadata) = &row.metadata else {
+    pub fn from_state_row(row: state::TableReplicationStateRow) -> EtlResult<Self> {
+        let Some(metadata) = row.metadata else {
             bail!(
                 ErrorKind::InvalidState,
                 "Table replication state not found",
@@ -255,7 +255,7 @@ impl TableReplicationPhase {
             );
         };
 
-        serde_json::from_value(metadata.clone()).map_err(|err| {
+        serde_json::from_value(metadata).map_err(|err| {
             etl_error!(
                 ErrorKind::DeserializationError,
                 "Table replication state deserialization failed",
@@ -522,7 +522,7 @@ mod tests {
             prev: None,
             is_current: true,
         };
-        assert!(TableReplicationPhase::from_state_row(&row).is_err());
+        assert!(TableReplicationPhase::from_state_row(row).is_err());
     }
 
     #[test]
@@ -536,7 +536,7 @@ mod tests {
             prev: None,
             is_current: true,
         };
-        assert!(TableReplicationPhase::from_state_row(&row).is_err());
+        assert!(TableReplicationPhase::from_state_row(row).is_err());
     }
 
     #[test]
@@ -568,7 +568,7 @@ mod tests {
                 prev: None,
                 is_current: true,
             };
-            let restored = TableReplicationPhase::from_state_row(&row).unwrap();
+            let restored = TableReplicationPhase::from_state_row(row).unwrap();
 
             // Compare everything except source_err (which is lossy by design)
             assert_eq!(phase.as_type(), restored.as_type());

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -258,7 +258,7 @@ impl StateStore for PostgresStore {
             state::get_table_replication_state_rows(&self.pool, self.pipeline_id as i64).await?;
 
         let mut table_states: BTreeMap<TableId, TableReplicationPhase> = BTreeMap::new();
-        for row in &replication_state_rows {
+        for row in replication_state_rows {
             let table_id = TableId::new(row.table_id.0);
             let phase = TableReplicationPhase::from_state_row(row)?;
             table_states.insert(table_id, phase);
@@ -298,13 +298,13 @@ impl StateStore for PostgresStore {
 
         // Perform all database updates in a single transaction
         let mut tx = self.pool.begin().await?;
-        for (table_id, state_type, metadata) in &db_updates {
+        for (table_id, state_type, metadata) in db_updates {
             state::update_replication_state_raw(
                 &mut *tx,
                 self.pipeline_id as i64,
-                *table_id,
-                *state_type,
-                metadata.clone(),
+                table_id,
+                state_type,
+                metadata,
             )
             .await?;
         }
@@ -339,7 +339,7 @@ impl StateStore for PostgresStore {
                     )
                 })?;
 
-        let restored_phase = TableReplicationPhase::from_state_row(&restored_row)?;
+        let restored_phase = TableReplicationPhase::from_state_row(restored_row)?;
 
         let mut inner = self.inner.lock().await;
         inner.set_table_state(table_id, restored_phase.clone());


### PR DESCRIPTION
Take ownership of metadata values instead of cloning where possible. `from_state_row` now consumes the row, and callers iterate by value.