### PR TITLE
test(etl): register notify_on_* before starting pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,13 @@
 - When fixing a specific crate, run the narrowest relevant tests first, then broaden if needed.
 - Add or update tests when behavior changes, regressions are possible, or new logic is introduced.
 - Do not prefix `#[test]` functions with `test_`. Name them after what they verify — e.g. `fn parses_empty_input()` not `fn test_parses_empty_input()`.
+- Register `NotifyingStore::notify_on_*` and `TestDestinationWrapper::wait_for_*` handles before the producer can fire. These helpers only arm on updates that arrive *after* registration, so register the notifier first, then start the producer.
+
+  ```rust
+  let ready = store.notify_on_table_state_type(id, Ready).await;
+  pipeline.start().await.unwrap();
+  ready.notified().await;
+  ```
 
 ## Review Checklist
 - Code compiles for the changed target or workspace as appropriate.

--- a/etl/src/workers/policy.rs
+++ b/etl/src/workers/policy.rs
@@ -8,6 +8,7 @@ pub(crate) enum RetryDirective {
     /// The operation should only be retried after manual intervention.
     Manual,
     /// The operation should not be retried.
+    #[cfg_attr(not(feature = "failpoints"), allow(dead_code))]
     NoRetry,
 }
 

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -1813,18 +1813,11 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
         destination.clone(),
     );
 
-    // Start the pipeline after spawning the insert task.
-    pipeline.start().await.unwrap();
-
-    // Spawn a task that inserts data concurrently using a separate connection.
-    // This creates a race condition where some rows may be captured during table
-    // copy and others during streaming replication.
     let rows_to_insert = 10;
-    let users_table_name = database_schema.users_schema().name.clone();
-    let orders_table_name = database_schema.orders_schema().name.clone();
-    let mut duplicate_database = database.duplicate().await;
 
-    // Wait for both tables to reach Ready state.
+    // Register notifications before starting the pipeline so we do not miss
+    // state transitions or events that happen during startup. `notify_on_*`
+    // and `wait_for_*` only fire on updates that occur after registration.
     let users_ready_notify = store
         .notify_on_table_state_type(
             database_schema.users_schema().id,
@@ -1847,6 +1840,15 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
             (rows_to_insert * 2) as u64,
         )])
         .await;
+
+    pipeline.start().await.unwrap();
+
+    // Spawn a task that inserts data concurrently using a separate connection.
+    // This creates a race condition where some rows may be captured during table
+    // copy and others during streaming replication.
+    let users_table_name = database_schema.users_schema().name.clone();
+    let orders_table_name = database_schema.orders_schema().name.clone();
+    let mut duplicate_database = database.duplicate().await;
 
     // Use a JoinHandle to ensure the task completes and the database isn't dropped
     // prematurely.

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -1581,11 +1581,13 @@ async fn empty_tables_are_created_at_destination() {
         destination.clone(),
     );
 
-    pipeline.start().await.unwrap();
-
-    // Wait for the table to be ready.
+    // Register the ready notifier before starting the pipeline so we do not
+    // miss the Init -> Ready transition driven by the apply worker during
+    // startup.
     let table_ready_notify =
         state_store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
 
     table_ready_notify.notified().await;
 


### PR DESCRIPTION
`pipeline_processes_concurrent_inserts_during_startup` registered
`notify_on_table_state_type` for both tables after `pipeline.start()`
returned. `pipeline.start()` spawns the apply worker and returns; the
worker then drives the table states asynchronously. If a table
transitioned to `Ready` before the notify was registered, the Notify
was never armed and the test hung until the 120s `TimedNotify` timeout.

`NotifyingStore::notify_on_*` and
`TestDestinationWrapper::wait_for_*` only fire on updates that occur
after registration, so all wait-for conditions must be set up before
the producer is started. Move the three registrations above
`pipeline.start()` to close the window.