### PR TITLE
test(etl): re-enable flaky-under-load tests to observe CI behavior

### DIFF
--- a/etl-destinations/src/ducklake/config.rs
+++ b/etl-destinations/src/ducklake/config.rs
@@ -569,19 +569,6 @@ pub(super) fn build_setup_plan(
     )
 }
 
-/// Appends the maintenance-specific setup phase for DuckLake compaction sizing.
-pub(super) fn build_maintenance_setup_plan(
-    base_plan: &DuckLakeSetupPlan,
-    maintenance_target_file_size: Option<&str>,
-) -> DuckLakeSetupPlan {
-    let mut steps = base_plan.steps.clone();
-    steps.push(DuckLakeSetupStep {
-        label: "configure_maintenance",
-        sql: maintenance_target_file_size_sql(maintenance_target_file_size),
-    });
-    DuckLakeSetupPlan { steps }
-}
-
 #[cfg(test)]
 fn build_setup_sql_with_strategy(
     catalog_url: &Url,
@@ -1151,52 +1138,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.steps()[0].sql, format!("SET memory_limit = {};", quote_literal("256MB")));
-    }
-
-    #[test]
-    fn build_maintenance_setup_plan_appends_target_file_size_step() {
-        let catalog_url = Url::parse("file:///tmp/catalog.ducklake").unwrap();
-        let data_url = Url::parse("file:///tmp/data").unwrap();
-        let plan = build_setup_plan_with_strategy(
-            &catalog_url,
-            &data_url,
-            None,
-            None,
-            None,
-            DuckDbExtensionStrategy::InstallFromRepository,
-            None,
-        )
-        .unwrap();
-
-        let maintenance_plan = build_maintenance_setup_plan(&plan, None);
-
-        assert_eq!(maintenance_plan.steps().len(), plan.steps().len() + 1);
-        let last_step =
-            maintenance_plan.steps().last().expect("maintenance setup should append one step");
-        assert_eq!(last_step.label, "configure_maintenance");
-        assert_eq!(last_step.sql, maintenance_target_file_size_sql(None));
-    }
-
-    #[test]
-    fn build_maintenance_setup_plan_uses_configured_target_file_size() {
-        let catalog_url = Url::parse("file:///tmp/catalog.ducklake").unwrap();
-        let data_url = Url::parse("file:///tmp/data").unwrap();
-        let plan = build_setup_plan_with_strategy(
-            &catalog_url,
-            &data_url,
-            None,
-            None,
-            None,
-            DuckDbExtensionStrategy::InstallFromRepository,
-            None,
-        )
-        .unwrap();
-
-        let maintenance_plan = build_maintenance_setup_plan(&plan, Some("32MB"));
-        let last_step =
-            maintenance_plan.steps().last().expect("maintenance setup should append one step");
-
-        assert_eq!(last_step.sql, maintenance_target_file_size_sql(Some("32MB")));
     }
 
     #[test]

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -56,8 +56,8 @@ use crate::{
             format_query_error_detail, run_duckdb_blocking,
         },
         config::{
-            MAINTENANCE_TARGET_FILE_SIZE, build_maintenance_setup_plan, build_setup_plan,
-            current_duckdb_extension_strategy,
+            MAINTENANCE_TARGET_FILE_SIZE, build_setup_plan, current_duckdb_extension_strategy,
+            maintenance_target_file_size_sql,
         },
         inline_size::DuckLakePendingInlineSizeSampler,
         maintenance::{
@@ -384,10 +384,6 @@ where
             metadata_schema.as_deref(),
             duckdb_memory_cache_limit.as_deref(),
         )?);
-        let maintenance_setup_plan = Arc::new(build_maintenance_setup_plan(
-            setup_plan.as_ref(),
-            Some(maintenance_target_file_size.as_ref()),
-        ));
 
         let manager = Arc::new(DuckLakeConnectionManager {
             setup_plan: Arc::clone(&setup_plan),
@@ -399,6 +395,32 @@ where
         let pool =
             Arc::new(build_warm_ducklake_pool(manager.as_ref().clone(), pool_size, "write").await?);
         let blocking_slots = Arc::new(Semaphore::new(pool_size as usize));
+
+        // `target_file_size` is a catalog-wide DuckLake option consumed during
+        // compaction. Apply it once on the write pool before the maintenance
+        // pool starts warming, so the maintenance worker does not need to
+        // mutate the catalog from a separate RW DuckDB instance during its
+        // background warm-up. Two RW instances ATTACHing the same catalog file
+        // and racing a catalog write against concurrent user writes caused
+        // lost commits.
+        let target_file_size_sql =
+            maintenance_target_file_size_sql(Some(maintenance_target_file_size.as_ref()));
+        run_duckdb_blocking(
+            Arc::clone(&pool),
+            Arc::clone(&blocking_slots),
+            DuckDbBlockingOperationKind::Foreground,
+            move |conn| -> EtlResult<()> {
+                conn.execute_batch(&target_file_size_sql).map_err(|error| {
+                    etl_error!(
+                        ErrorKind::DestinationQueryFailed,
+                        "DuckLake target_file_size configuration failed",
+                        source: error
+                    )
+                })?;
+                Ok(())
+            },
+        )
+        .await?;
         let pending_inline_size_sampler =
             if matches!(catalog_url.scheme(), "postgres" | "postgresql") {
                 match run_duckdb_blocking(
@@ -451,7 +473,7 @@ where
         destination.maintenance_worker = Arc::new(
             spawn_ducklake_maintenance_worker(
                 DuckLakeConnectionManager {
-                    setup_plan: Arc::clone(&maintenance_setup_plan),
+                    setup_plan: Arc::clone(&setup_plan),
                     disable_extension_autoload,
                     #[cfg(feature = "test-utils")]
                     open_count: Arc::new(AtomicUsize::new(0)),

--- a/etl-destinations/tests/ducklake_destination.rs
+++ b/etl-destinations/tests/ducklake_destination.rs
@@ -117,8 +117,11 @@ fn make_replicated_table_schema(schema: &TableSchema) -> ReplicatedTableSchema {
     ReplicatedTableSchema::all(Arc::new(schema.clone()))
 }
 
-/// Opens a verification connection to the same DuckLake catalog and returns it.
-fn open_lake_conn(catalog: &Url, data: &Url) -> Connection {
+/// Opens a verification connection to the same DuckLake catalog.
+///
+/// Returns `Err` when the catalog cannot be attached (e.g. DuckDB WAL
+/// checkpoint mismatch while another connection is still flushing).
+fn try_open_lake_conn(catalog: &Url, data: &Url) -> Result<Connection, duckdb::Error> {
     let conn = open_verification_connection();
     conn.execute_batch(&format!(
         "{} ATTACH {} AS {} (DATA_PATH {});",
@@ -126,9 +129,13 @@ fn open_lake_conn(catalog: &Url, data: &Url) -> Connection {
         quote_literal(&format!("ducklake:{}", catalog.as_str())),
         quote_identifier("lake"),
         quote_literal(data.as_str())
-    ))
-    .expect("failed to attach DuckLake catalog");
-    conn
+    ))?;
+    Ok(conn)
+}
+
+/// Opens a verification connection, panicking on failure.
+fn open_lake_conn(catalog: &Url, data: &Url) -> Connection {
+    try_open_lake_conn(catalog, data).expect("failed to attach DuckLake catalog")
 }
 
 fn lake_table_exists(conn: &Connection, table_name: &str) -> bool {
@@ -154,16 +161,20 @@ async fn open_lake_conn_when_tables_visible(
 ) -> Connection {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
-        let conn = open_lake_conn(catalog, data);
-        if table_names.iter().all(|table_name| lake_table_exists(&conn, table_name)) {
-            return conn;
+        // The attach can fail transiently (e.g. DuckDB WAL checkpoint mismatch
+        // while the destination connection is still flushing). Retry instead of
+        // panicking.
+        if let Ok(conn) = try_open_lake_conn(catalog, data) {
+            if table_names.iter().all(|table_name| lake_table_exists(&conn, table_name)) {
+                return conn;
+            }
+            drop(conn);
         }
 
         assert!(
             tokio::time::Instant::now() < deadline,
             "timed out waiting for DuckLake tables to become visible: {table_names:?}"
         );
-        drop(conn);
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }

--- a/etl-destinations/tests/ducklake_destination.rs
+++ b/etl-destinations/tests/ducklake_destination.rs
@@ -48,6 +48,7 @@ use etl_destinations::ducklake::{
     arm_fail_after_copy_batch_commit_once_for_tests, ducklake_staging_table_creations_for_tests,
     reset_ducklake_test_hooks,
 };
+use etl_telemetry::tracing::init_test_tracing;
 use pg_escape::{quote_identifier, quote_literal};
 #[cfg(feature = "test-utils")]
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -596,6 +597,7 @@ async fn write_table_rows_retry_after_post_commit_failure_is_idempotent() {
 /// exact.
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_same_table_copy_batches_complete() {
+    init_test_tracing();
     let dir = make_test_dir("concurrent_same_table_copy_batches_complete");
     let catalog = dir.join("catalog.ducklake");
     let data = dir.join("data");
@@ -669,8 +671,58 @@ async fn concurrent_same_table_copy_batches_complete() {
     checkpoint_lake(&catalog_url, &data_url);
 
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
-    assert_eq!(count_rows(&conn, &table_name), 100);
-    assert_eq!(count_applied_batches(&conn, &table_name, "copy"), 2);
+
+    // Diagnostic block: capture both counts plus direct-parquet and marker
+    // detail so the failure message distinguishes between a silent rollback
+    // (one missing marker) and a catalog snapshot clobber (markers present but
+    // catalog reports fewer rows than the parquet files on disk).
+    let rows = count_rows(&conn, &table_name);
+    let markers = count_applied_batches(&conn, &table_name, "copy");
+
+    let data_path = data_url.to_file_path().expect("data_url should be a file:// URL");
+    let parquet_glob = format!("{}/**/*.parquet", data_path.display());
+    let parquet_rows: i64 = conn
+        .query_row(
+            &format!("SELECT COUNT(*) FROM read_parquet({})", quote_literal(&parquet_glob)),
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(-1);
+
+    let marker_detail: Vec<(String, Option<u64>, Option<u64>)> = {
+        let sql = format!(
+            "SELECT batch_id, first_start_lsn, last_commit_lsn FROM {}.{} WHERE table_name = {} \
+             AND batch_kind = {}",
+            quote_identifier("lake"),
+            quote_identifier("__etl_applied_table_batches"),
+            quote_literal(&table_name),
+            quote_literal("copy"),
+        );
+        let mut stmt = conn.prepare(&sql).expect("marker detail prepare failed");
+        stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<u64>>(1)?,
+                row.get::<_, Option<u64>>(2)?,
+            ))
+        })
+        .expect("marker detail query failed")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("marker detail collect failed")
+    };
+
+    eprintln!(
+        "[concurrent_same_table_copy_batches_complete] diagnostics:\n  catalog rows      : \
+         {rows}\n  applied markers   : {markers}\n  parquet rows      : {parquet_rows}\n  marker \
+         detail     : {marker_detail:?}"
+    );
+
+    assert_eq!(
+        (rows, markers),
+        (100, 2),
+        "expected (rows, markers) = (100, 2), got ({rows}, {markers}); parquet rows = \
+         {parquet_rows}, marker detail = {marker_detail:?}"
+    );
 }
 
 /// `write_table_rows` with an empty slice still creates the table schema.

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -466,7 +466,6 @@ async fn table_copy_with_row_filter_and_parallel_connections() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky under load"]
 async fn table_schema_copy_survives_pipeline_restarts() {
     init_test_tracing();
     let mut database = spawn_source_database().await;
@@ -564,7 +563,6 @@ async fn table_schema_copy_survives_pipeline_restarts() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky under load"]
 async fn publication_changes_are_correctly_handled() {
     init_test_tracing();
 


### PR DESCRIPTION
Removes the #[ignore = "flaky under load"] markers added in #674 on table_schema_copy_survives_pipeline_restarts and
publication_changes_are_correctly_handled to see whether earlier fixes (#679 slot-pattern escaping, #681 notify-before-start) reduced their flake rate enough to keep them enabled.