### PR TITLE
Harden CI workflow against untrusted pull requests

### DIFF
--- a/.github/workflows/approve-ci.yml
+++ b/.github/workflows/approve-ci.yml
@@ -1,0 +1,24 @@
+name: Auto-approve CI for repo collaborators
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-label-collaborator-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repo collaborator status and add label
+        run: |
+          STATUS=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }} --silent -i 2>&1 | head -1 | awk '{print $2}')
+          echo "Collaborator check for ${{ github.actor }}: HTTP $STATUS"
+          if [ "$STATUS" = "204" ]; then
+            gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label ci-approved
+          else
+            echo "Not a collaborator, skipping auto-label"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,16 @@ jobs:
 
   test-full:
     name: Tests (Full)
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.author_association == 'MEMBER'
+      || github.event.pull_request.author_association == 'COLLABORATOR'
+      || github.event.pull_request.author_association == 'OWNER'
+      || contains(github.event.pull_request.labels.*.name, 'ci-approved')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-      id-token: write
+      id-token: none
     strategy:
       matrix:
         postgres_version: [18, 17, 16, 15, 14]


### PR DESCRIPTION

- Add `ci-approved` label check to `test-full` so external PRs cannot
  run tests with secrets access without maintainer approval.
- Add `approve-ci.yml` workflow (`pull_request_target`) that auto-adds
  the `ci-approved` label for repo collaborators.
- Remove unused `id-token: write` permission from `test-full`.