### PR TITLE
fix(test-utils): check notify conditions at registration time

### DIFF
--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -152,7 +152,13 @@ impl NotifyingStore {
     }
 
     /// Registers a notification that fires when a table reaches a specific
-    /// state type after this method is called.
+    /// state type.
+    ///
+    /// If the condition is already satisfied at registration time, the
+    /// returned [`TimedNotify`] is pre-armed so the next `.notified()` call
+    /// returns immediately. Otherwise it fires on the next matching state
+    /// transition. This avoids a race where the transition of interest
+    /// happens between pipeline startup and condition registration.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the expected state is not reached. This
@@ -165,12 +171,18 @@ impl NotifyingStore {
         let notify = Arc::new(Notify::new());
         let mut inner = self.inner.write().await;
         inner.table_state_type_conditions.push((table_id, expected_state, notify.clone()));
+        inner.check_conditions();
 
         TimedNotify::new(notify)
     }
 
     /// Registers a notification that fires when a table state matches a custom
-    /// condition after this method is called.
+    /// condition.
+    ///
+    /// If the condition is already satisfied at registration time, the
+    /// returned [`TimedNotify`] is pre-armed so the next `.notified()` call
+    /// returns immediately. Otherwise it fires on the next state transition
+    /// that satisfies the condition.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the condition is not met. This prevents tests
@@ -182,12 +194,18 @@ impl NotifyingStore {
         let notify = Arc::new(Notify::new());
         let mut inner = self.inner.write().await;
         inner.table_state_conditions.push((table_id, notify.clone(), Box::new(condition)));
+        inner.check_conditions();
 
         TimedNotify::new(notify)
     }
 
-    /// Registers a notification that fires when a table has stored at least the
-    /// expected number of schema snapshots after this method is called.
+    /// Registers a notification that fires when a table has stored at least
+    /// the expected number of schema snapshots.
+    ///
+    /// If the condition is already satisfied at registration time, the
+    /// returned [`TimedNotify`] is pre-armed so the next `.notified()` call
+    /// returns immediately. Otherwise it fires on the next schema update
+    /// that reaches the expected count.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the expected schema count is not reached. This
@@ -200,6 +218,7 @@ impl NotifyingStore {
         let notify = Arc::new(Notify::new());
         let mut inner = self.inner.write().await;
         inner.table_schema_count_conditions.push((table_id, expected_count, notify.clone()));
+        inner.check_conditions();
 
         TimedNotify::new(notify)
     }

--- a/etl/src/workers/policy.rs
+++ b/etl/src/workers/policy.rs
@@ -8,6 +8,7 @@ pub(crate) enum RetryDirective {
     /// The operation should only be retried after manual intervention.
     Manual,
     /// The operation should not be retried.
+    #[cfg_attr(not(feature = "failpoints"), allow(dead_code))]
     NoRetry,
 }
 


### PR DESCRIPTION
`NotifyingStore::notify_on_table_state_type`,
`notify_on_table_state`, and `notify_on_table_schema_count` only pushed the condition onto a list. The condition was evaluated exclusively inside `check_conditions()`, which runs on state/schema updates. If the transition of interest happened between `Pipeline::start()` returning and the test calling one of these `notify_on_*` methods, the Notify was never armed and the test hung until the 120s `TimedNotify` timeout.

Evaluate the condition once at registration by calling `check_conditions()` after pushing, so an already-satisfied condition is armed immediately. The retain-based logic in `check_conditions()` naturally removes the condition after firing, matching the one-shot semantics of the existing transition-driven path.

This is the latent race that recently started manifesting as timeouts in `pipeline::publication_changes_are_correctly_handled`, `pipeline::publication_for_all_tables_in_schema_ignores_new_tables_until_restart`, and `pipeline::pipeline_processes_concurrent_inserts_during_startup`.