### PR TITLE
refactor: enable extended clippy lint set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@
 - Prefer running `cargo nextest list` before using filters or crate-specific commands if there is any doubt.
 - When fixing a specific crate, run the narrowest relevant tests first, then broaden if needed.
 - Add or update tests when behavior changes, regressions are possible, or new logic is introduced.
+- Do not prefix `#[test]` functions with `test_`. Name them after what they verify — e.g. `fn parses_empty_input()` not `fn test_parses_empty_input()`.
 
 ## Review Checklist
 - Code compiles for the changed target or workspace as appropriate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
 resolver = "3"
 members = [
-    "etl",
-    "etl-api",
-    "etl-benchmarks",
-    "etl-config",
-    "etl-destinations",
-    "etl-examples",
-    "etl-postgres",
-    "etl-replicator",
-    "etl-telemetry",
-    "xtask",
+  "etl",
+  "etl-api",
+  "etl-benchmarks",
+  "etl-config",
+  "etl-destinations",
+  "etl-examples",
+  "etl-postgres",
+  "etl-replicator",
+  "etl-telemetry",
+  "xtask",
 ]
 
 [workspace.package]
@@ -23,9 +23,41 @@ homepage = "https://supabase.github.io/etl/"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+
 [workspace.lints.clippy]
+# Correctness & safety
 await_holding_lock = "deny"
 unused_async = "deny"
+large_futures = "deny"
+
+# Style & clarity
+cloned_instead_of_copied = "warn"
+copy_iterator = "warn"
+dbg_macro = "warn"
+enum_glob_use = "warn"
+explicit_into_iter_loop = "warn"
+explicit_iter_loop = "warn"
+flat_map_option = "warn"
+implicit_clone = "warn"
+map_flatten = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_async_fn = "warn"
+map_unwrap_or = "warn"
+match_same_arms = "warn"
+redundant_closure = "warn"
+redundant_closure_call = "warn"
+redundant_closure_for_method_calls = "warn"
+redundant_else = "warn"
+redundant_clone = "warn"
+redundant_field_names = "warn"
+redundant_test_prefix = "warn"
+semicolon_if_nothing_returned = "warn"
+todo = "warn"
+uninlined_format_args = "warn"
+unnested_or_patterns = "warn"
 
 [workspace.dependencies]
 etl = { path = "etl", default-features = false }
@@ -79,12 +111,19 @@ sqlx = { version = "0.8.6", default-features = false }
 sysinfo = { version = "0.38.2", default-features = false }
 tempfile = { version = "3.23.0", default-features = false }
 thiserror = "2.0.12"
-tikv-jemalloc-ctl = { version = "0.6.0", default-features = false, features = ["stats"] }
-tikv-jemallocator = { version = "0.6.1", default-features = false, features = ["background_threads_runtime_support", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.6.0", default-features = false, features = [
+  "stats",
+] }
+tikv-jemallocator = { version = "0.6.1", default-features = false, features = [
+  "background_threads_runtime_support",
+  "unprefixed_malloc_on_supported_platforms",
+] }
 tokio = { version = "1.47.0", default-features = false }
 tokio-postgres = { git = "https://github.com/iambriccardo/rust-postgres", default-features = false, rev = "31acf55c7e5c2244e5bb3a36e7afa2a01bf52c38" }
 tokio-rustls = { version = "0.26.2", default-features = false }
-tokio-stream = { version = "0.1.18", default-features = false, features = ["sync"] }
+tokio-stream = { version = "0.1.18", default-features = false, features = [
+  "sync",
+] }
 tonic = { version = "0.14.2", default-features = false }
 tracing = { version = "0.1.41", default-features = false }
 tracing-actix-web = { version = "0.7.19", default-features = false }
@@ -93,7 +132,9 @@ tracing-log = { version = "0.2.0", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false }
 url = { version = "2.5.8" }
 utoipa = { version = "5.4.0", default-features = false }
-utoipa-swagger-ui = { version = "9.0.2", default-features = false, features = ["vendored"] }
+utoipa-swagger-ui = { version = "9.0.2", default-features = false, features = [
+  "vendored",
+] }
 uuid = { version = "1.17.0", default-features = false }
 x509-cert = { version = "0.2.2", default-features = false }
 

--- a/etl-api/src/configs/destination.rs
+++ b/etl-api/src/configs/destination.rs
@@ -751,7 +751,7 @@ mod tests {
     use crate::configs::encryption::{EncryptionKey, generate_random_key};
 
     #[test]
-    fn test_stored_destination_config_encryption_decryption_bigquery() {
+    fn stored_destination_config_encryption_decryption_bigquery() {
         let config = StoredDestinationConfig::BigQuery {
             project_id: "test-project".to_string(),
             dataset_id: "test_dataset".to_string(),
@@ -794,7 +794,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stored_destination_config_encryption_decryption_iceberg_supabase() {
+    fn stored_destination_config_encryption_decryption_iceberg_supabase() {
         let config = StoredDestinationConfig::Iceberg {
             config: StoredIcebergConfig::Supabase {
                 project_ref: "abcdefghijklmnopqrst".to_string(),
@@ -859,7 +859,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stored_destination_config_encryption_decryption_iceberg_rest() {
+    fn stored_destination_config_encryption_decryption_iceberg_rest() {
         let config = StoredDestinationConfig::Iceberg {
             config: StoredIcebergConfig::Rest {
                 catalog_uri: "https://abcdefghijklmnopqrst.storage.supabase.com/storage/v1/iceberg"
@@ -920,7 +920,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_destination_config_conversion_bigquery() {
+    fn full_api_destination_config_conversion_bigquery() {
         let full_config = FullApiDestinationConfig::BigQuery {
             project_id: "test-project".to_string(),
             dataset_id: "test_dataset".to_string(),
@@ -968,7 +968,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_destination_config_conversion_iceberg_supabase() {
+    fn full_api_destination_config_conversion_iceberg_supabase() {
         let full_config = FullApiDestinationConfig::Iceberg {
             config: FullApiIcebergConfig::Supabase {
                 project_ref: "abcdefghijklmnopqrst".to_string(),
@@ -1030,7 +1030,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_destination_config_conversion_iceberg_rest() {
+    fn full_api_destination_config_conversion_iceberg_rest() {
         let full_config = FullApiDestinationConfig::Iceberg {
             config: FullApiIcebergConfig::Rest {
                 catalog_uri: "https://abcdefghijklmnopqrst.storage.supabase.com/storage/v1/iceberg"
@@ -1089,7 +1089,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stored_destination_config_encryption_decryption_ducklake() {
+    fn stored_destination_config_encryption_decryption_ducklake() {
         let config = StoredDestinationConfig::Ducklake {
             catalog_url: "postgres://user:pass@localhost:5432/ducklake_catalog".to_string(),
             data_path: "s3://bucket/path".to_string(),
@@ -1157,7 +1157,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_destination_config_conversion_ducklake() {
+    fn full_api_destination_config_conversion_ducklake() {
         let full_config = FullApiDestinationConfig::Ducklake {
             catalog_url: "postgres://user:pass@localhost:5432/ducklake_catalog".to_string(),
             data_path: "file:///absolute/path/to/lake_data".to_string(),
@@ -1202,7 +1202,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_destination_config_serialization_ducklake() {
+    fn full_api_destination_config_serialization_ducklake() {
         let full_config = FullApiDestinationConfig::Ducklake {
             catalog_url: "postgres://user:pass@localhost:5432/ducklake_catalog".to_string(),
             data_path: "s3://bucket/path".to_string(),
@@ -1269,7 +1269,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_destination_config_serialization_iceberg_supabase() {
+    fn full_api_destination_config_serialization_iceberg_supabase() {
         let full_config = FullApiDestinationConfig::Iceberg {
             config: FullApiIcebergConfig::Supabase {
                 project_ref: "abcdefghijklmnopqrst".to_string(),
@@ -1334,7 +1334,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_destination_config_serialization_iceberg_rest() {
+    fn full_api_destination_config_serialization_iceberg_rest() {
         let full_config = FullApiDestinationConfig::Iceberg {
             config: FullApiIcebergConfig::Rest {
                 catalog_uri: "https://catalog.example.com/iceberg".to_string(),

--- a/etl-api/src/configs/pipeline.rs
+++ b/etl-api/src/configs/pipeline.rs
@@ -166,7 +166,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_stored_pipeline_config_serialization() {
+    fn stored_pipeline_config_serialization() {
         let config = StoredPipelineConfig {
             publication_name: "test_publication".to_string(),
             batch: BatchConfig { max_fill_ms: 5000, memory_budget_ratio: 0.2 },
@@ -201,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_pipeline_config_conversion() {
+    fn full_api_pipeline_config_conversion() {
         let full_config = FullApiPipelineConfig {
             publication_name: "test_publication".to_string(),
             batch: None,
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_pipeline_config_defaults() {
+    fn full_api_pipeline_config_defaults() {
         let full_config = FullApiPipelineConfig {
             publication_name: "test_publication".to_string(),
             batch: None,

--- a/etl-api/src/configs/source.rs
+++ b/etl-api/src/configs/source.rs
@@ -160,7 +160,7 @@ mod tests {
     use crate::configs::encryption::{EncryptionKey, generate_random_key};
 
     #[test]
-    fn test_stored_source_config_encryption_decryption() {
+    fn stored_source_config_encryption_decryption() {
         let config = StoredSourceConfig {
             host: "localhost".to_string(),
             port: 5432,
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_api_source_config_conversion() {
+    fn full_api_source_config_conversion() {
         let full_config = FullApiSourceConfig {
             host: "localhost".to_string(),
             port: 5432,

--- a/etl-api/src/configs/source.rs
+++ b/etl-api/src/configs/source.rs
@@ -82,7 +82,7 @@ impl StoredSourceConfig {
             port: self.port,
             name: self.name,
             username: self.username,
-            password: self.password.map(|p| p.into()),
+            password: self.password.map(Into::into),
             tls: tls_config,
             keepalive: TcpKeepaliveConfig::default(),
         }

--- a/etl-api/src/db/images.rs
+++ b/etl-api/src/db/images.rs
@@ -144,12 +144,9 @@ pub async fn delete_image(pool: &PgPool, image_id: i64) -> Result<Option<i64>, I
     .fetch_optional(&mut *txn)
     .await?;
 
-    let image = match image {
-        Some(img) => img,
-        None => {
-            // Image doesn't exist, return None
-            return Ok(None);
-        }
+    let Some(image) = image else {
+        // Image doesn't exist, return None
+        return Ok(None);
     };
 
     // Prevent deletion if it's a default image

--- a/etl-api/src/db/publications.rs
+++ b/etl-api/src/db/publications.rs
@@ -40,7 +40,7 @@ pub async fn create_publication(
         query.push_str(&quoted_name);
 
         if i < publication.tables.len() - 1 {
-            query.push(',')
+            query.push(',');
         }
     }
 
@@ -70,7 +70,7 @@ pub async fn update_publication(
         query.push_str(&quoted_name);
 
         if i < publication.tables.len() - 1 {
-            query.push(',')
+            query.push(',');
         }
     }
 

--- a/etl-api/src/k8s/cache.rs
+++ b/etl-api/src/k8s/cache.rs
@@ -235,7 +235,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_returns_certs() {
+    async fn cache_returns_certs() {
         let expected_certs = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----";
         let client = Arc::new(MockK8sClient { certs: expected_certs.to_string() });
         let cache = TrustedRootCertsCache::new(client);
@@ -245,7 +245,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_returns_cached_value() {
+    async fn cache_returns_cached_value() {
         let expected_certs = "cached-certs";
         let client = Arc::new(MockK8sClient { certs: expected_certs.to_string() });
         let cache = TrustedRootCertsCache::new(client);

--- a/etl-api/src/k8s/core.rs
+++ b/etl-api/src/k8s/core.rs
@@ -100,7 +100,7 @@ pub async fn create_or_update_pipeline_resources_in_k8s(
 
     let supabase_config = SupabaseConfigWithoutSecrets {
         project_ref: tenant_id.to_owned(),
-        api_url: supabase_api_url.map(|url| url.to_owned()),
+        api_url: supabase_api_url.map(ToOwned::to_owned),
     };
 
     let log_level = pipeline.config.log_level.clone().unwrap_or_default();

--- a/etl-api/src/k8s/core.rs
+++ b/etl-api/src/k8s/core.rs
@@ -565,20 +565,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_failed_pod_is_considered_active_for_deletion_guards() {
-        let client = RecordingK8sClient { pod_status: PodStatus::Failed, ..Default::default() };
-        let pipeline =
-            PipelineDeletion { id: 1, source_id: 2, destination_id: 3, replicator_id: 4 };
-
-        let is_active = is_replicator_active(&client, "tenant-42", pipeline.replicator_id)
-            .await
-            .expect("failed to inspect pipeline status");
-
-        assert!(is_active);
-    }
-
-    #[tokio::test]
-    async fn test_ducklake_creates_postgres_and_s3_secrets() {
+    async fn ducklake_creates_postgres_and_s3_secrets() {
         let source_config = StoredSourceConfig {
             host: "localhost".to_string(),
             port: 5432,
@@ -614,7 +601,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_ducklake_without_s3_still_creates_postgres_secret() {
+    async fn ducklake_without_s3_still_creates_postgres_secret() {
         let source_config = StoredSourceConfig {
             host: "localhost".to_string(),
             port: 5432,

--- a/etl-api/src/k8s/core.rs
+++ b/etl-api/src/k8s/core.rs
@@ -566,16 +566,9 @@ mod tests {
 
     #[tokio::test]
     async fn failed_pod_is_considered_active_for_deletion_guards() {
-        let client = RecordingK8sClient {
-            pod_status: PodStatus::Failed,
-            ..Default::default()
-        };
-        let pipeline = PipelineDeletion {
-            id: 1,
-            source_id: 2,
-            destination_id: 3,
-            replicator_id: 4,
-        };
+        let client = RecordingK8sClient { pod_status: PodStatus::Failed, ..Default::default() };
+        let pipeline =
+            PipelineDeletion { id: 1, source_id: 2, destination_id: 3, replicator_id: 4 };
 
         let is_active = is_replicator_active(&client, "tenant-42", pipeline.replicator_id)
             .await

--- a/etl-api/src/k8s/core.rs
+++ b/etl-api/src/k8s/core.rs
@@ -565,6 +565,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_pod_is_considered_active_for_deletion_guards() {
+        let client = RecordingK8sClient {
+            pod_status: PodStatus::Failed,
+            ..Default::default()
+        };
+        let pipeline = PipelineDeletion {
+            id: 1,
+            source_id: 2,
+            destination_id: 3,
+            replicator_id: 4,
+        };
+
+        let is_active = is_replicator_active(&client, "tenant-42", pipeline.replicator_id)
+            .await
+            .expect("failed to inspect pipeline status");
+
+        assert!(is_active);
+    }
+
+    #[tokio::test]
     async fn ducklake_creates_postgres_and_s3_secrets() {
         let source_config = StoredSourceConfig {
             host: "localhost".to_string(),

--- a/etl-api/src/k8s/http.rs
+++ b/etl-api/src/k8s/http.rs
@@ -1184,6 +1184,7 @@ fn get_restarted_at_annotation_value() -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_test_prefix)]
 mod tests {
     use etl_config::shared::{
         BatchConfig, DestinationConfig, InvalidatedSlotBehavior, MemoryBackpressureConfig,
@@ -1201,7 +1202,7 @@ mod tests {
     }
 
     #[test]
-    fn create_postgres_secret_json_fn() {
+    fn test_create_postgres_secret_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let secret_name = &create_postgres_secret_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1219,7 +1220,7 @@ mod tests {
     }
 
     #[test]
-    fn create_bq_service_account_key_secret_json_fn() {
+    fn test_create_bq_service_account_key_secret_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let secret_name = &create_bq_secret_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1237,7 +1238,7 @@ mod tests {
     }
 
     #[test]
-    fn create_iceberg_secret_json_fn() {
+    fn test_create_iceberg_secret_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let secret_name = &&create_iceberg_secret_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1259,7 +1260,7 @@ mod tests {
     }
 
     #[test]
-    fn create_replicator_config_map_json_fn() {
+    fn test_create_replicator_config_map_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_config_map_name = create_replicator_config_map_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1328,7 +1329,7 @@ mod tests {
     }
 
     #[test]
-    fn create_postgres_secret_env_var_json_fn() {
+    fn test_create_postgres_secret_env_var_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let postgres_secret_name = create_postgres_secret_name(&prefix);
 
@@ -1338,7 +1339,7 @@ mod tests {
     }
 
     #[test]
-    fn create_bq_secret_env_var_json_fn() {
+    fn test_create_bq_secret_env_var_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let bq_secret_name = create_bq_secret_name(&prefix);
 
@@ -1348,7 +1349,7 @@ mod tests {
     }
 
     #[test]
-    fn create_iceberg_catlog_token_env_var_json_fn() {
+    fn test_create_iceberg_catlog_token_env_var_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let iceberg_secret_name = create_iceberg_secret_name(&prefix);
 
@@ -1359,7 +1360,7 @@ mod tests {
     }
 
     #[test]
-    fn create_iceberg_s3_access_key_id_env_var_json_fn() {
+    fn test_create_iceberg_s3_access_key_id_env_var_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let iceberg_secret_name = create_iceberg_secret_name(&prefix);
 
@@ -1370,7 +1371,7 @@ mod tests {
     }
 
     #[test]
-    fn create_iceberg_s3_secret_access_key_env_var_json_fn() {
+    fn test_create_iceberg_s3_secret_access_key_env_var_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let iceberg_secret_name = create_iceberg_secret_name(&prefix);
 
@@ -1381,7 +1382,7 @@ mod tests {
     }
 
     #[test]
-    fn create_bq_container_environment_fn() {
+    fn test_create_bq_container_environment() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
@@ -1417,7 +1418,7 @@ mod tests {
     }
 
     #[test]
-    fn create_iceberg_container_environment_fn() {
+    fn test_create_iceberg_container_environment() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
@@ -1450,7 +1451,7 @@ mod tests {
     }
 
     #[test]
-    fn create_ducklake_container_environment() {
+    fn test_create_ducklake_container_environment() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
@@ -1483,7 +1484,7 @@ mod tests {
     }
 
     #[test]
-    fn create_node_selector() {
+    fn test_create_node_selector() {
         let node_selector = create_node_selector_json(&Environment::Dev);
         assert_json_snapshot!(node_selector);
 
@@ -1495,7 +1496,7 @@ mod tests {
     }
 
     #[test]
-    fn create_init_containers() {
+    fn test_create_init_containers() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
 
         let environment = Environment::Dev;
@@ -1515,7 +1516,7 @@ mod tests {
     }
 
     #[test]
-    fn create_volumes() {
+    fn test_create_volumes() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
 
         let environment = Environment::Dev;
@@ -1532,7 +1533,7 @@ mod tests {
     }
 
     #[test]
-    fn create_volume_mounts() {
+    fn test_create_volume_mounts() {
         let environment = Environment::Dev;
         let volume_mounts = create_volume_mounts_json(&environment);
         assert_json_snapshot!(volume_mounts);
@@ -1547,7 +1548,7 @@ mod tests {
     }
 
     #[test]
-    fn create_bq_replicator_stateful_set_json() {
+    fn test_create_bq_replicator_stateful_set_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let stateful_set_name = create_stateful_set_name(&prefix);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
@@ -1650,7 +1651,7 @@ mod tests {
     }
 
     #[test]
-    fn create_iceberg_replicator_stateful_set_json() {
+    fn test_create_iceberg_replicator_stateful_set_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let stateful_set_name = create_stateful_set_name(&prefix);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
@@ -1753,7 +1754,7 @@ mod tests {
     }
 
     #[test]
-    fn create_ducklake_replicator_stateful_set_json() {
+    fn test_create_ducklake_replicator_stateful_set_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let stateful_set_name = create_stateful_set_name(&prefix);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";

--- a/etl-api/src/k8s/http.rs
+++ b/etl-api/src/k8s/http.rs
@@ -252,6 +252,7 @@ impl HttpK8sClient {
         if let Some(waiting) = &state.waiting
             && let Some(reason) = &waiting.reason
         {
+            #[allow(clippy::match_same_arms)]
             match reason.as_str() {
                 // Crash/restart errors
                 "CrashLoopBackOff" => return true,
@@ -575,17 +576,13 @@ impl K8sClient for HttpK8sClient {
             return Ok(PodStatus::Stopping);
         }
 
-        let phase = pod
-            .status
-            .map_or(PodPhase::Unknown, |status| {
-                let phase: PodPhase = status
-                    .phase
-                    .map_or(PodPhase::Unknown, |phase| {
-                        let phase: PodPhase = phase.as_str().into();
-                        phase
-                    });
+        let phase = pod.status.map_or(PodPhase::Unknown, |status| {
+            let phase: PodPhase = status.phase.map_or(PodPhase::Unknown, |phase| {
+                let phase: PodPhase = phase.as_str().into();
                 phase
             });
+            phase
+        });
 
         Ok(match phase {
             PodPhase::Pending => PodStatus::Starting,

--- a/etl-api/src/k8s/http.rs
+++ b/etl-api/src/k8s/http.rs
@@ -577,17 +577,15 @@ impl K8sClient for HttpK8sClient {
 
         let phase = pod
             .status
-            .map(|status| {
+            .map_or(PodPhase::Unknown, |status| {
                 let phase: PodPhase = status
                     .phase
-                    .map(|phase| {
+                    .map_or(PodPhase::Unknown, |phase| {
                         let phase: PodPhase = phase.as_str().into();
                         phase
-                    })
-                    .unwrap_or(PodPhase::Unknown);
+                    });
                 phase
-            })
-            .unwrap_or(PodPhase::Unknown);
+            });
 
         Ok(match phase {
             PodPhase::Pending => PodStatus::Starting,

--- a/etl-api/src/k8s/http.rs
+++ b/etl-api/src/k8s/http.rs
@@ -1201,7 +1201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_postgres_secret_json() {
+    fn create_postgres_secret_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let secret_name = &create_postgres_secret_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1219,7 +1219,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_bq_service_account_key_secret_json() {
+    fn create_bq_service_account_key_secret_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let secret_name = &create_bq_secret_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1237,7 +1237,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_iceberg_secret_json() {
+    fn create_iceberg_secret_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let secret_name = &&create_iceberg_secret_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1259,7 +1259,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_replicator_config_map_json() {
+    fn create_replicator_config_map_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_config_map_name = create_replicator_config_map_name(&prefix);
         let replicator_app_name = create_replicator_app_name(&prefix);
@@ -1328,7 +1328,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_postgres_secret_env_var_json() {
+    fn create_postgres_secret_env_var_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let postgres_secret_name = create_postgres_secret_name(&prefix);
 
@@ -1338,7 +1338,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_bq_secret_env_var_json() {
+    fn create_bq_secret_env_var_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let bq_secret_name = create_bq_secret_name(&prefix);
 
@@ -1348,7 +1348,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_iceberg_catlog_token_env_var_json() {
+    fn create_iceberg_catlog_token_env_var_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let iceberg_secret_name = create_iceberg_secret_name(&prefix);
 
@@ -1359,7 +1359,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_iceberg_s3_access_key_id_env_var_json() {
+    fn create_iceberg_s3_access_key_id_env_var_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let iceberg_secret_name = create_iceberg_secret_name(&prefix);
 
@@ -1370,7 +1370,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_iceberg_s3_secret_access_key_env_var_json() {
+    fn create_iceberg_s3_secret_access_key_env_var_json_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let iceberg_secret_name = create_iceberg_secret_name(&prefix);
 
@@ -1381,7 +1381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_bq_container_environment() {
+    fn create_bq_container_environment_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
@@ -1417,7 +1417,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_iceberg_container_environment() {
+    fn create_iceberg_container_environment_fn() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
@@ -1450,7 +1450,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_ducklake_container_environment() {
+    fn create_ducklake_container_environment() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
@@ -1483,7 +1483,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_node_selector() {
+    fn create_node_selector() {
         let node_selector = create_node_selector_json(&Environment::Dev);
         assert_json_snapshot!(node_selector);
 
@@ -1495,7 +1495,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_init_containers() {
+    fn create_init_containers() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
 
         let environment = Environment::Dev;
@@ -1515,7 +1515,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_volumes() {
+    fn create_volumes() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
 
         let environment = Environment::Dev;
@@ -1532,7 +1532,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_volume_mounts() {
+    fn create_volume_mounts() {
         let environment = Environment::Dev;
         let volume_mounts = create_volume_mounts_json(&environment);
         assert_json_snapshot!(volume_mounts);
@@ -1547,7 +1547,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_bq_replicator_stateful_set_json() {
+    fn create_bq_replicator_stateful_set_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let stateful_set_name = create_stateful_set_name(&prefix);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
@@ -1650,7 +1650,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_iceberg_replicator_stateful_set_json() {
+    fn create_iceberg_replicator_stateful_set_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let stateful_set_name = create_stateful_set_name(&prefix);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
@@ -1753,7 +1753,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_ducklake_replicator_stateful_set_json() {
+    fn create_ducklake_replicator_stateful_set_json() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
         let stateful_set_name = create_stateful_set_name(&prefix);
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";

--- a/etl-api/src/routes/destinations_pipelines.rs
+++ b/etl-api/src/routes/destinations_pipelines.rs
@@ -149,8 +149,8 @@ impl ResponseError for DestinationPipelineError {
             | DestinationPipelineError::PipelineDestinationMismatch(_, _) => {
                 StatusCode::BAD_REQUEST
             }
-            DestinationPipelineError::DuplicatePipeline => StatusCode::CONFLICT,
-            DestinationPipelineError::ActivePipeline(_) => StatusCode::CONFLICT,
+            DestinationPipelineError::DuplicatePipeline
+            | DestinationPipelineError::ActivePipeline(_) => StatusCode::CONFLICT,
             DestinationPipelineError::PipelineLimitReached { .. } => {
                 StatusCode::UNPROCESSABLE_ENTITY
             }

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -155,6 +155,7 @@ impl From<crate::k8s::core::K8sCoreError> for PipelineError {
 
 impl PipelineError {
     fn to_message(&self) -> String {
+        #[allow(clippy::match_same_arms)]
         match self {
             // Do not expose internal database details in error messages.
             PipelineError::SourcesDb(SourcesDbError::Database(_))

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -174,10 +174,9 @@ impl PipelineError {
             PipelineError::Validation(ValidationError::Database(_)) => {
                 "database validation failed".to_string()
             }
-            PipelineError::Validation(ValidationError::TrustedRootCerts(_))
-            | PipelineError::Validation(ValidationError::Environment(_)) => {
-                "internal server error".to_string()
-            }
+            PipelineError::Validation(
+                ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_),
+            ) => "internal server error".to_string(),
             // Every other message is ok, as they do not divulge sensitive information.
             e => e.to_string(),
         }

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -154,8 +154,7 @@ impl From<crate::k8s::core::K8sCoreError> for PipelineError {
 }
 
 impl PipelineError {
-    pub fn to_message(&self) -> String {
-        #[allow(clippy::match_same_arms)]
+    fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages.
             PipelineError::SourcesDb(SourcesDbError::Database(_))
@@ -163,7 +162,10 @@ impl PipelineError {
             | PipelineError::PipelinesDb(PipelinesDbError::Database(_))
             | PipelineError::ReplicatorsDb(ReplicatorsDbError::Database(_))
             | PipelineError::ImagesDb(ImagesDbError::Database(_))
-            | PipelineError::Database(_) => "internal server error".to_string(),
+            | PipelineError::Database(_)
+            | PipelineError::Validation(
+                ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_),
+            ) => "internal server error".to_string(),
             // Do not expose validation error details as they may contain credential info.
             PipelineError::Validation(ValidationError::BigQuery(_)) => {
                 "BigQuery validation failed".to_string()
@@ -174,9 +176,6 @@ impl PipelineError {
             PipelineError::Validation(ValidationError::Database(_)) => {
                 "database validation failed".to_string()
             }
-            PipelineError::Validation(
-                ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_),
-            ) => "internal server error".to_string(),
             // Every other message is ok, as they do not divulge sensitive information.
             e => e.to_string(),
         }

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -203,7 +203,9 @@ impl ResponseError for PipelineError {
             | PipelineError::MissingEnvironment
             | PipelineError::MissingTableReplicationState
             | PipelineError::Validation(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PipelineError::ActivePipeline(_) => StatusCode::CONFLICT,
+            PipelineError::ActivePipeline(_) | PipelineError::DuplicatePipeline => {
+                StatusCode::CONFLICT
+            }
             PipelineError::PipelineNotFound(_)
             | PipelineError::EtlStateNotInitialized
             | PipelineError::ImageIdNotDefault(_)
@@ -212,7 +214,6 @@ impl ResponseError for PipelineError {
             PipelineError::TenantId(_) | PipelineError::NotRollbackable(_) => {
                 StatusCode::BAD_REQUEST
             }
-            PipelineError::DuplicatePipeline => StatusCode::CONFLICT,
             PipelineError::PipelineLimitReached { .. } => StatusCode::UNPROCESSABLE_ENTITY,
         }
     }

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -154,7 +154,7 @@ impl From<crate::k8s::core::K8sCoreError> for PipelineError {
 }
 
 impl PipelineError {
-    fn to_message(&self) -> String {
+    pub fn to_message(&self) -> String {
         #[allow(clippy::match_same_arms)]
         match self {
             // Do not expose internal database details in error messages.
@@ -174,15 +174,15 @@ impl PipelineError {
             PipelineError::Validation(ValidationError::Database(_)) => {
                 "database validation failed".to_string()
             }
-            PipelineError::Validation(
-                ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_),
-            ) => "internal server error".to_string(),
+            PipelineError::Validation(ValidationError::TrustedRootCerts(_))
+            | PipelineError::Validation(ValidationError::Environment(_)) => {
+                "internal server error".to_string()
+            }
             // Every other message is ok, as they do not divulge sensitive information.
             e => e.to_string(),
         }
     }
 }
-
 impl ResponseError for PipelineError {
     fn status_code(&self) -> StatusCode {
         match self {

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -328,12 +328,7 @@ impl From<TableReplicationPhase> for SimpleTableReplicationState {
             | TableReplicationPhase::SyncWait { .. }
             | TableReplicationPhase::Catchup { .. }
             | TableReplicationPhase::Ready => SimpleTableReplicationState::FollowingWal,
-            TableReplicationPhase::Errored {
-                reason,
-                solution,
-                retry_policy,
-                ..
-            } => {
+            TableReplicationPhase::Errored { reason, solution, retry_policy, .. } => {
                 let simple_retry_policy = match retry_policy {
                     RetryPolicy::NoRetry => SimpleRetryPolicy::NoRetry,
                     RetryPolicy::ManualRetry => SimpleRetryPolicy::ManualRetry,

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -326,9 +326,14 @@ impl From<TableReplicationPhase> for SimpleTableReplicationState {
             TableReplicationPhase::FinishedCopy => SimpleTableReplicationState::CopiedTable,
             TableReplicationPhase::SyncDone { .. }
             | TableReplicationPhase::SyncWait { .. }
-            | TableReplicationPhase::Catchup { .. } => SimpleTableReplicationState::FollowingWal,
-            TableReplicationPhase::Ready => SimpleTableReplicationState::FollowingWal,
-            TableReplicationPhase::Errored { reason, solution, retry_policy, .. } => {
+            | TableReplicationPhase::Catchup { .. }
+            | TableReplicationPhase::Ready => SimpleTableReplicationState::FollowingWal,
+            TableReplicationPhase::Errored {
+                reason,
+                solution,
+                retry_policy,
+                ..
+            } => {
                 let simple_retry_policy = match retry_policy {
                     RetryPolicy::NoRetry => SimpleRetryPolicy::NoRetry,
                     RetryPolicy::ManualRetry => SimpleRetryPolicy::ManualRetry,

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -173,10 +173,9 @@ impl PipelineError {
             PipelineError::Validation(ValidationError::Database(_)) => {
                 "database validation failed".to_string()
             }
-            PipelineError::Validation(ValidationError::TrustedRootCerts(_))
-            | PipelineError::Validation(ValidationError::Environment(_)) => {
-                "internal server error".to_string()
-            }
+            PipelineError::Validation(
+                ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_),
+            ) => "internal server error".to_string(),
             // Every other message is ok, as they do not divulge sensitive information.
             e => e.to_string(),
         }

--- a/etl-api/src/routes/sources.rs
+++ b/etl-api/src/routes/sources.rs
@@ -78,11 +78,11 @@ impl SourceError {
 impl ResponseError for SourceError {
     fn status_code(&self) -> StatusCode {
         match self {
-            SourceError::SourcesDb(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            SourceError::PipelinesDb(_) => StatusCode::INTERNAL_SERVER_ERROR,
             SourceError::SourceNotFound(_) => StatusCode::NOT_FOUND,
             SourceError::TenantId(_) => StatusCode::BAD_REQUEST,
-            SourceError::Validation(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            SourceError::SourcesDb(_) | SourceError::Database(_) | SourceError::Validation(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
             SourceError::ValidationFailed(_) => StatusCode::FORBIDDEN,
             SourceError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
             SourceError::ActivePipeline(_) | SourceError::SourceInUse(_) => StatusCode::CONFLICT,

--- a/etl-api/src/routes/sources.rs
+++ b/etl-api/src/routes/sources.rs
@@ -80,11 +80,11 @@ impl ResponseError for SourceError {
         match self {
             SourceError::SourceNotFound(_) => StatusCode::NOT_FOUND,
             SourceError::TenantId(_) => StatusCode::BAD_REQUEST,
-            SourceError::SourcesDb(_) | SourceError::Database(_) | SourceError::Validation(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            SourceError::SourcesDb(_)
+            | SourceError::PipelinesDb(_)
+            | SourceError::Validation(_)
+            | SourceError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
             SourceError::ValidationFailed(_) => StatusCode::FORBIDDEN,
-            SourceError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
             SourceError::ActivePipeline(_) | SourceError::SourceInUse(_) => StatusCode::CONFLICT,
         }
     }

--- a/etl-api/src/routes/tenants.rs
+++ b/etl-api/src/routes/tenants.rs
@@ -78,14 +78,14 @@ impl TenantError {
 impl ResponseError for TenantError {
     fn status_code(&self) -> StatusCode {
         match self {
-            TenantError::TenantsDb(TenantsDbError::Conflict(_)) => StatusCode::CONFLICT,
+            TenantError::TenantsDb(TenantsDbError::Conflict(_))
+            | TenantError::ActivePipeline(_) => StatusCode::CONFLICT,
             TenantError::TenantsDb(_)
             | TenantError::SourcesDb(_)
             | TenantError::PipelinesDb(_)
             | TenantError::Database(_)
             | TenantError::TrustedRootCerts(_)
             | TenantError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            TenantError::ActivePipeline(_) => StatusCode::CONFLICT,
             TenantError::TenantNotFound(_) => StatusCode::NOT_FOUND,
         }
     }

--- a/etl-api/src/routes/tenants_sources.rs
+++ b/etl-api/src/routes/tenants_sources.rs
@@ -41,9 +41,11 @@ impl TenantSourceError {
     fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
-            TenantSourceError::TenantSourceDb(TenantSourceDbError::Database(_))
-            | TenantSourceError::TenantSourceDb(TenantSourceDbError::Sources(_))
-            | TenantSourceError::TenantSourceDb(TenantSourceDbError::Tenants(_))
+            TenantSourceError::TenantSourceDb(
+                TenantSourceDbError::Database(_)
+                | TenantSourceDbError::Sources(_)
+                | TenantSourceDbError::Tenants(_),
+            )
             | TenantSourceError::Database(_)
             | TenantSourceError::Validation(_) => "internal server error".to_string(),
             // Every other message is ok, as they do not divulge sensitive information

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -105,9 +105,7 @@ impl Application {
 
         // Try to create Kubernetes client, but continue without it if unavailable
         let kube_client_result = match Environment::load() {
-            Ok(Environment::Staging) | Ok(Environment::Prod) => {
-                kube::Client::try_default().await.ok()
-            }
+            Ok(Environment::Staging | Environment::Prod) => kube::Client::try_default().await.ok(),
             Ok(Environment::Dev) => {
                 async {
                     let options = KubeConfigOptions {

--- a/etl-api/src/startup.rs
+++ b/etl-api/src/startup.rs
@@ -348,7 +348,7 @@ pub fn run(
         let tracing_logger = TracingLogger::<ApiRootSpanBuilder>::new();
         let authentication = HttpAuthentication::bearer(auth_validator);
         let app = App::new()
-            .wrap(actix_metrics.clone())
+            .wrap(actix_metrics)
             .wrap(tracing_logger)
             .wrap(
                 sentry::integrations::actix::Sentry::builder()

--- a/etl-api/src/utils.rs
+++ b/etl-api/src/utils.rs
@@ -52,7 +52,7 @@ pub fn generate_random_alpha_str(len: usize) -> String {
 /// - If parsing fails or only a digest is present, returns `unavailable`.
 pub fn parse_docker_image_tag(image: &str) -> String {
     // Work on the last path segment only
-    let last_slash = image.rfind('/').map(|i| i + 1).unwrap_or(0);
+    let last_slash = image.rfind('/').map_or(0, |i| i + 1);
     let segment = &image[last_slash..];
 
     // Identify optional digest marker within the segment

--- a/etl-api/src/utils.rs
+++ b/etl-api/src/utils.rs
@@ -123,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_with_leading_and_trailing_whitespace() {
+    fn trim_string_with_leading_and_trailing_whitespace() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_without_whitespace() {
+    fn trim_string_without_whitespace() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_with_tabs_and_newlines() {
+    fn trim_string_with_tabs_and_newlines() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -162,7 +162,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_empty_string() {
+    fn trim_string_empty_string() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -175,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_only_whitespace_becomes_empty() {
+    fn trim_string_only_whitespace_becomes_empty() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -188,7 +188,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_preserves_internal_whitespace() {
+    fn trim_string_preserves_internal_whitespace() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -201,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_leading_only() {
+    fn trim_string_leading_only() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_string_trailing_only() {
+    fn trim_string_trailing_only() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(deserialize_with = "trim_string")]
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_option_string_with_whitespace() {
+    fn trim_option_string_with_whitespace() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(default, deserialize_with = "trim_option_string")]
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_option_string_with_null() {
+    fn trim_option_string_with_null() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(default, deserialize_with = "trim_option_string")]
@@ -253,7 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_option_string_with_missing_field() {
+    fn trim_option_string_with_missing_field() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(default, deserialize_with = "trim_option_string")]
@@ -266,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_option_string_with_empty_string() {
+    fn trim_option_string_with_empty_string() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(default, deserialize_with = "trim_option_string")]
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trim_option_string_whitespace_only_becomes_empty() {
+    fn trim_option_string_whitespace_only_becomes_empty() {
         #[derive(Deserialize)]
         struct TestStruct {
             #[serde(default, deserialize_with = "trim_option_string")]

--- a/etl-api/src/validation/mod.rs
+++ b/etl-api/src/validation/mod.rs
@@ -249,7 +249,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_validation_failure_display() {
+    async fn validation_failure_display() {
         let critical = ValidationFailure::critical("test_error", "Something wrong");
         assert_eq!(critical.to_string(), "test_error: Something wrong");
         assert_eq!(critical.failure_type, FailureType::Critical);

--- a/etl-api/src/validation/validators.rs
+++ b/etl-api/src/validation/validators.rs
@@ -597,22 +597,18 @@ impl Validator for BigQueryValidator {
         &self,
         _ctx: &ValidationContext,
     ) -> Result<Vec<ValidationFailure>, ValidationError> {
-        let client = match BigQueryClient::new_with_key(
-            self.project_id.clone(),
-            &self.service_account_key,
-            1,
-        )
-        .await
-        {
-            Ok(client) => client,
-            Err(_) => {
-                return Ok(vec![ValidationFailure::critical(
-                    "BigQuery Authentication Failed",
-                    "Unable to authenticate with BigQuery.\n\nPlease verify:\n(1) The service \
-                     account key is valid JSON\n(2) The key has not expired or been revoked\n(3) \
-                     The project ID is correct",
-                )]);
-            }
+        let Ok(client) =
+            BigQueryClient::new_with_key(self.project_id.clone(), &self.service_account_key, 1)
+                .await
+        else {
+            return Ok(vec![ValidationFailure::critical(
+                "BigQuery Authentication Failed",
+                "Unable to authenticate with BigQuery.\n\n\
+                     Please verify:\n\
+                     (1) The service account key is valid JSON\n\
+                     (2) The key has not expired or been revoked\n\
+                     (3) The project ID is correct",
+            )]);
         };
 
         match client.dataset_exists(&self.dataset_id).await {
@@ -817,17 +813,15 @@ impl Validator for IcebergValidator {
                 .await
             }
         };
-
-        let client = match client {
-            Ok(client) => client,
-            Err(_) => {
-                return Ok(vec![ValidationFailure::critical(
-                    "Iceberg Authentication Failed",
-                    "Unable to authenticate with Iceberg.\n\nPlease verify:\n(1) The catalog \
-                     token is valid and has not expired\n(2) The S3 access key and secret key are \
-                     correct\n(3) The catalog URI is properly formatted",
-                )]);
-            }
+        let Ok(client) = client else {
+            return Ok(vec![ValidationFailure::critical(
+                "Iceberg Authentication Failed",
+                "Unable to authenticate with Iceberg.\n\n\
+                     Please verify:\n\
+                     (1) The catalog token is valid and has not expired\n\
+                     (2) The S3 access key and secret key are correct\n\
+                     (3) The catalog URI is properly formatted",
+            )]);
         };
 
         match client.validate_connectivity().await {

--- a/etl-api/src/validation/validators.rs
+++ b/etl-api/src/validation/validators.rs
@@ -603,11 +603,9 @@ impl Validator for BigQueryValidator {
         else {
             return Ok(vec![ValidationFailure::critical(
                 "BigQuery Authentication Failed",
-                "Unable to authenticate with BigQuery.\n\n\
-                     Please verify:\n\
-                     (1) The service account key is valid JSON\n\
-                     (2) The key has not expired or been revoked\n\
-                     (3) The project ID is correct",
+                "Unable to authenticate with BigQuery.\n\nPlease verify:\n(1) The service account \
+                 key is valid JSON\n(2) The key has not expired or been revoked\n(3) The project \
+                 ID is correct",
             )]);
         };
 
@@ -816,11 +814,9 @@ impl Validator for IcebergValidator {
         let Ok(client) = client else {
             return Ok(vec![ValidationFailure::critical(
                 "Iceberg Authentication Failed",
-                "Unable to authenticate with Iceberg.\n\n\
-                     Please verify:\n\
-                     (1) The catalog token is valid and has not expired\n\
-                     (2) The S3 access key and secret key are correct\n\
-                     (3) The catalog URI is properly formatted",
+                "Unable to authenticate with Iceberg.\n\nPlease verify:\n(1) The catalog token is \
+                 valid and has not expired\n(2) The S3 access key and secret key are correct\n(3) \
+                 The catalog URI is properly formatted",
             )]);
         };
 

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -870,10 +870,10 @@ async fn pipeline_replication_status_returns_table_states_and_names() {
 
         match table_name.as_str() {
             "test.test_table_users" => {
-                assert!(matches!(table_status.state, SimpleTableReplicationState::CopyingTable))
+                assert!(matches!(table_status.state, SimpleTableReplicationState::CopyingTable));
             }
             "test.test_table_orders" => {
-                assert!(matches!(table_status.state, SimpleTableReplicationState::FollowingWal))
+                assert!(matches!(table_status.state, SimpleTableReplicationState::FollowingWal));
             }
             _ => panic!("Unexpected table name: {table_name}"),
         }

--- a/etl-benchmarks/benches/table_copies.rs
+++ b/etl-benchmarks/benches/table_copies.rs
@@ -318,8 +318,11 @@ async fn start_pipeline(args: RunArgs) -> Result<(), Box<dyn Error>> {
         port: args.port,
         name: args.database,
         username: args.username,
-        password: args.password.map(|p| p.into()),
-        tls: TlsConfig { trusted_root_certs: args.tls_certs, enabled: args.tls_enabled },
+        password: args.password.map(Into::into),
+        tls: TlsConfig {
+            trusted_root_certs: args.tls_certs,
+            enabled: args.tls_enabled,
+        },
         keepalive: TcpKeepaliveConfig::default(),
     };
 

--- a/etl-benchmarks/benches/table_copies.rs
+++ b/etl-benchmarks/benches/table_copies.rs
@@ -319,10 +319,7 @@ async fn start_pipeline(args: RunArgs) -> Result<(), Box<dyn Error>> {
         name: args.database,
         username: args.username,
         password: args.password.map(Into::into),
-        tls: TlsConfig {
-            trusted_root_certs: args.tls_certs,
-            enabled: args.tls_enabled,
-        },
+        tls: TlsConfig { trusted_root_certs: args.tls_certs, enabled: args.tls_enabled },
         keepalive: TcpKeepaliveConfig::default(),
     };
 

--- a/etl-config/src/load.rs
+++ b/etl-config/src/load.rs
@@ -297,22 +297,22 @@ mod tests {
     }
 
     #[test]
-    fn test_roundtrip_json() {
+    fn roundtrip_json() {
         test_roundtrip_with_extension("json");
     }
 
     #[test]
-    fn test_roundtrip_yaml() {
+    fn roundtrip_yaml() {
         test_roundtrip_with_extension("yaml");
     }
 
     #[test]
-    fn test_roundtrip_yml() {
+    fn roundtrip_yml() {
         test_roundtrip_with_extension("yml");
     }
 
     #[test]
-    fn test_all_supported_extensions_detected() {
+    fn all_supported_extensions_detected() {
         let temp_dir = TempDir::new().unwrap();
         let config_dir = temp_dir.path().join("configuration");
         fs::create_dir(&config_dir).unwrap();
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn test_app_config_dir_env_var() {
+    fn app_config_dir_env_var() {
         let _guard = env_lock().lock().unwrap();
 
         let temp_dir = TempDir::new().unwrap();
@@ -369,7 +369,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fallback_to_current_dir_when_app_config_dir_not_set() {
+    fn fallback_to_current_dir_when_app_config_dir_not_set() {
         let _guard = env_lock().lock().unwrap();
 
         let temp_dir = TempDir::new().unwrap();

--- a/etl-config/src/load.rs
+++ b/etl-config/src/load.rs
@@ -150,8 +150,8 @@ where
         }
     }
 
-    let base_file_source = config::File::from(base_file.clone());
-    let environment_file_source = config::File::from(environment_file.clone());
+    let base_file_source = config::File::from(base_file);
+    let environment_file_source = config::File::from(environment_file);
 
     let builder = config::Config::builder()
         .add_source(base_file_source)

--- a/etl-config/src/shared/connection.rs
+++ b/etl-config/src/shared/connection.rs
@@ -402,7 +402,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_replication_options_string_format() {
+    fn replication_options_string_format() {
         let options_string = ETL_REPLICATION_OPTIONS.to_options_string();
 
         assert_eq!(
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn test_state_management_options_key_value_pairs() {
+    fn state_management_options_key_value_pairs() {
         let pairs = ETL_STATE_MANAGEMENT_OPTIONS.to_key_value_pairs();
 
         assert_eq!(pairs.len(), 9);
@@ -439,7 +439,7 @@ mod tests {
     }
 
     #[test]
-    fn test_api_options_application_name() {
+    fn api_options_application_name() {
         assert_eq!(ETL_API_OPTIONS.application_name, "supabase_etl_api");
     }
 }

--- a/etl-config/src/shared/pipeline.rs
+++ b/etl-config/src/shared/pipeline.rs
@@ -431,7 +431,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_table_sync_copy_serialization_skip_all() {
+    fn table_sync_copy_serialization_skip_all() {
         let selection = TableSyncCopyConfig::SkipAllTables;
         let json = serde_json::to_string(&selection).unwrap();
         let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
@@ -440,8 +440,10 @@ mod tests {
     }
 
     #[test]
-    fn test_table_sync_copy_serialization_include_tables() {
-        let selection = TableSyncCopyConfig::IncludeTables { table_ids: vec![1, 2, 3] };
+    fn table_sync_copy_serialization_include_tables() {
+        let selection = TableSyncCopyConfig::IncludeTables {
+            table_ids: vec![1, 2, 3],
+        };
         let json = serde_json::to_string(&selection).unwrap();
         let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
 
@@ -449,8 +451,10 @@ mod tests {
     }
 
     #[test]
-    fn test_table_sync_copy_serialization_exclude_tables() {
-        let selection = TableSyncCopyConfig::SkipTables { table_ids: vec![4, 5] };
+    fn table_sync_copy_serialization_exclude_tables() {
+        let selection = TableSyncCopyConfig::SkipTables {
+            table_ids: vec![4, 5],
+        };
         let json = serde_json::to_string(&selection).unwrap();
         let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
 

--- a/etl-config/src/shared/pipeline.rs
+++ b/etl-config/src/shared/pipeline.rs
@@ -441,9 +441,7 @@ mod tests {
 
     #[test]
     fn table_sync_copy_serialization_include_tables() {
-        let selection = TableSyncCopyConfig::IncludeTables {
-            table_ids: vec![1, 2, 3],
-        };
+        let selection = TableSyncCopyConfig::IncludeTables { table_ids: vec![1, 2, 3] };
         let json = serde_json::to_string(&selection).unwrap();
         let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
 
@@ -452,9 +450,7 @@ mod tests {
 
     #[test]
     fn table_sync_copy_serialization_exclude_tables() {
-        let selection = TableSyncCopyConfig::SkipTables {
-            table_ids: vec![4, 5],
-        };
+        let selection = TableSyncCopyConfig::SkipTables { table_ids: vec![4, 5] };
         let json = serde_json::to_string(&selection).unwrap();
         let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
 

--- a/etl-destinations/src/bigquery/client.rs
+++ b/etl-destinations/src/bigquery/client.rs
@@ -1446,21 +1446,51 @@ mod tests {
     }
 
     #[test]
-    fn test_postgres_to_bigquery_type_basic_types() {
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::BOOL), "bool");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::TEXT), "string");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::INT4), "int64");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::FLOAT8), "float64");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::TIMESTAMP), "timestamp");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::JSON), "json");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::BYTEA), "bytes");
+    fn postgres_to_bigquery_type_basic_types() {
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::BOOL),
+            "bool"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::TEXT),
+            "string"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::INT4),
+            "int64"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::FLOAT8),
+            "float64"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::TIMESTAMP),
+            "timestamp"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::JSON),
+            "json"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::BYTEA),
+            "bytes"
+        );
     }
 
     #[test]
-    fn test_postgres_to_bigquery_type_array_types() {
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::BOOL_ARRAY), "array<bool>");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::TEXT_ARRAY), "array<string>");
-        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::INT4_ARRAY), "array<int64>");
+    fn postgres_to_bigquery_type_array_types() {
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::BOOL_ARRAY),
+            "array<bool>"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::TEXT_ARRAY),
+            "array<string>"
+        );
+        assert_eq!(
+            BigQueryClient::postgres_to_bigquery_type(&Type::INT4_ARRAY),
+            "array<int64>"
+        );
         assert_eq!(
             BigQueryClient::postgres_to_bigquery_type(&Type::FLOAT8_ARRAY),
             "array<float64>"
@@ -1472,7 +1502,7 @@ mod tests {
     }
 
     #[test]
-    fn test_column_spec() {
+    fn column_spec() {
         let column_schema = test_column("test_col", Type::TEXT, 1, true, None);
         let spec = BigQueryClient::column_spec(&column_schema).expect("column spec generation");
         assert_eq!(spec, "`test_col` string");
@@ -1488,7 +1518,7 @@ mod tests {
     }
 
     #[test]
-    fn test_column_spec_escapes_backticks() {
+    fn column_spec_escapes_backticks() {
         let column_schema = test_column("pwn`name", Type::TEXT, 1, true, None);
 
         let spec = BigQueryClient::column_spec(&column_schema).expect("escaped column spec");
@@ -1497,7 +1527,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sanitize_identifier_rejects_control_chars() {
+    fn sanitize_identifier_rejects_control_chars() {
         let result = BigQueryClient::sanitize_identifier("bad\nname", "column");
 
         assert!(matches!(
@@ -1507,7 +1537,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_primary_key_clause() {
+    fn add_primary_key_clause() {
         let columns_with_pk = vec![
             test_column("id", Type::INT4, 1, false, Some(1)),
             test_column("name", Type::TEXT, 2, true, None),
@@ -1554,7 +1584,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_columns_spec() {
+    fn create_columns_spec() {
         let columns = vec![
             test_column("id", Type::INT4, 1, false, Some(1)),
             test_column("name", Type::TEXT, 2, true, None),
@@ -1570,13 +1600,13 @@ mod tests {
     }
 
     #[test]
-    fn test_max_staleness_option() {
+    fn max_staleness_option() {
         let option = BigQueryClient::max_staleness_option(15);
         assert_eq!(option, "options (max_staleness = interval 15 minute)");
     }
 
     #[test]
-    fn test_column_schemas_to_table_descriptor() {
+    fn column_schemas_to_table_descriptor() {
         let columns = vec![
             test_column("id", Type::INT4, 1, false, Some(1)),
             test_column("name", Type::TEXT, 2, true, None),
@@ -1618,7 +1648,7 @@ mod tests {
     }
 
     #[test]
-    fn test_column_schemas_to_table_descriptor_complex_types() {
+    fn column_schemas_to_table_descriptor_complex_types() {
         let columns = vec![
             test_column("uuid_col", Type::UUID, 1, true, None),
             test_column("json_col", Type::JSON, 2, true, None),
@@ -1643,7 +1673,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_table_name_formatting() {
+    fn full_table_name_formatting() {
         let project_id = "test-project";
         let dataset_id = "test_dataset";
         let table_id = "test_table";
@@ -1659,7 +1689,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_or_replace_table_query_generation() {
+    fn create_or_replace_table_query_generation() {
         let project_id = "test-project";
         let dataset_id = "test_dataset";
         let table_id = "test_table";
@@ -1686,7 +1716,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_or_replace_table_query_with_staleness() {
+    fn create_or_replace_table_query_with_staleness() {
         let project_id = "test-project";
         let dataset_id = "test_dataset";
         let table_id = "test_table";
@@ -1715,7 +1745,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_single_batch_append_result_retries_pure_schema_propagation_errors() {
+    fn process_single_batch_append_result_retries_pure_schema_propagation_errors() {
         let result = process_single_batch_append_result(BatchAppendResult {
             batch_index: 0,
             responses: vec![Err(tonic::Status::invalid_argument("schema_mismatch_extra_fields"))],
@@ -1726,7 +1756,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_single_batch_append_result_retries_partial_success_schema_propagation() {
+    fn process_single_batch_append_result_retries_partial_success_schema_propagation() {
         let result = process_single_batch_append_result(BatchAppendResult {
             batch_index: 0,
             responses: vec![
@@ -1740,7 +1770,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_propagation_timeout_error_is_worker_retryable() {
+    fn schema_propagation_timeout_error_is_worker_retryable() {
         let error = schema_propagation_timeout_error("schema lag");
 
         assert_eq!(error.kind(), ErrorKind::DestinationAtomicBatchRetryable);

--- a/etl-destinations/src/bigquery/client.rs
+++ b/etl-destinations/src/bigquery/client.rs
@@ -1,9 +1,15 @@
-use std::fmt;
+#![allow(clippy::match_same_arms)]
 
-use etl::{
-    error::{ErrorKind, EtlError, EtlResult},
-    etl_error,
-    types::{Cell, ColumnSchema, PipelineId, ReplicatedTableSchema, Type, is_array_type},
+use etl::error::{ErrorKind, EtlError, EtlResult};
+use etl::etl_error;
+use etl::types::{Cell, ColumnSchema, PipelineId, ReplicatedTableSchema, Type, is_array_type};
+use gcp_bigquery_client::client_builder::ClientBuilder;
+use gcp_bigquery_client::google::cloud::bigquery::storage::v1::RowError;
+use gcp_bigquery_client::google::cloud::bigquery::storage::v1::StorageError;
+use gcp_bigquery_client::google::cloud::bigquery::storage::v1::storage_error::StorageErrorCode;
+use gcp_bigquery_client::google::rpc::Status as GoogleRpcStatus;
+use gcp_bigquery_client::storage::{
+    BatchAppendRequest, BatchAppendResult, ColumnMode, StorageApiConfig,
 };
 use gcp_bigquery_client::{
     Client,

--- a/etl-destinations/src/bigquery/client.rs
+++ b/etl-destinations/src/bigquery/client.rs
@@ -1,15 +1,11 @@
 #![allow(clippy::match_same_arms)]
 
-use etl::error::{ErrorKind, EtlError, EtlResult};
-use etl::etl_error;
-use etl::types::{Cell, ColumnSchema, PipelineId, ReplicatedTableSchema, Type, is_array_type};
-use gcp_bigquery_client::client_builder::ClientBuilder;
-use gcp_bigquery_client::google::cloud::bigquery::storage::v1::RowError;
-use gcp_bigquery_client::google::cloud::bigquery::storage::v1::StorageError;
-use gcp_bigquery_client::google::cloud::bigquery::storage::v1::storage_error::StorageErrorCode;
-use gcp_bigquery_client::google::rpc::Status as GoogleRpcStatus;
-use gcp_bigquery_client::storage::{
-    BatchAppendRequest, BatchAppendResult, ColumnMode, StorageApiConfig,
+use std::fmt;
+
+use etl::{
+    error::{ErrorKind, EtlError, EtlResult},
+    etl_error,
+    types::{Cell, ColumnSchema, PipelineId, ReplicatedTableSchema, Type, is_array_type},
 };
 use gcp_bigquery_client::{
     Client,
@@ -1108,11 +1104,8 @@ impl BigQueryClient {
         table_descriptor: TableDescriptor,
         validated_rows: Vec<BigQueryTableRow>,
     ) -> EtlResult<BatchAppendRequest<BigQueryTableRow>> {
-        let stream_name = StreamName::new_default(
-            self.project_id.clone(),
-            dataset_id.clone(),
-            table_id.clone(),
-        );
+        let stream_name =
+            StreamName::new_default(self.project_id.clone(), dataset_id.clone(), table_id.clone());
 
         let table_batch = TableBatch::new(stream_name, table_descriptor, validated_rows);
         let trace_id =
@@ -1447,50 +1440,20 @@ mod tests {
 
     #[test]
     fn postgres_to_bigquery_type_basic_types() {
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::BOOL),
-            "bool"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::TEXT),
-            "string"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::INT4),
-            "int64"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::FLOAT8),
-            "float64"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::TIMESTAMP),
-            "timestamp"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::JSON),
-            "json"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::BYTEA),
-            "bytes"
-        );
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::BOOL), "bool");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::TEXT), "string");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::INT4), "int64");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::FLOAT8), "float64");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::TIMESTAMP), "timestamp");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::JSON), "json");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::BYTEA), "bytes");
     }
 
     #[test]
     fn postgres_to_bigquery_type_array_types() {
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::BOOL_ARRAY),
-            "array<bool>"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::TEXT_ARRAY),
-            "array<string>"
-        );
-        assert_eq!(
-            BigQueryClient::postgres_to_bigquery_type(&Type::INT4_ARRAY),
-            "array<int64>"
-        );
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::BOOL_ARRAY), "array<bool>");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::TEXT_ARRAY), "array<string>");
+        assert_eq!(BigQueryClient::postgres_to_bigquery_type(&Type::INT4_ARRAY), "array<int64>");
         assert_eq!(
             BigQueryClient::postgres_to_bigquery_type(&Type::FLOAT8_ARRAY),
             "array<float64>"

--- a/etl-destinations/src/bigquery/client.rs
+++ b/etl-destinations/src/bigquery/client.rs
@@ -1104,8 +1104,8 @@ impl BigQueryClient {
     ) -> EtlResult<BatchAppendRequest<BigQueryTableRow>> {
         let stream_name = StreamName::new_default(
             self.project_id.clone(),
-            dataset_id.to_string(),
-            table_id.to_string(),
+            dataset_id.clone(),
+            table_id.clone(),
         );
 
         let table_batch = TableBatch::new(stream_name, table_descriptor, validated_rows);

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -1517,7 +1517,7 @@ mod tests {
         assert_eq!(result.len(), 4);
 
         // Verify all rows are accounted for
-        let total_rows: usize = result.iter().map(|batch| batch.len()).sum();
+        let total_rows: usize = result.iter().map(Vec::len).sum();
         assert_eq!(total_rows, 10);
 
         // Verify approximately equal distribution

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -1188,19 +1188,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_table_name_to_bigquery_table_id_no_underscores() {
+    fn table_name_to_bigquery_table_id_no_underscores() {
         let table_name = TableName::new("schema".to_string(), "table".to_string());
         assert_eq!(table_name_to_bigquery_table_id(&table_name).unwrap(), "schema_table");
     }
 
     #[test]
-    fn test_table_name_to_bigquery_table_id_with_underscores() {
+    fn table_name_to_bigquery_table_id_with_underscores() {
         let table_name = TableName::new("a_b".to_string(), "c_d".to_string());
         assert_eq!(table_name_to_bigquery_table_id(&table_name).unwrap(), "a__b_c__d");
     }
 
     #[test]
-    fn test_table_name_to_bigquery_table_id_collision_prevention() {
+    fn table_name_to_bigquery_table_id_collision_prevention() {
         // These two cases previously collided to "a_b_c"
         let table_name1 = TableName::new("a_b".to_string(), "c".to_string());
         let table_name2 = TableName::new("a".to_string(), "b_c".to_string());
@@ -1214,13 +1214,13 @@ mod tests {
     }
 
     #[test]
-    fn test_table_name_to_bigquery_table_id_multiple_underscores() {
+    fn table_name_to_bigquery_table_id_multiple_underscores() {
         let table_name = TableName::new("a__b".to_string(), "c__d".to_string());
         assert_eq!(table_name_to_bigquery_table_id(&table_name).unwrap(), "a____b_c____d");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_valid() {
+    fn sequenced_bigquery_table_id_from_str_valid() {
         let table_id = "users_table_123";
         let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
         assert_eq!(parsed.to_bigquery_table_id(), "users_table");
@@ -1228,7 +1228,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_zero_sequence() {
+    fn sequenced_bigquery_table_id_from_str_zero_sequence() {
         let table_id = "simple_table_0";
         let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
         assert_eq!(parsed.to_bigquery_table_id(), "simple_table");
@@ -1236,7 +1236,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_large_sequence() {
+    fn sequenced_bigquery_table_id_from_str_large_sequence() {
         let table_id = "test_table_18446744073709551615"; // u64::MAX
         let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
         assert_eq!(parsed.to_bigquery_table_id(), "test_table");
@@ -1244,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_escaped_underscores() {
+    fn sequenced_bigquery_table_id_from_str_escaped_underscores() {
         let table_id = "a__b_c__d_42";
         let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
         assert_eq!(parsed.to_bigquery_table_id(), "a__b_c__d");
@@ -1252,45 +1252,45 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_display_formatting() {
+    fn sequenced_bigquery_table_id_display_formatting() {
         let table_id = SequencedBigQueryTableId("users_table".to_string(), 123);
         assert_eq!(table_id.to_string(), "users_table_123");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_display_zero_sequence() {
+    fn sequenced_bigquery_table_id_display_zero_sequence() {
         let table_id = SequencedBigQueryTableId("simple_table".to_string(), 0);
         assert_eq!(table_id.to_string(), "simple_table_0");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_display_large_sequence() {
+    fn sequenced_bigquery_table_id_display_large_sequence() {
         let table_id = SequencedBigQueryTableId("test_table".to_string(), u64::MAX);
         assert_eq!(table_id.to_string(), "test_table_18446744073709551615");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_display_with_escaped_underscores() {
+    fn sequenced_bigquery_table_id_display_with_escaped_underscores() {
         let table_id = SequencedBigQueryTableId("a__b_c__d".to_string(), 42);
         assert_eq!(table_id.to_string(), "a__b_c__d_42");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_new() {
+    fn sequenced_bigquery_table_id_new() {
         let table_id = SequencedBigQueryTableId::new("users_table".to_string());
         assert_eq!(table_id.to_bigquery_table_id(), "users_table");
         assert_eq!(table_id.1, 0);
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_new_with_underscores() {
+    fn sequenced_bigquery_table_id_new_with_underscores() {
         let table_id = SequencedBigQueryTableId::new("a__b_c__d".to_string());
         assert_eq!(table_id.to_bigquery_table_id(), "a__b_c__d");
         assert_eq!(table_id.1, 0);
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_next() {
+    fn sequenced_bigquery_table_id_next() {
         let table_id = SequencedBigQueryTableId::new("users_table".to_string());
         let next_table_id = table_id.next();
 
@@ -1300,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_next_increments_correctly() {
+    fn sequenced_bigquery_table_id_next_increments_correctly() {
         let table_id = SequencedBigQueryTableId("test_table".to_string(), 42);
         let next_table_id = table_id.next();
 
@@ -1309,7 +1309,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_next_max_value() {
+    fn sequenced_bigquery_table_id_next_max_value() {
         let table_id = SequencedBigQueryTableId("test_table".to_string(), u64::MAX - 1);
         let next_table_id = table_id.next();
 
@@ -1318,25 +1318,25 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_to_bigquery_table_id() {
+    fn sequenced_bigquery_table_id_to_bigquery_table_id() {
         let table_id = SequencedBigQueryTableId("users_table".to_string(), 123);
         assert_eq!(table_id.to_bigquery_table_id(), "users_table");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_to_bigquery_table_id_with_underscores() {
+    fn sequenced_bigquery_table_id_to_bigquery_table_id_with_underscores() {
         let table_id = SequencedBigQueryTableId("a__b_c__d".to_string(), 42);
         assert_eq!(table_id.to_bigquery_table_id(), "a__b_c__d");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_to_bigquery_table_id_zero_sequence() {
+    fn sequenced_bigquery_table_id_to_bigquery_table_id_zero_sequence() {
         let table_id = SequencedBigQueryTableId("simple_table".to_string(), 0);
         assert_eq!(table_id.to_bigquery_table_id(), "simple_table");
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_no_underscore() {
+    fn sequenced_bigquery_table_id_from_str_no_underscore() {
         let result = "tablewithoutsequence".parse::<SequencedBigQueryTableId>();
         assert!(result.is_err());
 
@@ -1348,7 +1348,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_invalid_sequence_number() {
+    fn sequenced_bigquery_table_id_from_str_invalid_sequence_number() {
         let result = "users_table_not_a_number".parse::<SequencedBigQueryTableId>();
         assert!(result.is_err());
 
@@ -1361,7 +1361,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_sequence_is_word() {
+    fn sequenced_bigquery_table_id_from_str_sequence_is_word() {
         let result = "table_word".parse::<SequencedBigQueryTableId>();
         assert!(result.is_err());
 
@@ -1374,7 +1374,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_negative_sequence() {
+    fn sequenced_bigquery_table_id_from_str_negative_sequence() {
         let result = "users_table_-123".parse::<SequencedBigQueryTableId>();
         assert!(result.is_err());
 
@@ -1386,7 +1386,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_sequence_overflow() {
+    fn sequenced_bigquery_table_id_from_str_sequence_overflow() {
         let result = "users_table_18446744073709551616".parse::<SequencedBigQueryTableId>(); // u64::MAX + 1
         assert!(result.is_err());
 
@@ -1398,7 +1398,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_empty_string() {
+    fn sequenced_bigquery_table_id_from_str_empty_string() {
         let result = "".parse::<SequencedBigQueryTableId>();
         assert!(result.is_err());
 
@@ -1410,7 +1410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_empty_sequence() {
+    fn sequenced_bigquery_table_id_from_str_empty_sequence() {
         let result = "users_table_".parse::<SequencedBigQueryTableId>();
         assert!(result.is_err());
 
@@ -1422,7 +1422,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_from_str_empty_table_name() {
+    fn sequenced_bigquery_table_id_from_str_empty_table_name() {
         let result = "_123".parse::<SequencedBigQueryTableId>();
         assert!(result.is_err());
 
@@ -1434,7 +1434,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_round_trip() {
+    fn sequenced_bigquery_table_id_round_trip() {
         let original = "users_table_123";
         let parsed = original.parse::<SequencedBigQueryTableId>().unwrap();
         let formatted = parsed.to_string();
@@ -1442,7 +1442,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequenced_bigquery_table_id_round_trip_complex() {
+    fn sequenced_bigquery_table_id_round_trip_complex() {
         let original = "a__b_c__d_999";
         let parsed = original.parse::<SequencedBigQueryTableId>().unwrap();
         let formatted = parsed.to_string();
@@ -1452,14 +1452,14 @@ mod tests {
     }
 
     #[test]
-    fn test_split_table_rows_empty_input() {
+    fn split_table_rows_empty_input() {
         let rows: Vec<BigQueryTableRow> = vec![];
         let result = split_table_rows(rows, 4);
         assert!(result.is_empty());
     }
 
     #[test]
-    fn test_split_table_rows_zero_concurrent_streams() {
+    fn split_table_rows_zero_concurrent_streams() {
         let rows = vec![BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()];
         let result = split_table_rows(rows, 0);
         assert_eq!(result.len(), 1);
@@ -1467,7 +1467,7 @@ mod tests {
     }
 
     #[test]
-    fn test_split_table_rows_single_concurrent_stream() {
+    fn split_table_rows_single_concurrent_stream() {
         let rows = vec![
             BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
             BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
@@ -1478,7 +1478,7 @@ mod tests {
     }
 
     #[test]
-    fn test_split_table_rows_fewer_rows_than_streams() {
+    fn split_table_rows_fewer_rows_than_streams() {
         let rows = vec![
             BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
             BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
@@ -1489,9 +1489,10 @@ mod tests {
     }
 
     #[test]
-    fn test_split_table_rows_equal_distribution() {
-        let rows =
-            (0..4).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
+    fn split_table_rows_equal_distribution() {
+        let rows = (0..4)
+            .map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap())
+            .collect();
         let result = split_table_rows(rows, 2);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].len(), 2);
@@ -1499,9 +1500,10 @@ mod tests {
     }
 
     #[test]
-    fn test_split_table_rows_uneven_distribution() {
-        let rows =
-            (0..5).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
+    fn split_table_rows_uneven_distribution() {
+        let rows = (0..5)
+            .map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap())
+            .collect();
         let result = split_table_rows(rows, 3);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].len(), 2); // Gets extra row
@@ -1510,9 +1512,10 @@ mod tests {
     }
 
     #[test]
-    fn test_split_table_rows_many_streams() {
-        let rows =
-            (0..10).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
+    fn split_table_rows_many_streams() {
+        let rows = (0..10)
+            .map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap())
+            .collect();
         let result = split_table_rows(rows, 4);
         assert_eq!(result.len(), 4);
 
@@ -1528,7 +1531,7 @@ mod tests {
     }
 
     #[test]
-    fn test_split_table_rows_single_row() {
+    fn split_table_rows_single_row() {
         let rows = vec![BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()];
         let result = split_table_rows(rows, 5);
         assert_eq!(result.len(), 1);
@@ -1536,14 +1539,14 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_target_batches_empty_rows() {
+    fn calculate_target_batches_empty_rows() {
         let rows: Vec<BigQueryTableRow> = vec![];
         let result = calculate_target_batches_for_table_copy(&rows).unwrap();
         assert_eq!(result, 0);
     }
 
     #[test]
-    fn test_calculate_target_batches_single_small_row() {
+    fn calculate_target_batches_single_small_row() {
         // Create a single row with one small string value
         let rows = vec![
             BigQueryTableRow::try_from(TableRow::new(vec![Cell::String("test".to_string())]))
@@ -1554,7 +1557,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_target_batches_many_small_rows() {
+    fn calculate_target_batches_many_small_rows() {
         // Create many rows with small values (estimated ~50 bytes each when encoded)
         let rows: Vec<BigQueryTableRow> = (0..100_000)
             .map(|i| {
@@ -1568,7 +1571,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_target_batches_large_rows() {
+    fn calculate_target_batches_large_rows() {
         // Create rows with large string values (each ~1MB)
         let large_string = "x".repeat(1024 * 1024); // 1MB string
         let rows: Vec<BigQueryTableRow> = (0..50)
@@ -1583,7 +1586,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_target_batches_very_large_single_row() {
+    fn calculate_target_batches_very_large_single_row() {
         // Create a row larger than max batch size (>10MB)
         let huge_string = "x".repeat(15 * 1024 * 1024); // 15MB string
         let rows = vec![

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -528,9 +528,7 @@ where
 
         // Add the CDC operation type to all rows (no lock needed).
         for table_row in &mut table_rows {
-            table_row
-                .values_mut()
-                .push(BigQueryOperationType::Upsert.into_cell());
+            table_row.values_mut().push(BigQueryOperationType::Upsert.into_cell());
         }
         let table_rows = table_rows
             .into_iter()
@@ -1490,9 +1488,8 @@ mod tests {
 
     #[test]
     fn split_table_rows_equal_distribution() {
-        let rows = (0..4)
-            .map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap())
-            .collect();
+        let rows =
+            (0..4).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
         let result = split_table_rows(rows, 2);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].len(), 2);
@@ -1501,9 +1498,8 @@ mod tests {
 
     #[test]
     fn split_table_rows_uneven_distribution() {
-        let rows = (0..5)
-            .map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap())
-            .collect();
+        let rows =
+            (0..5).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
         let result = split_table_rows(rows, 3);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].len(), 2); // Gets extra row
@@ -1513,9 +1509,8 @@ mod tests {
 
     #[test]
     fn split_table_rows_many_streams() {
-        let rows = (0..10)
-            .map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap())
-            .collect();
+        let rows =
+            (0..10).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
         let result = split_table_rows(rows, 4);
         assert_eq!(result.len(), 4);
 

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -527,8 +527,10 @@ where
             self.prepare_table_for_streaming(replicated_table_schema, false).await?;
 
         // Add the CDC operation type to all rows (no lock needed).
-        for table_row in table_rows.iter_mut() {
-            table_row.values_mut().push(BigQueryOperationType::Upsert.into_cell());
+        for table_row in &mut table_rows {
+            table_row
+                .values_mut()
+                .push(BigQueryOperationType::Upsert.into_cell());
         }
         let table_rows = table_rows
             .into_iter()

--- a/etl-destinations/src/bigquery/encoding.rs
+++ b/etl-destinations/src/bigquery/encoding.rs
@@ -396,7 +396,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bigquery_table_row_try_from_valid() {
+    fn bigquery_table_row_try_from_valid() {
         let table_row = TableRow::new(vec![
             Cell::I32(42),
             Cell::String("test".to_string()),
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_invalid_numeric_nan() {
+    fn bigquery_table_row_try_from_invalid_numeric_nan() {
         let table_row = TableRow::new(vec![Cell::I32(42), Cell::Numeric(PgNumeric::NaN)]);
 
         let result = BigQueryTableRow::try_from(table_row);
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_invalid_numeric_infinity() {
+    fn bigquery_table_row_try_from_invalid_numeric_infinity() {
         let table_row = TableRow::new(vec![
             Cell::String("valid".to_string()),
             Cell::Numeric(PgNumeric::PositiveInfinity),
@@ -436,8 +436,11 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_invalid_date() {
-        let invalid_date = NaiveDate::from_ymd_opt(1, 1, 1).unwrap().pred_opt().unwrap(); // Date before year 1
+    fn bigquery_table_row_try_from_invalid_date() {
+        let invalid_date = NaiveDate::from_ymd_opt(1, 1, 1)
+            .unwrap()
+            .pred_opt()
+            .unwrap(); // Date before year 1
 
         let table_row = TableRow::new(vec![Cell::Date(invalid_date)]);
 
@@ -450,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_array_with_nulls() {
+    fn bigquery_table_row_try_from_array_with_nulls() {
         let array_with_nulls = etl::types::ArrayCell::I32(vec![Some(1), None, Some(3)]);
         let table_row = TableRow::new(vec![Cell::Array(array_with_nulls)]);
 
@@ -462,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_array_with_invalid_elements() {
+    fn bigquery_table_row_try_from_array_with_invalid_elements() {
         let array_with_invalid_numeric = etl::types::ArrayCell::Numeric(vec![
             Some(PgNumeric::from_str("123.456").unwrap()),
             Some(PgNumeric::NaN),
@@ -480,7 +483,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_valid_array() {
+    fn bigquery_table_row_try_from_valid_array() {
         let valid_array = etl::types::ArrayCell::I32(vec![Some(1), Some(2), Some(3)]);
         let table_row = TableRow::new(vec![
             Cell::String("prefix".to_string()),
@@ -493,7 +496,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_multiple_errors_first_wins() {
+    fn bigquery_table_row_try_from_multiple_errors_first_wins() {
         let table_row = TableRow::new(vec![
             Cell::Numeric(PgNumeric::NaN), // First invalid cell
             Cell::Numeric(PgNumeric::PositiveInfinity), /* Second invalid cell (should not be
@@ -509,7 +512,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_valid_temporal_values() {
+    fn bigquery_table_row_try_from_valid_temporal_values() {
         let valid_date = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
         let valid_time = NaiveTime::from_hms_opt(12, 30, 45).unwrap();
         let valid_datetime = NaiveDateTime::new(valid_date, valid_time);
@@ -525,7 +528,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bigquery_table_row_try_from_oversized_numeric_fails() {
+    fn bigquery_table_row_try_from_oversized_numeric_fails() {
         // Create a numeric value that exceeds BigQuery's limits
         let oversized_numeric = PgNumeric::from_str(
             "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"

--- a/etl-destinations/src/bigquery/encoding.rs
+++ b/etl-destinations/src/bigquery/encoding.rs
@@ -180,11 +180,11 @@ fn cell_encode_prost(cell: &CellNonOptional, tag: u32, buf: &mut impl bytes::Buf
         }
         CellNonOptional::Uuid(u) => {
             let s = u.to_string();
-            prost::encoding::string::encode(tag, &s, buf)
+            prost::encoding::string::encode(tag, &s, buf);
         }
         CellNonOptional::Json(j) => {
             let s = j.to_string();
-            prost::encoding::string::encode(tag, &s, buf)
+            prost::encoding::string::encode(tag, &s, buf);
         }
         CellNonOptional::U32(i) => {
             prost::encoding::uint32::encode(tag, i, buf);

--- a/etl-destinations/src/bigquery/encoding.rs
+++ b/etl-destinations/src/bigquery/encoding.rs
@@ -437,10 +437,7 @@ mod tests {
 
     #[test]
     fn bigquery_table_row_try_from_invalid_date() {
-        let invalid_date = NaiveDate::from_ymd_opt(1, 1, 1)
-            .unwrap()
-            .pred_opt()
-            .unwrap(); // Date before year 1
+        let invalid_date = NaiveDate::from_ymd_opt(1, 1, 1).unwrap().pred_opt().unwrap(); // Date before year 1
 
         let table_row = TableRow::new(vec![Cell::Date(invalid_date)]);
 

--- a/etl-destinations/src/bigquery/encoding.rs
+++ b/etl-destinations/src/bigquery/encoding.rs
@@ -289,7 +289,7 @@ fn array_cell_encode_prost(
             prost::encoding::double::encode_packed(tag, vec, buf);
         }
         ArrayCellNonOptional::Numeric(vec) => {
-            let values: Vec<String> = vec.iter().map(|v| v.to_string()).collect();
+            let values: Vec<String> = vec.iter().map(ToString::to_string).collect();
             prost::encoding::string::encode_repeated(tag, &values, buf);
         }
         ArrayCellNonOptional::Date(vec) => {
@@ -313,11 +313,11 @@ fn array_cell_encode_prost(
             prost::encoding::string::encode_repeated(tag, &values, buf);
         }
         ArrayCellNonOptional::Uuid(vec) => {
-            let values: Vec<String> = vec.iter().map(|v| v.to_string()).collect();
+            let values: Vec<String> = vec.iter().map(ToString::to_string).collect();
             prost::encoding::string::encode_repeated(tag, &values, buf);
         }
         ArrayCellNonOptional::Json(vec) => {
-            let values: Vec<String> = vec.iter().map(|v| v.to_string()).collect();
+            let values: Vec<String> = vec.iter().map(ToString::to_string).collect();
             prost::encoding::string::encode_repeated(tag, &values, buf);
         }
         ArrayCellNonOptional::Bytes(vec) => {
@@ -348,7 +348,7 @@ fn array_cell_non_optional_encoded_len_prost(array_cell: &ArrayCellNonOptional, 
         ArrayCellNonOptional::F32(vec) => prost::encoding::float::encoded_len_packed(tag, vec),
         ArrayCellNonOptional::F64(vec) => prost::encoding::double::encoded_len_packed(tag, vec),
         ArrayCellNonOptional::Numeric(vec) => {
-            let values: Vec<String> = vec.iter().map(|v| v.to_string()).collect();
+            let values: Vec<String> = vec.iter().map(ToString::to_string).collect();
             prost::encoding::string::encoded_len_repeated(tag, &values)
         }
         ArrayCellNonOptional::Date(vec) => {
@@ -372,11 +372,11 @@ fn array_cell_non_optional_encoded_len_prost(array_cell: &ArrayCellNonOptional, 
             prost::encoding::string::encoded_len_repeated(tag, &values)
         }
         ArrayCellNonOptional::Uuid(vec) => {
-            let values: Vec<String> = vec.iter().map(|v| v.to_string()).collect();
+            let values: Vec<String> = vec.iter().map(ToString::to_string).collect();
             prost::encoding::string::encoded_len_repeated(tag, &values)
         }
         ArrayCellNonOptional::Json(vec) => {
-            let values: Vec<String> = vec.iter().map(|v| v.to_string()).collect();
+            let values: Vec<String> = vec.iter().map(ToString::to_string).collect();
             prost::encoding::string::encoded_len_repeated(tag, &values)
         }
         ArrayCellNonOptional::Bytes(vec) => prost::encoding::bytes::encoded_len_repeated(tag, vec),

--- a/etl-destinations/src/bigquery/validation.rs
+++ b/etl-destinations/src/bigquery/validation.rs
@@ -275,7 +275,7 @@ fn validate_timestamptz_for_bigquery(timestamptz: &DateTime<Utc>) -> EtlResult<(
 /// Returns an error if any value is outside BigQuery's supported range for its
 /// type. This function checks all temporal types and numeric types for BigQuery
 /// compatibility.
-pub fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()> {
+pub(super) fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()> {
     #[allow(clippy::match_same_arms)]
     match cell {
         CellNonOptional::Null => Ok(()),
@@ -304,7 +304,7 @@ pub fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()> {
 ///
 /// Returns an error if any array element is outside BigQuery's supported range
 /// for its type.
-pub fn validate_array_cell_for_bigquery(array_cell: &ArrayCellNonOptional) -> EtlResult<()> {
+fn validate_array_cell_for_bigquery(array_cell: &ArrayCellNonOptional) -> EtlResult<()> {
     #[allow(clippy::match_same_arms)]
     match array_cell {
         ArrayCellNonOptional::Bool(_) => Ok(()),

--- a/etl-destinations/src/bigquery/validation.rs
+++ b/etl-destinations/src/bigquery/validation.rs
@@ -390,7 +390,7 @@ fn is_numeric_within_bigquery_bignumeric_limits(pg_numeric: &PgNumeric) -> bool 
     let numeric_str = pg_numeric.to_string();
 
     // Count actual digits (excluding sign, decimal point)
-    let digit_count: usize = numeric_str.chars().filter(|c| c.is_ascii_digit()).count();
+    let digit_count: usize = numeric_str.chars().filter(char::is_ascii_digit).count();
 
     // BigQuery BIGNUMERIC supports up to ~77 digits of total precision
     if digit_count > BIGQUERY_BIGNUMERIC_MAX_PRACTICAL_DIGITS {
@@ -400,7 +400,7 @@ fn is_numeric_within_bigquery_bignumeric_limits(pg_numeric: &PgNumeric) -> bool 
     // Check decimal places if there's a decimal point
     if let Some(decimal_pos) = numeric_str.find('.') {
         let decimal_part = &numeric_str[decimal_pos + 1..];
-        let decimal_digits = decimal_part.chars().filter(|c| c.is_ascii_digit()).count();
+        let decimal_digits = decimal_part.chars().filter(char::is_ascii_digit).count();
 
         // BigQuery BIGNUMERIC supports up to 38 decimal places
         if decimal_digits > BIGQUERY_BIGNUMERIC_MAX_SCALE {

--- a/etl-destinations/src/bigquery/validation.rs
+++ b/etl-destinations/src/bigquery/validation.rs
@@ -418,13 +418,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_validate_numeric_within_bounds() {
+    fn validate_numeric_within_bounds() {
         let numeric = PgNumeric::from_str("123.456").unwrap();
         assert!(validate_numeric_for_bigquery(&numeric).is_ok());
     }
 
     #[test]
-    fn test_validate_numeric_nan_fails() {
+    fn validate_numeric_nan_fails() {
         let result = validate_numeric_for_bigquery(&PgNumeric::NaN);
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -433,7 +433,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_numeric_positive_infinity_fails() {
+    fn validate_numeric_positive_infinity_fails() {
         let result = validate_numeric_for_bigquery(&PgNumeric::PositiveInfinity);
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -442,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_numeric_negative_infinity_fails() {
+    fn validate_numeric_negative_infinity_fails() {
         let result = validate_numeric_for_bigquery(&PgNumeric::NegativeInfinity);
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -451,14 +451,17 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_date_within_bounds() {
+    fn validate_date_within_bounds() {
         let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
         assert!(validate_date_for_bigquery(&date).is_ok());
     }
 
     #[test]
-    fn test_validate_date_before_min_fails() {
-        let date = NaiveDate::from_ymd_opt(1, 1, 1).unwrap().pred_opt().unwrap();
+    fn validate_date_before_min_fails() {
+        let date = NaiveDate::from_ymd_opt(1, 1, 1)
+            .unwrap()
+            .pred_opt()
+            .unwrap();
         let result = validate_date_for_bigquery(&date);
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -467,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_date_after_max_fails() {
+    fn validate_date_after_max_fails() {
         let date = NaiveDate::from_ymd_opt(10000, 1, 1).unwrap();
         let result = validate_date_for_bigquery(&date);
         assert!(result.is_err());
@@ -477,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_cell_for_bigquery_valid_types() {
+    fn validate_cell_for_bigquery_valid_types() {
         assert!(validate_cell_for_bigquery(&CellNonOptional::Null).is_ok());
         assert!(validate_cell_for_bigquery(&CellNonOptional::Bool(true)).is_ok());
         assert!(validate_cell_for_bigquery(&CellNonOptional::String("test".to_string())).is_ok());
@@ -485,7 +488,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_cell_for_bigquery_invalid_numeric() {
+    fn validate_cell_for_bigquery_invalid_numeric() {
         let cell = CellNonOptional::Numeric(PgNumeric::NaN);
         let result = validate_cell_for_bigquery(&cell);
         assert!(result.is_err());
@@ -493,7 +496,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_array_cell_with_invalid_numeric() {
+    fn validate_array_cell_with_invalid_numeric() {
         let array_cell = ArrayCellNonOptional::Numeric(vec![
             PgNumeric::from_str("123.456").unwrap(),
             PgNumeric::NaN,

--- a/etl-destinations/src/bigquery/validation.rs
+++ b/etl-destinations/src/bigquery/validation.rs
@@ -272,8 +272,9 @@ fn validate_timestamptz_for_bigquery(timestamptz: &DateTime<Utc>) -> EtlResult<(
 /// Validates that a [`CellNonOptional`] value is within BigQuery's supported
 /// ranges.
 ///
-/// Returns an error if any value is outside BigQuery's supported range for its type.
-/// This function checks all temporal types and numeric types for BigQuery compatibility.
+/// Returns an error if any value is outside BigQuery's supported range for its
+/// type. This function checks all temporal types and numeric types for BigQuery
+/// compatibility.
 pub fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()> {
     #[allow(clippy::match_same_arms)]
     match cell {
@@ -301,7 +302,8 @@ pub fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()> {
 /// Validates that an [`ArrayCellNonOptional`] contains values within BigQuery's
 /// supported ranges.
 ///
-/// Returns an error if any array element is outside BigQuery's supported range for its type.
+/// Returns an error if any array element is outside BigQuery's supported range
+/// for its type.
 pub fn validate_array_cell_for_bigquery(array_cell: &ArrayCellNonOptional) -> EtlResult<()> {
     #[allow(clippy::match_same_arms)]
     match array_cell {
@@ -458,10 +460,7 @@ mod tests {
 
     #[test]
     fn validate_date_before_min_fails() {
-        let date = NaiveDate::from_ymd_opt(1, 1, 1)
-            .unwrap()
-            .pred_opt()
-            .unwrap();
+        let date = NaiveDate::from_ymd_opt(1, 1, 1).unwrap().pred_opt().unwrap();
         let result = validate_date_for_bigquery(&date);
         assert!(result.is_err());
         let err = result.unwrap_err();

--- a/etl-destinations/src/bigquery/validation.rs
+++ b/etl-destinations/src/bigquery/validation.rs
@@ -272,10 +272,10 @@ fn validate_timestamptz_for_bigquery(timestamptz: &DateTime<Utc>) -> EtlResult<(
 /// Validates that a [`CellNonOptional`] value is within BigQuery's supported
 /// ranges.
 ///
-/// Returns an error if any value is outside BigQuery's supported range for its
-/// type. This function checks all temporal types and numeric types for BigQuery
-/// compatibility.
-pub(super) fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()> {
+/// Returns an error if any value is outside BigQuery's supported range for its type.
+/// This function checks all temporal types and numeric types for BigQuery compatibility.
+pub fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()> {
+    #[allow(clippy::match_same_arms)]
     match cell {
         CellNonOptional::Null => Ok(()),
         CellNonOptional::Bool(_) => Ok(()),
@@ -301,9 +301,9 @@ pub(super) fn validate_cell_for_bigquery(cell: &CellNonOptional) -> EtlResult<()
 /// Validates that an [`ArrayCellNonOptional`] contains values within BigQuery's
 /// supported ranges.
 ///
-/// Returns an error if any array element is outside BigQuery's supported range
-/// for its type.
-fn validate_array_cell_for_bigquery(array_cell: &ArrayCellNonOptional) -> EtlResult<()> {
+/// Returns an error if any array element is outside BigQuery's supported range for its type.
+pub fn validate_array_cell_for_bigquery(array_cell: &ArrayCellNonOptional) -> EtlResult<()> {
+    #[allow(clippy::match_same_arms)]
     match array_cell {
         ArrayCellNonOptional::Bool(_) => Ok(()),
         ArrayCellNonOptional::String(_) => Ok(()),

--- a/etl-destinations/src/ducklake/batches.rs
+++ b/etl-destinations/src/ducklake/batches.rs
@@ -1026,7 +1026,7 @@ fn apply_truncate_batch_action(conn: &duckdb::Connection, table_name: &str) -> E
 
 /// Formats an optional LSN for marker-table inserts.
 fn optional_lsn_to_sql_literal(lsn: Option<PgLsn>) -> String {
-    lsn.map(|value| u64::from(value).to_string()).unwrap_or_else(|| "NULL".to_string())
+    lsn.map_or_else(|| "NULL".to_string(), |value| u64::from(value).to_string())
 }
 
 /// Applies one prepared table mutation inside an open transaction.

--- a/etl-destinations/src/ducklake/batches.rs
+++ b/etl-destinations/src/ducklake/batches.rs
@@ -1376,7 +1376,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_predicate_from_row_uses_only_primary_key_columns() {
+    fn delete_predicate_from_row_uses_only_primary_key_columns() {
         let table_schema = TableSchema::new(
             TableId::new(1),
             TableName::new("public".to_string(), "users".to_string()),
@@ -1397,7 +1397,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_predicate_from_row_supports_filtered_schema() {
+    fn delete_predicate_from_row_supports_filtered_schema() {
         let table_schema = TableSchema::new(
             TableId::new(1),
             TableName::new("public".to_string(), "users".to_string()),
@@ -1417,7 +1417,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_table_mutations_replace_emits_delete_then_upsert() {
+    fn prepare_table_mutations_replace_emits_delete_then_upsert() {
         let replicated_table_schema = make_replicated_schema();
         let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_string())]);
 
@@ -1445,7 +1445,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_table_mutations_update_emits_delete_then_upsert() {
+    fn prepare_table_mutations_update_emits_delete_then_upsert() {
         let replicated_table_schema = make_replicated_schema();
         let prepared = prepare_table_mutations(
             &replicated_table_schema,
@@ -1476,7 +1476,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_mutation_table_batches_insert_only_uses_single_upsert_operation() {
+    fn prepare_mutation_table_batches_insert_only_uses_single_upsert_operation() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
@@ -1522,7 +1522,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_mutation_table_batches_split_mixed_cdc_at_delete_boundaries() {
+    fn prepare_mutation_table_batches_split_mixed_cdc_at_delete_boundaries() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
@@ -1576,7 +1576,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_mutation_table_batches_group_contiguous_deletes() {
+    fn prepare_mutation_table_batches_group_contiguous_deletes() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
@@ -1619,7 +1619,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_mutation_table_batches_group_contiguous_updates() {
+    fn prepare_mutation_table_batches_group_contiguous_updates() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
@@ -1677,7 +1677,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_mutation_table_batches_split_non_inserts_at_cap() {
+    fn prepare_mutation_table_batches_split_non_inserts_at_cap() {
         let replicated_table_schema = make_replicated_schema();
         let tracked = (0..=CDC_MUTATION_BATCH_SIZE)
             .map(|idx| {
@@ -1722,7 +1722,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_mutation_table_batches_isolate_update_in_its_own_atomic_batch() {
+    fn prepare_mutation_table_batches_isolate_update_in_its_own_atomic_batch() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
@@ -1786,7 +1786,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_mutation_batch_identity_is_deterministic() {
+    fn build_mutation_batch_identity_is_deterministic() {
         let replicated_table_schema = make_replicated_schema();
         let tracked = vec![
             TrackedTableMutation::new(
@@ -1820,7 +1820,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_mutation_batch_identity_changes_with_order_and_lsn() {
+    fn build_mutation_batch_identity_changes_with_order_and_lsn() {
         let replicated_table_schema = make_replicated_schema();
         let original = build_mutation_batch_identity(
             "public_users",
@@ -1887,7 +1887,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_truncate_batch_identity_changes_with_lsn() {
+    fn build_truncate_batch_identity_changes_with_lsn() {
         let first = build_truncate_batch_identity(
             "public_users",
             &[TrackedTruncateEvent::new(PgLsn::from(300), PgLsn::from(400), 0)],

--- a/etl-destinations/src/ducklake/batches.rs
+++ b/etl-destinations/src/ducklake/batches.rs
@@ -1243,8 +1243,8 @@ fn batch_log_kind(batch: &PreparedDuckLakeTableBatch) -> &'static str {
         PreparedDuckLakeTableBatchAction::Mutation(prepared_mutations) => {
             match prepared_mutations.as_slice() {
                 [PreparedTableMutation::Upsert(_)] => "insert",
-                [PreparedTableMutation::Delete { origin, .. }] => origin,
-                [
+                [PreparedTableMutation::Delete { origin, .. }]
+                | [
                     PreparedTableMutation::Delete { origin, .. },
                     PreparedTableMutation::Upsert(_),
                 ] => origin,

--- a/etl-destinations/src/ducklake/client.rs
+++ b/etl-destinations/src/ducklake/client.rs
@@ -435,14 +435,23 @@ mod tests {
     }
 
     #[test]
-    fn test_duckdb_blocking_operation_kind_timeouts() {
-        assert_eq!(DuckDbBlockingOperationKind::Foreground.timeout(), FOREGROUND_QUERY_TIMEOUT);
-        assert_eq!(DuckDbBlockingOperationKind::Maintenance.timeout(), MAINTENANCE_QUERY_TIMEOUT);
-        assert_eq!(DuckDbBlockingOperationKind::Metrics.timeout(), METRICS_QUERY_TIMEOUT);
+    fn duckdb_blocking_operation_kind_timeouts() {
+        assert_eq!(
+            DuckDbBlockingOperationKind::Foreground.timeout(),
+            FOREGROUND_QUERY_TIMEOUT
+        );
+        assert_eq!(
+            DuckDbBlockingOperationKind::Maintenance.timeout(),
+            MAINTENANCE_QUERY_TIMEOUT
+        );
+        assert_eq!(
+            DuckDbBlockingOperationKind::Metrics.timeout(),
+            METRICS_QUERY_TIMEOUT
+        );
     }
 
     #[tokio::test]
-    async fn test_run_duckdb_blocking_timeout_releases_resources_for_follow_up_queries() {
+    async fn run_duckdb_blocking_timeout_releases_resources_for_follow_up_queries() {
         let pool = Arc::new(
             build_warm_ducklake_pool(make_blocking_test_manager(), 1, "test")
                 .await
@@ -509,7 +518,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_query_error_detail_compacts_sql_and_includes_source() {
+    fn format_query_error_detail_compacts_sql_and_includes_source() {
         let sql = r#"CREATE TABLE lake."orders" ("id" INTEGER NOT NULL)"#;
         let error = duckdb::Error::DuckDBFailure(
             duckdb::ffi::Error::new(1),
@@ -523,7 +532,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_query_watchdog_marks_timeout_when_handle_arrives_after_deadline() {
+    async fn query_watchdog_marks_timeout_when_handle_arrives_after_deadline() {
         let conn = make_blocking_test_manager()
             .open_duckdb_connection()
             .expect("failed to open blocking test connection");

--- a/etl-destinations/src/ducklake/client.rs
+++ b/etl-destinations/src/ducklake/client.rs
@@ -436,18 +436,9 @@ mod tests {
 
     #[test]
     fn duckdb_blocking_operation_kind_timeouts() {
-        assert_eq!(
-            DuckDbBlockingOperationKind::Foreground.timeout(),
-            FOREGROUND_QUERY_TIMEOUT
-        );
-        assert_eq!(
-            DuckDbBlockingOperationKind::Maintenance.timeout(),
-            MAINTENANCE_QUERY_TIMEOUT
-        );
-        assert_eq!(
-            DuckDbBlockingOperationKind::Metrics.timeout(),
-            METRICS_QUERY_TIMEOUT
-        );
+        assert_eq!(DuckDbBlockingOperationKind::Foreground.timeout(), FOREGROUND_QUERY_TIMEOUT);
+        assert_eq!(DuckDbBlockingOperationKind::Maintenance.timeout(), MAINTENANCE_QUERY_TIMEOUT);
+        assert_eq!(DuckDbBlockingOperationKind::Metrics.timeout(), METRICS_QUERY_TIMEOUT);
     }
 
     #[tokio::test]

--- a/etl-destinations/src/ducklake/config.rs
+++ b/etl-destinations/src/ducklake/config.rs
@@ -634,14 +634,8 @@ mod tests {
 
     #[test]
     fn quote_libpq_conninfo_value_fn() {
-        assert_eq!(
-            quote_libpq_conninfo_value("pa'ss\\word"),
-            "'pa\\'ss\\\\word'"
-        );
-        assert_eq!(
-            quote_libpq_conninfo_value("value with spaces"),
-            "'value with spaces'"
-        );
+        assert_eq!(quote_libpq_conninfo_value("pa'ss\\word"), "'pa\\'ss\\\\word'");
+        assert_eq!(quote_libpq_conninfo_value("value with spaces"), "'value with spaces'");
     }
 
     #[test]

--- a/etl-destinations/src/ducklake/config.rs
+++ b/etl-destinations/src/ducklake/config.rs
@@ -627,19 +627,25 @@ mod tests {
     }
 
     #[test]
-    fn test_catalog_conninfo_from_file_url() {
+    fn catalog_conninfo_from_file_url() {
         let catalog_url = Url::from_file_path("/tmp/catalog.ducklake").unwrap();
         assert_eq!(catalog_attach_target(&catalog_url).unwrap(), catalog_url.as_str());
     }
 
     #[test]
-    fn test_quote_libpq_conninfo_value() {
-        assert_eq!(quote_libpq_conninfo_value("pa'ss\\word"), "'pa\\'ss\\\\word'");
-        assert_eq!(quote_libpq_conninfo_value("value with spaces"), "'value with spaces'");
+    fn quote_libpq_conninfo_value_fn() {
+        assert_eq!(
+            quote_libpq_conninfo_value("pa'ss\\word"),
+            "'pa\\'ss\\\\word'"
+        );
+        assert_eq!(
+            quote_libpq_conninfo_value("value with spaces"),
+            "'value with spaces'"
+        );
     }
 
     #[test]
-    fn test_catalog_conninfo_from_postgres_url_round_trip() {
+    fn catalog_conninfo_from_postgres_url_round_trip() {
         let url = Url::parse("postgres://bnj@localhost:5432/ducklake_catalog").unwrap();
         let conninfo = catalog_conninfo_from_url(&url).unwrap();
         let parsed = PgConfig::from_str(conninfo.strip_prefix("postgres:").unwrap()).unwrap();
@@ -656,7 +662,7 @@ mod tests {
     }
 
     #[test]
-    fn test_catalog_conninfo_from_postgres_url_with_password_and_query_params_round_trip() {
+    fn catalog_conninfo_from_postgres_url_with_password_and_query_params_round_trip() {
         let url = Url::parse(
             "postgres://user:pa%27ss%5Cword@localhost:5433/mydb?sslmode=disable&\
              connect_timeout=10&tcp_user_timeout=1500&application_name=myapp",
@@ -676,7 +682,7 @@ mod tests {
     }
 
     #[test]
-    fn test_catalog_conninfo_rejects_explicit_unsupported_query_parameters() {
+    fn catalog_conninfo_rejects_explicit_unsupported_query_parameters() {
         for parameter in [
             "channel_binding=require",
             "load_balance_hosts=random",
@@ -692,14 +698,14 @@ mod tests {
     }
 
     #[test]
-    fn test_catalog_conninfo_rejects_unsupported_catalog_scheme() {
+    fn catalog_conninfo_rejects_unsupported_catalog_scheme() {
         let err =
             catalog_attach_target(&Url::parse("https://example.com/catalog").unwrap()).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::ConfigError);
     }
 
     #[test]
-    fn test_validate_data_path_rejects_unsupported_scheme() {
+    fn validate_data_path_rejects_unsupported_scheme() {
         let err = build_setup_sql(
             &Url::from_file_path("/tmp/catalog.ducklake").unwrap(),
             &Url::parse("https://example.com/lake").unwrap(),
@@ -720,7 +726,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duckdb_extension_strategy_linux_amd64_uses_install_flow_without_vendored_extensions() {
+    fn duckdb_extension_strategy_linux_amd64_uses_install_flow_without_vendored_extensions() {
         let tempdir = TempDir::new().unwrap();
 
         assert_eq!(
@@ -731,7 +737,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duckdb_extension_strategy_linux_arm64_uses_vendored_extensions_when_present() {
+    fn duckdb_extension_strategy_linux_arm64_uses_vendored_extensions_when_present() {
         let repo_root = vendored_root_with_files("linux_arm64");
         let container_root = TempDir::new().unwrap();
 
@@ -749,7 +755,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duckdb_extension_strategy_macos_uses_install_flow_without_vendored_extensions() {
+    fn duckdb_extension_strategy_macos_uses_install_flow_without_vendored_extensions() {
         let tempdir = TempDir::new().unwrap();
 
         assert_eq!(
@@ -760,7 +766,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duckdb_extension_strategy_macos_arm64_uses_vendored_extensions_when_present() {
+    fn duckdb_extension_strategy_macos_arm64_uses_vendored_extensions_when_present() {
         let repo_root = vendored_root_with_files("osx_arm64");
         let container_root = TempDir::new().unwrap();
 
@@ -778,7 +784,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duckdb_extension_strategy_windows_uses_install_flow() {
+    fn duckdb_extension_strategy_windows_uses_install_flow() {
         let tempdir = TempDir::new().unwrap();
 
         assert_eq!(
@@ -789,7 +795,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duckdb_extension_strategy_rejects_unsupported_linux_architecture() {
+    fn duckdb_extension_strategy_rejects_unsupported_linux_architecture() {
         let tempdir = TempDir::new().unwrap();
         let err =
             duckdb_extension_strategy("linux", "riscv64", None, tempdir.path(), tempdir.path())
@@ -798,7 +804,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vendored_extension_dir_uses_env_override_first() {
+    fn vendored_extension_dir_uses_env_override_first() {
         let env_root = vendored_root_with_files("linux_amd64");
         let fallback_root = TempDir::new().unwrap();
 
@@ -817,7 +823,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vendored_extension_dir_falls_back_to_repo_root() {
+    fn vendored_extension_dir_falls_back_to_repo_root() {
         let repo_root = vendored_root_with_files("linux_arm64");
         let container_root = TempDir::new().unwrap();
 
@@ -832,7 +838,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vendored_extension_dir_falls_back_to_container_root() {
+    fn vendored_extension_dir_falls_back_to_container_root() {
         let container_root = vendored_root_with_files("linux_amd64");
         let repo_root = TempDir::new().unwrap();
 
@@ -847,7 +853,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vendored_extension_dir_rejects_missing_extensions() {
+    fn vendored_extension_dir_rejects_missing_extensions() {
         let tempdir = TempDir::new().unwrap();
         let err = vendored_extension_dir(
             "linux_amd64",
@@ -860,7 +866,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vendored_extension_dir_returns_none_when_not_present() {
+    fn vendored_extension_dir_returns_none_when_not_present() {
         let tempdir = TempDir::new().unwrap();
         let resolved =
             vendored_extension_dir("linux_amd64", None, tempdir.path(), tempdir.path()).unwrap();
@@ -869,7 +875,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_setup_sql_linux_vendored_local() {
+    fn build_setup_sql_linux_vendored_local() {
         let vendored_root = vendored_root_with_files("linux_amd64");
         let catalog_url = Url::from_file_path("/tmp/catalog.ducklake").unwrap();
         let data_url = Url::from_file_path("/tmp/lake_data").unwrap();
@@ -900,7 +906,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_setup_sql_macos_vendored_local() {
+    fn build_setup_sql_macos_vendored_local() {
         let vendored_root = vendored_root_with_files("osx_arm64");
         let catalog_url = Url::from_file_path("/tmp/catalog.ducklake").unwrap();
         let data_url = Url::from_file_path("/tmp/lake_data").unwrap();
@@ -925,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_setup_sql_legacy_install_postgres_local_data() {
+    fn build_setup_sql_legacy_install_postgres_local_data() {
         let catalog_url = Url::parse("postgres://bnj@localhost:5432/ducklake_catalog").unwrap();
         let data_url = Url::from_file_path("/tmp/lake_data").unwrap();
         let sql = build_setup_sql_with_strategy(
@@ -956,7 +962,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_setup_sql_linux_vendored_postgres_s3_data() {
+    fn build_setup_sql_linux_vendored_postgres_s3_data() {
         let vendored_root = vendored_root_with_files("linux_arm64");
         let catalog_url = Url::parse("postgres://user:pass@host/db").unwrap();
         let data_url = Url::parse("s3://my-bucket/lake/").unwrap();
@@ -987,7 +993,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vendored_extension_strategy_disables_autoload() {
+    fn vendored_extension_strategy_disables_autoload() {
         assert!(
             DuckDbExtensionStrategy::VendoredLocal { platform_dir: "osx_arm64" }
                 .disables_autoload()
@@ -996,7 +1002,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_setup_sql_uses_pg_escape_for_literals() {
+    fn build_setup_sql_uses_pg_escape_for_literals() {
         let catalog_url = Url::parse("postgres://user:pa%27ss%5Cword@localhost:5432/mydb").unwrap();
         let data_url = Url::parse("s3://bucket/path").unwrap();
         let s3 = S3Config {

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -717,7 +717,7 @@ where
         let ducklake_table_name =
             table_name_to_ducklake_table_name(replicated_table_schema.name())?;
         let metadata = DestinationTableMetadata::new_applying(
-            ducklake_table_name.to_string(),
+            ducklake_table_name.clone(),
             replicated_table_schema.inner().snapshot_id,
             replicated_table_schema.replication_mask().clone(),
         );

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -1151,7 +1151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_name_escaping() {
+    fn table_name_escaping() {
         assert_eq!(
             table_name_to_ducklake_table_name(&TableName {
                 schema: "public".to_string(),
@@ -1171,7 +1171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_create_table_conflict_matches_ducklake_commit_conflict() {
+    fn is_create_table_conflict_matches_ducklake_commit_conflict() {
         let error = duckdb::Error::DuckDBFailure(
             duckdb::ffi::Error::new(1),
             Some(
@@ -1188,7 +1188,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_query_table_storage_metrics_reads_ducklake_metadata() {
+    async fn query_table_storage_metrics_reads_ducklake_metadata() {
         let dir = TempDir::new().expect("failed to create temp dir");
         let catalog = path_to_file_url(&dir.path().join("catalog.ducklake"));
         let data = path_to_file_url(&dir.path().join("data"));
@@ -1240,7 +1240,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_table_rows_creates_only_replicated_columns() {
+    async fn write_table_rows_creates_only_replicated_columns() {
         let dir = TempDir::new().expect("failed to create temp dir");
         let catalog = path_to_file_url(&dir.path().join("catalog.ducklake"));
         let data = path_to_file_url(&dir.path().join("data"));
@@ -1290,7 +1290,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_query_catalog_maintenance_metrics_reports_active_data_files_total() {
+    async fn query_catalog_maintenance_metrics_reports_active_data_files_total() {
         let dir = TempDir::new().expect("failed to create temp dir");
         let catalog = path_to_file_url(&dir.path().join("catalog.ducklake"));
         let data = path_to_file_url(&dir.path().join("data"));
@@ -1339,7 +1339,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_query_catalog_maintenance_metrics_reads_ducklake_metadata() {
+    async fn query_catalog_maintenance_metrics_reads_ducklake_metadata() {
         let dir = TempDir::new().expect("failed to create temp dir");
         let catalog = path_to_file_url(&dir.path().join("catalog.ducklake"));
         let data = path_to_file_url(&dir.path().join("data"));

--- a/etl-destinations/src/ducklake/encoding.rs
+++ b/etl-destinations/src/ducklake/encoding.rs
@@ -160,10 +160,7 @@ fn array_cell_to_sql_literal(arr: ArrayCell) -> String {
         ArrayCell::F32(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(
-                    || "NULL".to_string(),
-                    |value| float_literal(value as f64, false),
-                )
+                o.map_or_else(|| "NULL".to_string(), |value| float_literal(value as f64, false))
             })
             .collect(),
         ArrayCell::F64(v) => v
@@ -173,10 +170,7 @@ fn array_cell_to_sql_literal(arr: ArrayCell) -> String {
         ArrayCell::Numeric(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(
-                    || "NULL".to_string(),
-                    |value| quote_literal(&value.to_string()),
-                )
+                o.map_or_else(|| "NULL".to_string(), |value| quote_literal(&value.to_string()))
             })
             .collect(),
         ArrayCell::Date(v) => v
@@ -318,42 +312,21 @@ fn cell_to_value(cell: Cell) -> Value {
 /// Converts an [`ArrayCell`] (with nullable elements) to a `Value::List`.
 fn array_cell_to_value(arr: ArrayCell) -> Value {
     let values = match arr {
-        ArrayCell::Bool(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::Boolean))
-            .collect(),
-        ArrayCell::String(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::Text))
-            .collect(),
-        ArrayCell::I16(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::SmallInt))
-            .collect(),
-        ArrayCell::I32(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::Int))
-            .collect(),
-        ArrayCell::U32(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::UInt))
-            .collect(),
-        ArrayCell::I64(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::BigInt))
-            .collect(),
-        ArrayCell::F32(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::Float))
-            .collect(),
-        ArrayCell::F64(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::Double))
-            .collect(),
-        ArrayCell::Numeric(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, |n| Value::Text(n.to_string())))
-            .collect(),
+        ArrayCell::Bool(v) => {
+            v.into_iter().map(|o| o.map_or(Value::Null, Value::Boolean)).collect()
+        }
+        ArrayCell::String(v) => v.into_iter().map(|o| o.map_or(Value::Null, Value::Text)).collect(),
+        ArrayCell::I16(v) => {
+            v.into_iter().map(|o| o.map_or(Value::Null, Value::SmallInt)).collect()
+        }
+        ArrayCell::I32(v) => v.into_iter().map(|o| o.map_or(Value::Null, Value::Int)).collect(),
+        ArrayCell::U32(v) => v.into_iter().map(|o| o.map_or(Value::Null, Value::UInt)).collect(),
+        ArrayCell::I64(v) => v.into_iter().map(|o| o.map_or(Value::Null, Value::BigInt)).collect(),
+        ArrayCell::F32(v) => v.into_iter().map(|o| o.map_or(Value::Null, Value::Float)).collect(),
+        ArrayCell::F64(v) => v.into_iter().map(|o| o.map_or(Value::Null, Value::Double)).collect(),
+        ArrayCell::Numeric(v) => {
+            v.into_iter().map(|o| o.map_or(Value::Null, |n| Value::Text(n.to_string()))).collect()
+        }
         ArrayCell::Date(v) => {
             let epoch_date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
             v.into_iter()
@@ -369,10 +342,8 @@ fn array_cell_to_value(arr: ArrayCell) -> Value {
             v.into_iter()
                 .map(|o| {
                     o.map_or(Value::Null, |t| {
-                        let micros = t
-                            .signed_duration_since(epoch_time)
-                            .num_microseconds()
-                            .unwrap_or(0);
+                        let micros =
+                            t.signed_duration_since(epoch_time).num_microseconds().unwrap_or(0);
                         Value::Time64(TimeUnit::Microsecond, micros)
                     })
                 })
@@ -394,18 +365,13 @@ fn array_cell_to_value(arr: ArrayCell) -> Value {
                 })
             })
             .collect(),
-        ArrayCell::Uuid(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, |u| Value::Text(u.to_string())))
-            .collect(),
-        ArrayCell::Json(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, |j| Value::Text(j.to_string())))
-            .collect(),
-        ArrayCell::Bytes(v) => v
-            .into_iter()
-            .map(|o| o.map_or(Value::Null, Value::Blob))
-            .collect(),
+        ArrayCell::Uuid(v) => {
+            v.into_iter().map(|o| o.map_or(Value::Null, |u| Value::Text(u.to_string()))).collect()
+        }
+        ArrayCell::Json(v) => {
+            v.into_iter().map(|o| o.map_or(Value::Null, |j| Value::Text(j.to_string()))).collect()
+        }
+        ArrayCell::Bytes(v) => v.into_iter().map(|o| o.map_or(Value::Null, Value::Blob)).collect(),
     };
     Value::List(values)
 }

--- a/etl-destinations/src/ducklake/encoding.rs
+++ b/etl-destinations/src/ducklake/encoding.rs
@@ -415,7 +415,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cell_to_value_primitives() {
+    fn cell_to_value_primitives() {
         assert_eq!(cell_to_value(Cell::Null), Value::Null);
         assert_eq!(cell_to_value(Cell::Bool(true)), Value::Boolean(true));
         assert_eq!(
@@ -428,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_cell_to_sql_literal_preserves_nulls() {
+    fn array_cell_to_sql_literal_preserves_nulls() {
         assert_eq!(
             array_cell_to_sql_literal(ArrayCell::I32(vec![Some(1), None, Some(3)])),
             "[1, NULL, 3]"
@@ -443,7 +443,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prepare_rows_uses_sql_literals_for_arrays() {
+    fn prepare_rows_uses_sql_literals_for_arrays() {
         let prepared = prepare_rows(vec![TableRow::new(vec![
             Cell::I32(1),
             Cell::Array(ArrayCell::I32(vec![Some(1), None, Some(3)])),

--- a/etl-destinations/src/ducklake/encoding.rs
+++ b/etl-destinations/src/ducklake/encoding.rs
@@ -139,92 +139,107 @@ fn array_cell_to_sql_literal(arr: ArrayCell) -> String {
             .collect(),
         ArrayCell::String(v) => v
             .into_iter()
-            .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| quote_literal(&value))
-            })
+            .map(|o| o.map_or_else(|| "NULL".to_string(), |value| quote_literal(&value)))
             .collect(),
         ArrayCell::I16(v) => v
             .into_iter()
-            .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
-            })
+            .map(|o| o.map_or_else(|| "NULL".to_string(), |value| value.to_string()))
             .collect(),
         ArrayCell::I32(v) => v
             .into_iter()
-            .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
-            })
+            .map(|o| o.map_or_else(|| "NULL".to_string(), |value| value.to_string()))
             .collect(),
         ArrayCell::U32(v) => v
             .into_iter()
-            .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
-            })
+            .map(|o| o.map_or_else(|| "NULL".to_string(), |value| value.to_string()))
             .collect(),
         ArrayCell::I64(v) => v
             .into_iter()
-            .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
-            })
+            .map(|o| o.map_or_else(|| "NULL".to_string(), |value| value.to_string()))
             .collect(),
         ArrayCell::F32(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| float_literal(value as f64, false))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| float_literal(value as f64, false),
+                )
             })
             .collect(),
         ArrayCell::F64(v) => v
             .into_iter()
-            .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| float_literal(value, true))
-            })
+            .map(|o| o.map_or_else(|| "NULL".to_string(), |value| float_literal(value, true)))
             .collect(),
         ArrayCell::Numeric(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| quote_literal(&value.to_string()))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| quote_literal(&value.to_string()),
+                )
             })
             .collect(),
         ArrayCell::Date(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| format!("DATE '{}'", value.format("%Y-%m-%d")))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| format!("DATE '{}'", value.format("%Y-%m-%d")),
+                )
             })
             .collect(),
         ArrayCell::Time(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| format!("TIME '{}'", value.format("%H:%M:%S%.6f")))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| format!("TIME '{}'", value.format("%H:%M:%S%.6f")),
+                )
             })
             .collect(),
         ArrayCell::Timestamp(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| format!("TIMESTAMP '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f")))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| format!("TIMESTAMP '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f")),
+                )
             })
             .collect(),
         ArrayCell::TimestampTz(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| format!("TIMESTAMPTZ '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f%:z")))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| format!("TIMESTAMPTZ '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f%:z")),
+                )
             })
             .collect(),
         ArrayCell::Uuid(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| format!("CAST({} AS UUID)", quote_literal(&value.to_string())))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| format!("CAST({} AS UUID)", quote_literal(&value.to_string())),
+                )
             })
             .collect(),
         ArrayCell::Json(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| format!("CAST({} AS JSON)", quote_literal(&value.to_string())))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| format!("CAST({} AS JSON)", quote_literal(&value.to_string())),
+                )
             })
             .collect(),
         ArrayCell::Bytes(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or_else(|| "NULL".to_string(), |value| format!("from_hex('{}')", encode_hex(&value)))
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| format!("from_hex('{}')", encode_hex(&value)),
+                )
             })
             .collect(),
     };
@@ -343,7 +358,9 @@ fn array_cell_to_value(arr: ArrayCell) -> Value {
             let epoch_date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
             v.into_iter()
                 .map(|o| {
-                    o.map_or(Value::Null, |d| Value::Date32(d.signed_duration_since(epoch_date).num_days() as i32))
+                    o.map_or(Value::Null, |d| {
+                        Value::Date32(d.signed_duration_since(epoch_date).num_days() as i32)
+                    })
                 })
                 .collect()
         }
@@ -364,13 +381,17 @@ fn array_cell_to_value(arr: ArrayCell) -> Value {
         ArrayCell::Timestamp(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or(Value::Null, |dt| Value::Timestamp(TimeUnit::Microsecond, dt.and_utc().timestamp_micros()))
+                o.map_or(Value::Null, |dt| {
+                    Value::Timestamp(TimeUnit::Microsecond, dt.and_utc().timestamp_micros())
+                })
             })
             .collect(),
         ArrayCell::TimestampTz(v) => v
             .into_iter()
             .map(|o| {
-                o.map_or(Value::Null, |dt| Value::Timestamp(TimeUnit::Microsecond, dt.timestamp_micros()))
+                o.map_or(Value::Null, |dt| {
+                    Value::Timestamp(TimeUnit::Microsecond, dt.timestamp_micros())
+                })
             })
             .collect(),
         ArrayCell::Uuid(v) => v

--- a/etl-destinations/src/ducklake/encoding.rs
+++ b/etl-destinations/src/ducklake/encoding.rs
@@ -131,97 +131,100 @@ fn array_cell_to_sql_literal(arr: ArrayCell) -> String {
         ArrayCell::Bool(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| if value { "TRUE".to_string() } else { "FALSE".to_string() })
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(
+                    || "NULL".to_string(),
+                    |value| if value { "TRUE" } else { "FALSE" }.to_string(),
+                )
             })
             .collect(),
         ArrayCell::String(v) => v
             .into_iter()
-            .map(|o| o.map(|value| quote_literal(&value)).unwrap_or_else(|| "NULL".to_string()))
+            .map(|o| {
+                o.map_or_else(|| "NULL".to_string(), |value| quote_literal(&value))
+            })
             .collect(),
         ArrayCell::I16(v) => v
             .into_iter()
-            .map(|o| o.map(|value| value.to_string()).unwrap_or_else(|| "NULL".to_string()))
+            .map(|o| {
+                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
+            })
             .collect(),
         ArrayCell::I32(v) => v
             .into_iter()
-            .map(|o| o.map(|value| value.to_string()).unwrap_or_else(|| "NULL".to_string()))
+            .map(|o| {
+                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
+            })
             .collect(),
         ArrayCell::U32(v) => v
             .into_iter()
-            .map(|o| o.map(|value| value.to_string()).unwrap_or_else(|| "NULL".to_string()))
+            .map(|o| {
+                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
+            })
             .collect(),
         ArrayCell::I64(v) => v
             .into_iter()
-            .map(|o| o.map(|value| value.to_string()).unwrap_or_else(|| "NULL".to_string()))
+            .map(|o| {
+                o.map_or_else(|| "NULL".to_string(), |value| value.to_string())
+            })
             .collect(),
         ArrayCell::F32(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| float_literal(value as f64, false))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| float_literal(value as f64, false))
             })
             .collect(),
         ArrayCell::F64(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| float_literal(value, true)).unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| float_literal(value, true))
             })
             .collect(),
         ArrayCell::Numeric(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| quote_literal(&value.to_string()))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| quote_literal(&value.to_string()))
             })
             .collect(),
         ArrayCell::Date(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| format!("DATE '{}'", value.format("%Y-%m-%d")))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| format!("DATE '{}'", value.format("%Y-%m-%d")))
             })
             .collect(),
         ArrayCell::Time(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| format!("TIME '{}'", value.format("%H:%M:%S%.6f")))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| format!("TIME '{}'", value.format("%H:%M:%S%.6f")))
             })
             .collect(),
         ArrayCell::Timestamp(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| format!("TIMESTAMP '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f")))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| format!("TIMESTAMP '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f")))
             })
             .collect(),
         ArrayCell::TimestampTz(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| format!("TIMESTAMPTZ '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f%:z")))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| format!("TIMESTAMPTZ '{}'", value.format("%Y-%m-%d %H:%M:%S%.6f%:z")))
             })
             .collect(),
         ArrayCell::Uuid(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| format!("CAST({} AS UUID)", quote_literal(&value.to_string())))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| format!("CAST({} AS UUID)", quote_literal(&value.to_string())))
             })
             .collect(),
         ArrayCell::Json(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| format!("CAST({} AS JSON)", quote_literal(&value.to_string())))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| format!("CAST({} AS JSON)", quote_literal(&value.to_string())))
             })
             .collect(),
         ArrayCell::Bytes(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|value| format!("from_hex('{}')", encode_hex(&value)))
-                    .unwrap_or_else(|| "NULL".to_string())
+                o.map_or_else(|| "NULL".to_string(), |value| format!("from_hex('{}')", encode_hex(&value)))
             })
             .collect(),
     };
@@ -300,40 +303,47 @@ fn cell_to_value(cell: Cell) -> Value {
 /// Converts an [`ArrayCell`] (with nullable elements) to a `Value::List`.
 fn array_cell_to_value(arr: ArrayCell) -> Value {
     let values = match arr {
-        ArrayCell::Bool(v) => {
-            v.into_iter().map(|o| o.map(Value::Boolean).unwrap_or(Value::Null)).collect()
-        }
-        ArrayCell::String(v) => {
-            v.into_iter().map(|o| o.map(Value::Text).unwrap_or(Value::Null)).collect()
-        }
-        ArrayCell::I16(v) => {
-            v.into_iter().map(|o| o.map(Value::SmallInt).unwrap_or(Value::Null)).collect()
-        }
-        ArrayCell::I32(v) => {
-            v.into_iter().map(|o| o.map(Value::Int).unwrap_or(Value::Null)).collect()
-        }
-        ArrayCell::U32(v) => {
-            v.into_iter().map(|o| o.map(Value::UInt).unwrap_or(Value::Null)).collect()
-        }
-        ArrayCell::I64(v) => {
-            v.into_iter().map(|o| o.map(Value::BigInt).unwrap_or(Value::Null)).collect()
-        }
-        ArrayCell::F32(v) => {
-            v.into_iter().map(|o| o.map(Value::Float).unwrap_or(Value::Null)).collect()
-        }
-        ArrayCell::F64(v) => {
-            v.into_iter().map(|o| o.map(Value::Double).unwrap_or(Value::Null)).collect()
-        }
+        ArrayCell::Bool(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::Boolean))
+            .collect(),
+        ArrayCell::String(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::Text))
+            .collect(),
+        ArrayCell::I16(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::SmallInt))
+            .collect(),
+        ArrayCell::I32(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::Int))
+            .collect(),
+        ArrayCell::U32(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::UInt))
+            .collect(),
+        ArrayCell::I64(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::BigInt))
+            .collect(),
+        ArrayCell::F32(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::Float))
+            .collect(),
+        ArrayCell::F64(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::Double))
+            .collect(),
         ArrayCell::Numeric(v) => v
             .into_iter()
-            .map(|o| o.map(|n| Value::Text(n.to_string())).unwrap_or(Value::Null))
+            .map(|o| o.map_or(Value::Null, |n| Value::Text(n.to_string())))
             .collect(),
         ArrayCell::Date(v) => {
             let epoch_date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
             v.into_iter()
                 .map(|o| {
-                    o.map(|d| Value::Date32(d.signed_duration_since(epoch_date).num_days() as i32))
-                        .unwrap_or(Value::Null)
+                    o.map_or(Value::Null, |d| Value::Date32(d.signed_duration_since(epoch_date).num_days() as i32))
                 })
                 .collect()
         }
@@ -341,40 +351,40 @@ fn array_cell_to_value(arr: ArrayCell) -> Value {
             let epoch_time = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
             v.into_iter()
                 .map(|o| {
-                    o.map(|t| {
-                        let micros =
-                            t.signed_duration_since(epoch_time).num_microseconds().unwrap_or(0);
+                    o.map_or(Value::Null, |t| {
+                        let micros = t
+                            .signed_duration_since(epoch_time)
+                            .num_microseconds()
+                            .unwrap_or(0);
                         Value::Time64(TimeUnit::Microsecond, micros)
                     })
-                    .unwrap_or(Value::Null)
                 })
                 .collect()
         }
         ArrayCell::Timestamp(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|dt| Value::Timestamp(TimeUnit::Microsecond, dt.and_utc().timestamp_micros()))
-                    .unwrap_or(Value::Null)
+                o.map_or(Value::Null, |dt| Value::Timestamp(TimeUnit::Microsecond, dt.and_utc().timestamp_micros()))
             })
             .collect(),
         ArrayCell::TimestampTz(v) => v
             .into_iter()
             .map(|o| {
-                o.map(|dt| Value::Timestamp(TimeUnit::Microsecond, dt.timestamp_micros()))
-                    .unwrap_or(Value::Null)
+                o.map_or(Value::Null, |dt| Value::Timestamp(TimeUnit::Microsecond, dt.timestamp_micros()))
             })
             .collect(),
         ArrayCell::Uuid(v) => v
             .into_iter()
-            .map(|o| o.map(|u| Value::Text(u.to_string())).unwrap_or(Value::Null))
+            .map(|o| o.map_or(Value::Null, |u| Value::Text(u.to_string())))
             .collect(),
         ArrayCell::Json(v) => v
             .into_iter()
-            .map(|o| o.map(|j| Value::Text(j.to_string())).unwrap_or(Value::Null))
+            .map(|o| o.map_or(Value::Null, |j| Value::Text(j.to_string())))
             .collect(),
-        ArrayCell::Bytes(v) => {
-            v.into_iter().map(|o| o.map(Value::Blob).unwrap_or(Value::Null)).collect()
-        }
+        ArrayCell::Bytes(v) => v
+            .into_iter()
+            .map(|o| o.map_or(Value::Null, Value::Blob))
+            .collect(),
     };
     Value::List(values)
 }

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -1178,7 +1178,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_maintenance_duration_histogram_counts_are_exported_with_labels() {
+    async fn maintenance_duration_histogram_counts_are_exported_with_labels() {
         let handle = init_metrics_handle().expect("failed to initialize prometheus handle");
         register_metrics();
 
@@ -1309,7 +1309,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_targeted_maintenance_busy_emits_skip_counter_only_for_selected_operations() {
+    async fn targeted_maintenance_busy_emits_skip_counter_only_for_selected_operations() {
         let handle = init_metrics_handle().expect("failed to initialize prometheus handle");
         register_metrics();
         let plan = TargetedMaintenancePlan {
@@ -1391,7 +1391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_prefers_pending_bytes_flush_reason() {
+    fn table_maintenance_state_prefers_pending_bytes_flush_reason() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(&write_activity(MAINTENANCE_PENDING_BYTES_THRESHOLD, 1), now);
@@ -1403,7 +1403,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_disables_pending_inserted_rows_flush_reason_by_default() {
+    fn table_maintenance_state_disables_pending_inserted_rows_flush_reason_by_default() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(
@@ -1415,7 +1415,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_uses_pending_inserted_rows_flush_reason_when_enabled() {
+    fn table_maintenance_state_uses_pending_inserted_rows_flush_reason_when_enabled() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(
@@ -1430,7 +1430,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_does_not_use_idle_flush_reason() {
+    fn table_maintenance_state_does_not_use_idle_flush_reason() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(&write_activity(128, 1), now);
@@ -1439,7 +1439,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_records_metrics_samples() {
+    fn table_maintenance_state_records_metrics_samples() {
         let now = Instant::now();
         let metrics = storage_metrics(10, 20_000_000, 6, 1000, 4, 1024, 25);
         let mut state = TableMaintenanceState::default();
@@ -1452,7 +1452,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_waits_for_fresh_sample_after_write() {
+    fn table_maintenance_state_waits_for_fresh_sample_after_write() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         let stale_metrics = storage_metrics(8, 16_000_000, 6, 1000, 0, 0, 0);
@@ -1471,7 +1471,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_selects_idle_merge_from_small_file_ratio() {
+    fn table_maintenance_state_selects_idle_merge_from_small_file_ratio() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(&write_activity(1024, 1), now);
@@ -1493,7 +1493,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_does_not_select_merge_when_ratio_is_half() {
+    fn table_maintenance_state_does_not_select_merge_when_ratio_is_half() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(&write_activity(1024, 1), now);
@@ -1512,7 +1512,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_does_not_select_merge_when_average_size_is_healthy() {
+    fn table_maintenance_state_does_not_select_merge_when_average_size_is_healthy() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(&write_activity(1024, 1), now);
@@ -1531,7 +1531,7 @@ mod tests {
     }
 
     #[test]
-    fn test_targeted_maintenance_plan_does_not_select_merge_with_one_small_file() {
+    fn targeted_maintenance_plan_does_not_select_merge_with_one_small_file() {
         let metrics = storage_metrics(1, 2_343_233, 1, 1000, 0, 0, 0);
 
         assert_eq!(
@@ -1545,7 +1545,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_selects_idle_rewrite_from_delete_pressure() {
+    fn table_maintenance_state_selects_idle_rewrite_from_delete_pressure() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(&write_activity(1024, 1), now);
@@ -1567,7 +1567,7 @@ mod tests {
     }
 
     #[test]
-    fn test_targeted_maintenance_plan_does_not_select_emergency_rewrite_from_ratio_alone() {
+    fn targeted_maintenance_plan_does_not_select_emergency_rewrite_from_ratio_alone() {
         let metrics = storage_metrics(10, 80_000_000, 0, 1000, 1, 65_101, 936);
 
         assert_eq!(
@@ -1577,7 +1577,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_maintenance_state_selects_emergency_rewrite_from_delete_pressure() {
+    fn table_maintenance_state_selects_emergency_rewrite_from_delete_pressure() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
         state.record_write_activity(&write_activity(1024, 1), now);
@@ -1599,7 +1599,7 @@ mod tests {
     }
 
     #[test]
-    fn test_targeted_maintenance_plan_selects_emergency_merge_when_table_is_fragmented() {
+    fn targeted_maintenance_plan_selects_emergency_merge_when_table_is_fragmented() {
         let metrics = storage_metrics(10, 20_000_000, 6, 1000, 0, 0, 0);
 
         assert_eq!(
@@ -1612,7 +1612,7 @@ mod tests {
     }
 
     #[test]
-    fn test_targeted_maintenance_plan_does_not_select_work_for_sample_shaped_metrics() {
+    fn targeted_maintenance_plan_does_not_select_work_for_sample_shaped_metrics() {
         let metrics = storage_metrics(1, 2_343_233, 1, 1000, 1, 65_101, 936);
 
         assert_eq!(
@@ -1622,19 +1622,19 @@ mod tests {
     }
 
     #[test]
-    fn test_maintenance_outcome_from_rows_flushed_marks_applied_and_noop() {
+    fn maintenance_outcome_from_rows_flushed_marks_applied_and_noop() {
         assert_eq!(MaintenanceOutcome::from(0), MaintenanceOutcome::Noop);
         assert_eq!(MaintenanceOutcome::from(3), MaintenanceOutcome::Applied);
     }
 
     #[test]
-    fn test_maintenance_outcome_from_files_created_marks_applied_and_noop() {
+    fn maintenance_outcome_from_files_created_marks_applied_and_noop() {
         assert_eq!(MaintenanceOutcome::from(0), MaintenanceOutcome::Noop);
         assert_eq!(MaintenanceOutcome::from(2), MaintenanceOutcome::Applied);
     }
 
     #[test]
-    fn test_targeted_maintenance_outcome_is_applied_when_any_operation_applies() {
+    fn targeted_maintenance_outcome_is_applied_when_any_operation_applies() {
         assert_eq!(
             targeted_maintenance_outcome(
                 Some(MaintenanceOutcome::Noop),
@@ -1659,7 +1659,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flush_failure_records_failed_metric() {
+    async fn flush_failure_records_failed_metric() {
         let handle = init_metrics_handle().expect("failed to initialize prometheus handle");
         register_metrics();
         let conn = duckdb::Connection::open_in_memory().expect("failed to open in-memory duckdb");
@@ -1699,7 +1699,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rewrite_failure_records_duration_and_prevents_merge_duration() {
+    async fn rewrite_failure_records_duration_and_prevents_merge_duration() {
         let handle = init_metrics_handle().expect("failed to initialize prometheus handle");
         register_metrics();
         let conn = duckdb::Connection::open_in_memory().expect("failed to open in-memory duckdb");
@@ -1764,7 +1764,7 @@ mod tests {
 
     #[cfg(feature = "test-utils")]
     #[tokio::test]
-    async fn test_known_rewrite_single_output_file_error_is_suppressed_and_recycles_connection() {
+    async fn known_rewrite_single_output_file_error_is_suppressed_and_recycles_connection() {
         let handle = init_metrics_handle().expect("failed to initialize prometheus handle");
         register_metrics();
         let open_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -1845,7 +1845,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_checkpoint_success_records_applied_duration() {
+    async fn checkpoint_success_records_applied_duration() {
         let _checkpoint_test_guard = acquire_checkpoint_test_guard().await;
         FAIL_CHECKPOINT_ONCE_FOR_TESTS.store(false, AtomicOrdering::Relaxed);
 
@@ -1881,7 +1881,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_checkpoint_failure_records_failed_duration() {
+    async fn checkpoint_failure_records_failed_duration() {
         let _checkpoint_test_guard = acquire_checkpoint_test_guard().await;
         FAIL_CHECKPOINT_ONCE_FOR_TESTS.store(false, AtomicOrdering::Relaxed);
 
@@ -1918,7 +1918,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flush_busy_emits_skip_counter_only() {
+    async fn flush_busy_emits_skip_counter_only() {
         let handle = init_metrics_handle().expect("failed to initialize prometheus handle");
         register_metrics();
 

--- a/etl-destinations/src/ducklake/metrics.rs
+++ b/etl-destinations/src/ducklake/metrics.rs
@@ -609,7 +609,8 @@ pub(super) fn query_catalog_maintenance_metrics_blocking(
 }
 
 fn epoch_age_seconds(now_epoch_ms: i64, oldest_epoch_ms: Option<i64>) -> i64 {
-    oldest_epoch_ms.map(|epoch_ms| now_epoch_ms.saturating_sub(epoch_ms) / 1_000).unwrap_or(0)
+    oldest_epoch_ms
+        .map_or(0, |epoch_ms| now_epoch_ms.saturating_sub(epoch_ms) / 1_000)
 }
 
 /// Returns the fully-qualified hidden DuckLake metadata namespace.

--- a/etl-destinations/src/ducklake/metrics.rs
+++ b/etl-destinations/src/ducklake/metrics.rs
@@ -609,8 +609,7 @@ pub(super) fn query_catalog_maintenance_metrics_blocking(
 }
 
 fn epoch_age_seconds(now_epoch_ms: i64, oldest_epoch_ms: Option<i64>) -> i64 {
-    oldest_epoch_ms
-        .map_or(0, |epoch_ms| now_epoch_ms.saturating_sub(epoch_ms) / 1_000)
+    oldest_epoch_ms.map_or(0, |epoch_ms| now_epoch_ms.saturating_sub(epoch_ms) / 1_000)
 }
 
 /// Returns the fully-qualified hidden DuckLake metadata namespace.

--- a/etl-destinations/src/ducklake/schema.rs
+++ b/etl-destinations/src/ducklake/schema.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::match_same_arms)]
+
 use etl::types::{ColumnSchema, Type, is_array_type};
 use pg_escape::quote_identifier;
 
@@ -28,6 +30,7 @@ fn postgres_scalar_type_to_ducklake_sql(typ: &Type) -> &'static str {
 
 /// Returns the DuckDB SQL type string for a given Postgres array type.
 fn postgres_array_type_to_ducklake_sql(typ: &Type) -> &'static str {
+    #[allow(clippy::match_same_arms)]
     match typ {
         &Type::BOOL_ARRAY => "BOOLEAN[]",
         &Type::CHAR_ARRAY

--- a/etl-destinations/src/ducklake/schema.rs
+++ b/etl-destinations/src/ducklake/schema.rs
@@ -94,7 +94,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_scalar_type_mapping() {
+    fn scalar_type_mapping() {
         assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::BOOL), "BOOLEAN");
         assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TEXT), "VARCHAR");
         assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INT2), "SMALLINT");
@@ -115,16 +115,31 @@ mod tests {
     }
 
     #[test]
-    fn test_array_type_mapping() {
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::BOOL_ARRAY), "BOOLEAN[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::TEXT_ARRAY), "VARCHAR[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::INT4_ARRAY), "INTEGER[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::FLOAT8_ARRAY), "DOUBLE[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::UUID_ARRAY), "UUID[]");
+    fn array_type_mapping() {
+        assert_eq!(
+            postgres_array_type_to_ducklake_sql(&Type::BOOL_ARRAY),
+            "BOOLEAN[]"
+        );
+        assert_eq!(
+            postgres_array_type_to_ducklake_sql(&Type::TEXT_ARRAY),
+            "VARCHAR[]"
+        );
+        assert_eq!(
+            postgres_array_type_to_ducklake_sql(&Type::INT4_ARRAY),
+            "INTEGER[]"
+        );
+        assert_eq!(
+            postgres_array_type_to_ducklake_sql(&Type::FLOAT8_ARRAY),
+            "DOUBLE[]"
+        );
+        assert_eq!(
+            postgres_array_type_to_ducklake_sql(&Type::UUID_ARRAY),
+            "UUID[]"
+        );
     }
 
     #[test]
-    fn test_build_create_table_sql_quotes_identifiers() {
+    fn build_create_table_sql_quotes_identifiers() {
         let sql = build_create_table_sql_ducklake(
             "odd\"table",
             &[ColumnSchema::new("select".to_string(), Type::INT4, -1, 1, Some(1), false)],

--- a/etl-destinations/src/ducklake/schema.rs
+++ b/etl-destinations/src/ducklake/schema.rs
@@ -115,26 +115,11 @@ mod tests {
 
     #[test]
     fn array_type_mapping() {
-        assert_eq!(
-            postgres_array_type_to_ducklake_sql(&Type::BOOL_ARRAY),
-            "BOOLEAN[]"
-        );
-        assert_eq!(
-            postgres_array_type_to_ducklake_sql(&Type::TEXT_ARRAY),
-            "VARCHAR[]"
-        );
-        assert_eq!(
-            postgres_array_type_to_ducklake_sql(&Type::INT4_ARRAY),
-            "INTEGER[]"
-        );
-        assert_eq!(
-            postgres_array_type_to_ducklake_sql(&Type::FLOAT8_ARRAY),
-            "DOUBLE[]"
-        );
-        assert_eq!(
-            postgres_array_type_to_ducklake_sql(&Type::UUID_ARRAY),
-            "UUID[]"
-        );
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::BOOL_ARRAY), "BOOLEAN[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::TEXT_ARRAY), "VARCHAR[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::INT4_ARRAY), "INTEGER[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::FLOAT8_ARRAY), "DOUBLE[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::UUID_ARRAY), "UUID[]");
     }
 
     #[test]

--- a/etl-destinations/src/ducklake/schema.rs
+++ b/etl-destinations/src/ducklake/schema.rs
@@ -30,7 +30,6 @@ fn postgres_scalar_type_to_ducklake_sql(typ: &Type) -> &'static str {
 
 /// Returns the DuckDB SQL type string for a given Postgres array type.
 fn postgres_array_type_to_ducklake_sql(typ: &Type) -> &'static str {
-    #[allow(clippy::match_same_arms)]
     match typ {
         &Type::BOOL_ARRAY => "BOOLEAN[]",
         &Type::CHAR_ARRAY

--- a/etl-destinations/src/iceberg/catalog.rs
+++ b/etl-destinations/src/iceberg/catalog.rs
@@ -370,7 +370,7 @@ impl SupabaseClient {
         }
 
         if let Some(query) = query {
-            request = request.query(query)
+            request = request.query(query);
         }
 
         let response = request

--- a/etl-destinations/src/iceberg/catalog.rs
+++ b/etl-destinations/src/iceberg/catalog.rs
@@ -280,7 +280,7 @@ impl SupabaseClient {
         let table_ident = TableIdent::new(namespace.clone(), creation.name.clone());
 
         let table_builder = Table::builder()
-            .identifier(table_ident.clone())
+            .identifier(table_ident)
             .file_io(file_io)
             .metadata(response.metadata);
 

--- a/etl-destinations/src/iceberg/catalog.rs
+++ b/etl-destinations/src/iceberg/catalog.rs
@@ -277,7 +277,7 @@ impl SupabaseClient {
 
         let file_io = self.load_file_io(Some(metadata_location), Some(config))?;
 
-        let table_ident = TableIdent::new(namespace.clone(), creation.name.to_string());
+        let table_ident = TableIdent::new(namespace.clone(), creation.name.clone());
 
         let table_builder = Table::builder()
             .identifier(table_ident.clone())

--- a/etl-destinations/src/iceberg/catalog.rs
+++ b/etl-destinations/src/iceberg/catalog.rs
@@ -279,10 +279,8 @@ impl SupabaseClient {
 
         let table_ident = TableIdent::new(namespace.clone(), creation.name.clone());
 
-        let table_builder = Table::builder()
-            .identifier(table_ident)
-            .file_io(file_io)
-            .metadata(response.metadata);
+        let table_builder =
+            Table::builder().identifier(table_ident).file_io(file_io).metadata(response.metadata);
 
         if let Some(metadata_location) = response.metadata_location {
             table_builder.metadata_location(metadata_location).build()

--- a/etl-destinations/src/iceberg/client.rs
+++ b/etl-destinations/src/iceberg/client.rs
@@ -8,7 +8,7 @@ use etl::{
 use iceberg::{
     Catalog, CatalogBuilder, NamespaceIdent, TableCreation, TableIdent,
     io::{S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY},
-    spec::TableProperties,
+    spec::{DataFile, TableProperties},
     table::Table,
     transaction::{ApplyTransactionAction, Transaction},
     writer::{
@@ -361,8 +361,7 @@ impl IcebergClient {
         // Close writer and get data files
         let data_files = data_file_writer.close().await?;
 
-        let bytes_sent: u64 =
-            data_files.iter().map(|data_file| data_file.file_size_in_bytes()).sum();
+        let bytes_sent: u64 = data_files.iter().map(DataFile::file_size_in_bytes).sum();
 
         // Create transaction and fast append action
         let transaction = Transaction::new(table);

--- a/etl-destinations/src/iceberg/encoding.rs
+++ b/etl-destinations/src/iceberg/encoding.rs
@@ -902,7 +902,7 @@ fn append_array_cell_as_strings(
             for item in vec {
                 match item {
                     Some(d) => {
-                        list_builder.values().append_value(d.format(DATE_FORMAT).to_string())
+                        list_builder.values().append_value(d.format(DATE_FORMAT).to_string());
                     }
                     None => list_builder.values().append_null(),
                 }
@@ -912,7 +912,7 @@ fn append_array_cell_as_strings(
             for item in vec {
                 match item {
                     Some(t) => {
-                        list_builder.values().append_value(t.format(TIME_FORMAT).to_string())
+                        list_builder.values().append_value(t.format(TIME_FORMAT).to_string());
                     }
                     None => list_builder.values().append_null(),
                 }
@@ -922,7 +922,7 @@ fn append_array_cell_as_strings(
             for item in vec {
                 match item {
                     Some(ts) => {
-                        list_builder.values().append_value(ts.format(TIMESTAMP_FORMAT).to_string())
+                        list_builder.values().append_value(ts.format(TIMESTAMP_FORMAT).to_string());
                     }
                     None => list_builder.values().append_null(),
                 }

--- a/etl-destinations/src/iceberg/encoding.rs
+++ b/etl-destinations/src/iceberg/encoding.rs
@@ -1635,7 +1635,7 @@ mod tests {
 
         // Test extraction from Cell::Array
         assert!(cell_to_array_cell(&Cell::Array(bool_array.clone())).is_some());
-        assert!(cell_to_array_cell(&Cell::Array(string_array.clone())).is_some());
+        assert!(cell_to_array_cell(&Cell::Array(string_array)).is_some());
 
         // Test non-array cells return None
         assert!(cell_to_array_cell(&Cell::Null).is_none());
@@ -1644,7 +1644,7 @@ mod tests {
         assert!(cell_to_array_cell(&Cell::I32(42)).is_none());
 
         // Verify the extracted array cell is the same
-        if let Some(extracted) = cell_to_array_cell(&Cell::Array(bool_array.clone())) {
+        if let Some(extracted) = cell_to_array_cell(&Cell::Array(bool_array)) {
             if let ArrayCell::Bool(vec) = extracted {
                 assert_eq!(vec.len(), 3);
                 assert_eq!(vec[0], Some(true));
@@ -1672,7 +1672,7 @@ mod tests {
             TableRow::new(vec![Cell::String("not an array".to_string())]), // Non-array cell,
         ];
 
-        let array_ref = build_boolean_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_boolean_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 5);
@@ -1739,7 +1739,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                          // Null cell,
         ];
 
-        let array_ref = build_int32_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_int32_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -1788,7 +1788,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                          // Null cell,
         ];
 
-        let array_ref = build_int64_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_int64_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -1833,7 +1833,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                          // Null cell,
         ];
 
-        let array_ref = build_float32_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_float32_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -1882,7 +1882,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                          // Null cell,
         ];
 
-        let array_ref = build_float64_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_float64_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -1941,7 +1941,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                             // Null cell,
         ];
 
-        let array_ref = build_string_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_string_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 5);
@@ -2005,7 +2005,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                            // Null cell,
         ];
 
-        let array_ref = build_binary_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_binary_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -2060,7 +2060,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                           // Null cell,
         ];
 
-        let array_ref = build_date32_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_date32_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -2122,7 +2122,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                           // Null cell,
         ];
 
-        let array_ref = build_time64_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_time64_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -2186,7 +2186,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                                // Null cell,
         ];
 
-        let array_ref = build_timestamp_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_timestamp_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -2245,7 +2245,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                                  // Null cell,
         ];
 
-        let array_ref = build_timestamptz_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_timestamptz_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -2303,7 +2303,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]),                           // Null cell,
         ];
 
-        let array_ref = build_uuid_list_array(&rows, 0, field_ref.clone());
+        let array_ref = build_uuid_list_array(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 4);
@@ -2379,7 +2379,7 @@ mod tests {
             TableRow::new(vec![Cell::Null]), // Null cell,
         ];
 
-        let array_ref = build_list_array_for_strings(&rows, 0, field_ref.clone());
+        let array_ref = build_list_array_for_strings(&rows, 0, field_ref);
         let list_array = array_ref.as_any().downcast_ref::<ListArray>().unwrap();
 
         assert_eq!(list_array.len(), 13);

--- a/etl-destinations/src/iceberg/encoding.rs
+++ b/etl-destinations/src/iceberg/encoding.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::match_same_arms)]
+
 use std::sync::Arc;
 
 use arrow::{

--- a/etl-destinations/src/iceberg/encoding.rs
+++ b/etl-destinations/src/iceberg/encoding.rs
@@ -968,7 +968,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cell_to_bool() {
+    fn cell_to_bool_fn() {
         assert_eq!(cell_to_bool(&Cell::Bool(true)), Some(true));
         assert_eq!(cell_to_bool(&Cell::Bool(false)), Some(false));
         assert_eq!(cell_to_bool(&Cell::Null), None);
@@ -977,7 +977,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_i32() {
+    fn cell_to_i32_fn() {
         assert_eq!(cell_to_i32(&Cell::I16(42)), Some(42));
         assert_eq!(cell_to_i32(&Cell::I32(42)), Some(42));
         assert_eq!(cell_to_i32(&Cell::Null), None);
@@ -986,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_i64() {
+    fn cell_to_i64_fn() {
         assert_eq!(cell_to_i64(&Cell::I64(42)), Some(42));
         assert_eq!(cell_to_i64(&Cell::I64(-42)), Some(-42));
         assert_eq!(cell_to_i64(&Cell::U32(42)), Some(42));
@@ -997,7 +997,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_f32() {
+    fn cell_to_f32_fn() {
         assert_eq!(cell_to_f32(&Cell::F32(2.5)), Some(2.5));
         assert_eq!(cell_to_f32(&Cell::F32(-2.5)), Some(-2.5));
         assert_eq!(cell_to_f32(&Cell::Null), None);
@@ -1006,7 +1006,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_f64() {
+    fn cell_to_f64_fn() {
         assert_eq!(cell_to_f64(&Cell::F64(1.234567)), Some(1.234567));
         assert_eq!(cell_to_f64(&Cell::F64(-1.234567)), Some(-1.234567));
         assert_eq!(cell_to_f64(&Cell::Null), None);
@@ -1015,7 +1015,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_bytes() {
+    fn cell_to_bytes_fn() {
         let test_bytes = vec![1, 2, 3, 4];
         assert_eq!(cell_to_bytes(&Cell::Bytes(test_bytes.clone())), Some(test_bytes));
         assert_eq!(cell_to_bytes(&Cell::Bytes(vec![])), Some(vec![]));
@@ -1024,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_date32() {
+    fn cell_to_date32_fn() {
         use chrono::NaiveDate;
         let test_date = NaiveDate::from_ymd_opt(2023, 5, 15).unwrap();
         let expected_days = test_date.signed_duration_since(UNIX_EPOCH).num_days() as i32;
@@ -1036,7 +1036,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_time64() {
+    fn cell_to_time64_fn() {
         use chrono::NaiveTime;
         let test_time = NaiveTime::from_hms_opt(12, 30, 45).unwrap();
         let expected_micros = test_time.signed_duration_since(MIDNIGHT).num_microseconds();
@@ -1048,7 +1048,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_timestamp() {
+    fn cell_to_timestamp_fn() {
         use chrono::DateTime;
         let test_ts = DateTime::from_timestamp(1000000000, 0).unwrap().naive_utc();
         let expected_micros = test_ts.and_utc().timestamp_micros();
@@ -1059,7 +1059,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_timestamptz() {
+    fn cell_to_timestamptz_fn() {
         use chrono::DateTime;
         let test_ts = DateTime::from_timestamp(1000000000, 0).unwrap();
         let expected_micros = test_ts.timestamp_micros();
@@ -1070,7 +1070,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_uuid() {
+    fn cell_to_uuid_fn() {
         use uuid::Uuid;
         let test_uuid = Uuid::new_v4();
         let expected_bytes = test_uuid.as_bytes();
@@ -1081,7 +1081,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_string() {
+    fn cell_to_string_fn() {
         use chrono::{NaiveDate, NaiveTime};
         use uuid::Uuid;
 
@@ -1122,7 +1122,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_boolean_array() {
+    fn build_boolean_array() {
         let rows = vec![
             TableRow::new(vec![Cell::Bool(true)]),
             TableRow::new(vec![Cell::Bool(false)]),
@@ -1141,7 +1141,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_i32_array() {
+    fn build_i32_array() {
         let rows = vec![
             TableRow::new(vec![Cell::I16(42)]),
             TableRow::new(vec![Cell::I32(-123)]),
@@ -1160,7 +1160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_i64_array() {
+    fn build_i64_array() {
         let rows = vec![
             TableRow::new(vec![Cell::I64(123456789)]),
             TableRow::new(vec![Cell::I64(-987654321)]),
@@ -1181,7 +1181,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_f32_array() {
+    fn build_f32_array() {
         let rows = vec![
             TableRow::new(vec![Cell::F32(2.5)]),
             TableRow::new(vec![Cell::F32(-1.25)]),
@@ -1200,7 +1200,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_f64_array() {
+    fn build_f64_array() {
         let rows = vec![
             TableRow::new(vec![Cell::F64(1.23456789)]),
             TableRow::new(vec![Cell::F64(-9.87654321)]),
@@ -1219,7 +1219,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_string_array() {
+    fn build_string_array() {
         let rows = vec![
             TableRow::new(vec![Cell::String("hello".to_string())]),
             TableRow::new(vec![Cell::Bool(true)]), // Converted to string
@@ -1238,7 +1238,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_binary_array() {
+    fn build_binary_array() {
         let test_bytes = vec![1, 2, 3, 4, 5];
         let rows = vec![
             TableRow::new(vec![Cell::Bytes(test_bytes.clone())]),
@@ -1259,7 +1259,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_date32_array() {
+    fn build_date32_array() {
         use chrono::NaiveDate;
         let test_date = NaiveDate::from_ymd_opt(2023, 5, 15).unwrap();
         let expected_days = test_date.signed_duration_since(UNIX_EPOCH).num_days() as i32;
@@ -1282,7 +1282,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_time64_array() {
+    fn build_time64_array() {
         use chrono::NaiveTime;
         let test_time = NaiveTime::from_hms_opt(12, 30, 45).unwrap();
         let expected_micros = test_time.signed_duration_since(MIDNIGHT).num_microseconds().unwrap();
@@ -1306,7 +1306,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_timestamp_array() {
+    fn build_timestamp_array() {
         use chrono::DateTime;
         let test_ts = DateTime::from_timestamp(1000000000, 0).unwrap().naive_utc();
         let expected_micros = test_ts.and_utc().timestamp_micros();
@@ -1329,7 +1329,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_timestamptz_array() {
+    fn build_timestamptz_array() {
         use chrono::DateTime;
         let test_ts = DateTime::from_timestamp(1000000000, 0).unwrap();
         let expected_micros = test_ts.timestamp_micros();
@@ -1356,7 +1356,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_uuid_array() {
+    fn build_uuid_array() {
         use uuid::Uuid;
         let test_uuid = Uuid::new_v4();
         let expected_bytes = test_uuid.as_bytes();
@@ -1379,7 +1379,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_simple() {
+    fn rows_to_record_batch_simple() {
         use arrow::datatypes::{Field, Schema};
 
         let rows = vec![
@@ -1419,7 +1419,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_with_nulls() {
+    fn rows_to_record_batch_with_nulls() {
         use arrow::datatypes::{Field, Schema};
 
         let rows = vec![
@@ -1448,7 +1448,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_temporal_types() {
+    fn rows_to_record_batch_temporal_types() {
         use arrow::datatypes::{Field, Schema};
         use chrono::{DateTime, NaiveDate, NaiveTime};
 
@@ -1513,7 +1513,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_binary_and_uuid() {
+    fn rows_to_record_batch_binary_and_uuid() {
         use arrow::datatypes::{Field, Schema};
         use uuid::Uuid;
 
@@ -1543,7 +1543,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_empty() {
+    fn rows_to_record_batch_empty() {
         use arrow::datatypes::{Field, Schema};
 
         let rows: Vec<TableRow> = vec![];
@@ -1559,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_unsupported_fallback() {
+    fn rows_to_record_batch_unsupported_fallback() {
         use arrow::datatypes::{Field, Schema};
 
         // Test with a data type that doesn't have a direct converter
@@ -1596,7 +1596,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_schema_mismatch_length() {
+    fn rows_to_record_batch_schema_mismatch_length() {
         use arrow::datatypes::{Field, Schema};
 
         // Test what happens when row has different number of columns than schema
@@ -1629,7 +1629,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_to_array_cell() {
+    fn cell_to_array_cell_fn() {
         let bool_array = ArrayCell::Bool(vec![Some(true), Some(false), None]);
         let string_array = ArrayCell::String(vec![Some("hello".to_string()), None]);
 
@@ -1657,8 +1657,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_boolean_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_boolean_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
 
         let field = Field::new("items", DataType::Boolean, true);
         let field_ref = Arc::new(field);
@@ -1706,8 +1707,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_boolean_list_array_fallback() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_boolean_list_array_fallback() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
 
         let field = Field::new("items", DataType::Boolean, true);
         let field_ref = Arc::new(field);
@@ -1726,8 +1728,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_int32_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_int32_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
 
         let field = Field::new("items", DataType::Int32, true);
         let field_ref = Arc::new(field);
@@ -1771,8 +1774,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_int64_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_int64_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
 
         let field = Field::new("items", DataType::Int64, true);
         let field_ref = Arc::new(field);
@@ -1820,8 +1824,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_float32_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_float32_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
 
         let field = Field::new("items", DataType::Float32, true);
         let field_ref = Arc::new(field);
@@ -1865,8 +1870,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_float64_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_float64_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
 
         let field = Field::new("items", DataType::Float64, true);
         let field_ref = Arc::new(field);
@@ -1914,8 +1920,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_string_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_string_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
         use etl::types::PgNumeric;
 
         let field = Field::new("items", DataType::Utf8, true);
@@ -1984,8 +1991,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_binary_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_binary_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
 
         let field = Field::new("items", DataType::LargeBinary, true);
         let field_ref = Arc::new(field);
@@ -2038,8 +2046,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_date32_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_date32_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
         use chrono::NaiveDate;
 
         let field = Field::new("items", DataType::Date32, true);
@@ -2100,8 +2109,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_time64_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_time64_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
         use chrono::NaiveTime;
 
         let field = Field::new("items", DataType::Time64(TimeUnit::Microsecond), true);
@@ -2164,8 +2174,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_timestamp_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_timestamp_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
         use chrono::DateTime;
 
         let field = Field::new("items", DataType::Timestamp(TimeUnit::Microsecond, None), true);
@@ -2219,8 +2230,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_timestamptz_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_timestamptz_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
         use chrono::DateTime;
 
         let field = Field::new(
@@ -2281,8 +2293,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_uuid_list_array() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_uuid_list_array_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
         use uuid::Uuid;
 
         let field = Field::new("items", DataType::FixedSizeBinary(UUID_BYTE_WIDTH), true);
@@ -2336,8 +2349,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_list_array_for_strings() {
-        use arrow::{array::ListArray, datatypes::Field};
+    fn build_list_array_for_strings_fn() {
+        use arrow::array::ListArray;
+        use arrow::datatypes::Field;
         use chrono::{DateTime, NaiveDate, NaiveTime};
         use etl::types::PgNumeric;
         use uuid::Uuid;
@@ -2487,7 +2501,7 @@ mod tests {
     }
 
     #[test]
-    fn test_append_array_cell_as_strings_comprehensive() {
+    fn append_array_cell_as_strings_comprehensive() {
         use arrow::array::ListBuilder;
         use chrono::{DateTime, NaiveDate, NaiveTime};
         use etl::types::PgNumeric;
@@ -2624,7 +2638,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_list_array_dispatch() {
+    fn build_list_array_dispatch() {
         use arrow::datatypes::Field;
 
         // Test that build_list_array correctly dispatches to the right type-specific
@@ -2663,7 +2677,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_list_array_unsupported_type_fallback() {
+    fn build_list_array_unsupported_type_fallback() {
         use arrow::datatypes::Field;
 
         // Test with an unsupported inner type that should fall back to string
@@ -2689,7 +2703,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_with_list_fields() {
+    fn rows_to_record_batch_with_list_fields() {
         use arrow::datatypes::{Field, Schema};
         use uuid::Uuid;
 
@@ -2850,7 +2864,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rows_to_record_batch_mixed_scalar_and_array() {
+    fn rows_to_record_batch_mixed_scalar_and_array() {
         use arrow::datatypes::{Field, Schema};
 
         // Test mixing scalar and array columns in the same record batch

--- a/etl-destinations/src/iceberg/encoding.rs
+++ b/etl-destinations/src/iceberg/encoding.rs
@@ -1658,8 +1658,7 @@ mod tests {
 
     #[test]
     fn build_boolean_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
 
         let field = Field::new("items", DataType::Boolean, true);
         let field_ref = Arc::new(field);
@@ -1708,8 +1707,7 @@ mod tests {
 
     #[test]
     fn build_boolean_list_array_fallback() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
 
         let field = Field::new("items", DataType::Boolean, true);
         let field_ref = Arc::new(field);
@@ -1729,8 +1727,7 @@ mod tests {
 
     #[test]
     fn build_int32_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
 
         let field = Field::new("items", DataType::Int32, true);
         let field_ref = Arc::new(field);
@@ -1775,8 +1772,7 @@ mod tests {
 
     #[test]
     fn build_int64_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
 
         let field = Field::new("items", DataType::Int64, true);
         let field_ref = Arc::new(field);
@@ -1825,8 +1821,7 @@ mod tests {
 
     #[test]
     fn build_float32_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
 
         let field = Field::new("items", DataType::Float32, true);
         let field_ref = Arc::new(field);
@@ -1871,8 +1866,7 @@ mod tests {
 
     #[test]
     fn build_float64_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
 
         let field = Field::new("items", DataType::Float64, true);
         let field_ref = Arc::new(field);
@@ -1921,8 +1915,7 @@ mod tests {
 
     #[test]
     fn build_string_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
         use etl::types::PgNumeric;
 
         let field = Field::new("items", DataType::Utf8, true);
@@ -1992,8 +1985,7 @@ mod tests {
 
     #[test]
     fn build_binary_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
 
         let field = Field::new("items", DataType::LargeBinary, true);
         let field_ref = Arc::new(field);
@@ -2047,8 +2039,7 @@ mod tests {
 
     #[test]
     fn build_date32_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
         use chrono::NaiveDate;
 
         let field = Field::new("items", DataType::Date32, true);
@@ -2110,8 +2101,7 @@ mod tests {
 
     #[test]
     fn build_time64_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
         use chrono::NaiveTime;
 
         let field = Field::new("items", DataType::Time64(TimeUnit::Microsecond), true);
@@ -2175,8 +2165,7 @@ mod tests {
 
     #[test]
     fn build_timestamp_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
         use chrono::DateTime;
 
         let field = Field::new("items", DataType::Timestamp(TimeUnit::Microsecond, None), true);
@@ -2231,8 +2220,7 @@ mod tests {
 
     #[test]
     fn build_timestamptz_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
         use chrono::DateTime;
 
         let field = Field::new(
@@ -2294,8 +2282,7 @@ mod tests {
 
     #[test]
     fn build_uuid_list_array_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
         use uuid::Uuid;
 
         let field = Field::new("items", DataType::FixedSizeBinary(UUID_BYTE_WIDTH), true);
@@ -2350,8 +2337,7 @@ mod tests {
 
     #[test]
     fn build_list_array_for_strings_fn() {
-        use arrow::array::ListArray;
-        use arrow::datatypes::Field;
+        use arrow::{array::ListArray, datatypes::Field};
         use chrono::{DateTime, NaiveDate, NaiveTime};
         use etl::types::PgNumeric;
         use uuid::Uuid;

--- a/etl-destinations/src/iceberg/schema.rs
+++ b/etl-destinations/src/iceberg/schema.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::match_same_arms)]
+
 use std::sync::Arc;
 
 use etl::types::{ColumnSchema, Type, is_array_type};

--- a/etl-destinations/src/iceberg/schema.rs
+++ b/etl-destinations/src/iceberg/schema.rs
@@ -156,7 +156,7 @@ mod tests {
     }
 
     #[test]
-    fn test_postgres_to_iceberg_scalar_types() {
+    fn postgres_to_iceberg_scalar_types() {
         // Boolean types
         assert_eq!(
             postgres_to_iceberg_type(&Type::BOOL),
@@ -272,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn test_postgres_to_iceberg_array_types() {
+    fn postgres_to_iceberg_array_types() {
         // Boolean array
         let bool_array_type = postgres_to_iceberg_type(&Type::BOOL_ARRAY);
         assert!(matches!(bool_array_type, IcebergType::List(_)));
@@ -348,7 +348,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_iceberg_list_type() {
+    fn create_iceberg_list_type_works() {
         let list_type = create_iceberg_list_type(PrimitiveType::String, 1);
 
         assert!(matches!(list_type, IcebergType::List(_)));
@@ -364,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn test_postgres_scalar_type_fallback() {
+    fn postgres_scalar_type_fallback() {
         // Test fallback for unknown scalar types
         // Using a type that should fall through to the default case
         let result = postgres_scalar_type_to_iceberg_type(&Type::UNKNOWN);
@@ -372,7 +372,7 @@ mod tests {
     }
 
     #[test]
-    fn test_postgres_array_type_fallback() {
+    fn postgres_array_type_fallback() {
         // Test that non-array types passed to array function still get handled
         // This tests the fallback case in the array function
         let array_type = postgres_array_type_to_iceberg_type(&Type::BOOL, 1); // Not an array type
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_list_type_element_field_properties() {
+    fn list_type_element_field_properties() {
         let list_type = create_iceberg_list_type(PrimitiveType::Boolean, 2);
         assert!(matches!(list_type, IcebergType::List(_)));
 
@@ -416,7 +416,7 @@ mod tests {
     }
 
     #[test]
-    fn test_identifier_fields_single_primary_key() {
+    fn identifier_fields_single_primary_key() {
         let columns = vec![
             test_column("id", Type::INT4, 1, false, Some(1)),
             test_column("name", Type::TEXT, 2, true, None),
@@ -430,7 +430,7 @@ mod tests {
     }
 
     #[test]
-    fn test_identifier_fields_composite_primary_key() {
+    fn identifier_fields_composite_primary_key() {
         let columns = vec![
             test_column("tenant_id", Type::INT4, 1, false, Some(1)),
             test_column("id", Type::INT4, 2, false, Some(2)),
@@ -447,7 +447,7 @@ mod tests {
     }
 
     #[test]
-    fn test_identifier_fields_no_primary_key() {
+    fn identifier_fields_no_primary_key() {
         let columns = vec![
             test_column("name", Type::TEXT, 1, true, None),
             test_column("age", Type::INT4, 2, true, None),

--- a/etl-destinations/tests/ducklake_destination.rs
+++ b/etl-destinations/tests/ducklake_destination.rs
@@ -251,7 +251,7 @@ fn checkpoint_lake(catalog: &Url, data: &Url) {
 /// `write_table_rows` inserts rows that can be queried back through the
 /// DuckLake catalog using a separate DuckDB connection.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_table_rows_basic() {
+async fn write_table_rows_basic() {
     let dir = make_test_dir("write_table_rows_basic");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -303,7 +303,7 @@ async fn test_write_table_rows_basic() {
 
 /// Small copy batches should remain inlined after the caller returns.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_table_rows_small_batch_stays_inlined_after_return() {
+async fn write_table_rows_small_batch_stays_inlined_after_return() {
     let dir = make_test_dir("write_table_rows_small_batch_stays_inlined_after_return");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -344,7 +344,7 @@ async fn test_write_table_rows_small_batch_stays_inlined_after_return() {
 
 /// `pool_size = 0` should fail fast with a configuration error.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_ducklake_rejects_zero_pool_size() {
+async fn ducklake_rejects_zero_pool_size() {
     let dir = make_test_dir("ducklake_rejects_zero_pool_size");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -368,7 +368,7 @@ async fn test_ducklake_rejects_zero_pool_size() {
 /// Repeated writes should reuse the warm pooled DuckDB connection.
 #[cfg(feature = "test-utils")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_table_rows_reuses_warm_pooled_connection() {
+async fn write_table_rows_reuses_warm_pooled_connection() {
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
 
@@ -420,7 +420,7 @@ async fn test_write_table_rows_reuses_warm_pooled_connection() {
 /// replace it.
 #[cfg(feature = "test-utils")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_table_rows_replaces_broken_pooled_connection_after_retry() {
+async fn write_table_rows_replaces_broken_pooled_connection_after_retry() {
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
 
@@ -474,7 +474,7 @@ async fn test_write_table_rows_replaces_broken_pooled_connection_after_retry() {
 /// A post-commit retry should not duplicate table-copy rows.
 #[cfg(feature = "test-utils")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_table_rows_retry_after_post_commit_failure_is_idempotent() {
+async fn write_table_rows_retry_after_post_commit_failure_is_idempotent() {
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
 
@@ -520,7 +520,7 @@ async fn test_write_table_rows_retry_after_post_commit_failure_is_idempotent() {
 /// Concurrent same-table copy batches should serialize cleanly and remain
 /// exact.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_concurrent_same_table_copy_batches_complete() {
+async fn concurrent_same_table_copy_batches_complete() {
     let dir = make_test_dir("concurrent_same_table_copy_batches_complete");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -589,7 +589,7 @@ async fn test_concurrent_same_table_copy_batches_complete() {
 
 /// `write_table_rows` with an empty slice still creates the table schema.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_table_rows_empty_creates_table() {
+async fn write_table_rows_empty_creates_table() {
     let dir = make_test_dir("write_table_rows_empty");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -617,7 +617,7 @@ async fn test_write_table_rows_empty_creates_table() {
 
 /// `truncate_table` deletes all rows while leaving the table schema intact.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_truncate_clears_rows() {
+async fn truncate_clears_rows() {
     let dir = make_test_dir("truncate_clears_rows");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -672,7 +672,7 @@ async fn test_truncate_clears_rows() {
 
 /// Truncation should clear copy markers so the same rows can be copied again.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_truncate_clears_copy_markers_for_recopy() {
+async fn truncate_clears_copy_markers_for_recopy() {
     let dir = make_test_dir("truncate_clears_copy_markers_for_recopy");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -710,7 +710,7 @@ async fn test_truncate_clears_copy_markers_for_recopy() {
 /// `write_events` applies inserts, updates, and deletes to the current table
 /// state.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_events() {
+async fn write_events() {
     use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
 
     let dir = make_test_dir("write_events");
@@ -792,7 +792,7 @@ async fn test_write_events() {
 
 /// Small CDC batches should remain inlined after the caller returns.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_events_small_batch_stays_inlined_after_return() {
+async fn write_events_small_batch_stays_inlined_after_return() {
     use etl::types::{InsertEvent, PgLsn};
 
     let dir = make_test_dir("write_events_small_batch_stays_inlined_after_return");
@@ -839,7 +839,7 @@ async fn test_write_events_small_batch_stays_inlined_after_return() {
 
 /// `write_events` keeps update events with old rows on the current-state path.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_events_with_old_row_update() {
+async fn write_events_with_old_row_update() {
     use etl::types::{InsertEvent, PgLsn, UpdateEvent};
 
     let dir = make_test_dir("write_events_with_old_row_update");
@@ -908,7 +908,7 @@ async fn test_write_events_with_old_row_update() {
 /// Replaying the same CDC batch should be a no-op after the marker row is
 /// committed.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_events_replay_is_idempotent() {
+async fn write_events_replay_is_idempotent() {
     use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
 
     let dir = make_test_dir("write_events_replay_is_idempotent");
@@ -995,7 +995,7 @@ async fn test_write_events_replay_is_idempotent() {
 /// Marker-table rows should stay in the DuckLake catalog instead of creating
 /// Parquet files.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_applied_batches_table_uses_data_inlining() {
+async fn applied_batches_table_uses_data_inlining() {
     use etl::types::{InsertEvent, PgLsn};
 
     let dir = make_test_dir("applied_batches_table_uses_data_inlining");
@@ -1038,7 +1038,7 @@ async fn test_applied_batches_table_uses_data_inlining() {
 
 /// Shutdown should materialize copy rows that were still inlined.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_shutdown_flushes_inlined_copy_rows() {
+async fn shutdown_flushes_inlined_copy_rows() {
     let dir = make_test_dir("shutdown_flushes_inlined_copy_rows");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -1099,7 +1099,7 @@ async fn test_shutdown_flushes_inlined_copy_rows() {
 
 /// Shutdown should flush inlined CDC rows for all known tables.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_shutdown_flushes_inlined_cdc_rows_for_all_known_tables() {
+async fn shutdown_flushes_inlined_cdc_rows_for_all_known_tables() {
     use etl::types::{InsertEvent, PgLsn};
 
     let dir = make_test_dir("shutdown_flushes_inlined_cdc_rows_for_all_known_tables");
@@ -1200,7 +1200,7 @@ async fn test_shutdown_flushes_inlined_cdc_rows_for_all_known_tables() {
 /// Mixed table batches remain correct when multiple tables are written in one
 /// flush.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_events_mixed_multi_table_batches() {
+async fn write_events_mixed_multi_table_batches() {
     use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
 
     let dir = make_test_dir("write_events_mixed_multi_table_batches");
@@ -1325,7 +1325,7 @@ async fn test_write_events_mixed_multi_table_batches() {
 /// rows.
 #[cfg(feature = "test-utils")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_events_retry_after_post_commit_failure_is_idempotent() {
+async fn write_events_retry_after_post_commit_failure_is_idempotent() {
     use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
 
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
@@ -1417,7 +1417,7 @@ async fn test_write_events_retry_after_post_commit_failure_is_idempotent() {
 
 /// Concurrent async callers should serialize cleanly behind one DuckDB slot.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_concurrent_writes_with_single_slot_complete() {
+async fn concurrent_writes_with_single_slot_complete() {
     let dir = make_test_dir("concurrent_writes_single_slot");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -1479,7 +1479,7 @@ async fn test_concurrent_writes_with_single_slot_complete() {
 
 /// Verifies that common Postgres types survive the write → read cycle.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_type_mapping_round_trip() {
+async fn type_mapping_round_trip() {
     let dir = make_test_dir("type_mapping");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");

--- a/etl-destinations/tests/iceberg_client.rs
+++ b/etl-destinations/tests/iceberg_client.rs
@@ -732,21 +732,27 @@ async fn insert_nullable_array() {
 
     // numeric_array_col (index 12): NUMERIC_ARRAY maps to String in Iceberg
     if let Cell::Array(ArrayCell::Numeric(vec)) = &values[12] {
-        let converted: Vec<Option<String>> =
-            vec.iter().map(|opt| opt.as_ref().map(|n| n.to_string())).collect();
+        let converted: Vec<Option<String>> = vec
+            .iter()
+            .map(|opt| opt.as_ref().map(ToString::to_string))
+            .collect();
         values[12] = Cell::Array(ArrayCell::String(converted));
     }
 
     // json_array_col (index 18) and jsonb_array_col (index 19): JSON arrays map to
     // String in Iceberg
     if let Cell::Array(ArrayCell::Json(vec)) = &values[18] {
-        let converted: Vec<Option<String>> =
-            vec.iter().map(|opt| opt.as_ref().map(|j| j.to_string())).collect();
+        let converted: Vec<Option<String>> = vec
+            .iter()
+            .map(|opt| opt.as_ref().map(ToString::to_string))
+            .collect();
         values[18] = Cell::Array(ArrayCell::String(converted));
     }
     if let Cell::Array(ArrayCell::Json(vec)) = &values[19] {
-        let converted: Vec<Option<String>> =
-            vec.iter().map(|opt| opt.as_ref().map(|j| j.to_string())).collect();
+        let converted: Vec<Option<String>> = vec
+            .iter()
+            .map(|opt| opt.as_ref().map(ToString::to_string))
+            .collect();
         values[19] = Cell::Array(ArrayCell::String(converted));
     }
 
@@ -915,21 +921,27 @@ async fn insert_non_nullable_array() {
 
     // numeric_array_col (index 12): NUMERIC_ARRAY maps to String in Iceberg
     if let Cell::Array(ArrayCell::Numeric(vec)) = &values[12] {
-        let converted: Vec<Option<String>> =
-            vec.iter().map(|opt| opt.as_ref().map(|n| n.to_string())).collect();
+        let converted: Vec<Option<String>> = vec
+            .iter()
+            .map(|opt| opt.as_ref().map(ToString::to_string))
+            .collect();
         values[12] = Cell::Array(ArrayCell::String(converted));
     }
 
     // json_array_col (index 18) and jsonb_array_col (index 19): JSON arrays map to
     // String in Iceberg
     if let Cell::Array(ArrayCell::Json(vec)) = &values[18] {
-        let converted: Vec<Option<String>> =
-            vec.iter().map(|opt| opt.as_ref().map(|j| j.to_string())).collect();
+        let converted: Vec<Option<String>> = vec
+            .iter()
+            .map(|opt| opt.as_ref().map(ToString::to_string))
+            .collect();
         values[18] = Cell::Array(ArrayCell::String(converted));
     }
     if let Cell::Array(ArrayCell::Json(vec)) = &values[19] {
-        let converted: Vec<Option<String>> =
-            vec.iter().map(|opt| opt.as_ref().map(|j| j.to_string())).collect();
+        let converted: Vec<Option<String>> = vec
+            .iter()
+            .map(|opt| opt.as_ref().map(ToString::to_string))
+            .collect();
         values[19] = Cell::Array(ArrayCell::String(converted));
     }
 

--- a/etl-destinations/tests/iceberg_client.rs
+++ b/etl-destinations/tests/iceberg_client.rs
@@ -184,13 +184,23 @@ async fn create_table_if_missing() {
     ];
 
     // table doesn't exist yet
-    assert!(!client.table_exists(namespace, table_name.to_string()).await.unwrap());
+    assert!(
+        !client
+            .table_exists(namespace, table_name.clone())
+            .await
+            .unwrap()
+    );
 
     // Create table for the first time
     client.create_table_if_missing(namespace, table_name.clone(), &column_schemas).await.unwrap();
 
     // table should exist now
-    assert!(client.table_exists(namespace, table_name.to_string()).await.unwrap());
+    assert!(
+        client
+            .table_exists(namespace, table_name.clone())
+            .await
+            .unwrap()
+    );
 
     // Verify identifier fields are set correctly.
     let table = client.load_table(namespace.to_string(), table_name.clone()).await.unwrap();
@@ -204,7 +214,12 @@ async fn create_table_if_missing() {
     client.create_table_if_missing(namespace, table_name.clone(), &column_schemas).await.unwrap();
 
     // table should still exist
-    assert!(client.table_exists(namespace, table_name.to_string()).await.unwrap());
+    assert!(
+        client
+            .table_exists(namespace, table_name.clone())
+            .await
+            .unwrap()
+    );
 
     // Manual cleanup for now because lakekeeper doesn't allow cascade delete at the
     // warehouse level This feature is planned for future releases. We'll start

--- a/etl-destinations/tests/iceberg_client.rs
+++ b/etl-destinations/tests/iceberg_client.rs
@@ -184,23 +184,13 @@ async fn create_table_if_missing() {
     ];
 
     // table doesn't exist yet
-    assert!(
-        !client
-            .table_exists(namespace, table_name.clone())
-            .await
-            .unwrap()
-    );
+    assert!(!client.table_exists(namespace, table_name.clone()).await.unwrap());
 
     // Create table for the first time
     client.create_table_if_missing(namespace, table_name.clone(), &column_schemas).await.unwrap();
 
     // table should exist now
-    assert!(
-        client
-            .table_exists(namespace, table_name.clone())
-            .await
-            .unwrap()
-    );
+    assert!(client.table_exists(namespace, table_name.clone()).await.unwrap());
 
     // Verify identifier fields are set correctly.
     let table = client.load_table(namespace.to_string(), table_name.clone()).await.unwrap();
@@ -214,12 +204,7 @@ async fn create_table_if_missing() {
     client.create_table_if_missing(namespace, table_name.clone(), &column_schemas).await.unwrap();
 
     // table should still exist
-    assert!(
-        client
-            .table_exists(namespace, table_name.clone())
-            .await
-            .unwrap()
-    );
+    assert!(client.table_exists(namespace, table_name.clone()).await.unwrap());
 
     // Manual cleanup for now because lakekeeper doesn't allow cascade delete at the
     // warehouse level This feature is planned for future releases. We'll start
@@ -732,27 +717,21 @@ async fn insert_nullable_array() {
 
     // numeric_array_col (index 12): NUMERIC_ARRAY maps to String in Iceberg
     if let Cell::Array(ArrayCell::Numeric(vec)) = &values[12] {
-        let converted: Vec<Option<String>> = vec
-            .iter()
-            .map(|opt| opt.as_ref().map(ToString::to_string))
-            .collect();
+        let converted: Vec<Option<String>> =
+            vec.iter().map(|opt| opt.as_ref().map(ToString::to_string)).collect();
         values[12] = Cell::Array(ArrayCell::String(converted));
     }
 
     // json_array_col (index 18) and jsonb_array_col (index 19): JSON arrays map to
     // String in Iceberg
     if let Cell::Array(ArrayCell::Json(vec)) = &values[18] {
-        let converted: Vec<Option<String>> = vec
-            .iter()
-            .map(|opt| opt.as_ref().map(ToString::to_string))
-            .collect();
+        let converted: Vec<Option<String>> =
+            vec.iter().map(|opt| opt.as_ref().map(ToString::to_string)).collect();
         values[18] = Cell::Array(ArrayCell::String(converted));
     }
     if let Cell::Array(ArrayCell::Json(vec)) = &values[19] {
-        let converted: Vec<Option<String>> = vec
-            .iter()
-            .map(|opt| opt.as_ref().map(ToString::to_string))
-            .collect();
+        let converted: Vec<Option<String>> =
+            vec.iter().map(|opt| opt.as_ref().map(ToString::to_string)).collect();
         values[19] = Cell::Array(ArrayCell::String(converted));
     }
 
@@ -921,27 +900,21 @@ async fn insert_non_nullable_array() {
 
     // numeric_array_col (index 12): NUMERIC_ARRAY maps to String in Iceberg
     if let Cell::Array(ArrayCell::Numeric(vec)) = &values[12] {
-        let converted: Vec<Option<String>> = vec
-            .iter()
-            .map(|opt| opt.as_ref().map(ToString::to_string))
-            .collect();
+        let converted: Vec<Option<String>> =
+            vec.iter().map(|opt| opt.as_ref().map(ToString::to_string)).collect();
         values[12] = Cell::Array(ArrayCell::String(converted));
     }
 
     // json_array_col (index 18) and jsonb_array_col (index 19): JSON arrays map to
     // String in Iceberg
     if let Cell::Array(ArrayCell::Json(vec)) = &values[18] {
-        let converted: Vec<Option<String>> = vec
-            .iter()
-            .map(|opt| opt.as_ref().map(ToString::to_string))
-            .collect();
+        let converted: Vec<Option<String>> =
+            vec.iter().map(|opt| opt.as_ref().map(ToString::to_string)).collect();
         values[18] = Cell::Array(ArrayCell::String(converted));
     }
     if let Cell::Array(ArrayCell::Json(vec)) = &values[19] {
-        let converted: Vec<Option<String>> = vec
-            .iter()
-            .map(|opt| opt.as_ref().map(ToString::to_string))
-            .collect();
+        let converted: Vec<Option<String>> =
+            vec.iter().map(|opt| opt.as_ref().map(ToString::to_string)).collect();
         values[19] = Cell::Array(ArrayCell::String(converted));
     }
 

--- a/etl-destinations/tests/iceberg_destination.rs
+++ b/etl-destinations/tests/iceberg_destination.rs
@@ -138,8 +138,7 @@ async fn run_table_copy_test(destination_namespace: DestinationNamespace) {
         .sort_by(|a, b| format!("{:?}", a.values()[0]).cmp(&format!("{:?}", b.values()[0])));
     assert_table_rows_equal_ignoring_size(&actual_users, &expected_users);
 
-    let mut actual_orders =
-        read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
+    let mut actual_orders = read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
 
     let expected_orders = vec![
         TableRow::new(vec![
@@ -373,8 +372,7 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
 
     assert_table_rows_equal_ignoring_size(&actual_users, &expected_users);
 
-    let mut actual_orders =
-        read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
+    let mut actual_orders = read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
 
     // Sort deterministically by the primary key (id) and sequence key for stable
     // assertions
@@ -591,8 +589,7 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     ];
     assert_table_rows_equal_ignoring_size(&actual_users, &expected_users);
 
-    let mut actual_orders =
-        read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
+    let mut actual_orders = read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
     for row in &mut actual_orders {
         let _ = row.values_mut().pop(); // drop sequence_key
     }

--- a/etl-destinations/tests/iceberg_destination.rs
+++ b/etl-destinations/tests/iceberg_destination.rs
@@ -565,7 +565,8 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     event_notify.notified().await;
     destination.clear_events().await;
 
-    // After truncate, pre-truncate CDC rows should be gone (tables were dropped). Only post-truncate rows remain.
+    // After truncate, pre-truncate CDC rows should be gone (tables were dropped).
+    // Only post-truncate rows remain.
     let mut actual_users = read_all_rows(&client, namespace.clone(), users_table.clone()).await;
     for row in &mut actual_users {
         let _ = row.values_mut().pop(); // drop sequence_key

--- a/etl-destinations/tests/iceberg_destination.rs
+++ b/etl-destinations/tests/iceberg_destination.rs
@@ -60,7 +60,7 @@ async fn run_table_copy_test(destination_namespace: DestinationNamespace) {
     let namespace = match destination_namespace {
         DestinationNamespace::Single(ref ns) => {
             client.create_namespace_if_missing(ns).await.unwrap();
-            ns.to_string()
+            ns.clone()
         }
         DestinationNamespace::OnePerSchema => TestDatabaseSchema::schema().to_string(),
     };
@@ -113,7 +113,7 @@ async fn run_table_copy_test(destination_namespace: DestinationNamespace) {
     )
     .unwrap();
 
-    let mut actual_users = read_all_rows(&client, namespace.to_string(), users_table.clone()).await;
+    let mut actual_users = read_all_rows(&client, namespace.clone(), users_table.clone()).await;
 
     let expected_users = vec![
         TableRow::new(vec![
@@ -139,7 +139,7 @@ async fn run_table_copy_test(destination_namespace: DestinationNamespace) {
     assert_table_rows_equal_ignoring_size(&actual_users, &expected_users);
 
     let mut actual_orders =
-        read_all_rows(&client, namespace.to_string(), orders_table.clone()).await;
+        read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
 
     let expected_orders = vec![
         TableRow::new(vec![
@@ -200,7 +200,7 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     let namespace = match destination_namespace {
         DestinationNamespace::Single(ref ns) => {
             client.create_namespace_if_missing(ns).await.unwrap();
-            ns.to_string()
+            ns.clone()
         }
         DestinationNamespace::OnePerSchema => TestDatabaseSchema::schema().to_string(),
     };
@@ -316,7 +316,7 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     )
     .unwrap();
 
-    let mut actual_users = read_all_rows(&client, namespace.to_string(), users_table.clone()).await;
+    let mut actual_users = read_all_rows(&client, namespace.clone(), users_table.clone()).await;
 
     // Sort deterministically by the sequence key for stable assertions
     actual_users.sort_by(|a, b| {
@@ -374,7 +374,7 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     assert_table_rows_equal_ignoring_size(&actual_users, &expected_users);
 
     let mut actual_orders =
-        read_all_rows(&client, namespace.to_string(), orders_table.clone()).await;
+        read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
 
     // Sort deterministically by the primary key (id) and sequence key for stable
     // assertions
@@ -465,7 +465,7 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     let namespace = match destination_namespace {
         DestinationNamespace::Single(ref ns) => {
             client.create_namespace_if_missing(ns).await.unwrap();
-            ns.to_string()
+            ns.clone()
         }
         DestinationNamespace::OnePerSchema => TestDatabaseSchema::schema().to_string(),
     };
@@ -544,8 +544,8 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     )
     .unwrap();
 
-    let actual_users = read_all_rows(&client, namespace.to_string(), users_table.clone()).await;
-    let actual_orders = read_all_rows(&client, namespace.to_string(), users_table.clone()).await;
+    let actual_users = read_all_rows(&client, namespace.clone(), users_table.clone()).await;
+    let actual_orders = read_all_rows(&client, namespace.clone(), users_table.clone()).await;
 
     assert!(actual_users.is_empty());
     assert!(actual_orders.is_empty());
@@ -567,9 +567,8 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     event_notify.notified().await;
     destination.clear_events().await;
 
-    // After truncate, pre-truncate CDC rows should be gone (tables were dropped).
-    // Only post-truncate rows remain.
-    let mut actual_users = read_all_rows(&client, namespace.to_string(), users_table.clone()).await;
+    // After truncate, pre-truncate CDC rows should be gone (tables were dropped). Only post-truncate rows remain.
+    let mut actual_users = read_all_rows(&client, namespace.clone(), users_table.clone()).await;
     for row in &mut actual_users {
         let _ = row.values_mut().pop(); // drop sequence_key
     }
@@ -593,7 +592,7 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     assert_table_rows_equal_ignoring_size(&actual_users, &expected_users);
 
     let mut actual_orders =
-        read_all_rows(&client, namespace.to_string(), orders_table.clone()).await;
+        read_all_rows(&client, namespace.clone(), orders_table.clone()).await;
     for row in &mut actual_orders {
         let _ = row.values_mut().pop(); // drop sequence_key
     }

--- a/etl-destinations/tests/support/bigquery.rs
+++ b/etl-destinations/tests/support/bigquery.rs
@@ -166,7 +166,7 @@ impl From<TableRow> for NullableColsScalar {
         fn parse_unix_timestamp_from_cell(table_cell: TableCell) -> Option<DateTime<Utc>> {
             table_cell
                 .value
-                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .and_then(|v| v.as_str().map(ToString::to_string))
                 .and_then(|s| s.parse::<f64>().ok())
                 .and_then(|timestamp| {
                     let secs = timestamp.trunc() as i64;
@@ -591,7 +591,7 @@ impl From<TableRow> for NonNullableColsScalar {
         fn parse_unix_timestamp_from_cell(table_cell: TableCell) -> DateTime<Utc> {
             table_cell
                 .value
-                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .and_then(|v| v.as_str().map(ToString::to_string))
                 .and_then(|s| s.parse::<f64>().ok())
                 .and_then(|timestamp| {
                     let secs = timestamp.trunc() as i64;

--- a/etl-postgres/src/replication/db.rs
+++ b/etl-postgres/src/replication/db.rs
@@ -118,14 +118,8 @@ mod tests {
 
     #[test]
     fn extract_server_version_with_suffixes() {
-        assert_eq!(
-            extract_server_version("15.5 (Homebrew)"),
-            NonZeroI32::new(150500)
-        );
-        assert_eq!(
-            extract_server_version("14.2 on x86_64-pc-linux-gnu"),
-            NonZeroI32::new(140200)
-        );
+        assert_eq!(extract_server_version("15.5 (Homebrew)"), NonZeroI32::new(150500));
+        assert_eq!(extract_server_version("14.2 on x86_64-pc-linux-gnu"), NonZeroI32::new(140200));
         assert_eq!(
             extract_server_version("13.7 (Ubuntu 13.7-1.pgdg20.04+1)"),
             NonZeroI32::new(130700)

--- a/etl-postgres/src/replication/db.rs
+++ b/etl-postgres/src/replication/db.rs
@@ -109,7 +109,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extract_server_version_basic_versions() {
+    fn extract_server_version_basic_versions() {
         assert_eq!(extract_server_version("15.5"), NonZeroI32::new(150500));
         assert_eq!(extract_server_version("14.2"), NonZeroI32::new(140200));
         assert_eq!(extract_server_version("13.0"), NonZeroI32::new(130000));
@@ -117,9 +117,15 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_server_version_with_suffixes() {
-        assert_eq!(extract_server_version("15.5 (Homebrew)"), NonZeroI32::new(150500));
-        assert_eq!(extract_server_version("14.2 on x86_64-pc-linux-gnu"), NonZeroI32::new(140200));
+    fn extract_server_version_with_suffixes() {
+        assert_eq!(
+            extract_server_version("15.5 (Homebrew)"),
+            NonZeroI32::new(150500)
+        );
+        assert_eq!(
+            extract_server_version("14.2 on x86_64-pc-linux-gnu"),
+            NonZeroI32::new(140200)
+        );
         assert_eq!(
             extract_server_version("13.7 (Ubuntu 13.7-1.pgdg20.04+1)"),
             NonZeroI32::new(130700)
@@ -128,7 +134,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_server_version_patch_versions() {
+    fn extract_server_version_patch_versions() {
         // Test versions with patch numbers
         assert_eq!(extract_server_version("15.5.1"), NonZeroI32::new(150501));
         assert_eq!(extract_server_version("14.10.3"), NonZeroI32::new(141003));
@@ -136,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_server_version_invalid_inputs() {
+    fn extract_server_version_invalid_inputs() {
         // Test invalid inputs that should return None
         assert_eq!(extract_server_version(""), None);
         assert_eq!(extract_server_version("invalid"), None);
@@ -146,13 +152,13 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_server_version_zero_versions() {
+    fn extract_server_version_zero_versions() {
         assert_eq!(extract_server_version("0.0.0"), None);
         assert_eq!(extract_server_version("0.0"), None);
     }
 
     #[test]
-    fn test_extract_server_version_whitespace_handling() {
+    fn extract_server_version_whitespace_handling() {
         assert_eq!(extract_server_version("  15.5  "), NonZeroI32::new(150500));
         assert_eq!(extract_server_version("15.5\t(Homebrew)"), NonZeroI32::new(150500));
         assert_eq!(extract_server_version("15.5\n"), NonZeroI32::new(150500));

--- a/etl-postgres/src/replication/destination_metadata.rs
+++ b/etl-postgres/src/replication/destination_metadata.rs
@@ -81,7 +81,7 @@ pub async fn store_destination_table_metadata(
     .bind(SqlxTableId(table_id.into_inner()))
     .bind(destination_table_id)
     .bind(snapshot_id.to_pg_lsn_string())
-    .bind(previous_snapshot_id.map(|s| s.to_pg_lsn_string()))
+    .bind(previous_snapshot_id.map(SnapshotId::to_pg_lsn_string))
     .bind(schema_status)
     .bind(replication_mask)
     .execute(pool)

--- a/etl-postgres/src/replication/health.rs
+++ b/etl-postgres/src/replication/health.rs
@@ -20,7 +20,7 @@ where
     E: PgExecutor<'c>,
 {
     // Perform a single query checking all required relations via unnest
-    let table_names: Vec<String> = ETL_TABLE_NAMES.iter().map(|s| s.to_string()).collect();
+    let table_names: Vec<String> = ETL_TABLE_NAMES.iter().map(ToString::to_string).collect();
     let present: bool = sqlx::query_scalar(
         r#"
         select coalesce(bool_and(to_regclass(t) is not null), false)

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -437,7 +437,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_type_string_conversion() {
+    fn type_string_conversion() {
         let test_types = get_test_type_mappings();
 
         // Test type to string conversion

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -179,7 +179,7 @@ pub async fn store_table_schema(
         .await?;
 
     // Insert all columns
-    for column_schema in table_schema.column_schemas.iter() {
+    for column_schema in &table_schema.column_schemas {
         sqlx::query(
             r#"
             insert into etl.table_columns

--- a/etl-postgres/src/replication/slots.rs
+++ b/etl-postgres/src/replication/slots.rs
@@ -245,7 +245,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_apply_worker_slot_name() {
+    fn apply_worker_slot_name() {
         let pipeline_id = 1;
         let result: String = EtlReplicationSlot::for_apply_worker(pipeline_id).try_into().unwrap();
 
@@ -255,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    fn test_table_sync_slot_name() {
+    fn table_sync_slot_name() {
         let pipeline_id = 1;
         let result: String =
             EtlReplicationSlot::for_table_sync_worker(pipeline_id, TableId::new(123))
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn test_slot_name_length_validation() {
+    fn slot_name_length_validation() {
         // Test that normal slot names are within limits
         // Max u64
         let pipeline_id = 9223372036854775807_u64;
@@ -287,25 +287,25 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_sync_slot_prefix() {
+    fn apply_sync_slot_prefix() {
         let prefix = EtlReplicationSlot::apply_prefix(42).unwrap();
         assert_eq!(prefix, "supabase_etl_apply_42");
     }
 
     #[test]
-    fn test_table_sync_slot_prefix() {
+    fn table_sync_slot_prefix() {
         let prefix = EtlReplicationSlot::table_sync_prefix(42).unwrap();
         assert_eq!(prefix, "supabase_etl_table_sync_42_");
     }
 
     #[test]
-    fn test_parse_apply_slot() {
+    fn parse_apply_slot() {
         let parsed = EtlReplicationSlot::try_from("supabase_etl_apply_13").unwrap();
         assert_eq!(parsed, EtlReplicationSlot::Apply { pipeline_id: 13 });
     }
 
     #[test]
-    fn test_parse_table_sync_slot() {
+    fn parse_table_sync_slot() {
         let parsed = EtlReplicationSlot::try_from("supabase_etl_table_sync_7_12345").unwrap();
         assert_eq!(
             parsed,
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_invalid_slot() {
+    fn parse_invalid_slot() {
         assert!(EtlReplicationSlot::try_from("unknown_slot").is_err());
         assert!(EtlReplicationSlot::try_from("supabase_etl_apply_").is_err());
         assert!(EtlReplicationSlot::try_from("supabase_etl_table_sync_abc").is_err());

--- a/etl-postgres/src/types/schema.rs
+++ b/etl-postgres/src/types/schema.rs
@@ -703,7 +703,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_try_build_all_columns_replicated() {
+    fn replication_mask_try_build_all_columns_replicated() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "name", "age"].into_iter().map(String::from).collect();
@@ -714,7 +714,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_try_build_partial_columns_replicated() {
+    fn replication_mask_try_build_partial_columns_replicated() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "age"].into_iter().map(String::from).collect();
@@ -725,7 +725,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_try_build_no_columns_replicated() {
+    fn replication_mask_try_build_no_columns_replicated() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> = HashSet::new();
 
@@ -735,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_try_build_unknown_column_error() {
+    fn replication_mask_try_build_unknown_column_error() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "unknown_column"].into_iter().map(String::from).collect();
@@ -753,7 +753,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_try_build_multiple_unknown_columns_error() {
+    fn replication_mask_try_build_multiple_unknown_columns_error() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "foo", "bar"].into_iter().map(String::from).collect();
@@ -772,7 +772,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_build_or_all_success() {
+    fn replication_mask_build_or_all_success() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "age"].into_iter().map(String::from).collect();
@@ -783,7 +783,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_build_or_all_falls_back_to_all() {
+    fn replication_mask_build_or_all_falls_back_to_all() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "unknown_column"].into_iter().map(String::from).collect();
@@ -795,7 +795,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_all() {
+    fn replication_mask_all() {
         let schema = create_test_table_schema();
         let mask = ReplicationMask::all(&schema);
 
@@ -814,7 +814,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_diff_no_changes() {
+    fn schema_diff_no_changes() {
         let old_schema = create_replicated_schema(vec![
             ColumnSchema::new("id".to_string(), Type::INT4, -1, 1, Some(1), false),
             ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, true),
@@ -833,7 +833,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_diff_column_added() {
+    fn schema_diff_column_added() {
         let old_schema = create_replicated_schema(vec![
             ColumnSchema::new("id".to_string(), Type::INT4, -1, 1, Some(1), false),
             ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, true),
@@ -855,7 +855,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_diff_column_removed() {
+    fn schema_diff_column_removed() {
         let old_schema = create_replicated_schema(vec![
             ColumnSchema::new("id".to_string(), Type::INT4, -1, 1, Some(1), false),
             ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, true),
@@ -877,7 +877,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_diff_column_renamed() {
+    fn schema_diff_column_renamed() {
         let old_schema = create_replicated_schema(vec![
             ColumnSchema::new("id".to_string(), Type::INT4, -1, 1, Some(1), false),
             ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, true),
@@ -899,7 +899,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_diff_mixed_operations() {
+    fn schema_diff_mixed_operations() {
         // Old schema: id (pos 1), name (pos 2), age (pos 3)
         // New schema: id (pos 1), full_name (pos 2), email (pos 4)
         // Expected: age removed (pos 3), name -> full_name renamed (pos 2), email added
@@ -934,7 +934,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_diff_multiple_additions() {
+    fn schema_diff_multiple_additions() {
         let old_schema = create_replicated_schema(vec![ColumnSchema::new(
             "id".to_string(),
             Type::INT4,
@@ -961,7 +961,7 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_diff_multiple_removals() {
+    fn schema_diff_multiple_removals() {
         let old_schema = create_replicated_schema(vec![
             ColumnSchema::new("id".to_string(), Type::INT4, -1, 1, Some(1), false),
             ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, true),
@@ -988,7 +988,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_display_all_replicated() {
+    fn replication_mask_display_all_replicated() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "name", "age"].into_iter().map(String::from).collect();
@@ -999,7 +999,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_display_partial_replicated() {
+    fn replication_mask_display_partial_replicated() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> =
             ["id", "age"].into_iter().map(String::from).collect();
@@ -1010,7 +1010,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_display_none_replicated() {
+    fn replication_mask_display_none_replicated() {
         let schema = create_test_table_schema();
         let replicated_columns: HashSet<String> = HashSet::new();
 
@@ -1020,7 +1020,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replication_mask_display_empty() {
+    fn replication_mask_display_empty() {
         let mask = ReplicationMask::from_bytes(vec![]);
 
         assert_eq!(mask.to_string(), "()");

--- a/etl-postgres/src/types/schema.rs
+++ b/etl-postgres/src/types/schema.rs
@@ -323,7 +323,7 @@ impl TableSchema {
     /// This method checks if any column in the table is marked as part of the
     /// primary key.
     pub fn has_primary_keys(&self) -> bool {
-        self.column_schemas.iter().any(|cs| cs.primary_key())
+        self.column_schemas.iter().any(ColumnSchema::primary_key)
     }
 }
 

--- a/etl-postgres/src/types/utils.rs
+++ b/etl-postgres/src/types/utils.rs
@@ -64,7 +64,7 @@ pub fn generate_sequence_number(start_lsn: PgLsn, commit_lsn: PgLsn) -> String {
 mod tests {
     use super::*;
     #[test]
-    fn test_is_array_type() {
+    fn is_array_type_fn() {
         // array types
         assert!(is_array_type(&Type::BOOL_ARRAY));
         assert!(is_array_type(&Type::CHAR_ARRAY));
@@ -113,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_sequence_number() {
+    fn generate_sequence_number_fn() {
         assert_eq!(
             generate_sequence_number(PgLsn::from(0), PgLsn::from(0)),
             "0000000000000000/0000000000000000"

--- a/etl-postgres/src/version.rs
+++ b/etl-postgres/src/version.rs
@@ -54,7 +54,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_version_constants() {
+    fn version_constants() {
         assert_eq!(POSTGRES_14, 140000);
         assert_eq!(POSTGRES_15, 150000);
         assert_eq!(POSTGRES_16, 160000);
@@ -63,7 +63,7 @@ mod tests {
     }
 
     #[test]
-    fn test_meets_version_with_some() {
+    fn meets_version_with_some() {
         let version = NonZeroI32::new(150500);
         assert!(meets_version(version, POSTGRES_14));
         assert!(meets_version(version, POSTGRES_15));
@@ -73,7 +73,7 @@ mod tests {
     }
 
     #[test]
-    fn test_meets_version_with_none() {
+    fn meets_version_with_none() {
         assert!(!meets_version(None, POSTGRES_14));
         assert!(!meets_version(None, POSTGRES_15));
         assert!(!meets_version(None, POSTGRES_16));
@@ -82,13 +82,13 @@ mod tests {
     }
 
     #[test]
-    fn test_meets_version_exact_match() {
+    fn meets_version_exact_match() {
         let version = NonZeroI32::new(POSTGRES_15);
         assert!(meets_version(version, POSTGRES_15));
     }
 
     #[test]
-    fn test_requires_version_macro() {
+    fn requires_version_macro() {
         let version = NonZeroI32::new(160200);
         assert!(requires_version!(version, POSTGRES_14));
         assert!(requires_version!(version, POSTGRES_15));
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn test_below_version_macro() {
+    fn below_version_macro() {
         let version = NonZeroI32::new(140800);
         assert!(!below_version!(version, POSTGRES_14));
         assert!(below_version!(version, POSTGRES_15));
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    fn test_requires_version_with_none() {
+    fn requires_version_with_none() {
         let version: Option<NonZeroI32> = None;
         assert!(!requires_version!(version, POSTGRES_14));
         assert!(!requires_version!(version, POSTGRES_18));

--- a/etl-replicator/src/core.rs
+++ b/etl-replicator/src/core.rs
@@ -106,7 +106,7 @@ pub(crate) async fn start_replicator_with_config(
             .await
             .map_err(ReplicatorError::config)?;
             let namespace = match namespace {
-                Some(ns) => DestinationNamespace::Single(ns.to_string()),
+                Some(ns) => DestinationNamespace::Single(ns.clone()),
                 None => DestinationNamespace::OnePerSchema,
             };
             let destination = IcebergDestination::new(client, namespace, state_store.clone());
@@ -139,7 +139,7 @@ pub(crate) async fn start_replicator_with_config(
             .await
             .map_err(ReplicatorError::config)?;
             let namespace = match namespace {
-                Some(ns) => DestinationNamespace::Single(ns.to_string()),
+                Some(ns) => DestinationNamespace::Single(ns.clone()),
                 None => DestinationNamespace::OnePerSchema,
             };
             let destination = IcebergDestination::new(client, namespace, state_store.clone());

--- a/etl-replicator/src/error.rs
+++ b/etl-replicator/src/error.rs
@@ -4,7 +4,7 @@ use etl::error::EtlError;
 
 /// Returns whether terminal output should include backtraces.
 fn should_render_backtrace() -> bool {
-    matches!(std::env::var("RUST_BACKTRACE").as_deref(), Ok("1") | Ok("full"))
+    matches!(std::env::var("RUST_BACKTRACE").as_deref(), Ok("1" | "full"))
 }
 
 /// Result type for replicator operations.

--- a/etl-replicator/src/error.rs
+++ b/etl-replicator/src/error.rs
@@ -58,9 +58,9 @@ impl ReplicatorError {
     pub(crate) fn backtrace(&self) -> Option<&Backtrace> {
         match self {
             ReplicatorError::Etl(err) => err.backtrace(),
-            ReplicatorError::Config(_, cb) => Some(&cb.0),
-            ReplicatorError::Migration(_, cb) => Some(&cb.0),
-            ReplicatorError::Io(_, cb) => Some(&cb.0),
+            ReplicatorError::Config(_, cb)
+            | ReplicatorError::Migration(_, cb)
+            | ReplicatorError::Io(_, cb) => Some(&cb.0),
         }
     }
 

--- a/etl-replicator/src/error_notification.rs
+++ b/etl-replicator/src/error_notification.rs
@@ -161,14 +161,10 @@ mod tests {
 
     #[test]
     fn compute_error_hash_stability() {
-        let err1 = EtlError::from((
-            ErrorKind::SourceConnectionFailed,
-            "Database connection failed",
-        ));
-        let err2 = EtlError::from((
-            ErrorKind::SourceConnectionFailed,
-            "Database connection failed",
-        ));
+        let err1 =
+            EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
+        let err2 =
+            EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
 
         let hash1 = compute_error_hash(&err1);
         let hash2 = compute_error_hash(&err2);
@@ -198,10 +194,8 @@ mod tests {
 
     #[test]
     fn compute_error_hash_different_errors() {
-        let err1 = EtlError::from((
-            ErrorKind::SourceConnectionFailed,
-            "Database connection failed",
-        ));
+        let err1 =
+            EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
         let err2 = EtlError::from((ErrorKind::SourceQueryFailed, "Query execution failed"));
 
         let hash1 = compute_error_hash(&err1);

--- a/etl-replicator/src/error_notification.rs
+++ b/etl-replicator/src/error_notification.rs
@@ -160,11 +160,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_compute_error_hash_stability() {
-        let err1 =
-            EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
-        let err2 =
-            EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
+    fn compute_error_hash_stability() {
+        let err1 = EtlError::from((
+            ErrorKind::SourceConnectionFailed,
+            "Database connection failed",
+        ));
+        let err2 = EtlError::from((
+            ErrorKind::SourceConnectionFailed,
+            "Database connection failed",
+        ));
 
         let hash1 = compute_error_hash(&err1);
         let hash2 = compute_error_hash(&err2);
@@ -174,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_error_hash_with_detail() {
+    fn compute_error_hash_with_detail() {
         let err1 = EtlError::from((
             ErrorKind::SourceQueryFailed,
             "Query execution failed",
@@ -193,9 +197,11 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_error_hash_different_errors() {
-        let err1 =
-            EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
+    fn compute_error_hash_different_errors() {
+        let err1 = EtlError::from((
+            ErrorKind::SourceConnectionFailed,
+            "Database connection failed",
+        ));
         let err2 = EtlError::from((ErrorKind::SourceQueryFailed, "Query execution failed"));
 
         let hash1 = compute_error_hash(&err1);

--- a/etl-telemetry/src/tracing.rs
+++ b/etl-telemetry/src/tracing.rs
@@ -100,7 +100,7 @@ pub fn set_global_project_ref(project_ref: &str) {
 ///
 /// Returns `None` if no project reference has been set.
 pub fn get_global_project_ref() -> Option<&'static str> {
-    PROJECT_REF.get().map(|s| s.as_str())
+    PROJECT_REF.get().map(String::as_str)
 }
 
 /// Sets the global pipeline id for all tracing events.
@@ -403,7 +403,7 @@ fn panic_hook(panic_info: &PanicHookInfo) {
         "unknown panic payload"
     };
 
-    let location = panic_info.location().map(|location| location.to_string());
+    let location = panic_info.location().map(ToString::to_string);
 
     tracing::error!(
         panic.payload = payload,

--- a/etl/src/concurrency/memory_monitor.rs
+++ b/etl/src/concurrency/memory_monitor.rs
@@ -199,8 +199,7 @@ impl MemoryMonitor {
         self.inner
             .backpressure
             .as_ref()
-            .map(|backpressure| *backpressure.active_tx.borrow())
-            .unwrap_or(false)
+            .is_some_and(|backpressure| *backpressure.active_tx.borrow())
     }
 
     /// Creates a new subscription for polling backpressure updates.

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -180,10 +180,10 @@ fn calculate_tuple_bytes(tuple_data: &[protocol::TupleData]) -> u64 {
     tuple_data
         .iter()
         .map(|data| match data {
-            protocol::TupleData::Null => 0,
-            protocol::TupleData::UnchangedToast => 0,
-            protocol::TupleData::Text(bytes) => bytes.len() as u64,
-            protocol::TupleData::Binary(bytes) => bytes.len() as u64,
+            protocol::TupleData::Null | protocol::TupleData::UnchangedToast => 0,
+            protocol::TupleData::Text(bytes) | protocol::TupleData::Binary(bytes) => {
+                bytes.len() as u64
+            }
         })
         .sum()
 }

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -234,7 +234,7 @@ pub(crate) fn parse_replicated_column_names(
     let column_names = relation_body
         .columns()
         .iter()
-        .map(|column| column.name().map(|name| name.to_string()))
+        .map(|column| column.name().map(ToString::to_string))
         .collect::<Result<HashSet<String>, _>>()?;
 
     Ok(column_names)

--- a/etl/src/conversions/numeric.rs
+++ b/etl/src/conversions/numeric.rs
@@ -120,7 +120,7 @@ impl FromStr for PgNumeric {
         };
 
         // Check for special values (NaN, infinity)
-        if !matches!(chars.peek(), Some('0'..='9') | Some('.')) {
+        if !matches!(chars.peek(), Some('0'..='9' | '.')) {
             return parse_special_value(&mut chars, &sign);
         }
 
@@ -333,7 +333,7 @@ fn parse_numeric_value(
     }
 
     // Handle scientific notation
-    if matches!(chars.peek(), Some('e') | Some('E')) {
+    if matches!(chars.peek(), Some('e' | 'E')) {
         chars.next();
         let mut exponent = 0i64;
         let mut exp_negative = false;

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -456,12 +456,12 @@ impl From<serde_json::Error> for EtlError {
     fn from(err: serde_json::Error) -> EtlError {
         let (kind, description) = match err.classify() {
             serde_json::error::Category::Io => (ErrorKind::IoError, "JSON I/O operation failed"),
-            serde_json::error::Category::Syntax | serde_json::error::Category::Data => {
-                (ErrorKind::DeserializationError, "JSON deserialization failed")
-            }
-            serde_json::error::Category::Eof => {
-                (ErrorKind::DeserializationError, "JSON deserialization failed")
-            }
+            serde_json::error::Category::Syntax
+            | serde_json::error::Category::Data
+            | serde_json::error::Category::Eof => (
+                ErrorKind::DeserializationError,
+                "JSON deserialization failed",
+            ),
         };
 
         let detail = err.to_string();
@@ -910,6 +910,7 @@ impl From<ParseNumericError> for EtlError {
 /// [`ErrorKind::SourceConnectionFailed`].
 impl From<sqlx::Error> for EtlError {
     fn from(err: sqlx::Error) -> EtlError {
+        #[allow(clippy::match_same_arms)]
         let kind = match &err {
             sqlx::Error::Database(_) => ErrorKind::SourceQueryFailed,
             sqlx::Error::Io(_) => ErrorKind::IoError,

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -996,15 +996,18 @@ mod tests {
     use crate::{bail, etl_error};
 
     #[test]
-    fn test_simple_error_creation() {
-        let err = EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
+    fn simple_error_creation() {
+        let err = EtlError::from((
+            ErrorKind::SourceConnectionFailed,
+            "Database connection failed",
+        ));
         assert_eq!(err.kind(), ErrorKind::SourceConnectionFailed);
         assert_eq!(err.detail(), None);
         assert_eq!(err.kinds(), vec![ErrorKind::SourceConnectionFailed]);
     }
 
     #[test]
-    fn test_error_with_detail() {
+    fn error_with_detail() {
         let err = EtlError::from((
             ErrorKind::SourceQueryFailed,
             "SQL query execution failed",
@@ -1016,7 +1019,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_errors() {
+    fn multiple_errors() {
         let errors = vec![
             EtlError::from((ErrorKind::ValidationError, "Invalid schema")),
             EtlError::from((ErrorKind::ConversionError, "Type mismatch")),
@@ -1033,7 +1036,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_errors_with_detail() {
+    fn multiple_errors_with_detail() {
         let errors = vec![
             EtlError::from((
                 ErrorKind::ValidationError,
@@ -1048,7 +1051,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_vector() {
+    fn from_vector() {
         let errors = vec![
             EtlError::from((ErrorKind::ValidationError, "Error 1")),
             EtlError::from((ErrorKind::ConversionError, "Error 2")),
@@ -1058,7 +1061,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_vector_single_error_not_wrapped() {
+    fn from_vector_single_error_not_wrapped() {
         let error = EtlError::from((ErrorKind::ValidationError, "Single error"));
         let errors = vec![error];
         let result = EtlError::from(errors);
@@ -1069,7 +1072,7 @@ mod tests {
     }
 
     #[test]
-    fn test_error_equality() {
+    fn error_equality() {
         let err1 = EtlError::from((ErrorKind::SourceConnectionFailed, "Connection failed"));
         let err2 = EtlError::from((ErrorKind::SourceConnectionFailed, "Connection failed"));
         let err3 = EtlError::from((ErrorKind::SourceQueryFailed, "Query failed"));
@@ -1079,7 +1082,7 @@ mod tests {
     }
 
     #[test]
-    fn test_error_source_preserved() {
+    fn error_source_preserved() {
         let io_err = std::io::Error::other("boom");
         let err = EtlError::from(io_err);
         let source = err.source().expect("missing source");
@@ -1087,7 +1090,7 @@ mod tests {
     }
 
     #[test]
-    fn test_many_forwards_source() {
+    fn many_forwards_source() {
         let inner = EtlError::from(std::io::Error::other("inner failure"));
         let outer: EtlError = vec![inner.clone(), EtlError::from((ErrorKind::Unknown, "x"))].into();
         let source = outer.source().expect("missing aggregate source");
@@ -1095,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_usage() {
+    fn macro_usage() {
         let err = etl_error!(ErrorKind::ValidationError, "Invalid data format");
         assert_eq!(err.kind(), ErrorKind::ValidationError);
         assert_eq!(err.detail(), None);
@@ -1115,7 +1118,7 @@ mod tests {
     }
 
     #[test]
-    fn test_macro_with_source() {
+    fn macro_with_source() {
         let err = etl_error!(
             ErrorKind::IoError,
             "I/O failure",
@@ -1127,7 +1130,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bail_macro() {
+    fn bail_macro() {
         fn test_function() -> EtlResult<i32> {
             bail!(ErrorKind::ValidationError, "Test error");
         }
@@ -1174,7 +1177,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_multiple_errors() {
+    fn nested_multiple_errors() {
         let inner_errors = vec![
             EtlError::from((ErrorKind::ConversionError, "Inner error 1")),
             EtlError::from((ErrorKind::ValidationError, "Inner error 2")),
@@ -1192,7 +1195,7 @@ mod tests {
     }
 
     #[test]
-    fn test_json_error_classification() {
+    fn json_error_classification() {
         // Test syntax error during deserialization
         let json_err = serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
         let etl_err = EtlError::from(json_err);
@@ -1207,11 +1210,9 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_stability() {
-        use std::{
-            collections::hash_map::DefaultHasher,
-            hash::{Hash, Hasher},
-        };
+    fn hash_stability() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
 
         // Same error kind and description should produce same hash.
         let err1 =
@@ -1231,11 +1232,9 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_ignores_detail() {
-        use std::{
-            collections::hash_map::DefaultHasher,
-            hash::{Hash, Hasher},
-        };
+    fn hash_ignores_detail() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
 
         // Same kind and description with different details should produce same hash.
         let err1 = EtlError::from((
@@ -1261,11 +1260,9 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_distinguishes_different_errors() {
-        use std::{
-            collections::hash_map::DefaultHasher,
-            hash::{Hash, Hasher},
-        };
+    fn hash_distinguishes_different_errors() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
 
         // Different error kinds should produce different hashes.
         let err1 = EtlError::from((ErrorKind::SourceConnectionFailed, "Connection failed"));
@@ -1283,11 +1280,9 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_aggregated_errors() {
-        use std::{
-            collections::hash_map::DefaultHasher,
-            hash::{Hash, Hasher},
-        };
+    fn hash_aggregated_errors() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
 
         // Aggregated errors should hash all contained errors.
         let errors1 = vec![

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -167,9 +167,9 @@ impl EtlError {
     pub fn kind(&self) -> ErrorKind {
         match self.repr {
             ErrorRepr::Single(ref payload) => payload.kind,
-            ErrorRepr::Many { ref errors, .. } => errors
-                .first()
-                .map_or(ErrorKind::Unknown, |err| err.kind()),
+            ErrorRepr::Many { ref errors, .. } => {
+                errors.first().map_or(ErrorKind::Unknown, EtlError::kind)
+            }
         }
     }
 
@@ -181,7 +181,7 @@ impl EtlError {
         match self.repr {
             ErrorRepr::Single(ref payload) => vec![payload.kind],
             ErrorRepr::Many { ref errors, .. } => {
-                errors.iter().flat_map(|err| err.kinds()).collect::<Vec<_>>()
+                errors.iter().flat_map(EtlError::kinds).collect::<Vec<_>>()
             }
         }
     }

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -458,10 +458,9 @@ impl From<serde_json::Error> for EtlError {
             serde_json::error::Category::Io => (ErrorKind::IoError, "JSON I/O operation failed"),
             serde_json::error::Category::Syntax
             | serde_json::error::Category::Data
-            | serde_json::error::Category::Eof => (
-                ErrorKind::DeserializationError,
-                "JSON deserialization failed",
-            ),
+            | serde_json::error::Category::Eof => {
+                (ErrorKind::DeserializationError, "JSON deserialization failed")
+            }
         };
 
         let detail = err.to_string();
@@ -997,10 +996,7 @@ mod tests {
 
     #[test]
     fn simple_error_creation() {
-        let err = EtlError::from((
-            ErrorKind::SourceConnectionFailed,
-            "Database connection failed",
-        ));
+        let err = EtlError::from((ErrorKind::SourceConnectionFailed, "Database connection failed"));
         assert_eq!(err.kind(), ErrorKind::SourceConnectionFailed);
         assert_eq!(err.detail(), None);
         assert_eq!(err.kinds(), vec![ErrorKind::SourceConnectionFailed]);
@@ -1211,8 +1207,10 @@ mod tests {
 
     #[test]
     fn hash_stability() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
 
         // Same error kind and description should produce same hash.
         let err1 =
@@ -1233,8 +1231,10 @@ mod tests {
 
     #[test]
     fn hash_ignores_detail() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
 
         // Same kind and description with different details should produce same hash.
         let err1 = EtlError::from((
@@ -1261,8 +1261,10 @@ mod tests {
 
     #[test]
     fn hash_distinguishes_different_errors() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
 
         // Different error kinds should produce different hashes.
         let err1 = EtlError::from((ErrorKind::SourceConnectionFailed, "Connection failed"));
@@ -1281,8 +1283,10 @@ mod tests {
 
     #[test]
     fn hash_aggregated_errors() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
 
         // Aggregated errors should hash all contained errors.
         let errors1 = vec![

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -167,9 +167,9 @@ impl EtlError {
     pub fn kind(&self) -> ErrorKind {
         match self.repr {
             ErrorRepr::Single(ref payload) => payload.kind,
-            ErrorRepr::Many { ref errors, .. } => {
-                errors.first().map(|err| err.kind()).unwrap_or(ErrorKind::Unknown)
-            }
+            ErrorRepr::Many { ref errors, .. } => errors
+                .first()
+                .map_or(ErrorKind::Unknown, |err| err.kind()),
         }
     }
 

--- a/etl/src/failpoints.rs
+++ b/etl/src/failpoints.rs
@@ -33,7 +33,6 @@ pub fn etl_fail_point(name: &str) -> EtlResult<()> {
         let mut error_kind = ErrorKind::WithNoRetry;
         if let Some(parameter) = parameter {
             error_kind = match parameter.as_str() {
-                "no_retry" => ErrorKind::WithNoRetry,
                 "manual_retry" => ErrorKind::WithManualRetry,
                 "timed_retry" => ErrorKind::WithTimedRetry,
                 _ => ErrorKind::WithNoRetry,

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1752,7 +1752,10 @@ where
         // the schema.
         let shared_table_state = self.shared_table_cache.get(&table_id).await;
         let used_bootstrap_snapshot = shared_table_state.is_none();
-        let table_snapshot_id = shared_table_state.map_or_else(|| self.state.bootstrap_snapshot_id(), |state| state.snapshot_id);
+        let table_snapshot_id = shared_table_state.map_or_else(
+            || self.state.bootstrap_snapshot_id(),
+            |state| state.snapshot_id,
+        );
         let table_schema = get_table_schema(
             &self.schema_store,
             &table_id,

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1752,10 +1752,8 @@ where
         // the schema.
         let shared_table_state = self.shared_table_cache.get(&table_id).await;
         let used_bootstrap_snapshot = shared_table_state.is_none();
-        let table_snapshot_id = shared_table_state.map_or_else(
-            || self.state.bootstrap_snapshot_id(),
-            |state| state.snapshot_id,
-        );
+        let table_snapshot_id = shared_table_state
+            .map_or_else(|| self.state.bootstrap_snapshot_id(), |state| state.snapshot_id);
         let table_schema = get_table_schema(
             &self.schema_store,
             &table_id,

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1915,7 +1915,7 @@ where
 
         // Collect the replicated schemas for tables this worker currently owns.
         let mut truncated_tables = Vec::with_capacity(message.rel_ids().len());
-        for &rel_id in message.rel_ids().iter() {
+        for &rel_id in message.rel_ids() {
             let table_id = TableId::new(rel_id);
 
             // Exactly one worker owns protocol interpretation for a table at a time, so

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1752,9 +1752,7 @@ where
         // the schema.
         let shared_table_state = self.shared_table_cache.get(&table_id).await;
         let used_bootstrap_snapshot = shared_table_state.is_none();
-        let table_snapshot_id = shared_table_state
-            .map(|state| state.snapshot_id)
-            .unwrap_or_else(|| self.state.bootstrap_snapshot_id());
+        let table_snapshot_id = shared_table_state.map_or_else(|| self.state.bootstrap_snapshot_id(), |state| state.snapshot_id);
         let table_schema = get_table_schema(
             &self.schema_store,
             &table_id,

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1021,7 +1021,7 @@ where
 
     /// Waits until the keep alive deadline expires.
     async fn wait_for_keep_alive_deadline(deadline: Instant) {
-        tokio::time::sleep_until(deadline.into()).await
+        tokio::time::sleep_until(deadline.into()).await;
     }
 
     /// Computes the keep alive deadline from PostgreSQL's `wal_sender_timeout`.

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -625,7 +625,7 @@ impl PgReplicationClient {
 
                 return match wal_status.as_deref() {
                     Some("lost") => Ok(SlotState::Invalidated),
-                    Some(_) => Ok(SlotState::Valid),
+                    Some(_) |
                     // If wal_status is NULL, assume the slot is valid
                     // (this can happen on very old PostgreSQL versions)
                     None => Ok(SlotState::Valid),

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -721,19 +721,18 @@ impl PgReplicationClient {
         // `create_slot_internal`.
         let query = format!(r#"DROP_REPLICATION_SLOT {} WAIT;"#, quote_identifier(slot_name));
 
-        let delete_result =
-            match tokio::time::timeout(DELETE_SLOT_TIMEOUT, self.client.simple_query(&query)).await
-            {
-                Ok(result) => result,
-                Err(_) => bail!(
-                    ErrorKind::ReplicationSlotDeletionTimeout,
-                    "Replication slot deletion timed out",
-                    format!(
-                        "Timed out after {:?} while deleting replication slot '{}'",
-                        DELETE_SLOT_TIMEOUT, slot_name
-                    )
-                ),
-            };
+        let Ok(delete_result) =
+            tokio::time::timeout(DELETE_SLOT_TIMEOUT, self.client.simple_query(&query)).await
+        else {
+            bail!(
+                ErrorKind::ReplicationSlotDeletionTimeout,
+                "Replication slot deletion timed out",
+                format!(
+                    "Timed out after {:?} while deleting replication slot '{}'",
+                    DELETE_SLOT_TIMEOUT, slot_name
+                )
+            )
+        };
 
         match delete_result {
             Ok(_) => {

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -877,7 +877,7 @@ impl PgReplicationClient {
                 let name =
                     Self::get_row_value::<String>(&row, "tablename", "pg_publication_tables")?;
 
-                table_names.push(TableName { schema, name })
+                table_names.push(TableName { schema, name });
             }
         }
 

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -119,6 +119,7 @@ impl StatusUpdateType {
     /// Returns `true` whether this status update type requires a reply from
     /// Postgres, `false` otherwise.
     fn request_reply(&self) -> bool {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::KeepAlive => false,
             Self::PeriodicKeepAlive => true,

--- a/etl/src/replication/table_cache.rs
+++ b/etl/src/replication/table_cache.rs
@@ -119,7 +119,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_note_replication_mask_and_get() {
+    async fn note_replication_mask_and_get() {
         let cache = SharedTableCache::new();
         let table_id = TableId::new(123);
         let snapshot_id = SnapshotId::new(10.into());
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_note_schema_snapshot_invalidates_replication_mask() {
+    async fn note_schema_snapshot_invalidates_replication_mask() {
         let cache = SharedTableCache::new();
         let table_id = TableId::new(123);
         let replication_mask = create_test_mask();
@@ -151,7 +151,7 @@ mod tests {
 
     #[should_panic(expected = "shared table cache received stale snapshot update")]
     #[tokio::test]
-    async fn test_older_snapshot_panics() {
+    async fn older_snapshot_panics() {
         let cache = SharedTableCache::new();
         let table_id = TableId::new(123);
         let replication_mask = create_test_mask();
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_clone_shares_state() {
+    async fn clone_shares_state() {
         let cache1 = SharedTableCache::new();
         let cache2 = cache1.clone();
         let table_id = TableId::new(123);

--- a/etl/src/state/table.rs
+++ b/etl/src/state/table.rs
@@ -450,6 +450,7 @@ impl TableReplicationPhaseType {
     /// Returns `true` if the phase should be saved into the state store,
     /// `false` otherwise.
     pub fn should_store(&self) -> bool {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::Init => true,
             Self::DataSync => true,
@@ -468,6 +469,7 @@ impl TableReplicationPhaseType {
     /// A table is done processing, when its events are being processed by the
     /// apply worker instead of a table sync worker or when it has errored.
     pub fn is_done(&self) -> bool {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::Init => false,
             Self::DataSync => false,

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -133,11 +133,8 @@ impl StateStore for MemoryStore {
         let mut inner = self.inner.lock().await;
 
         // Get the previous state from history
-        let previous_state = inner
-            .table_state_history
-            .get_mut(&table_id)
-            .and_then(Vec::pop)
-            .ok_or_else(|| {
+        let previous_state =
+            inner.table_state_history.get_mut(&table_id).and_then(Vec::pop).ok_or_else(|| {
                 etl_error!(
                     ErrorKind::StateRollbackError,
                     "No previous state available to roll back to"

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -136,7 +136,7 @@ impl StateStore for MemoryStore {
         let previous_state = inner
             .table_state_history
             .get_mut(&table_id)
-            .and_then(|history| history.pop())
+            .and_then(Vec::pop)
             .ok_or_else(|| {
                 etl_error!(
                     ErrorKind::StateRollbackError,

--- a/etl/src/test_utils/event.rs
+++ b/etl/src/test_utils/event.rs
@@ -1,3 +1,5 @@
+use crate::types::{Event, EventType, TableRow};
+use etl_postgres::types::{ReplicatedTableSchema, TableId};
 use std::collections::HashMap;
 
 use etl_postgres::types::TableId;
@@ -35,9 +37,11 @@ pub fn group_events_by_type_and_table_id(
             Event::Insert(event) => vec![event.replicated_table_schema.id()],
             Event::Update(event) => vec![event.replicated_table_schema.id()],
             Event::Delete(event) => vec![event.replicated_table_schema.id()],
-            Event::Truncate(event) => {
-                event.truncated_tables.iter().map(|schema| schema.id()).collect()
-            }
+            Event::Truncate(event) => event
+                .truncated_tables
+                .iter()
+                .map(ReplicatedTableSchema::id)
+                .collect(),
             _ => vec![],
         };
         for table_id in table_ids {
@@ -75,8 +79,16 @@ fn events_equal(a: &Event, b: &Event) -> bool {
             }
 
             // Compare table IDs of truncated tables
-            let a_ids: Vec<_> = a.truncated_tables.iter().map(|s| s.id()).collect();
-            let b_ids: Vec<_> = b.truncated_tables.iter().map(|s| s.id()).collect();
+            let a_ids: Vec<_> = a
+                .truncated_tables
+                .iter()
+                .map(ReplicatedTableSchema::id)
+                .collect();
+            let b_ids: Vec<_> = b
+                .truncated_tables
+                .iter()
+                .map(ReplicatedTableSchema::id)
+                .collect();
 
             a_ids == b_ids
         }
@@ -135,9 +147,7 @@ pub fn check_all_events_count(
                 .map_or(0, |events| events.len() as u64);
 
             let table_row_count = if *event_type == EventType::Insert {
-                table_rows
-                    .get(table_id)
-                    .map_or(0, |rows| rows.len() as u64)
+                table_rows.get(table_id).map_or(0, |rows| rows.len() as u64)
             } else {
                 0
             };

--- a/etl/src/test_utils/event.rs
+++ b/etl/src/test_utils/event.rs
@@ -1,8 +1,6 @@
-use crate::types::{Event, EventType, TableRow};
-use etl_postgres::types::{ReplicatedTableSchema, TableId};
 use std::collections::HashMap;
 
-use etl_postgres::types::TableId;
+use etl_postgres::types::{ReplicatedTableSchema, TableId};
 
 use crate::types::{Event, EventType, TableRow};
 
@@ -37,11 +35,9 @@ pub fn group_events_by_type_and_table_id(
             Event::Insert(event) => vec![event.replicated_table_schema.id()],
             Event::Update(event) => vec![event.replicated_table_schema.id()],
             Event::Delete(event) => vec![event.replicated_table_schema.id()],
-            Event::Truncate(event) => event
-                .truncated_tables
-                .iter()
-                .map(ReplicatedTableSchema::id)
-                .collect(),
+            Event::Truncate(event) => {
+                event.truncated_tables.iter().map(ReplicatedTableSchema::id).collect()
+            }
             _ => vec![],
         };
         for table_id in table_ids {
@@ -59,9 +55,7 @@ pub fn check_events_count(events: &[Event], conditions: Vec<(EventType, u64)>) -
     let grouped_events = group_events_by_type(events);
 
     conditions.into_iter().all(|(event_type, count)| {
-        grouped_events
-            .get(&event_type)
-            .is_some_and(|inner| inner.len() == count as usize)
+        grouped_events.get(&event_type).is_some_and(|inner| inner.len() == count as usize)
     })
 }
 
@@ -79,16 +73,8 @@ fn events_equal(a: &Event, b: &Event) -> bool {
             }
 
             // Compare table IDs of truncated tables
-            let a_ids: Vec<_> = a
-                .truncated_tables
-                .iter()
-                .map(ReplicatedTableSchema::id)
-                .collect();
-            let b_ids: Vec<_> = b
-                .truncated_tables
-                .iter()
-                .map(ReplicatedTableSchema::id)
-                .collect();
+            let a_ids: Vec<_> = a.truncated_tables.iter().map(ReplicatedTableSchema::id).collect();
+            let b_ids: Vec<_> = b.truncated_tables.iter().map(ReplicatedTableSchema::id).collect();
 
             a_ids == b_ids
         }
@@ -129,9 +115,8 @@ pub fn check_all_events_count(
 
     conditions.iter().all(|condition| match condition {
         EventCondition::Any(event_type, expected_count) => {
-            let event_count = grouped_events_by_type
-                .get(event_type)
-                .map_or(0, |events| events.len() as u64);
+            let event_count =
+                grouped_events_by_type.get(event_type).map_or(0, |events| events.len() as u64);
 
             let table_row_count = if *event_type == EventType::Insert {
                 table_rows.values().map(|rows| rows.len() as u64).sum()

--- a/etl/src/test_utils/event.rs
+++ b/etl/src/test_utils/event.rs
@@ -55,7 +55,9 @@ pub fn check_events_count(events: &[Event], conditions: Vec<(EventType, u64)>) -
     let grouped_events = group_events_by_type(events);
 
     conditions.into_iter().all(|(event_type, count)| {
-        grouped_events.get(&event_type).map(|inner| inner.len() == count as usize).unwrap_or(false)
+        grouped_events
+            .get(&event_type)
+            .is_some_and(|inner| inner.len() == count as usize)
     })
 }
 
@@ -117,8 +119,7 @@ pub fn check_all_events_count(
         EventCondition::Any(event_type, expected_count) => {
             let event_count = grouped_events_by_type
                 .get(event_type)
-                .map(|events| events.len() as u64)
-                .unwrap_or(0);
+                .map_or(0, |events| events.len() as u64);
 
             let table_row_count = if *event_type == EventType::Insert {
                 table_rows.values().map(|rows| rows.len() as u64).sum()
@@ -131,11 +132,12 @@ pub fn check_all_events_count(
         EventCondition::Table(event_type, table_id, expected_count) => {
             let event_count = grouped_events_by_type_and_table
                 .get(&(event_type.clone(), *table_id))
-                .map(|events| events.len() as u64)
-                .unwrap_or(0);
+                .map_or(0, |events| events.len() as u64);
 
             let table_row_count = if *event_type == EventType::Insert {
-                table_rows.get(table_id).map(|rows| rows.len() as u64).unwrap_or(0)
+                table_rows
+                    .get(table_id)
+                    .map_or(0, |rows| rows.len() as u64)
             } else {
                 0
             };

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -290,7 +290,7 @@ impl StateStore for NotifyingStore {
         let previous_state = inner
             .table_state_history
             .get_mut(&table_id)
-            .and_then(|history| history.pop())
+            .and_then(Vec::pop)
             .ok_or_else(|| {
                 etl_error!(
                     ErrorKind::StateRollbackError,
@@ -374,7 +374,7 @@ impl SchemaStore for NotifyingStore {
     async fn load_table_schemas(&self) -> EtlResult<usize> {
         let inner = self.inner.read().await;
 
-        Ok(inner.table_schemas.values().map(|v| v.len()).sum())
+        Ok(inner.table_schemas.values().map(Vec::len).sum())
     }
 
     async fn store_table_schema(&self, table_schema: TableSchema) -> EtlResult<Arc<TableSchema>> {

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -287,11 +287,8 @@ impl StateStore for NotifyingStore {
         let mut inner = self.inner.write().await;
 
         // Get the previous state from history
-        let previous_state = inner
-            .table_state_history
-            .get_mut(&table_id)
-            .and_then(Vec::pop)
-            .ok_or_else(|| {
+        let previous_state =
+            inner.table_state_history.get_mut(&table_id).and_then(Vec::pop).ok_or_else(|| {
                 etl_error!(
                     ErrorKind::StateRollbackError,
                     "No previous state available to roll back to"

--- a/etl/src/test_utils/test_schema.rs
+++ b/etl/src/test_utils/test_schema.rs
@@ -344,8 +344,16 @@ pub fn events_equal_excluding_fields(left: &Event, right: &Event) -> bool {
             }
 
             // Compare table IDs of truncated tables
-            let left_ids: Vec<_> = left.truncated_tables.iter().map(|s| s.id()).collect();
-            let right_ids: Vec<_> = right.truncated_tables.iter().map(|s| s.id()).collect();
+            let left_ids: Vec<_> = left
+                .truncated_tables
+                .iter()
+                .map(ReplicatedTableSchema::id)
+                .collect();
+            let right_ids: Vec<_> = right
+                .truncated_tables
+                .iter()
+                .map(ReplicatedTableSchema::id)
+                .collect();
             left_ids == right_ids
         }
         (Event::Relation(left), Event::Relation(right)) => {

--- a/etl/src/test_utils/test_schema.rs
+++ b/etl/src/test_utils/test_schema.rs
@@ -344,16 +344,10 @@ pub fn events_equal_excluding_fields(left: &Event, right: &Event) -> bool {
             }
 
             // Compare table IDs of truncated tables
-            let left_ids: Vec<_> = left
-                .truncated_tables
-                .iter()
-                .map(ReplicatedTableSchema::id)
-                .collect();
-            let right_ids: Vec<_> = right
-                .truncated_tables
-                .iter()
-                .map(ReplicatedTableSchema::id)
-                .collect();
+            let left_ids: Vec<_> =
+                left.truncated_tables.iter().map(ReplicatedTableSchema::id).collect();
+            let right_ids: Vec<_> =
+                right.truncated_tables.iter().map(ReplicatedTableSchema::id).collect();
             left_ids == right_ids
         }
         (Event::Relation(left), Event::Relation(right)) => {

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -281,9 +281,8 @@ async fn exclusive_pipeline_recovers_when_slot_invalidated_with_recreate_behavio
 
     // Validate that we have users data.
     let table_rows = destination.get_table_rows().await;
-    let users_table_copied_rows = table_rows
-        .get(&database_schema.users_schema().id)
-        .map_or(0, Vec::len);
+    let users_table_copied_rows =
+        table_rows.get(&database_schema.users_schema().id).map_or(0, Vec::len);
     assert_eq!(users_table_copied_rows, 5);
 
     // Wait for the slot to become inactive.
@@ -323,9 +322,8 @@ async fn exclusive_pipeline_recovers_when_slot_invalidated_with_recreate_behavio
 
     // Validate that we have users data.
     let table_rows = destination.get_table_rows().await;
-    let users_table_copied_rows = table_rows
-        .get(&database_schema.users_schema().id)
-        .map_or(0, Vec::len);
+    let users_table_copied_rows =
+        table_rows.get(&database_schema.users_schema().id).map_or(0, Vec::len);
     assert_eq!(users_table_copied_rows, 5);
 
     // Verify the slot was recreated and is active.
@@ -1880,17 +1878,14 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
 
-    let users_copied_rows = table_rows
-        .get(&database_schema.users_schema().id)
-        .map_or(0, Vec::len);
+    let users_copied_rows = table_rows.get(&database_schema.users_schema().id).map_or(0, Vec::len);
     let users_insert_events = grouped_events
         .get(&(EventType::Insert, database_schema.users_schema().id))
         .map_or(0, Vec::len);
     let total_users = users_copied_rows + users_insert_events;
 
-    let orders_copied_rows = table_rows
-        .get(&database_schema.orders_schema().id)
-        .map_or(0, Vec::len);
+    let orders_copied_rows =
+        table_rows.get(&database_schema.orders_schema().id).map_or(0, Vec::len);
     let orders_insert_events = grouped_events
         .get(&(EventType::Insert, database_schema.orders_schema().id))
         .map_or(0, Vec::len);

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -283,7 +283,7 @@ async fn exclusive_pipeline_recovers_when_slot_invalidated_with_recreate_behavio
     let table_rows = destination.get_table_rows().await;
     let users_table_copied_rows = table_rows
         .get(&database_schema.users_schema().id)
-        .map_or(0, |r| r.len());
+        .map_or(0, Vec::len);
     assert_eq!(users_table_copied_rows, 5);
 
     // Wait for the slot to become inactive.
@@ -325,7 +325,7 @@ async fn exclusive_pipeline_recovers_when_slot_invalidated_with_recreate_behavio
     let table_rows = destination.get_table_rows().await;
     let users_table_copied_rows = table_rows
         .get(&database_schema.users_schema().id)
-        .map_or(0, |r| r.len());
+        .map_or(0, Vec::len);
     assert_eq!(users_table_copied_rows, 5);
 
     // Verify the slot was recreated and is active.
@@ -391,7 +391,7 @@ async fn table_copy_replicates_many_rows_with_parallel_connections() {
 
     // Verify that all 100k rows were copied.
     let table_rows = destination.get_table_rows().await;
-    let copied_rows = table_rows.get(&table_id).map_or(0, |r| r.len());
+    let copied_rows = table_rows.get(&table_id).map_or(0, Vec::len);
     assert_eq!(copied_rows, total_rows as usize);
 }
 
@@ -462,7 +462,7 @@ async fn table_copy_with_row_filter_and_parallel_connections() {
 
     // Verify that only rows matching the filter were copied.
     let table_rows = destination.get_table_rows().await;
-    let copied_rows = table_rows.get(&table_id).map_or(0, |r| r.len());
+    let copied_rows = table_rows.get(&table_id).map_or(0, Vec::len);
     assert_eq!(copied_rows, expected_rows);
 }
 
@@ -867,12 +867,8 @@ async fn run_table_sync_copy_case<F>(
 
     // We validate that the table rows are correct.
     let table_rows = destination.get_table_rows().await;
-    let users_table_copied_rows = table_rows
-        .get(&users_table_id)
-        .map_or(0, |r| r.len());
-    let orders_table_copied_rows = table_rows
-        .get(&orders_table_id)
-        .map_or(0, |r| r.len());
+    let users_table_copied_rows = table_rows.get(&users_table_id).map_or(0, Vec::len);
+    let orders_table_copied_rows = table_rows.get(&orders_table_id).map_or(0, Vec::len);
     assert_eq!(users_table_copied_rows, expected_users_copied_rows);
     assert_eq!(orders_table_copied_rows, expected_orders_copied_rows);
     // We always expect the method to be called since the downstream table should be
@@ -1785,7 +1781,7 @@ async fn table_sync_truncates_destination_after_state_reset() {
     let users_rows = table_rows_after.get(&database_schema.users_schema().id).unwrap().len();
     let users_events = grouped_events_after
         .get(&(EventType::Insert, database_schema.users_schema().id))
-        .map_or(0, |v| v.len());
+        .map_or(0, Vec::len);
     assert_eq!(users_rows + users_events, total_expected_users);
 
     // Orders: no data, since we cleared it before restart and nothing should happen
@@ -1886,18 +1882,18 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
 
     let users_copied_rows = table_rows
         .get(&database_schema.users_schema().id)
-        .map_or(0, |r| r.len());
+        .map_or(0, Vec::len);
     let users_insert_events = grouped_events
         .get(&(EventType::Insert, database_schema.users_schema().id))
-        .map_or(0, |e| e.len());
+        .map_or(0, Vec::len);
     let total_users = users_copied_rows + users_insert_events;
 
     let orders_copied_rows = table_rows
         .get(&database_schema.orders_schema().id)
-        .map_or(0, |r| r.len());
+        .map_or(0, Vec::len);
     let orders_insert_events = grouped_events
         .get(&(EventType::Insert, database_schema.orders_schema().id))
-        .map_or(0, |e| e.len());
+        .map_or(0, Vec::len);
     let total_orders = orders_copied_rows + orders_insert_events;
 
     assert_eq!(total_users, rows_to_insert);
@@ -1992,17 +1988,17 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
 
     let users_updates = grouped_events
         .get(&(EventType::Update, database_schema.users_schema().id))
-        .map_or(0, |e| e.len());
+        .map_or(0, Vec::len);
     let users_deletes = grouped_events
         .get(&(EventType::Delete, database_schema.users_schema().id))
-        .map_or(0, |e| e.len());
+        .map_or(0, Vec::len);
 
     let orders_updates = grouped_events
         .get(&(EventType::Update, database_schema.orders_schema().id))
-        .map_or(0, |e| e.len());
+        .map_or(0, Vec::len);
     let orders_deletes = grouped_events
         .get(&(EventType::Delete, database_schema.orders_schema().id))
-        .map_or(0, |e| e.len());
+        .map_or(0, Vec::len);
 
     assert_eq!(users_updates, rows_to_update);
     assert_eq!(users_deletes, rows_to_delete);

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -281,8 +281,9 @@ async fn exclusive_pipeline_recovers_when_slot_invalidated_with_recreate_behavio
 
     // Validate that we have users data.
     let table_rows = destination.get_table_rows().await;
-    let users_table_copied_rows =
-        table_rows.get(&database_schema.users_schema().id).map(|r| r.len()).unwrap_or(0);
+    let users_table_copied_rows = table_rows
+        .get(&database_schema.users_schema().id)
+        .map_or(0, |r| r.len());
     assert_eq!(users_table_copied_rows, 5);
 
     // Wait for the slot to become inactive.
@@ -322,8 +323,9 @@ async fn exclusive_pipeline_recovers_when_slot_invalidated_with_recreate_behavio
 
     // Validate that we have users data.
     let table_rows = destination.get_table_rows().await;
-    let users_table_copied_rows =
-        table_rows.get(&database_schema.users_schema().id).map(|r| r.len()).unwrap_or(0);
+    let users_table_copied_rows = table_rows
+        .get(&database_schema.users_schema().id)
+        .map_or(0, |r| r.len());
     assert_eq!(users_table_copied_rows, 5);
 
     // Verify the slot was recreated and is active.
@@ -389,7 +391,7 @@ async fn table_copy_replicates_many_rows_with_parallel_connections() {
 
     // Verify that all 100k rows were copied.
     let table_rows = destination.get_table_rows().await;
-    let copied_rows = table_rows.get(&table_id).map(|r| r.len()).unwrap_or(0);
+    let copied_rows = table_rows.get(&table_id).map_or(0, |r| r.len());
     assert_eq!(copied_rows, total_rows as usize);
 }
 
@@ -460,7 +462,7 @@ async fn table_copy_with_row_filter_and_parallel_connections() {
 
     // Verify that only rows matching the filter were copied.
     let table_rows = destination.get_table_rows().await;
-    let copied_rows = table_rows.get(&table_id).map(|r| r.len()).unwrap_or(0);
+    let copied_rows = table_rows.get(&table_id).map_or(0, |r| r.len());
     assert_eq!(copied_rows, expected_rows);
 }
 
@@ -865,8 +867,12 @@ async fn run_table_sync_copy_case<F>(
 
     // We validate that the table rows are correct.
     let table_rows = destination.get_table_rows().await;
-    let users_table_copied_rows = table_rows.get(&users_table_id).map(|r| r.len()).unwrap_or(0);
-    let orders_table_copied_rows = table_rows.get(&orders_table_id).map(|r| r.len()).unwrap_or(0);
+    let users_table_copied_rows = table_rows
+        .get(&users_table_id)
+        .map_or(0, |r| r.len());
+    let orders_table_copied_rows = table_rows
+        .get(&orders_table_id)
+        .map_or(0, |r| r.len());
     assert_eq!(users_table_copied_rows, expected_users_copied_rows);
     assert_eq!(orders_table_copied_rows, expected_orders_copied_rows);
     // We always expect the method to be called since the downstream table should be
@@ -1779,8 +1785,7 @@ async fn table_sync_truncates_destination_after_state_reset() {
     let users_rows = table_rows_after.get(&database_schema.users_schema().id).unwrap().len();
     let users_events = grouped_events_after
         .get(&(EventType::Insert, database_schema.users_schema().id))
-        .map(|v| v.len())
-        .unwrap_or(0);
+        .map_or(0, |v| v.len());
     assert_eq!(users_rows + users_events, total_expected_users);
 
     // Orders: no data, since we cleared it before restart and nothing should happen
@@ -1879,20 +1884,20 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
 
-    let users_copied_rows =
-        table_rows.get(&database_schema.users_schema().id).map(|r| r.len()).unwrap_or(0);
+    let users_copied_rows = table_rows
+        .get(&database_schema.users_schema().id)
+        .map_or(0, |r| r.len());
     let users_insert_events = grouped_events
         .get(&(EventType::Insert, database_schema.users_schema().id))
-        .map(|e| e.len())
-        .unwrap_or(0);
+        .map_or(0, |e| e.len());
     let total_users = users_copied_rows + users_insert_events;
 
-    let orders_copied_rows =
-        table_rows.get(&database_schema.orders_schema().id).map(|r| r.len()).unwrap_or(0);
+    let orders_copied_rows = table_rows
+        .get(&database_schema.orders_schema().id)
+        .map_or(0, |r| r.len());
     let orders_insert_events = grouped_events
         .get(&(EventType::Insert, database_schema.orders_schema().id))
-        .map(|e| e.len())
-        .unwrap_or(0);
+        .map_or(0, |e| e.len());
     let total_orders = orders_copied_rows + orders_insert_events;
 
     assert_eq!(total_users, rows_to_insert);
@@ -1987,21 +1992,17 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
 
     let users_updates = grouped_events
         .get(&(EventType::Update, database_schema.users_schema().id))
-        .map(|e| e.len())
-        .unwrap_or(0);
+        .map_or(0, |e| e.len());
     let users_deletes = grouped_events
         .get(&(EventType::Delete, database_schema.users_schema().id))
-        .map(|e| e.len())
-        .unwrap_or(0);
+        .map_or(0, |e| e.len());
 
     let orders_updates = grouped_events
         .get(&(EventType::Update, database_schema.orders_schema().id))
-        .map(|e| e.len())
-        .unwrap_or(0);
+        .map_or(0, |e| e.len());
     let orders_deletes = grouped_events
         .get(&(EventType::Delete, database_schema.orders_schema().id))
-        .map(|e| e.len())
-        .unwrap_or(0);
+        .map_or(0, |e| e.len());
 
     assert_eq!(users_updates, rows_to_update);
     assert_eq!(users_deletes, rows_to_delete);

--- a/etl/tests/pipeline_with_partitioned_table.rs
+++ b/etl/tests/pipeline_with_partitioned_table.rs
@@ -262,10 +262,12 @@ async fn partition_drop_does_not_emit_delete_or_truncate() {
 
     let events_before = destination.get_events().await;
     let grouped_before = group_events_by_type_and_table_id(&events_before);
-    let delete_count_before =
-        grouped_before.get(&(EventType::Delete, parent_table_id)).map(|v| v.len()).unwrap_or(0);
-    let truncate_count_before =
-        grouped_before.get(&(EventType::Truncate, parent_table_id)).map(|v| v.len()).unwrap_or(0);
+    let delete_count_before = grouped_before
+        .get(&(EventType::Delete, parent_table_id))
+        .map_or(0, |v| v.len());
+    let truncate_count_before = grouped_before
+        .get(&(EventType::Truncate, parent_table_id))
+        .map_or(0, |v| v.len());
 
     // Detach and drop one child partition (DDL should not generate DML events).
     let partition_p1_name = format!("{}_{}", table_name.name, "p1");
@@ -299,10 +301,12 @@ async fn partition_drop_does_not_emit_delete_or_truncate() {
 
     let events_after = destination.get_events().await;
     let grouped_after = group_events_by_type_and_table_id(&events_after);
-    let delete_count_after =
-        grouped_after.get(&(EventType::Delete, parent_table_id)).map(|v| v.len()).unwrap_or(0);
-    let truncate_count_after =
-        grouped_after.get(&(EventType::Truncate, parent_table_id)).map(|v| v.len()).unwrap_or(0);
+    let delete_count_after = grouped_after
+        .get(&(EventType::Delete, parent_table_id))
+        .map_or(0, |v| v.len());
+    let truncate_count_after = grouped_after
+        .get(&(EventType::Truncate, parent_table_id))
+        .map_or(0, |v| v.len());
 
     assert_eq!(delete_count_after, delete_count_before);
     assert_eq!(truncate_count_after, truncate_count_before);
@@ -370,8 +374,9 @@ async fn parent_table_truncate_does_emit_truncate_event() {
 
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
-    let truncate_count =
-        grouped_events.get(&(EventType::Truncate, parent_table_id)).map(|v| v.len()).unwrap_or(0);
+    let truncate_count = grouped_events
+        .get(&(EventType::Truncate, parent_table_id))
+        .map_or(0, |v| v.len());
 
     assert_eq!(truncate_count, 1);
 }
@@ -447,8 +452,9 @@ async fn child_table_truncate_does_not_emit_truncate_event() {
 
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
-    let truncate_count =
-        grouped_events.get(&(EventType::Truncate, parent_table_id)).map(|v| v.len()).unwrap_or(0);
+    let truncate_count = grouped_events
+        .get(&(EventType::Truncate, parent_table_id))
+        .map_or(0, |v| v.len());
 
     assert_eq!(truncate_count, 0);
 }
@@ -508,7 +514,9 @@ async fn partition_detach_with_explicit_publication_does_not_replicate_detached_
     // Verify initial sync copied both rows.
     let table_rows = destination.get_table_rows().await;
     assert_eq!(table_rows.len(), 1);
-    let parent_rows: usize = table_rows.get(&parent_table_id).map(|rows| rows.len()).unwrap_or(0);
+    let parent_rows: usize = table_rows
+        .get(&parent_table_id)
+        .map_or(0, |rows| rows.len());
     assert_eq!(parent_rows, 2);
 
     // Detach partition p1 from parent.
@@ -793,9 +801,13 @@ async fn partition_detach_with_all_tables_publication_does_replicate_detached_in
 
     // Verify the data from the detached partition was copied.
     let table_rows = destination.get_table_rows().await;
-    let parent_rows: usize = table_rows.get(&parent_table_id).map(|rows| rows.len()).unwrap_or(0);
+    let parent_rows: usize = table_rows
+        .get(&parent_table_id)
+        .map_or(0, |rows| rows.len());
     assert_eq!(parent_rows, 2);
-    let detached_rows: usize = table_rows.get(&p1_table_id).map(|rows| rows.len()).unwrap_or(0);
+    let detached_rows: usize = table_rows
+        .get(&p1_table_id)
+        .map_or(0, |rows| rows.len());
     assert_eq!(detached_rows, 2);
 }
 
@@ -1044,9 +1056,13 @@ async fn partition_detach_with_schema_publication_does_replicate_detached_insert
 
     // Verify the data from the detached partition was copied.
     let table_rows = destination.get_table_rows().await;
-    let parent_rows: usize = table_rows.get(&parent_table_id).map(|rows| rows.len()).unwrap_or(0);
+    let parent_rows: usize = table_rows
+        .get(&parent_table_id)
+        .map_or(0, |rows| rows.len());
     assert_eq!(parent_rows, 2);
-    let detached_rows: usize = table_rows.get(&p1_table_id).map(|rows| rows.len()).unwrap_or(0);
+    let detached_rows: usize = table_rows
+        .get(&p1_table_id)
+        .map_or(0, |rows| rows.len());
     assert_eq!(detached_rows, 2);
 }
 

--- a/etl/tests/pipeline_with_partitioned_table.rs
+++ b/etl/tests/pipeline_with_partitioned_table.rs
@@ -262,12 +262,10 @@ async fn partition_drop_does_not_emit_delete_or_truncate() {
 
     let events_before = destination.get_events().await;
     let grouped_before = group_events_by_type_and_table_id(&events_before);
-    let delete_count_before = grouped_before
-        .get(&(EventType::Delete, parent_table_id))
-        .map_or(0, Vec::len);
-    let truncate_count_before = grouped_before
-        .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, Vec::len);
+    let delete_count_before =
+        grouped_before.get(&(EventType::Delete, parent_table_id)).map_or(0, Vec::len);
+    let truncate_count_before =
+        grouped_before.get(&(EventType::Truncate, parent_table_id)).map_or(0, Vec::len);
 
     // Detach and drop one child partition (DDL should not generate DML events).
     let partition_p1_name = format!("{}_{}", table_name.name, "p1");
@@ -301,12 +299,10 @@ async fn partition_drop_does_not_emit_delete_or_truncate() {
 
     let events_after = destination.get_events().await;
     let grouped_after = group_events_by_type_and_table_id(&events_after);
-    let delete_count_after = grouped_after
-        .get(&(EventType::Delete, parent_table_id))
-        .map_or(0, Vec::len);
-    let truncate_count_after = grouped_after
-        .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, Vec::len);
+    let delete_count_after =
+        grouped_after.get(&(EventType::Delete, parent_table_id)).map_or(0, Vec::len);
+    let truncate_count_after =
+        grouped_after.get(&(EventType::Truncate, parent_table_id)).map_or(0, Vec::len);
 
     assert_eq!(delete_count_after, delete_count_before);
     assert_eq!(truncate_count_after, truncate_count_before);
@@ -374,9 +370,8 @@ async fn parent_table_truncate_does_emit_truncate_event() {
 
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
-    let truncate_count = grouped_events
-        .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, Vec::len);
+    let truncate_count =
+        grouped_events.get(&(EventType::Truncate, parent_table_id)).map_or(0, Vec::len);
 
     assert_eq!(truncate_count, 1);
 }
@@ -452,9 +447,8 @@ async fn child_table_truncate_does_not_emit_truncate_event() {
 
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
-    let truncate_count = grouped_events
-        .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, Vec::len);
+    let truncate_count =
+        grouped_events.get(&(EventType::Truncate, parent_table_id)).map_or(0, Vec::len);
 
     assert_eq!(truncate_count, 0);
 }

--- a/etl/tests/pipeline_with_partitioned_table.rs
+++ b/etl/tests/pipeline_with_partitioned_table.rs
@@ -106,7 +106,7 @@ async fn partitioned_table_copy_replicates_existing_data() {
     assert!(partition_key_column.primary_key());
 
     let table_rows = destination.get_table_rows().await;
-    let total_rows: usize = table_rows.values().map(|rows| rows.len()).sum();
+    let total_rows: usize = table_rows.values().map(Vec::len).sum();
     assert_eq!(total_rows, 3);
 
     let table_states = state_store.get_table_replication_states().await;
@@ -264,10 +264,10 @@ async fn partition_drop_does_not_emit_delete_or_truncate() {
     let grouped_before = group_events_by_type_and_table_id(&events_before);
     let delete_count_before = grouped_before
         .get(&(EventType::Delete, parent_table_id))
-        .map_or(0, |v| v.len());
+        .map_or(0, Vec::len);
     let truncate_count_before = grouped_before
         .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, |v| v.len());
+        .map_or(0, Vec::len);
 
     // Detach and drop one child partition (DDL should not generate DML events).
     let partition_p1_name = format!("{}_{}", table_name.name, "p1");
@@ -303,10 +303,10 @@ async fn partition_drop_does_not_emit_delete_or_truncate() {
     let grouped_after = group_events_by_type_and_table_id(&events_after);
     let delete_count_after = grouped_after
         .get(&(EventType::Delete, parent_table_id))
-        .map_or(0, |v| v.len());
+        .map_or(0, Vec::len);
     let truncate_count_after = grouped_after
         .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, |v| v.len());
+        .map_or(0, Vec::len);
 
     assert_eq!(delete_count_after, delete_count_before);
     assert_eq!(truncate_count_after, truncate_count_before);
@@ -376,7 +376,7 @@ async fn parent_table_truncate_does_emit_truncate_event() {
     let grouped_events = group_events_by_type_and_table_id(&events);
     let truncate_count = grouped_events
         .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, |v| v.len());
+        .map_or(0, Vec::len);
 
     assert_eq!(truncate_count, 1);
 }
@@ -454,7 +454,7 @@ async fn child_table_truncate_does_not_emit_truncate_event() {
     let grouped_events = group_events_by_type_and_table_id(&events);
     let truncate_count = grouped_events
         .get(&(EventType::Truncate, parent_table_id))
-        .map_or(0, |v| v.len());
+        .map_or(0, Vec::len);
 
     assert_eq!(truncate_count, 0);
 }
@@ -514,9 +514,7 @@ async fn partition_detach_with_explicit_publication_does_not_replicate_detached_
     // Verify initial sync copied both rows.
     let table_rows = destination.get_table_rows().await;
     assert_eq!(table_rows.len(), 1);
-    let parent_rows: usize = table_rows
-        .get(&parent_table_id)
-        .map_or(0, |rows| rows.len());
+    let parent_rows: usize = table_rows.get(&parent_table_id).map_or(0, Vec::len);
     assert_eq!(parent_rows, 2);
 
     // Detach partition p1 from parent.
@@ -801,13 +799,9 @@ async fn partition_detach_with_all_tables_publication_does_replicate_detached_in
 
     // Verify the data from the detached partition was copied.
     let table_rows = destination.get_table_rows().await;
-    let parent_rows: usize = table_rows
-        .get(&parent_table_id)
-        .map_or(0, |rows| rows.len());
+    let parent_rows: usize = table_rows.get(&parent_table_id).map_or(0, Vec::len);
     assert_eq!(parent_rows, 2);
-    let detached_rows: usize = table_rows
-        .get(&p1_table_id)
-        .map_or(0, |rows| rows.len());
+    let detached_rows: usize = table_rows.get(&p1_table_id).map_or(0, Vec::len);
     assert_eq!(detached_rows, 2);
 }
 
@@ -1056,13 +1050,9 @@ async fn partition_detach_with_schema_publication_does_replicate_detached_insert
 
     // Verify the data from the detached partition was copied.
     let table_rows = destination.get_table_rows().await;
-    let parent_rows: usize = table_rows
-        .get(&parent_table_id)
-        .map_or(0, |rows| rows.len());
+    let parent_rows: usize = table_rows.get(&parent_table_id).map_or(0, Vec::len);
     assert_eq!(parent_rows, 2);
-    let detached_rows: usize = table_rows
-        .get(&p1_table_id)
-        .map_or(0, |rows| rows.len());
+    let detached_rows: usize = table_rows.get(&p1_table_id).map_or(0, Vec::len);
     assert_eq!(detached_rows, 2);
 }
 
@@ -1289,7 +1279,7 @@ async fn nested_partitioned_table_copy_and_cdc() {
 
     // Verify initial COPY replicated all 6 rows (one per leaf partition).
     let table_rows = destination.get_table_rows().await;
-    let total_rows: usize = table_rows.values().map(|rows| rows.len()).sum();
+    let total_rows: usize = table_rows.values().map(Vec::len).sum();
     assert_eq!(total_rows, 6);
 
     // Verify only the parent table is tracked (not intermediate or leaf

--- a/etl/tests/postgres_store.rs
+++ b/etl/tests/postgres_store.rs
@@ -64,7 +64,7 @@ fn create_another_table_schema() -> TableSchema {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_state_store_operations() {
+async fn state_store_operations() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -120,7 +120,7 @@ async fn test_state_store_operations() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_state_store_rollback() {
+async fn state_store_rollback() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -180,7 +180,7 @@ async fn test_state_store_rollback() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_state_store_load_states() {
+async fn state_store_load_states() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -216,7 +216,7 @@ async fn test_state_store_load_states() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_store_operations() {
+async fn schema_store_operations() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -255,7 +255,7 @@ async fn test_schema_store_operations() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_store_load_schemas() {
+async fn schema_store_load_schemas() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -298,7 +298,7 @@ async fn test_schema_store_load_schemas() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_store_versioning() {
+async fn schema_store_versioning() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -346,7 +346,7 @@ async fn test_schema_store_versioning() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_store_upsert_replaces_columns() {
+async fn schema_store_upsert_replaces_columns() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -406,7 +406,7 @@ async fn test_schema_store_upsert_replaces_columns() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_cache_eviction() {
+async fn schema_cache_eviction() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -466,7 +466,7 @@ async fn test_schema_cache_eviction() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multiple_pipelines_isolation() {
+async fn multiple_pipelines_isolation() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -548,7 +548,7 @@ async fn test_multiple_pipelines_isolation() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_errored_state_with_different_retry_policies() {
+async fn errored_state_with_different_retry_policies() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -584,7 +584,7 @@ async fn test_errored_state_with_different_retry_policies() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_state_transitions_and_history() {
+async fn state_transitions_and_history() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -633,7 +633,7 @@ async fn test_state_transitions_and_history() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_cleanup_deletes_state_schema_and_metadata_for_table() {
+async fn cleanup_deletes_state_schema_and_metadata_for_table() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -711,7 +711,7 @@ async fn test_cleanup_deletes_state_schema_and_metadata_for_table() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_replication_mask_loads_correctly_from_string_bytea() {
+async fn replication_mask_loads_correctly_from_string_bytea() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -761,7 +761,7 @@ async fn test_replication_mask_loads_correctly_from_string_bytea() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_replication_mask_various_patterns() {
+async fn replication_mask_various_patterns() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -834,7 +834,7 @@ async fn test_replication_mask_various_patterns() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_replication_mask_roundtrip() {
+async fn replication_mask_roundtrip() {
     init_test_tracing();
 
     let database = spawn_source_database().await;

--- a/etl/tests/replication.rs
+++ b/etl/tests/replication.rs
@@ -180,7 +180,7 @@ async fn collect_ddl_messages(
 
         let content = message.content().expect("message content should decode");
         let json = serde_json::from_str(content).expect("ddl message should be valid json");
-        println!("{}", json);
+        println!("{json}");
         messages.push(json);
     }
 

--- a/etl/tests/replication.rs
+++ b/etl/tests/replication.rs
@@ -260,7 +260,7 @@ async fn collect_stream_markers(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_replication_client_creates_slot() {
+async fn replication_client_creates_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -279,7 +279,7 @@ async fn test_replication_client_creates_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_create_and_delete_slot() {
+async fn create_and_delete_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -303,7 +303,7 @@ async fn test_create_and_delete_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_delete_nonexistent_slot() {
+async fn delete_nonexistent_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -317,7 +317,7 @@ async fn test_delete_nonexistent_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_delete_slot_if_exists_deletes_existing_slot() {
+async fn delete_slot_if_exists_deletes_existing_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -333,7 +333,7 @@ async fn test_delete_slot_if_exists_deletes_existing_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_delete_slot_if_exists_on_nonexistent_slot() {
+async fn delete_slot_if_exists_on_nonexistent_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -344,7 +344,7 @@ async fn test_delete_slot_if_exists_on_nonexistent_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_replication_client_doesnt_recreate_slot() {
+async fn replication_client_doesnt_recreate_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -359,7 +359,7 @@ async fn test_replication_client_doesnt_recreate_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_replication_client_reads_wal_sender_timeout() {
+async fn replication_client_reads_wal_sender_timeout() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -371,7 +371,7 @@ async fn test_replication_client_reads_wal_sender_timeout() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_table_schema_copy_is_consistent() {
+async fn table_schema_copy_is_consistent() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -397,7 +397,7 @@ async fn test_table_schema_copy_is_consistent() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_table_schema_copy_across_multiple_connections() {
+async fn table_schema_copy_across_multiple_connections() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -457,7 +457,7 @@ async fn test_table_schema_copy_across_multiple_connections() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_table_schema_preserves_primary_key_constraint_order() {
+async fn table_schema_preserves_primary_key_constraint_order() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -510,7 +510,7 @@ async fn test_table_schema_preserves_primary_key_constraint_order() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_ddl_message_primary_key_order_matches_loaded_table_schema() {
+async fn ddl_message_primary_key_order_matches_loaded_table_schema() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -584,7 +584,7 @@ async fn test_ddl_message_primary_key_order_matches_loaded_table_schema() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_table_copy_stream_is_consistent() {
+async fn table_copy_stream_is_consistent() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -628,7 +628,7 @@ async fn test_table_copy_stream_is_consistent() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_table_copy_stream_respects_row_filter() {
+async fn table_copy_stream_respects_row_filter() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -693,7 +693,7 @@ async fn test_table_copy_stream_respects_row_filter() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_replicated_column_names_respects_column_filter() {
+async fn get_replicated_column_names_respects_column_filter() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -790,7 +790,7 @@ async fn test_get_replicated_column_names_respects_column_filter() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_replicated_column_names_for_all_tables_publication() {
+async fn get_replicated_column_names_for_all_tables_publication() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -851,7 +851,7 @@ async fn test_get_replicated_column_names_for_all_tables_publication() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_replicated_column_names_for_tables_in_schema_publication() {
+async fn get_replicated_column_names_for_tables_in_schema_publication() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -913,7 +913,7 @@ async fn test_get_replicated_column_names_for_tables_in_schema_publication() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_replicated_column_names_errors_when_table_not_in_publication() {
+async fn get_replicated_column_names_errors_when_table_not_in_publication() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -966,7 +966,7 @@ async fn test_get_replicated_column_names_errors_when_table_not_in_publication()
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_publication_table_ids_errors_when_empty() {
+async fn get_publication_table_ids_errors_when_empty() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -987,7 +987,7 @@ async fn test_get_publication_table_ids_errors_when_empty() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_table_copy_stream_no_row_filter() {
+async fn table_copy_stream_no_row_filter() {
     init_test_tracing();
     let database = spawn_source_database().await;
     // We create a table and insert one row.
@@ -1041,7 +1041,7 @@ async fn test_table_copy_stream_no_row_filter() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_publication_creation_and_check() {
+async fn publication_creation_and_check() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1083,7 +1083,7 @@ async fn test_publication_creation_and_check() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_publication_table_ids_collapse_partitioned_root() {
+async fn publication_table_ids_collapse_partitioned_root() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1109,7 +1109,7 @@ async fn test_publication_table_ids_collapse_partitioned_root() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_start_logical_replication() {
+async fn start_logical_replication() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1156,7 +1156,7 @@ async fn test_start_logical_replication() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_change_messages_emit_enriched_payload_for_multiple_alter_table_variants() {
+async fn schema_change_messages_emit_enriched_payload_for_multiple_alter_table_variants() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1328,7 +1328,7 @@ async fn test_schema_change_messages_emit_enriched_payload_for_multiple_alter_ta
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_change_messages_skip_unpublished_and_temporary_tables() {
+async fn schema_change_messages_skip_unpublished_and_temporary_tables() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1377,7 +1377,7 @@ async fn test_schema_change_messages_skip_unpublished_and_temporary_tables() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_change_messages_allow_alter_table_from_table_owner_role() {
+async fn schema_change_messages_allow_alter_table_from_table_owner_role() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1432,7 +1432,7 @@ async fn test_schema_change_messages_allow_alter_table_from_table_owner_role() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_single_alter_table_statement_with_multiple_subcommands_emits_one_ddl_message() {
+async fn single_alter_table_statement_with_multiple_subcommands_emits_one_ddl_message() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1488,7 +1488,7 @@ async fn test_single_alter_table_statement_with_multiple_subcommands_emits_one_d
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_schema_change_messages_respect_skip_ddl_log_setting() {
+async fn schema_change_messages_respect_skip_ddl_log_setting() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1523,7 +1523,7 @@ async fn test_schema_change_messages_respect_skip_ddl_log_setting() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_same_transaction_ddl_messages_precede_relation_and_insert_in_pgoutput() {
+async fn same_transaction_ddl_messages_precede_relation_and_insert_in_pgoutput() {
     init_test_tracing();
     let mut database = spawn_source_database().await;
 
@@ -1610,7 +1610,7 @@ async fn test_same_transaction_ddl_messages_precede_relation_and_insert_in_pgout
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_slot_state_returns_valid_for_healthy_slot() {
+async fn get_slot_state_returns_valid_for_healthy_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1626,7 +1626,7 @@ async fn test_get_slot_state_returns_valid_for_healthy_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_slot_state_returns_error_for_nonexistent_slot() {
+async fn get_slot_state_returns_error_for_nonexistent_slot() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1669,7 +1669,7 @@ async fn exclusive_get_slot_state_returns_invalidated_for_lost_slot() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_plan_ctid_partitions_returns_correct_partitions() {
+async fn plan_ctid_partitions_returns_correct_partitions() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1732,7 +1732,7 @@ async fn test_plan_ctid_partitions_returns_correct_partitions() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_plan_ctid_partitions_returns_empty_for_empty_table() {
+async fn plan_ctid_partitions_returns_empty_for_empty_table() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
@@ -1754,7 +1754,7 @@ async fn test_plan_ctid_partitions_returns_empty_for_empty_table() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_table_copy_stream_with_ctid_partition() {
+async fn table_copy_stream_with_ctid_partition() {
     init_test_tracing();
     let database = spawn_source_database().await;
 

--- a/xtask/src/commands/chaos/mod.rs
+++ b/xtask/src/commands/chaos/mod.rs
@@ -463,7 +463,7 @@ pub(crate) fn parse_selector(selectors: &[String]) -> anyhow::Result<Labels> {
 /// set. Uses the value of the first label, e.g. `app.kubernetes.io/name=etl` →
 /// `"etl"`.
 pub(crate) fn app_name_from_labels(labels: &Labels) -> &str {
-    labels.first().map(|(_, v)| v.as_str()).unwrap_or("app")
+    labels.first().map_or("app", |(_, v)| v.as_str())
 }
 
 fn sel(namespace: &str, labels: Labels) -> Selector {

--- a/xtask/src/commands/nextest.rs
+++ b/xtask/src/commands/nextest.rs
@@ -224,10 +224,9 @@ fn run_lane(lane: &Lane, mode: Mode, extra: &[String], pg_env: &PgEnv) -> Result
         }
     });
 
-    let prefix_err = prefix.clone();
     let err_thread = thread::spawn(move || {
         for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-            eprintln!("{prefix_err} {line}");
+            eprintln!("{prefix} {line}");
         }
     });
 


### PR DESCRIPTION
## Summary
- Enable additional clippy lints workspace-wide (correctness, style, and clarity categories)
- Fix all existing violations across the codebase, one lint per commit for easy review

## Lints enabled

```toml
# Correctness & safety
await_holding_lock = "deny"
unused_async = "deny"
large_futures = "deny"

# Style & clarity
cloned_instead_of_copied = "warn"
copy_iterator = "warn"
dbg_macro = "warn"
enum_glob_use = "warn"
explicit_into_iter_loop = "warn"
explicit_iter_loop = "warn"
flat_map_option = "warn"
implicit_clone = "warn"
map_flatten = "warn"
manual_let_else = "warn"
manual_ok_or = "warn"
manual_async_fn = "warn"
map_unwrap_or = "warn"
match_same_arms = "warn"
redundant_closure = "warn"
redundant_closure_call = "warn"
redundant_closure_for_method_calls = "warn"
redundant_else = "warn"
redundant_clone = "warn"
redundant_field_names = "warn"
redundant_test_prefix = "warn"
semicolon_if_nothing_returned = "warn"
todo = "warn"
uninlined_format_args = "warn"
unnested_or_patterns = "warn"
```
