### PR TITLE
feat(api): Add configurable specs for pipelines

### DIFF
--- a/etl-api/src/config.rs
+++ b/etl-api/src/config.rs
@@ -19,6 +19,9 @@ pub struct ApiConfig {
     pub database: PgConnectionConfig,
     /// Application server settings.
     pub application: ApplicationSettings,
+    /// Kubernetes-specific API configuration.
+    #[serde(default)]
+    pub k8s: K8sConfig,
     /// Source database configuration and validation settings.
     #[serde(default)]
     pub source: SourceConfig,
@@ -41,6 +44,27 @@ pub struct ApiConfig {
     /// If provided, enables ConfigCat feature flag evaluation.
     /// If `None`, the API operates without feature flag support.
     pub configcat_sdk_key: Option<String>,
+}
+
+/// Kubernetes-specific API configuration.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct K8sConfig {
+    /// Optional request sizing overrides for replicator workloads.
+    #[serde(default)]
+    pub replicator_resources: ReplicatorResourcesConfig,
+}
+
+/// Optional request sizing overrides for replicator workloads.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ReplicatorResourcesConfig {
+    /// Override for the replicator memory request, in Mi.
+    pub replicator_memory_request_mib: Option<i32>,
+    /// Override for the replicator CPU request, in millicores.
+    pub replicator_cpu_request_millicores: Option<i32>,
+    /// Override for the Vector sidecar memory request, in Mi.
+    pub vector_memory_request_mib: Option<i32>,
+    /// Override for the Vector sidecar CPU request, in millicores.
+    pub vector_cpu_request_millicores: Option<i32>,
 }
 
 /// Configuration for source database connections and behavior.

--- a/etl-api/src/feature_flags.rs
+++ b/etl-api/src/feature_flags.rs
@@ -1,10 +1,32 @@
+use std::ops::Deref;
+use std::sync::Arc;
+
 use actix_web::web::Data;
 use tracing::info;
+
+/// Shared ConfigCat client handle used across the API and Kubernetes client.
+#[derive(Clone, Debug)]
+pub struct FeatureFlagsClient(Arc<configcat::Client>);
+
+impl FeatureFlagsClient {
+    /// Wraps a ConfigCat client so it can be shared across async components.
+    pub fn new(client: configcat::Client) -> Self {
+        Self(Arc::new(client))
+    }
+}
+
+impl Deref for FeatureFlagsClient {
+    type Target = configcat::Client;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
 
 /// Initializes the ConfigCat client for feature flag evaluation in the API.
 pub fn init_feature_flags(
     configcat_sdk_key: Option<&str>,
-) -> anyhow::Result<Option<configcat::Client>> {
+) -> anyhow::Result<Option<FeatureFlagsClient>> {
     match configcat_sdk_key {
         Some(key) => {
             info!("initializing configcat with supplied sdk key");
@@ -12,10 +34,12 @@ pub fn init_feature_flags(
             let builder = configcat::Client::builder(key);
 
             let client = builder.build()?;
-            Ok(Some(client))
+
+            Ok(Some(FeatureFlagsClient::new(client)))
         }
         None => {
             info!("configcat not configured for api, skipping initialization");
+
             Ok(None)
         }
     }
@@ -26,13 +50,14 @@ pub fn init_feature_flags(
 /// Checks the `maximumPipelinesPerTenant` feature flag and falls back to
 /// the default if the flag is not set or the client is unavailable.
 pub async fn get_max_pipelines_per_tenant(
-    client: Option<&Data<configcat::Client>>,
+    client: Option<&Data<FeatureFlagsClient>>,
     tenant_id: &str,
     default_value: i64,
 ) -> i64 {
     match client {
         Some(client) => {
             let user = configcat::User::new(tenant_id);
+
             client
                 .get_value("maximumPipelinesPerTenant", default_value, Some(user))
                 .await

--- a/etl-api/src/k8s/http.rs
+++ b/etl-api/src/k8s/http.rs
@@ -1,3 +1,4 @@
+use crate::config::K8sConfig;
 use crate::configs::log::LogLevel;
 use crate::k8s::{DestinationType, PodStatus, ReplicatorConfigMapFile};
 use crate::k8s::{K8sClient, K8sError, PodPhase};
@@ -74,25 +75,22 @@ pub const TRUSTED_ROOT_CERT_KEY_NAME: &str = "trusted_root_certs";
 /// Label used to identify replicator pods.
 const REPLICATOR_APP_LABEL: &str = "etl-replicator-app";
 
-/// Replicator memory request tuned for `c8gn.4xlarge` instances in prod.
-const REPLICATOR_MEMORY_REQUEST_PROD: i32 = 2000;
-/// Replicator CPU request tuned for `c8gn.4xlarge` instances in prod.
-const REPLICATOR_CPU_REQUEST_PROD: i32 = 500;
-
-/// Replicator memory request tuned for `c8gn.medium` instances in staging.
-const REPLICATOR_MEMORY_REQUEST_STAGING: i32 = 250;
-/// Replicator CPU request tuned for `c8gn.medium` instances in staging.
-const REPLICATOR_CPU_REQUEST_STAGING: i32 = 125;
-
-/// Vector memory request tuned for staging environments.
-const VECTOR_MEMORY_REQUEST_STAGING: i32 = 192;
-/// Vector CPU request tuned for staging environments.
-const VECTOR_CPU_REQUEST_STAGING: i32 = 75;
-
-/// Vector memory request tuned for production environments.
-const VECTOR_MEMORY_REQUEST_PROD: i32 = 256;
-/// Vector CPU request tuned for production environments.
-const VECTOR_CPU_REQUEST_PROD: i32 = 100;
+/// Default replicator memory request in prod, in Mi.
+const REPLICATOR_MEMORY_REQUEST_PROD_DEFAULT: i32 = 500;
+/// Default replicator CPU request in prod, in millicores.
+const REPLICATOR_CPU_REQUEST_PROD_DEFAULT: i32 = 500;
+/// Default replicator memory request outside prod, in Mi.
+const REPLICATOR_MEMORY_REQUEST_NON_PROD_DEFAULT: i32 = 250;
+/// Default replicator CPU request outside prod, in millicores.
+const REPLICATOR_CPU_REQUEST_NON_PROD_DEFAULT: i32 = 125;
+/// Default Vector memory request in prod, in Mi.
+const VECTOR_MEMORY_REQUEST_PROD_DEFAULT: i32 = 256;
+/// Default Vector CPU request in prod, in millicores.
+const VECTOR_CPU_REQUEST_PROD_DEFAULT: i32 = 100;
+/// Default Vector memory request outside prod, in Mi.
+const VECTOR_MEMORY_REQUEST_NON_PROD_DEFAULT: i32 = 192;
+/// Default Vector CPU request outside prod, in millicores.
+const VECTOR_CPU_REQUEST_NON_PROD_DEFAULT: i32 = 75;
 
 /// Memory limit multiplier (request × 1.2 = limit).
 ///
@@ -116,24 +114,54 @@ struct ReplicatorResourceConfig {
 }
 
 impl ReplicatorResourceConfig {
-    /// Loads the runtime limits for the current environment.
-    ///
-    /// Limits are computed from requests using multipliers:
-    /// - Memory: request × 1.2 = limit
-    /// - CPU: request × 2.0 = limit
+    /// Builds runtime limits using default config-backed sizing for the environment.
+    #[cfg(test)]
     fn load(environment: &Environment) -> Result<Self, K8sError> {
-        let (replicator_memory_request, replicator_cpu_request) = match environment {
-            Environment::Prod => (REPLICATOR_MEMORY_REQUEST_PROD, REPLICATOR_CPU_REQUEST_PROD),
+        Self::load_with_overrides(environment, &K8sConfig::default())
+    }
+
+    /// Builds runtime limits from environment defaults with optional config overrides.
+    fn load_with_overrides(
+        environment: &Environment,
+        k8s_config: &K8sConfig,
+    ) -> Result<Self, K8sError> {
+        let (default_replicator_memory_request, default_replicator_cpu_request) = match environment
+        {
+            Environment::Prod => (
+                REPLICATOR_MEMORY_REQUEST_PROD_DEFAULT,
+                REPLICATOR_CPU_REQUEST_PROD_DEFAULT,
+            ),
             _ => (
-                REPLICATOR_MEMORY_REQUEST_STAGING,
-                REPLICATOR_CPU_REQUEST_STAGING,
+                REPLICATOR_MEMORY_REQUEST_NON_PROD_DEFAULT,
+                REPLICATOR_CPU_REQUEST_NON_PROD_DEFAULT,
             ),
         };
-
-        let (vector_memory_request, vector_cpu_request) = match environment {
-            Environment::Prod => (VECTOR_MEMORY_REQUEST_PROD, VECTOR_CPU_REQUEST_PROD),
-            _ => (VECTOR_MEMORY_REQUEST_STAGING, VECTOR_CPU_REQUEST_STAGING),
+        let (default_vector_memory_request, default_vector_cpu_request) = match environment {
+            Environment::Prod => (
+                VECTOR_MEMORY_REQUEST_PROD_DEFAULT,
+                VECTOR_CPU_REQUEST_PROD_DEFAULT,
+            ),
+            _ => (
+                VECTOR_MEMORY_REQUEST_NON_PROD_DEFAULT,
+                VECTOR_CPU_REQUEST_NON_PROD_DEFAULT,
+            ),
         };
+        let replicator_memory_request = k8s_config
+            .replicator_resources
+            .replicator_memory_request_mib
+            .unwrap_or(default_replicator_memory_request);
+        let replicator_cpu_request = k8s_config
+            .replicator_resources
+            .replicator_cpu_request_millicores
+            .unwrap_or(default_replicator_cpu_request);
+        let vector_memory_request = k8s_config
+            .replicator_resources
+            .vector_memory_request_mib
+            .unwrap_or(default_vector_memory_request);
+        let vector_cpu_request = k8s_config
+            .replicator_resources
+            .vector_cpu_request_millicores
+            .unwrap_or(default_vector_cpu_request);
 
         let replicator_memory_limit =
             ((replicator_memory_request as f32) * MEMORY_LIMIT_MULTIPLIER).round() as i32;
@@ -166,6 +194,7 @@ pub struct HttpK8sClient {
     config_maps_api: Api<ConfigMap>,
     stateful_sets_api: Api<StatefulSet>,
     pods_api: Api<Pod>,
+    k8s_config: K8sConfig,
 }
 
 impl HttpK8sClient {
@@ -173,7 +202,7 @@ impl HttpK8sClient {
     ///
     /// Prefers in-cluster configuration and falls back to the local kubeconfig
     /// when running outside the cluster.
-    pub fn new(client: Client) -> Result<HttpK8sClient, K8sError> {
+    pub fn new(client: Client, k8s_config: K8sConfig) -> Result<HttpK8sClient, K8sError> {
         let secrets_api: Api<Secret> = Api::namespaced(client.clone(), DATA_PLANE_NAMESPACE);
         let config_maps_api: Api<ConfigMap> = Api::namespaced(client.clone(), DATA_PLANE_NAMESPACE);
         let stateful_sets_api: Api<StatefulSet> =
@@ -185,6 +214,7 @@ impl HttpK8sClient {
             config_maps_api,
             stateful_sets_api,
             pods_api,
+            k8s_config,
         })
     }
 
@@ -489,7 +519,7 @@ impl K8sClient for HttpK8sClient {
     ) -> Result<(), K8sError> {
         debug!("patching stateful set");
 
-        let config = ReplicatorResourceConfig::load(&environment)?;
+        let config = ReplicatorResourceConfig::load_with_overrides(&environment, &self.k8s_config)?;
 
         let stateful_set_name = create_stateful_set_name(prefix);
 

--- a/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -108,11 +108,11 @@ expression: stateful_set_json
             "resources": {
               "limits": {
                 "cpu": "1000m",
-                "memory": "2400Mi"
+                "memory": "600Mi"
               },
               "requests": {
                 "cpu": "500m",
-                "memory": "2000Mi"
+                "memory": "500Mi"
               }
             },
             "volumeMounts": [

--- a/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -119,11 +119,11 @@ expression: stateful_set_json
             "resources": {
               "limits": {
                 "cpu": "1000m",
-                "memory": "2400Mi"
+                "memory": "600Mi"
               },
               "requests": {
                 "cpu": "500m",
-                "memory": "2000Mi"
+                "memory": "500Mi"
               }
             },
             "volumeMounts": [

--- a/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -126,11 +126,11 @@ expression: stateful_set_json
             "resources": {
               "limits": {
                 "cpu": "1000m",
-                "memory": "2400Mi"
+                "memory": "600Mi"
               },
               "requests": {
                 "cpu": "500m",
-                "memory": "2000Mi"
+                "memory": "500Mi"
               }
             },
             "volumeMounts": [

--- a/etl-api/src/routes/destinations_pipelines.rs
+++ b/etl-api/src/routes/destinations_pipelines.rs
@@ -23,7 +23,7 @@ use crate::db::pipelines::{
     MAX_PIPELINES_PER_TENANT, PipelinesDbError, count_pipelines_for_tenant, read_pipeline,
 };
 use crate::db::sources::SourcesDbError;
-use crate::feature_flags::get_max_pipelines_per_tenant;
+use crate::feature_flags::{FeatureFlagsClient, get_max_pipelines_per_tenant};
 use crate::k8s::{TrustedRootCertsCache, TrustedRootCertsError};
 use crate::validation::ValidationError;
 
@@ -207,7 +207,7 @@ pub async fn create_destination_and_pipeline(
     pool: Data<PgPool>,
     destination_and_pipeline: Json<CreateDestinationPipelineRequest>,
     encryption_key: Data<EncryptionKey>,
-    feature_flags_client: Option<Data<configcat::Client>>,
+    feature_flags_client: Option<Data<FeatureFlagsClient>>,
 ) -> Result<impl Responder, DestinationPipelineError> {
     let tenant_id = extract_tenant_id(&req)?;
     let destination_and_pipeline = destination_and_pipeline.into_inner();

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -24,7 +24,7 @@ use crate::db::images::ImagesDbError;
 use crate::db::pipelines::{MAX_PIPELINES_PER_TENANT, PipelinesDbError, read_pipeline_components};
 use crate::db::replicators::ReplicatorsDbError;
 use crate::db::sources::SourcesDbError;
-use crate::feature_flags::get_max_pipelines_per_tenant;
+use crate::feature_flags::{FeatureFlagsClient, get_max_pipelines_per_tenant};
 use crate::k8s::core::{
     create_k8s_object_prefix, create_or_update_pipeline_resources_in_k8s,
     delete_pipeline_resources_in_k8s, is_replicator_pod_stopped,
@@ -526,7 +526,7 @@ pub async fn create_pipeline(
     pool: Data<PgPool>,
     encryption_key: Data<EncryptionKey>,
     pipeline: Json<CreatePipelineRequest>,
-    feature_flags_client: Option<Data<configcat::Client>>,
+    feature_flags_client: Option<Data<FeatureFlagsClient>>,
 ) -> Result<impl Responder, PipelineError> {
     let tenant_id = extract_tenant_id(&req)?;
     let pipeline = pipeline.into_inner();

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -15,7 +15,7 @@ use tracing_actix_web::TracingLogger;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::feature_flags::init_feature_flags;
+use crate::feature_flags::{FeatureFlagsClient, init_feature_flags};
 use crate::k8s::http::HttpK8sClient;
 use crate::k8s::{K8sClient, K8sError, TrustedRootCertsCache};
 use crate::{
@@ -126,8 +126,10 @@ impl Application {
             Err(_) => None,
         };
 
+        let feature_flags_client = init_feature_flags(config.configcat_sdk_key.as_deref())?;
+
         let k8s_client = match kube_client_result {
-            Some(client) => match HttpK8sClient::new(client) {
+            Some(client) => match HttpK8sClient::new(client, config.k8s.clone()) {
                 Ok(client) => Some(Arc::new(client) as Arc<dyn K8sClient>),
                 Err(e) => {
                     warn!(
@@ -142,8 +144,6 @@ impl Application {
                 None
             }
         };
-
-        let feature_flags_client = init_feature_flags(config.configcat_sdk_key.as_deref())?;
 
         let trusted_root_certs_cache = k8s_client.clone().map(TrustedRootCertsCache::new);
 
@@ -220,7 +220,7 @@ pub fn run(
     encryption_key: encryption::EncryptionKey,
     k8s_client: Option<Arc<dyn K8sClient>>,
     trusted_root_certs_cache: Option<TrustedRootCertsCache>,
-    feature_flags_client: Option<configcat::Client>,
+    feature_flags_client: Option<FeatureFlagsClient>,
 ) -> Result<Server, anyhow::Error> {
     let prometheus_handle = web::ThinData(init_metrics_handle()?);
     let config = web::Data::new(config);

--- a/etl-api/tests/support/test_app.rs
+++ b/etl-api/tests/support/test_app.rs
@@ -4,7 +4,7 @@ use aws_lc_rs::aead::{AES_256_GCM, RandomizedNonceKey};
 use aws_lc_rs::rand::fill;
 use base64::prelude::*;
 use etl_api::config::{
-    ApiConfig, ApplicationSettings, EncryptionKey as ConfigEncryptionKey, SourceConfig,
+    ApiConfig, ApplicationSettings, EncryptionKey as ConfigEncryptionKey, K8sConfig, SourceConfig,
 };
 use etl_api::k8s::{K8sClient, TrustedRootCertsCache};
 use etl_api::routes::destinations::{CreateDestinationRequest, UpdateDestinationRequest};
@@ -580,6 +580,7 @@ async fn spawn_test_app_with_services(
             host: base_address.to_string(),
             port,
         },
+        k8s: K8sConfig::default(),
         encryption_key: ConfigEncryptionKey {
             id: 0,
             key: BASE64_STANDARD.encode(key_bytes),


### PR DESCRIPTION
This PR adds configurable specs for pipelines that allows us to control the specifications of pipelines without deploying a new image version.