### PR TITLE
feat(api): Add option to delete the event trigger

### DIFF
--- a/etl-api/src/db/sources.rs
+++ b/etl-api/src/db/sources.rs
@@ -287,9 +287,37 @@ where
 }
 
 pub async fn uninstall_source_installation(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
+    drop_current_user_owned_ddl_event_triggers(conn).await?;
     drop_current_user_owned_etl_schema(conn).await
 }
 
+/// Drops ETL-managed DDL event triggers owned by the current user.
+async fn drop_current_user_owned_ddl_event_triggers(
+    conn: &mut PgConnection,
+) -> Result<(), sqlx::Error> {
+    let ddl_message_trigger_owned_by_current_user: bool = sqlx::query_scalar(
+        r#"
+        select exists(
+            select 1
+            from pg_event_trigger
+            where evtname = 'supabase_etl_ddl_message_trigger'
+              and evtowner = (select oid from pg_roles where rolname = current_user)
+        )
+        "#,
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+
+    if ddl_message_trigger_owned_by_current_user {
+        sqlx::query("drop event trigger if exists supabase_etl_ddl_message_trigger")
+            .execute(&mut *conn)
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Drops the `etl` schema when it is owned by the current user.
 async fn drop_current_user_owned_etl_schema(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
     let etl_schema_owned_by_current_user: bool = sqlx::query_scalar(
         r#"

--- a/etl-api/tests/tenants.rs
+++ b/etl-api/tests/tenants.rs
@@ -292,7 +292,8 @@ async fn tenant_with_active_pipeline_cannot_be_deleted() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn tenant_with_inactive_pipelines_can_be_deleted_and_uninstalls_source_state() {
+async fn tenant_with_inactive_pipelines_can_be_deleted_and_uninstalls_source_state_and_ddl_event_trigger()
+ {
     init_test_tracing();
 
     let trusted_source = create_trusted_source_database().await;
@@ -319,6 +320,15 @@ async fn tenant_with_inactive_pipelines_can_be_deleted_and_uninstalls_source_sta
     let source_id = response.id;
 
     run_etl_migrations_on_source_database(&trusted_source.trusted_config).await;
+
+    let ddl_trigger_exists_before_delete: bool = sqlx::query_scalar(
+        "select exists(select 1 from pg_event_trigger where evtname = \
+         'supabase_etl_ddl_message_trigger')",
+    )
+    .fetch_one(&trusted_source.admin_pool)
+    .await
+    .expect("failed to check ddl event trigger before tenant deletion");
+    assert!(ddl_trigger_exists_before_delete);
 
     create_default_image(&app).await;
     let destination_id = create_destination(&app, tenant_id).await;
@@ -357,6 +367,15 @@ async fn tenant_with_inactive_pipelines_can_be_deleted_and_uninstalls_source_sta
             .await
             .expect("failed to check etl schema");
     assert!(!etl_schema_exists);
+
+    let ddl_trigger_exists_after_delete: bool = sqlx::query_scalar(
+        "select exists(select 1 from pg_event_trigger where evtname = \
+         'supabase_etl_ddl_message_trigger')",
+    )
+    .fetch_one(&trusted_source.admin_pool)
+    .await
+    .expect("failed to check ddl event trigger after tenant deletion");
+    assert!(!ddl_trigger_exists_after_delete);
 
     let publication_exists: bool = sqlx::query_scalar(
         "select exists(select 1 from pg_publication where pubname = 'tenant_uninstall_pub')",


### PR DESCRIPTION
This PR adds a new query to remove the event trigger created by ETL which will be needed when uninstalling ETL.