### PR TITLE
fix(docker): align RUSTFLAGS for cargo build and chef in replicator Dockerfile

### DIFF
--- a/etl-replicator/Dockerfile
+++ b/etl-replicator/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update && \
 COPY .cargo/config.toml /app/.cargo/config.toml
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN RUSTFLAGS="-C panic=abort -C link-arg=-fuse-ld=lld" cargo chef cook --release --recipe-path recipe.json
 
 # Build application with optimizations.
 # The release profile in Cargo.toml handles: thin LTO, strip, opt-level=3.
@@ -65,7 +65,7 @@ COPY . .
 RUN sed -i '/"xtask"/d' Cargo.toml && rm -rf xtask
 RUN FEATURES=""; \
     if [ "$ENABLE_EGRESS" = "true" ]; then FEATURES="--features egress"; fi && \
-    RUSTFLAGS="-C panic=abort" cargo build --release -p etl-replicator $FEATURES && \
+    RUSTFLAGS="-C panic=abort -C link-arg=-fuse-ld=lld" cargo build --release -p etl-replicator $FEATURES && \
     strip target/release/etl-replicator
 
 # Runtime stage with distroless for security.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`etl-replicator` `cargo chef` cache is always invalidated, and on each and every build re-compilation happens i.e. `cargo chef` efforts are spilled.

<img width="341" height="354" alt="image" src="https://github.com/user-attachments/assets/f1de65d0-4018-4b66-b4ad-1a5d3119237d" />


## What is the new behavior?

Now, for code changes that do not involve crates added/removed/modified, previously compiled artifacts should be used, and we will have image creation time halved:
<img width="341" height="354" alt="image" src="https://github.com/user-attachments/assets/2b930f6d-4592-4047-a05d-c8b63bba04d5" />


## Additional context

Cargo tracks what needs to be recompiled using [fingerprit](https://github.com/rust-lang/cargo/blob/7a6c83cbaed582bb09c422c09157622781b8c19c/src/cargo/core/compiler/fingerprint/mod.rs#L85), and `RUSTFLAGS` affect whether an entity is considered changed (so, alas, requiring re-compilation). 

In our Dockerfile `RUSTFLAGS="-C panic=abort"` was used on `cargo build`, but not on `cargo chef` -- which means that not only our `cargo build` command got `-fuse-ld=lld` linker disabled for it (because `RUSTFLAGS` has higher precedence and overrides), but also that nothing cached by `cargo chef` was used by `cargo build` (because hashes didn't match, different configurations -> different hashes).

The `etl-api` wasn't affected, as it didn't use `RUSTFLAGS`.
