### PR TITLE
refactor(etl/store): copy-on-write instead of clonning stored state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@
 - Keep top-level binaries focused on orchestration; move implementation detail into helpers or modules.
 - Prefer clear, boring code over clever abstractions.
 - Prefer existing workspace patterns over introducing new local conventions.
+- Use `Arc::clone(&value)` instead of `value.clone()` when cloning `Arc` pointers — it makes the cheap reference-count increment explicit and avoids confusion with deep clones.
 - All logs should be strictly lowercase.
 
 ## Error Handling And Panics

--- a/etl-replicator/src/error_reporting.rs
+++ b/etl-replicator/src/error_reporting.rs
@@ -2,9 +2,8 @@ use etl::error::{EtlError, EtlResult};
 use etl::state::table::TableReplicationPhase;
 use etl::store::cleanup::CleanupStore;
 use etl::store::schema::SchemaStore;
-use etl::store::state::StateStore;
+use etl::store::state::{StateStore, TableMappings, TableReplicationStates};
 use etl::types::{TableId, TableSchema};
-use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tracing::info;
 
@@ -87,9 +86,7 @@ where
         self.inner.get_table_replication_state(table_id).await
     }
 
-    async fn get_table_replication_states(
-        &self,
-    ) -> EtlResult<BTreeMap<TableId, TableReplicationPhase>> {
+    async fn get_table_replication_states(&self) -> EtlResult<TableReplicationStates> {
         self.inner.get_table_replication_states().await
     }
 
@@ -125,7 +122,7 @@ where
         self.inner.get_table_mapping(source_table_id).await
     }
 
-    async fn get_table_mappings(&self) -> EtlResult<HashMap<TableId, String>> {
+    async fn get_table_mappings(&self) -> EtlResult<TableMappings> {
         self.inner.get_table_mappings().await
     }
 

--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -5,7 +5,7 @@
 
 use crate::bail;
 use crate::concurrency::memory_monitor::MemoryMonitor;
-use crate::concurrency::shutdown::{create_shutdown_channel, ShutdownTx};
+use crate::concurrency::shutdown::{ShutdownTx, create_shutdown_channel};
 use crate::destination::Destination;
 use crate::error::{ErrorKind, EtlResult};
 use crate::metrics::register_metrics;

--- a/etl/src/pipeline.rs
+++ b/etl/src/pipeline.rs
@@ -5,7 +5,7 @@
 
 use crate::bail;
 use crate::concurrency::memory_monitor::MemoryMonitor;
-use crate::concurrency::shutdown::{ShutdownTx, create_shutdown_channel};
+use crate::concurrency::shutdown::{create_shutdown_channel, ShutdownTx};
 use crate::destination::Destination;
 use crate::error::{ErrorKind, EtlResult};
 use crate::metrics::register_metrics;
@@ -366,7 +366,7 @@ where
         // The purging doesn't delete any data in the destination, it just removes internal state for
         // that table.
         let publication_set: HashSet<TableId> = publication_table_ids.iter().copied().collect();
-        for (table_id, _) in table_replication_states {
+        for &table_id in table_replication_states.keys() {
             if !publication_set.contains(&table_id) {
                 info!(
                     table_id = table_id.0,

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1899,18 +1899,17 @@ where
     }
 }
 
-/// Returns an iterator over tables that are still synchronizing.
-async fn get_syncing_tables<S>(
-    store: &S,
-) -> EtlResult<impl Iterator<Item = (TableId, TableReplicationPhase)> + use<S>>
+/// Returns tables that are still synchronizing.
+async fn get_syncing_tables<S>(store: &S) -> EtlResult<Vec<(TableId, TableReplicationPhase)>>
 where
     S: StateStore,
 {
-    Ok(store
-        .get_table_replication_states()
-        .await?
-        .into_iter()
-        .filter(|(_, state)| !state.as_type().is_done()))
+    let states = store.get_table_replication_states().await?;
+    Ok(states
+        .iter()
+        .filter(|(_, state)| !state.as_type().is_done())
+        .map(|(id, state)| (*id, state.clone()))
+        .collect())
 }
 
 /// Functions specific to the apply worker.

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -8,14 +8,14 @@ use crate::etl_error;
 use crate::state::table::TableReplicationPhase;
 use crate::store::cleanup::CleanupStore;
 use crate::store::schema::SchemaStore;
-use crate::store::state::StateStore;
+use crate::store::state::{StateStore, TableMappings, TableReplicationStates};
 
 /// Inner state of [`MemoryStore`]
 #[derive(Debug)]
 struct Inner {
     /// Current replication state for each table - this is the authoritative source of truth
     /// for table states. Every table being replicated must have an entry here.
-    table_replication_states: BTreeMap<TableId, TableReplicationPhase>,
+    table_replication_states: TableReplicationStates,
     /// Complete history of state transitions for each table, used for debugging and auditing.
     /// This is an append-only log that grows over time and provides visibility into
     /// table state evolution. Entries are chronologically ordered.
@@ -26,7 +26,7 @@ struct Inner {
     table_schemas: HashMap<TableId, Arc<TableSchema>>,
     /// Mapping from table IDs to human-readable table names for easier debugging
     /// and logging. These mappings are established during schema discovery.
-    table_mappings: HashMap<TableId, String>,
+    table_mappings: TableMappings,
 }
 
 /// In-memory storage for ETL pipeline state and schema information.
@@ -50,10 +50,10 @@ impl MemoryStore {
     /// state and schema information.
     pub fn new() -> Self {
         let inner = Inner {
-            table_replication_states: BTreeMap::new(),
+            table_replication_states: Arc::new(BTreeMap::new()),
             table_state_history: HashMap::new(),
             table_schemas: HashMap::new(),
-            table_mappings: HashMap::new(),
+            table_mappings: Arc::new(HashMap::new()),
         };
 
         Self {
@@ -78,12 +78,10 @@ impl StateStore for MemoryStore {
         Ok(inner.table_replication_states.get(&table_id).cloned())
     }
 
-    async fn get_table_replication_states(
-        &self,
-    ) -> EtlResult<BTreeMap<TableId, TableReplicationPhase>> {
+    async fn get_table_replication_states(&self) -> EtlResult<TableReplicationStates> {
         let inner = self.inner.lock().await;
 
-        Ok(inner.table_replication_states.clone())
+        Ok(Arc::clone(&inner.table_replication_states))
     }
 
     async fn load_table_replication_states(&self) -> EtlResult<usize> {
@@ -96,11 +94,15 @@ impl StateStore for MemoryStore {
         &self,
         updates: Vec<(TableId, TableReplicationPhase)>,
     ) -> EtlResult<()> {
-        let mut inner = self.inner.lock().await;
+        let mut guard = self.inner.lock().await;
+        // To enable split-borrow (`Arc::make_mut()` borrows `table_replication_states` mutably,
+        // while `inner.table_state_history` borrows different field).
+        let inner = &mut *guard;
 
+        let states = Arc::make_mut(&mut inner.table_replication_states);
         for (table_id, state) in updates {
             // Store the current state in history before updating
-            if let Some(current_state) = inner.table_replication_states.get(&table_id).cloned() {
+            if let Some(current_state) = states.get(&table_id).cloned() {
                 inner
                     .table_state_history
                     .entry(table_id)
@@ -108,7 +110,7 @@ impl StateStore for MemoryStore {
                     .push(current_state);
             }
 
-            inner.table_replication_states.insert(table_id, state);
+            states.insert(table_id, state);
         }
 
         Ok(())
@@ -133,9 +135,7 @@ impl StateStore for MemoryStore {
             })?;
 
         // Update the current state to the previous state
-        inner
-            .table_replication_states
-            .insert(table_id, previous_state.clone());
+        Arc::make_mut(&mut inner.table_replication_states).insert(table_id, previous_state.clone());
 
         Ok(previous_state)
     }
@@ -146,10 +146,10 @@ impl StateStore for MemoryStore {
         Ok(inner.table_mappings.get(source_table_id).cloned())
     }
 
-    async fn get_table_mappings(&self) -> EtlResult<HashMap<TableId, String>> {
+    async fn get_table_mappings(&self) -> EtlResult<TableMappings> {
         let inner = self.inner.lock().await;
 
-        Ok(inner.table_mappings.clone())
+        Ok(Arc::clone(&inner.table_mappings))
     }
 
     async fn load_table_mappings(&self) -> EtlResult<usize> {
@@ -164,9 +164,7 @@ impl StateStore for MemoryStore {
         destination_table_id: String,
     ) -> EtlResult<()> {
         let mut inner = self.inner.lock().await;
-        inner
-            .table_mappings
-            .insert(source_table_id, destination_table_id);
+        Arc::make_mut(&mut inner.table_mappings).insert(source_table_id, destination_table_id);
 
         Ok(())
     }
@@ -206,10 +204,10 @@ impl CleanupStore for MemoryStore {
     async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
         let mut inner = self.inner.lock().await;
 
-        inner.table_replication_states.remove(&table_id);
+        Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
         inner.table_state_history.remove(&table_id);
         inner.table_schemas.remove(&table_id);
-        inner.table_mappings.remove(&table_id);
+        Arc::make_mut(&mut inner.table_mappings).remove(&table_id);
 
         Ok(())
     }

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -1,5 +1,5 @@
 use etl_config::shared::{
-    IntoConnectOptions, PgConnectionConfig, ETL_MIGRATION_OPTIONS, ETL_STATE_MANAGEMENT_OPTIONS,
+    ETL_MIGRATION_OPTIONS, ETL_STATE_MANAGEMENT_OPTIONS, IntoConnectOptions, PgConnectionConfig,
 };
 use etl_postgres::replication::{schema, state, table_mappings};
 use etl_postgres::types::{TableId, TableSchema};

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -1,5 +1,5 @@
 use etl_config::shared::{
-    ETL_MIGRATION_OPTIONS, ETL_STATE_MANAGEMENT_OPTIONS, IntoConnectOptions, PgConnectionConfig,
+    IntoConnectOptions, PgConnectionConfig, ETL_MIGRATION_OPTIONS, ETL_STATE_MANAGEMENT_OPTIONS,
 };
 use etl_postgres::replication::{schema, state, table_mappings};
 use etl_postgres::types::{TableId, TableSchema};
@@ -19,7 +19,7 @@ use crate::metrics::{ETL_TABLES_TOTAL, PHASE_LABEL};
 use crate::state::table::TableReplicationPhase;
 use crate::store::cleanup::CleanupStore;
 use crate::store::schema::SchemaStore;
-use crate::store::state::StateStore;
+use crate::store::state::{StateStore, TableMappings, TableReplicationStates};
 use crate::types::PipelineId;
 
 /// Maximum number of connections in the pool.
@@ -96,11 +96,11 @@ struct Inner {
     /// Count of number of tables in each phase. Used for metrics.
     phase_counts: HashMap<&'static str, u64>,
     /// Cached table replication states indexed by table ID.
-    table_states: BTreeMap<TableId, TableReplicationPhase>,
+    table_states: TableReplicationStates,
     /// Cached table schemas indexed by table ID.
     table_schemas: HashMap<TableId, Arc<TableSchema>>,
     /// Cached table mappings from source table ID to destination table name.
-    table_mappings: HashMap<TableId, String>,
+    table_mappings: TableMappings,
 }
 
 impl Inner {
@@ -117,8 +117,10 @@ impl Inner {
 
     /// Inserts or updates a table state and adjusts phase counts accordingly.
     fn set_table_state(&mut self, table_id: TableId, state: TableReplicationPhase) {
+        let states = Arc::make_mut(&mut self.table_states);
+
         // Decrement old phase count if the state existed.
-        if let Some(old_state) = self.table_states.get(&table_id) {
+        if let Some(old_state) = states.get(&table_id) {
             let old_phase = old_state.as_type().as_static_str();
             if let Some(count) = self.phase_counts.get_mut(old_phase) {
                 *count = count.saturating_sub(1);
@@ -130,12 +132,13 @@ impl Inner {
         let phase_count = self.phase_counts.entry(new_phase).or_default();
         *phase_count = phase_count.saturating_add(1);
 
-        self.table_states.insert(table_id, state);
+        states.insert(table_id, state);
     }
 
     /// Removes a table state and adjusts phase counts accordingly.
     fn remove_table_state(&mut self, table_id: TableId) {
-        if let Some(old_state) = self.table_states.remove(&table_id) {
+        let states = Arc::make_mut(&mut self.table_states);
+        if let Some(old_state) = states.remove(&table_id) {
             let old_phase = old_state.as_type().as_static_str();
             if let Some(count) = self.phase_counts.get_mut(old_phase) {
                 *count = count.saturating_sub(1);
@@ -199,9 +202,9 @@ impl PostgresStore {
         let pool = create_database_pool(&source_config);
         let inner = Inner {
             phase_counts: HashMap::new(),
-            table_states: BTreeMap::new(),
+            table_states: Arc::new(BTreeMap::new()),
             table_schemas: HashMap::new(),
-            table_mappings: HashMap::new(),
+            table_mappings: Arc::new(HashMap::new()),
         };
 
         Ok(Self {
@@ -232,12 +235,10 @@ impl StateStore for PostgresStore {
     /// This method returns a complete snapshot of all cached table replication
     /// states. It's useful for pipeline initialization and state inspection
     /// operations that need visibility into all tables.
-    async fn get_table_replication_states(
-        &self,
-    ) -> EtlResult<BTreeMap<TableId, TableReplicationPhase>> {
+    async fn get_table_replication_states(&self) -> EtlResult<TableReplicationStates> {
         let inner = self.inner.lock().await;
 
-        Ok(inner.table_states.clone())
+        Ok(Arc::clone(&inner.table_states))
     }
 
     /// Loads table replication states from Postgres into memory cache.
@@ -265,7 +266,7 @@ impl StateStore for PostgresStore {
         // and from a single thread, we can afford to have a short critical section.
         let mut inner = self.inner.lock().await;
         inner.init_phase_counts(&table_states);
-        inner.table_states = table_states;
+        inner.table_states = Arc::new(table_states);
         emit_table_metrics(&inner.phase_counts);
 
         info!(
@@ -359,10 +360,10 @@ impl StateStore for PostgresStore {
     /// This method returns a complete snapshot of all cached table mappings,
     /// showing how source table IDs map to destination table names. Useful
     /// for operations that need visibility into the complete mapping configuration.
-    async fn get_table_mappings(&self) -> EtlResult<HashMap<TableId, String>> {
+    async fn get_table_mappings(&self) -> EtlResult<TableMappings> {
         let inner = self.inner.lock().await;
 
-        Ok(inner.table_mappings.clone())
+        Ok(Arc::clone(&inner.table_mappings))
     }
 
     /// Loads table mappings from Postgres into memory cache.
@@ -388,7 +389,7 @@ impl StateStore for PostgresStore {
         let table_mappings_len = table_mappings.len();
 
         let mut inner = self.inner.lock().await;
-        inner.table_mappings = table_mappings;
+        inner.table_mappings = Arc::new(table_mappings);
 
         info!(
             count = table_mappings_len,
@@ -426,9 +427,7 @@ impl StateStore for PostgresStore {
         })?;
 
         let mut inner = self.inner.lock().await;
-        inner
-            .table_mappings
-            .insert(source_table_id, destination_table_id);
+        Arc::make_mut(&mut inner.table_mappings).insert(source_table_id, destination_table_id);
 
         Ok(())
     }
@@ -554,7 +553,7 @@ impl CleanupStore for PostgresStore {
         let mut inner = self.inner.lock().await;
         inner.remove_table_state(table_id);
         inner.table_schemas.remove(&table_id);
-        inner.table_mappings.remove(&table_id);
+        Arc::make_mut(&mut inner.table_mappings).remove(&table_id);
         emit_table_metrics(&inner.phase_counts);
 
         Ok(())

--- a/etl/src/store/state/base.rs
+++ b/etl/src/store/state/base.rs
@@ -1,9 +1,16 @@
 use etl_postgres::types::TableId;
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
+use std::sync::Arc;
 
 use crate::error::EtlResult;
 use crate::state::table::TableReplicationPhase;
+
+/// Arc-wrapped dictionary of table replication states.
+pub type TableReplicationStates = Arc<BTreeMap<TableId, TableReplicationPhase>>;
+
+/// Arc-wrapped dictionary of table mappings.
+pub type TableMappings = Arc<HashMap<TableId, String>>;
 
 /// Trait for storing and retrieving table replication state and mapping information.
 ///
@@ -25,7 +32,7 @@ pub trait StateStore {
     /// Does not read from the persistent store.
     fn get_table_replication_states(
         &self,
-    ) -> impl Future<Output = EtlResult<BTreeMap<TableId, TableReplicationPhase>>> + Send;
+    ) -> impl Future<Output = EtlResult<TableReplicationStates>> + Send;
 
     /// Loads the table replication states from the persistent state into the cache.
     /// This should be called once at program start to load the state into the cache
@@ -71,9 +78,7 @@ pub trait StateStore {
     /// Returns all table mappings from the cache.
     ///
     /// Does not read from the persistent store.
-    fn get_table_mappings(
-        &self,
-    ) -> impl Future<Output = EtlResult<HashMap<TableId, String>>> + Send;
+    fn get_table_mappings(&self) -> impl Future<Output = EtlResult<TableMappings>> + Send;
 
     /// Loads all table mappings from the persistent state into the cache.
     ///

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -9,7 +9,7 @@ use crate::etl_error;
 use crate::state::table::{TableReplicationPhase, TableReplicationPhaseType};
 use crate::store::cleanup::CleanupStore;
 use crate::store::schema::SchemaStore;
-use crate::store::state::StateStore;
+use crate::store::state::{StateStore, TableMappings, TableReplicationStates};
 use crate::test_utils::notify::TimedNotify;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -29,10 +29,10 @@ type TableStateCondition = (
 );
 
 struct Inner {
-    table_replication_states: BTreeMap<TableId, TableReplicationPhase>,
+    table_replication_states: TableReplicationStates,
     table_state_history: HashMap<TableId, Vec<TableReplicationPhase>>,
     table_schemas: HashMap<TableId, Arc<TableSchema>>,
-    table_mappings: HashMap<TableId, String>,
+    table_mappings: TableMappings,
     table_state_type_conditions: Vec<TableStateTypeCondition>,
     table_state_conditions: Vec<TableStateCondition>,
     method_call_notifiers: HashMap<StateStoreMethod, Vec<Arc<Notify>>>,
@@ -40,7 +40,7 @@ struct Inner {
 
 impl Inner {
     fn check_conditions(&mut self) {
-        let table_states = self.table_replication_states.clone();
+        let table_states = Arc::clone(&self.table_replication_states);
         self.table_state_type_conditions
             .retain(|(tid, expected_state, notify)| {
                 if let Some(state) = table_states.get(tid) {
@@ -87,10 +87,10 @@ impl NotifyingStore {
     /// Creates a new [`NotifyingStore`] instance.
     pub fn new() -> Self {
         let inner = Inner {
-            table_replication_states: BTreeMap::new(),
+            table_replication_states: Arc::new(BTreeMap::new()),
             table_state_history: HashMap::new(),
             table_schemas: HashMap::new(),
-            table_mappings: HashMap::new(),
+            table_mappings: Arc::new(HashMap::new()),
             table_state_type_conditions: Vec::new(),
             table_state_conditions: Vec::new(),
             method_call_notifiers: HashMap::new(),
@@ -102,9 +102,9 @@ impl NotifyingStore {
     }
 
     /// Returns all table replication states.
-    pub async fn get_table_replication_states(&self) -> BTreeMap<TableId, TableReplicationPhase> {
+    pub async fn get_table_replication_states(&self) -> TableReplicationStates {
         let inner = self.inner.read().await;
-        inner.table_replication_states.clone()
+        Arc::clone(&inner.table_replication_states)
     }
 
     /// Returns all table schemas.
@@ -179,12 +179,10 @@ impl NotifyingStore {
     /// Resets the state of a table to [`TableReplicationPhase::Init`].
     pub async fn reset_table_state(&self, table_id: TableId) -> EtlResult<()> {
         let mut inner = self.inner.write().await;
-        inner.table_replication_states.remove(&table_id);
         inner.table_state_history.remove(&table_id);
-
-        inner
-            .table_replication_states
-            .insert(table_id, TableReplicationPhase::Init);
+        let states = Arc::make_mut(&mut inner.table_replication_states);
+        states.remove(&table_id);
+        states.insert(table_id, TableReplicationPhase::Init);
 
         Ok(())
     }
@@ -209,11 +207,9 @@ impl StateStore for NotifyingStore {
         result
     }
 
-    async fn get_table_replication_states(
-        &self,
-    ) -> EtlResult<BTreeMap<TableId, TableReplicationPhase>> {
+    async fn get_table_replication_states(&self) -> EtlResult<TableReplicationStates> {
         let inner = self.inner.read().await;
-        let result = Ok(inner.table_replication_states.clone());
+        let result = Ok(Arc::clone(&inner.table_replication_states));
 
         inner.dispatch_method_notification(StateStoreMethod::GetTableReplicationStates);
 
@@ -233,11 +229,13 @@ impl StateStore for NotifyingStore {
         &self,
         updates: Vec<(TableId, TableReplicationPhase)>,
     ) -> EtlResult<()> {
-        let mut inner = self.inner.write().await;
+        let mut guard = self.inner.write().await;
+        let inner = &mut *guard;
 
+        let states = Arc::make_mut(&mut inner.table_replication_states);
         for (table_id, state) in updates {
             // Store the current state in history before updating
-            if let Some(current_state) = inner.table_replication_states.get(&table_id).cloned() {
+            if let Some(current_state) = states.get(&table_id).cloned() {
                 inner
                     .table_state_history
                     .entry(table_id)
@@ -245,11 +243,11 @@ impl StateStore for NotifyingStore {
                     .push(current_state);
             }
 
-            inner.table_replication_states.insert(table_id, state);
+            states.insert(table_id, state);
         }
 
-        inner.check_conditions();
-        inner.dispatch_method_notification(StateStoreMethod::StoreTableReplicationState);
+        guard.check_conditions();
+        guard.dispatch_method_notification(StateStoreMethod::StoreTableReplicationState);
 
         Ok(())
     }
@@ -273,9 +271,7 @@ impl StateStore for NotifyingStore {
             })?;
 
         // Update the current state to the previous state
-        inner
-            .table_replication_states
-            .insert(table_id, previous_state.clone());
+        Arc::make_mut(&mut inner.table_replication_states).insert(table_id, previous_state.clone());
         inner.check_conditions();
 
         inner.dispatch_method_notification(StateStoreMethod::RollbackTableReplicationState);
@@ -288,9 +284,9 @@ impl StateStore for NotifyingStore {
         Ok(inner.table_mappings.get(source_table_id).cloned())
     }
 
-    async fn get_table_mappings(&self) -> EtlResult<HashMap<TableId, String>> {
+    async fn get_table_mappings(&self) -> EtlResult<TableMappings> {
         let inner = self.inner.read().await;
-        Ok(inner.table_mappings.clone())
+        Ok(Arc::clone(&inner.table_mappings))
     }
 
     async fn load_table_mappings(&self) -> EtlResult<usize> {
@@ -304,9 +300,7 @@ impl StateStore for NotifyingStore {
         destination_table_id: String,
     ) -> EtlResult<()> {
         let mut inner = self.inner.write().await;
-        inner
-            .table_mappings
-            .insert(source_table_id, destination_table_id);
+        Arc::make_mut(&mut inner.table_mappings).insert(source_table_id, destination_table_id);
 
         Ok(())
     }
@@ -345,10 +339,10 @@ impl CleanupStore for NotifyingStore {
     async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
         let mut inner = self.inner.write().await;
 
-        inner.table_replication_states.remove(&table_id);
+        Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
         inner.table_state_history.remove(&table_id);
         inner.table_schemas.remove(&table_id);
-        inner.table_mappings.remove(&table_id);
+        Arc::make_mut(&mut inner.table_mappings).remove(&table_id);
 
         Ok(())
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactoring/optimization

## What is the current behavior?

Both `MemoryStore` and `PostgresStore` use `Arc<Mutex<Inner>>` internally, then every read method acquires the lock, **deep-clones** the data out, then releases the lock. So, too many unnecessary cloning is happening.

## What is the new behavior?

Wrap returned data into `Arc`, so read path gets cheap `Arc::clone()` and write path uses `Arc::make_mut()` *copy-on-write* semantics i.e. clone will occur only for situations where there additional holders of an arc. 

Basically, we traded read-side cloning for write-side:
- before: on every read full deep copy of an object occurs, writes are directly to locked structures
- now: on every read arc counter bump occurs, on writes whenever strong count is >1 copy-on-write occurs (readers end up with stall arc, but semantically that what they were getting previously by cloning -- independent copy) i.e. new arc is created and written into, current holders end up with the previous arc pointer.

## Additional context

- `get_syncing_tables()` return owned vector now, which actually seems to be better a solution:
  - before: you get lazy iterator, but before you do you clone whole map, so you copy all items disregarding how you filter them out
  - now: you do not clone, working out of borrowing `iter()`, filter things out and build a collection, so in a sense only filtered items are cloned/copied, which is still better than cloning whole object and get iterator to it.

So, overall we should get bulk cloning number bound drop from `O(reads)` to `O(concurrent_writes)`. And since reads dominate writes, it appears to be a nice optimization.

Closes ETL-466
