### PR TITLE
fix(security): Fix security audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
This PR fixes the security audit https://rustsec.org/advisories/RUSTSEC-2026-0104.