### PR TITLE
fix(core): Improves DuckLake and BigQuery destination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,13 @@
   ready.notified().await;
   ```
 
+### Integration Test Style
+- Prefer one-way integration tests: perform the source-side writes first, wait for the expected notifications, then call `shutdown_and_wait()` immediately before assertions.
+- Avoid asserting destination state while the pipeline is still running unless the test is specifically about in-flight behavior or recovery during active replication.
+- For `TestDestinationWrapper`, prefer asserting against the cumulative event history from `get_events()`. Use `clear_events()` only when restarting the pipeline or when a test intentionally needs to discard earlier history and assert on a new phase in isolation.
+- Use `get_events_deduped()` only for replay/idempotence scenarios where duplicate wrapper observations are expected and the test is asserting logical equivalence rather than delivery history.
+- When asserting CDC event shapes, only expect combinations that PostgreSQL can actually emit for the table's replica identity mode. In particular, distinguish between `FULL`, primary-key identity, and `USING INDEX`, and remember that partial update rows only occur for update new-tuples.
+
 ## Review Checklist
 - Code compiles for the changed target or workspace as appropriate.
 - Code is formatted.

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -165,7 +165,10 @@ Understanding the two phases helps you:
 
 ### The Problem
 
-When a row is updated or deleted, what identifies which row changed? By default, Postgres only sends the primary key - enough to identify the row, but not to see the old values.
+When a row is updated or deleted, downstream systems need enough old-row information to identify which source row changed.
+
+The important nuance is that PostgreSQL does **not** always send an old-side tuple for `UPDATE`.
+Under key-based replica identity, it only sends a key image when it is needed.
 
 ### Settings
 
@@ -179,18 +182,37 @@ ALTER TABLE your_table REPLICA IDENTITY FULL;
 
 | Setting | What's sent with UPDATE/DELETE | Use case |
 |---------|-------------------------------|----------|
-| `DEFAULT` | Primary key columns only | Most cases |
-| `FULL` | All columns (old values) | Audit logs, CDC requiring old values |
-| `NOTHING` | Nothing | Not recommended |
-| `USING INDEX` | Columns from specified index | Tables without primary key |
+| `DEFAULT` | For `UPDATE`, old primary-key columns only when PostgreSQL needs them; for `DELETE`, old primary-key columns | Most tables with a primary key |
+| `FULL` | Full old row | Destinations or audits that need full old-row images |
+| `NOTHING` | Published `UPDATE` and `DELETE` are rejected by PostgreSQL | Rare special cases, generally unsuitable for CDC |
+| `USING INDEX` | For `UPDATE`, old replica-identity index columns only when PostgreSQL needs them; for `DELETE`, old replica-identity index columns | Tables whose replication identity differs from the primary key |
 
 ### Impact on ETL
 
-In your destination's `write_events()`, Update and Delete events have an `old_table_row` field of type `Option<(bool, TableRow)>`:
+In ETL, update and delete events expose:
 
-- With `DEFAULT`: Contains `Some((true, row))` where `row` has only primary key columns
-- With `FULL`: Contains `Some((false, row))` where `row` has all columns with previous values
-- With `NOTHING`: Contains `None`
+```rust
+pub old_table_row: Option<OldTableRow>
+```
+
+where:
+
+- `Some(OldTableRow::Key(row))` means PostgreSQL sent only the replica-identity columns, normalized into replicated table-column order.
+- `Some(OldTableRow::Full(row))` means PostgreSQL sent the full old row.
+- `None` means PostgreSQL did not send an old-side tuple for that update.
+
+For `UPDATE`, `old_table_row = None` is normal when:
+
+- the table uses `DEFAULT` or `USING INDEX`, and
+- PostgreSQL determined no old-side image was required.
+
+For example, a non-identity-column update often arrives without an old row.
+If an identity column changed, or PostgreSQL still needs old identity values
+(such as externally stored identity columns), PostgreSQL sends a key image instead.
+
+For `DELETE`, valid publications include an old row image. If a delete arrives with
+`old_table_row = None`, ETL is preserving an upstream invalid state defensively, and most destinations should treat it
+as unsafe for row-matching deletes.
 
 If you need old values for auditing or comparison, set `REPLICA IDENTITY FULL` on those tables.
 

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -15,7 +15,7 @@ Postgres supports two types of replication:
 
 Physical replication creates identical Postgres instances. Logical replication decodes changes into a format that any system can consume - not just another Postgres server.
 
-ETL uses logical replication to stream changes to destinations like BigQuery, Iceberg, or your custom systems.
+ETL uses logical replication to stream changes to downstream systems.
 
 ## The Write-Ahead Log (WAL)
 
@@ -33,7 +33,7 @@ flowchart LR
     A[WAL bytes] --> B["Decoder (pgoutput)"] --> C[INSERT/UPDATE/DELETE events]
 ```
 
-ETL receives these decoded events and forwards them to your destination.
+ETL receives these decoded events and forwards them to downstream consumers.
 
 ### WAL Level
 
@@ -96,7 +96,7 @@ The Apply Worker uses one persistent slot. Table Sync Workers create temporary s
 
 ### Slot Risks
 
-Slots prevent WAL cleanup. If ETL stops consuming (due to crashes, network issues, or a slow destination), WAL files accumulate on disk. This can fill your disk.
+Slots prevent WAL cleanup. If ETL stops consuming (due to crashes, network issues, or a slow consumer), WAL files accumulate on disk. This can fill your disk.
 
 To mitigate this risk:
 
@@ -122,7 +122,7 @@ The decoder transforms binary WAL records into structured messages:
 | `TRUNCATE` | Table cleared |
 | `COMMIT` | Transaction completed |
 
-ETL receives these messages and converts them to events for your destination.
+ETL receives these messages and converts them to events.
 
 ## Why Two Phases?
 
@@ -135,7 +135,7 @@ Logical replication only captures **changes**. It doesn't know about data that e
 So ETL first copies all existing rows using Postgres's `COPY` command:
 
 1. Create replication slot (captures consistent snapshot point)
-2. COPY all rows from table to destination
+2. COPY all rows from the table
 3. Start streaming changes from the snapshot point
 
 The slot ensures no changes are lost between the snapshot and when streaming begins.
@@ -149,7 +149,7 @@ flowchart LR
     A[Postgres WAL] --> B[Decoder] --> C[ETL] --> D[Destination]
 ```
 
-Each change is delivered as an event (Insert, Update, Delete) to your destination's `write_events()` method.
+Each change is delivered as an event (Insert, Update, Delete) through `write_events()`.
 
 ### Why This Matters
 
@@ -169,6 +169,12 @@ When a row is updated or deleted, downstream systems need enough old-row informa
 
 The important nuance is that PostgreSQL does **not** always send an old-side tuple for `UPDATE`.
 Under key-based replica identity, it only sends a key image when it is needed.
+For `DELETE`, PostgreSQL sends an old-side tuple whenever the delete is publishable.
+
+This means replica identity is both a PostgreSQL logging rule and a contract for
+downstream consumers. It determines whether an event contains enough old-row
+data to match an existing row, detect key changes, or compare before-and-after
+values.
 
 ### Settings
 
@@ -180,41 +186,47 @@ SELECT relname, relreplident FROM pg_class WHERE relname = 'your_table';
 ALTER TABLE your_table REPLICA IDENTITY FULL;
 ```
 
-| Setting | What's sent with UPDATE/DELETE | Use case |
-|---------|-------------------------------|----------|
-| `DEFAULT` | For `UPDATE`, old primary-key columns only when PostgreSQL needs them; for `DELETE`, old primary-key columns | Most tables with a primary key |
-| `FULL` | Full old row | Destinations or audits that need full old-row images |
-| `NOTHING` | Published `UPDATE` and `DELETE` are rejected by PostgreSQL | Rare special cases, generally unsuitable for CDC |
-| `USING INDEX` | For `UPDATE`, old replica-identity index columns only when PostgreSQL needs them; for `DELETE`, old replica-identity index columns | Tables whose replication identity differs from the primary key |
+| Setting | Published `UPDATE` payload | Published `DELETE` payload | Notes |
+|---------|----------------------------|----------------------------|-------|
+| `DEFAULT` with a primary key | Old primary-key columns only when PostgreSQL determines the old key must be logged; otherwise no old tuple | Old primary-key columns | Most tables with a primary key |
+| `DEFAULT` without a primary key | Source `UPDATE` is rejected when the table publishes updates | Source `DELETE` is rejected when the table publishes deletes | Equivalent to having no usable replica identity for update/delete |
+| `FULL` | Full old row | Full old row | Use when consumers need full old-row images |
+| `NOTHING` | Source `UPDATE` is rejected when the table publishes updates | Source `DELETE` is rejected when the table publishes deletes | Suitable only when updates/deletes are not published |
+| `USING INDEX` | Old replica-identity index columns only when PostgreSQL determines the old key must be logged; otherwise no old tuple | Old replica-identity index columns | Tables whose replication identity differs from the primary key |
 
 ### Impact on ETL
 
-In ETL, update and delete events expose:
+ETL preserves PostgreSQL's old-row semantics in update and delete events:
 
 ```rust
 pub old_table_row: Option<OldTableRow>
 ```
 
-where:
-
 - `Some(OldTableRow::Key(row))` means PostgreSQL sent only the replica-identity columns, normalized into replicated table-column order.
 - `Some(OldTableRow::Full(row))` means PostgreSQL sent the full old row.
-- `None` means PostgreSQL did not send an old-side tuple for that update.
+- `None` means PostgreSQL did not send an old-side tuple for that update. This
+  is normal under `DEFAULT` or `USING INDEX` when PostgreSQL determines no
+  old-side image is required.
 
-For `UPDATE`, `old_table_row = None` is normal when:
+For `FULL`, PostgreSQL sends a full old row for every published update and delete.
+For `DELETE`, valid pgoutput messages always include either a full old row or a
+key image. `REPLICA IDENTITY NOTHING`, and `DEFAULT` on a table without a primary
+key, do not produce update/delete events when those actions are published; the
+source statement is rejected instead.
+The Rust event API keeps the old-row fields optional at the boundary, but those
+`None` cases are broader than the PostgreSQL pgoutput shapes described here.
 
-- the table uses `DEFAULT` or `USING INDEX`, and
-- PostgreSQL determined no old-side image was required.
+TOAST adds one more wrinkle. PostgreSQL can mark unchanged toasted update values
+as `UnchangedToast` instead of resending the value. ETL can reconstruct those
+values only if the old-side row image contains them, so tables with toasted
+columns can produce partial update rows unless they use `REPLICA IDENTITY FULL`
+or the missing values are present in a logged key image.
 
-For example, a non-identity-column update often arrives without an old row.
-If an identity column changed, or PostgreSQL still needs old identity values
-(such as externally stored identity columns), PostgreSQL sends a key image instead.
-
-For `DELETE`, valid publications include an old row image. If a delete arrives with
-`old_table_row = None`, ETL is preserving an upstream invalid state defensively, and most destinations should treat it
-as unsafe for row-matching deletes.
-
-If you need old values for auditing or comparison, set `REPLICA IDENTITY FULL` on those tables.
+If you need old values for auditing, comparison, complete replacement rows, or
+reliable reconstruction of unchanged toasted columns, set `REPLICA IDENTITY FULL`
+on those tables. If a consumer only needs stable key values, `DEFAULT` with a
+primary key or `USING INDEX` is usually enough, but update events will not always
+include `old_table_row`.
 
 ## LSN (Log Sequence Number)
 
@@ -255,7 +267,7 @@ ETL stores:
 |-------|---------|
 | Replication phase | Know whether to copy or stream for each table |
 | Table schemas | Validate incoming data against expected schema |
-| Table mappings | Route events to correct destination tables |
+| Table mappings | Route events to correct downstream tables |
 
 On restart, ETL loads this state and resumes from where it left off.
 
@@ -271,13 +283,13 @@ Here's the complete flow:
 4. ETL copies existing data (Phase 1: Initial Copy)
 5. ETL streams ongoing changes (Phase 2: Streaming)
 6. Postgres decodes WAL using pgoutput
-7. ETL receives events and sends them to your destination
+7. ETL receives events and forwards them downstream
 8. ETL reports progress back to Postgres (so WAL can be cleaned up)
 9. State is persisted for crash recovery
 
 ## Next Steps
 
 - [Architecture](architecture.md): How ETL's components work together
-- [Event Types](events.md): All events your destination receives
+- [Event Types](events.md): All events emitted by ETL
 - [Configure Postgres](../guides/configure-postgres.md): Production setup
 - [First Pipeline](../guides/first-pipeline.md): Build something

--- a/docs/explanation/events.md
+++ b/docs/explanation/events.md
@@ -1,8 +1,9 @@
 # Event Types
 
-**Understanding the events ETL delivers to your destination**
+**Understanding the events ETL emits from Postgres logical replication**
 
-ETL streams events from Postgres logical replication to your destination via `write_events()`. This page documents all event types and how to handle them.
+ETL streams events from Postgres logical replication via `write_events()`.
+This page documents the event types and the PostgreSQL semantics they preserve.
 
 ## Event Overview
 
@@ -13,13 +14,42 @@ ETL streams events from Postgres logical replication to your destination via `wr
 | `Insert` | New row added | Yes |
 | `Update` | Row modified | Yes |
 | `Delete` | Row removed | Yes |
-| `Relation` | Table schema | Yes |
 | `Truncate` | Table cleared | Yes |
+| `Relation` | Table schema | Yes |
 | `Unsupported` | Unknown event | No |
 
 ## Data Modification Events
 
 These events carry row data and are associated with specific tables.
+
+### Row Images
+
+Data modification events use row-image helper types:
+
+```rust
+pub enum UpdatedTableRow {
+    Full(TableRow),
+    Partial(PartialTableRow),
+}
+
+pub enum OldTableRow {
+    Full(TableRow),
+    Key(TableRow),
+}
+```
+
+`TableRow` is a complete dense row. Its values are ordered to match the
+replicated table-column order.
+
+`PartialTableRow` is used when an update row is not complete. It exposes:
+
+- `total_columns()`: the number of replicated columns in the table schema;
+- `values()`: present values in replicated table-column order, excluding missing columns;
+- `missing_column_indexes()`: zero-based replicated-column indexes for values ETL could not reconstruct.
+
+`OldTableRow::Full(row)` contains a complete old row. `OldTableRow::Key(row)`
+contains only replica-identity columns, densely packed in replicated
+table-column order.
 
 ### Insert
 
@@ -50,38 +80,86 @@ pub struct UpdateEvent {
 }
 ```
 
-`updated_table_row` is:
+`updated_table_row` is the authoritative post-update payload:
 
 - `UpdatedTableRow::Full` when ETL knows every replicated column value after decoding the update.
 - `UpdatedTableRow::Partial` when PostgreSQL emitted `UnchangedToast` fields that ETL could not reconstruct safely.
 
-As a destination author, treat `updated_table_row` as the authoritative
-post-update payload. The `old_table_row` field is auxiliary old-side context
-that may be needed for row matching, key changes, or reconstruction logic.
+The `old_table_row` field is auxiliary old-side context that may be needed for
+row matching, key changes, or reconstruction logic.
 
-The `old_table_row` field depends on PostgreSQL replica-identity semantics:
+#### Unchanged Toast
 
-| REPLICA IDENTITY | `old_table_row` contains |
-|------------------|--------------------------|
+PostgreSQL may encode an unchanged toasted value as `UnchangedToast` in the
+update's new tuple instead of resending the full column value. ETL can turn the
+update into `UpdatedTableRow::Full` only when that value can be recovered from
+the old-side row image:
+
+- a `FULL` old row can recover unchanged toasted values for any replicated column;
+- a key-only old row can recover unchanged toasted values only for
+  replica-identity columns included in that key image;
+- no old row means unchanged toasted values cannot be recovered from the event.
+
+When any `UnchangedToast` field cannot be recovered, ETL emits
+`UpdatedTableRow::Partial` with known values and missing column indexes instead
+of pretending the unknown value is `NULL` or a replacement value.
+
+Destinations that need complete replacement rows, full before/after comparison,
+or complete audit records should require `REPLICA IDENTITY FULL` for tables with
+toasted columns, or keep enough prior state to fill missing values themselves.
+
+#### Old Row Mapping
+
+ETL maps PostgreSQL pgoutput update tuple markers directly:
+
+| pgoutput marker | ETL field |
+|-----------------|-----------|
+| `O` old tuple | `Some(OldTableRow::Full(row))` |
+| `K` old key | `Some(OldTableRow::Key(row))` |
+| no old tuple/key marker | `None` |
+| `N` new tuple | `updated_table_row` |
+
+PostgreSQL chooses which old-side marker to emit from the table's replica
+identity:
+
+| REPLICA IDENTITY | `old_table_row` contains for published updates |
+|------------------|----------------------------------------------|
 | `FULL` | `Some(OldTableRow::Full(row))` |
-| `DEFAULT` / `USING INDEX` | `Some(OldTableRow::Key(row))` when PostgreSQL emits a key image, otherwise `None` |
-| `NOTHING` | Published `UPDATE` is rejected by PostgreSQL |
+| `DEFAULT` with a primary key | `Some(OldTableRow::Key(row))` when PostgreSQL determines the old key must be logged, otherwise `None` |
+| `DEFAULT` without a primary key | Source `UPDATE` is rejected when the table publishes updates |
+| `USING INDEX` | `Some(OldTableRow::Key(row))` when PostgreSQL determines the old key must be logged, otherwise `None` |
+| `NOTHING` | Source `UPDATE` is rejected when the table publishes updates |
 
 `OldTableRow::Key(row)` stores only the replica-identity columns, normalized into replicated table-column order.
 
-For `UPDATE`, PostgreSQL only sends an old key image when it needs one, for example:
+For `UPDATE`, PostgreSQL only sends an old key image under `DEFAULT` or
+`USING INDEX` when it determines the old key must be logged. In practice, that
+happens when:
 
-- the replica-identity value changed, or
-- PostgreSQL still needs the old identity values, such as externally stored identity columns.
+- any replica-identity column changed, or
+- any replica-identity column contains external data, such as a toasted value
+  that must be available from the old tuple.
 
 That means non-identity updates under `DEFAULT` or `USING INDEX` often arrive with `old_table_row = None`.
+Under `FULL`, PostgreSQL sends a full old row for every published update.
+A `FULL` update with `old_table_row = None` is not a shape emitted by
+PostgreSQL pgoutput.
 
-Important implications:
+Key points for update handling:
 
-- `old_table_row = None` on an update is usually a valid `pgoutput` shape. It does not mean the table has no replica identity.
+- `old_table_row = None` on an update is a valid `pgoutput` shape for `DEFAULT` or `USING INDEX`. It does not mean the table has no replica identity.
 - `OldTableRow::Key(row)` contains only replica-identity columns, in replicated table-column order. It is not necessarily the source primary key.
-- If your destination matches source rows by replica identity, use the identity columns from `old_table_row`.
-- If your destination matches source rows by some other key, such as the source primary key, project the old or new row down to that key yourself.
+- Consumers that match source rows by replica identity should use identity columns from `old_table_row` when present.
+- Consumers that match source rows by another key, such as the source primary key, can project the old or new row down to that key.
+- Consumers that need before-and-after values for arbitrary columns need `REPLICA IDENTITY FULL`; key-based identity only gives old identity columns, and only when PostgreSQL logs them.
+
+For destination implementations, a practical update flow is:
+
+1. Treat `updated_table_row` as the post-update payload.
+2. Handle `UpdatedTableRow::Partial` before constructing a complete replacement row.
+3. Use `OldTableRow::Key` only as old replica-identity values.
+4. Use `OldTableRow::Full` when full before-image values are required.
+5. If `old_table_row` is `None`, match or upsert from the new row according to the destination's own keying model.
 
 ### Delete
 
@@ -99,20 +177,24 @@ pub struct DeleteEvent {
 
 For `DELETE`, valid PostgreSQL publications send an old-side image:
 
-| REPLICA IDENTITY | `old_table_row` contains |
-|------------------|--------------------------|
+| REPLICA IDENTITY | `old_table_row` contains for published deletes |
+|------------------|---------------------------------------------|
 | `FULL` | `Some(OldTableRow::Full(row))` |
-| `DEFAULT` / `USING INDEX` | `Some(OldTableRow::Key(row))` |
-| `NOTHING` | Published `DELETE` is rejected by PostgreSQL |
-
-If `old_table_row` is `None` on a delete, ETL is preserving an upstream invalid state defensively, and destinations should treat it as unsafe for row-matching deletes.
+| `DEFAULT` with a primary key | `Some(OldTableRow::Key(row))` |
+| `DEFAULT` without a primary key | Source `DELETE` is rejected when the table publishes deletes |
+| `USING INDEX` | `Some(OldTableRow::Key(row))` |
+| `NOTHING` | Source `DELETE` is rejected when the table publishes deletes |
 
 Important implications:
 
 - Deletes do not carry a new row image. `old_table_row` is the delete payload.
 - `OldTableRow::Key(row)` again means replica-identity columns only, not necessarily the table's primary key.
-- A destination that cannot apply deletes from a key-only image must reject non-`FULL` replica identity up front.
-- A destination that sees `old_table_row = None` on a delete should treat it as invalid rather than silently guessing how to match the row.
+- Consumers that require full old rows for deletes need `REPLICA IDENTITY FULL`.
+- The Rust field is optional at the event API boundary, but PostgreSQL pgoutput
+  populates it for every published delete. Tables without usable replica
+  identity fail at the source when they publish deletes.
+- Destination implementations should decide up front whether key-only deletes
+  are enough. If they are not, require `REPLICA IDENTITY FULL` for those tables.
 
 ### Truncate
 
@@ -178,13 +260,25 @@ pub struct RelationEvent {
 }
 ```
 
+PostgreSQL pgoutput builds relation messages by walking the table descriptor in
+`pg_attribute.attnum` order and skipping columns that are not published. It
+sends tuple data in the same order as the relation message.
+
+ETL builds replication and identity masks from relation-message column names, so
+the order is not needed to decide which columns are included. That name-based
+matching is sound because PostgreSQL live column names are unique within a table
+schema version. The order matters only after the masks are applied: stored table
+schemas are also ordered by `attnum`, so
+`ReplicatedTableSchema::column_schemas()` becomes a positional view that matches
+the tuple payloads exactly, even when a publication filters columns.
+
 ## Begin/Commit Behavior
 
 During initial copy, `Begin` and `Commit` events may be delivered **multiple times** due to parallel Table Sync Workers creating separate replication slots. Row data (Insert, Update, Delete) is delivered exactly once.
 
 Handle this by either:
 - Tracking LSNs to detect duplicate Begin/Commit events
-- Ignoring Begin/Commit if your destination does not require transactions
+- Ignoring Begin/Commit if transaction markers are not required
 
 ```rust
 async fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult<()>) -> EtlResult<()> {
@@ -196,7 +290,7 @@ async fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult
                 Event::Delete(e) => self.handle_delete(e).await?,
                 Event::Truncate(e) => self.handle_truncate(e).await?,
                 Event::Relation(e) => self.handle_schema(e).await?,
-                // Transaction markers - safe to ignore for most destinations
+                // Transaction markers - safe to ignore for most consumers.
                 Event::Begin(_) | Event::Commit(_) => {}
                 Event::Unsupported => {}
             }

--- a/docs/explanation/events.md
+++ b/docs/explanation/events.md
@@ -27,10 +27,11 @@ A new row was added to a table.
 
 ```rust
 pub struct InsertEvent {
-    pub start_lsn: PgLsn,      // Position where event was recorded
-    pub commit_lsn: PgLsn,     // Position where transaction commits
-    pub table_id: TableId,     // Which table
-    pub table_row: TableRow,   // The new row data
+    pub start_lsn: PgLsn,
+    pub commit_lsn: PgLsn,
+    pub tx_ordinal: u64,
+    pub replicated_table_schema: ReplicatedTableSchema,
+    pub table_row: TableRow,
 }
 ```
 
@@ -42,19 +43,45 @@ An existing row was modified.
 pub struct UpdateEvent {
     pub start_lsn: PgLsn,
     pub commit_lsn: PgLsn,
-    pub table_id: TableId,
-    pub table_row: TableRow,                     // New row data
-    pub old_table_row: Option<(bool, TableRow)>, // Previous row (see below)
+    pub tx_ordinal: u64,
+    pub replicated_table_schema: ReplicatedTableSchema,
+    pub updated_table_row: UpdatedTableRow,
+    pub old_table_row: Option<OldTableRow>,
 }
 ```
 
-The `old_table_row` field depends on Postgres `REPLICA IDENTITY` setting:
+`updated_table_row` is:
+
+- `UpdatedTableRow::Full` when ETL knows every replicated column value after decoding the update.
+- `UpdatedTableRow::Partial` when PostgreSQL emitted `UnchangedToast` fields that ETL could not reconstruct safely.
+
+As a destination author, treat `updated_table_row` as the authoritative
+post-update payload. The `old_table_row` field is auxiliary old-side context
+that may be needed for row matching, key changes, or reconstruction logic.
+
+The `old_table_row` field depends on PostgreSQL replica-identity semantics:
 
 | REPLICA IDENTITY | `old_table_row` contains |
 |------------------|--------------------------|
-| `DEFAULT` | Primary key columns only (`true`, row) |
-| `FULL` | All columns (`false`, row) |
-| `NOTHING` | `None` |
+| `FULL` | `Some(OldTableRow::Full(row))` |
+| `DEFAULT` / `USING INDEX` | `Some(OldTableRow::Key(row))` when PostgreSQL emits a key image, otherwise `None` |
+| `NOTHING` | Published `UPDATE` is rejected by PostgreSQL |
+
+`OldTableRow::Key(row)` stores only the replica-identity columns, normalized into replicated table-column order.
+
+For `UPDATE`, PostgreSQL only sends an old key image when it needs one, for example:
+
+- the replica-identity value changed, or
+- PostgreSQL still needs the old identity values, such as externally stored identity columns.
+
+That means non-identity updates under `DEFAULT` or `USING INDEX` often arrive with `old_table_row = None`.
+
+Important implications:
+
+- `old_table_row = None` on an update is usually a valid `pgoutput` shape. It does not mean the table has no replica identity.
+- `OldTableRow::Key(row)` contains only replica-identity columns, in replicated table-column order. It is not necessarily the source primary key.
+- If your destination matches source rows by replica identity, use the identity columns from `old_table_row`.
+- If your destination matches source rows by some other key, such as the source primary key, project the old or new row down to that key yourself.
 
 ### Delete
 
@@ -64,12 +91,28 @@ A row was removed from a table.
 pub struct DeleteEvent {
     pub start_lsn: PgLsn,
     pub commit_lsn: PgLsn,
-    pub table_id: TableId,                       // Which table
-    pub old_table_row: Option<(bool, TableRow)>, // Deleted row data
+    pub tx_ordinal: u64,
+    pub replicated_table_schema: ReplicatedTableSchema,
+    pub old_table_row: Option<OldTableRow>,
 }
 ```
 
-Same `REPLICA IDENTITY` rules apply as for Update.
+For `DELETE`, valid PostgreSQL publications send an old-side image:
+
+| REPLICA IDENTITY | `old_table_row` contains |
+|------------------|--------------------------|
+| `FULL` | `Some(OldTableRow::Full(row))` |
+| `DEFAULT` / `USING INDEX` | `Some(OldTableRow::Key(row))` |
+| `NOTHING` | Published `DELETE` is rejected by PostgreSQL |
+
+If `old_table_row` is `None` on a delete, ETL is preserving an upstream invalid state defensively, and destinations should treat it as unsafe for row-matching deletes.
+
+Important implications:
+
+- Deletes do not carry a new row image. `old_table_row` is the delete payload.
+- `OldTableRow::Key(row)` again means replica-identity columns only, not necessarily the table's primary key.
+- A destination that cannot apply deletes from a key-only image must reject non-`FULL` replica identity up front.
+- A destination that sees `old_table_row = None` on a delete should treat it as invalid rather than silently guessing how to match the row.
 
 ### Truncate
 
@@ -79,8 +122,9 @@ One or more tables were truncated (all rows deleted).
 pub struct TruncateEvent {
     pub start_lsn: PgLsn,
     pub commit_lsn: PgLsn,
-    pub options: i8,       // Postgres truncate options
-    pub rel_ids: Vec<u32>, // List of truncated table IDs
+    pub tx_ordinal: u64,
+    pub options: i8,
+    pub truncated_tables: Vec<ReplicatedTableSchema>,
 }
 ```
 
@@ -96,10 +140,11 @@ Marks the start of a transaction.
 
 ```rust
 pub struct BeginEvent {
-    pub start_lsn: PgLsn,   // Position where transaction started
-    pub commit_lsn: PgLsn,  // Position where transaction will commit
-    pub timestamp: i64,     // Transaction start time
-    pub xid: u32,           // Transaction ID
+    pub start_lsn: PgLsn,
+    pub commit_lsn: PgLsn,
+    pub tx_ordinal: u64,
+    pub timestamp: i64,
+    pub xid: u32,
 }
 ```
 
@@ -111,9 +156,10 @@ Marks successful transaction completion.
 pub struct CommitEvent {
     pub start_lsn: PgLsn,
     pub commit_lsn: PgLsn,
-    pub flags: i8,        // Postgres commit flags
-    pub end_lsn: u64,     // Final LSN after commit
-    pub timestamp: i64,   // Commit time
+    pub tx_ordinal: u64,
+    pub flags: i8,
+    pub end_lsn: PgLsn,
+    pub timestamp: i64,
 }
 ```
 
@@ -127,7 +173,8 @@ Provides table schema information. Sent before data events for a table.
 pub struct RelationEvent {
     pub start_lsn: PgLsn,
     pub commit_lsn: PgLsn,
-    pub table_schema: TableSchema, // Column definitions, types, etc.
+    pub tx_ordinal: u64,
+    pub replicated_table_schema: ReplicatedTableSchema,
 }
 ```
 

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -802,7 +802,9 @@ where
                     break;
                 }
 
-                let event = events_iter.next().unwrap();
+                let Some(event) = events_iter.next() else {
+                    break;
+                };
                 match event {
                     Event::Insert(mut insert) => {
                         let sequence_key = insert.event_sequence_key().to_string();
@@ -1201,25 +1203,11 @@ fn bigquery_update_rows(
     old_table_row: Option<OldTableRow>,
     sequence_key: String,
 ) -> EtlResult<Vec<BigQueryTableRow>> {
-    if old_table_row.is_none()
-        && matches!(replicated_table_schema.identity_type(), IdentityType::Full)
-    {
-        bail!(
-            ErrorKind::InvalidState,
-            "BigQuery full replica identity update requires an old row image",
-            format!(
-                "Table '{}' emitted an update without an old row image even though it uses FULL \
-                 replica identity",
-                replicated_table_schema.name()
-            )
-        );
-    }
-
     let primary_key_changed = match old_table_row.as_ref() {
         // PostgreSQL omits the old-side image only when the publisher
         // determined it was unnecessary. For primary-key identity, that means
-        // the destination key did not change. `FULL` is handled above and must
-        // always carry an old row.
+        // the destination key did not change. `FULL` updates are expected to
+        // carry an old row from pgoutput.
         Some(old_table_row) => {
             bigquery_primary_key_changed(replicated_table_schema, old_table_row, &new_table_row)?
         }
@@ -1228,9 +1216,20 @@ fn bigquery_update_rows(
 
     let mut rows = Vec::with_capacity(1 + usize::from(primary_key_changed));
     if primary_key_changed {
+        let Some(old_table_row) = old_table_row else {
+            bail!(
+                ErrorKind::InvalidState,
+                "BigQuery primary key change is missing old row",
+                format!(
+                    "Table '{}' primary key change was detected without an old row image",
+                    replicated_table_schema.name()
+                )
+            );
+        };
+
         rows.push(bigquery_delete_row(
             replicated_table_schema,
-            old_table_row.expect("checked above"),
+            old_table_row,
             sequence_key.clone(),
         )?);
     }
@@ -1319,8 +1318,17 @@ fn bigquery_primary_key_changed(
                 .map(|(_, value)| value);
 
             for old_value in old_key_values {
-                let new_value =
-                    new_primary_key_values.next().expect("validated primary-key column count");
+                let Some(new_value) = new_primary_key_values.next() else {
+                    bail!(
+                        ErrorKind::InvalidState,
+                        "BigQuery primary key schema mismatch",
+                        format!(
+                            "Table '{}' did not expose enough primary key columns",
+                            replicated_table_schema.name()
+                        )
+                    );
+                };
+
                 if old_value != new_value {
                     return Ok(true);
                 }
@@ -1405,7 +1413,18 @@ fn bigquery_primary_key_tagged_cells_from_old_row(
                     primary_key_column.ordinal_position == column_schema.ordinal_position
                 }) {
                     primary_key_columns.next();
-                    let value = key_values.next().expect("validated key image length");
+
+                    let Some(value) = key_values.next() else {
+                        bail!(
+                            ErrorKind::InvalidState,
+                            "BigQuery delete key image shape is inconsistent",
+                            format!(
+                                "Table '{}' key image ended before all primary key values",
+                                replicated_table_schema.name()
+                            )
+                        );
+                    };
+
                     tagged_cells.push((column_index + 1, value));
                 }
             }
@@ -2129,25 +2148,6 @@ mod tests {
                 (3, CellNonOptional::String("UPSERT".to_string())),
                 (4, CellNonOptional::String("lsn:1".to_string())),
             ]
-        );
-    }
-
-    #[test]
-    fn bigquery_update_rows_rejects_full_identity_update_without_old_row() {
-        let replicated_table_schema = replicated_schema(IdentityType::Full);
-
-        let error = bigquery_update_rows(
-            &replicated_table_schema,
-            TableRow::new(vec![Cell::I32(1), Cell::String("updated".to_string())]),
-            None,
-            "lsn:1".to_string(),
-        )
-        .unwrap_err();
-
-        assert_eq!(error.kind(), ErrorKind::InvalidState);
-        assert_eq!(
-            error.description(),
-            Some("BigQuery full replica identity update requires an old row image")
         );
     }
 }

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -819,9 +819,10 @@ where
                         entry.1.push(BigQueryTableRow::try_from(insert.table_row)?);
                     }
                     Event::Update(update) => {
+                        validate_bigquery_replica_identity(&update.replicated_table_schema)?;
                         let sequence_key = update.event_sequence_key().to_string();
                         let table_id = update.replicated_table_schema.id();
-                        let mut table_row = match update.updated_table_row {
+                        let table_row = match update.updated_table_row {
                             UpdatedTableRow::Full(row) => row,
                             UpdatedTableRow::Partial(_) => {
                                 return Err(etl_error!(
@@ -835,20 +836,32 @@ where
                                 ));
                             }
                         };
-                        table_row.values_mut().push(BigQueryOperationType::Upsert.into_cell());
-                        table_row.values_mut().push(Cell::String(sequence_key));
 
                         let entry = table_id_to_data.entry(table_id).or_insert_with(|| {
                             (update.replicated_table_schema.clone(), Vec::new())
                         });
-                        entry.1.push(BigQueryTableRow::try_from(table_row)?);
+                        entry.1.extend(bigquery_update_rows(
+                            &update.replicated_table_schema,
+                            table_row,
+                            update.old_table_row,
+                            sequence_key,
+                        )?);
                     }
                     Event::Delete(delete) => {
+                        validate_bigquery_replica_identity(&delete.replicated_table_schema)?;
                         let sequence_key = delete.event_sequence_key().to_string();
-                        let Some(old_table_row) = delete.old_table_row else {
-                            info!("delete event has no row, skipping");
-                            continue;
-                        };
+                        let old_table_row = delete.old_table_row.ok_or_else(|| {
+                            etl_error!(
+                                ErrorKind::InvalidState,
+                                "BigQuery delete requires an old row image",
+                                format!(
+                                    "Table '{}' emitted a delete without an old row image. \
+                                     BigQuery deletes are keyed by the source primary key and \
+                                     cannot be applied safely without it.",
+                                    delete.replicated_table_schema.name()
+                                )
+                            )
+                        })?;
 
                         let table_id = delete.replicated_table_schema.id();
                         let entry = table_id_to_data.entry(table_id).or_insert_with(|| {
@@ -1069,12 +1082,16 @@ where
 
 /// Validates that a replicated table schema can be applied in BigQuery.
 ///
-/// BigQuery matches deletes and upserts by the destination table primary key,
-/// so the source table must always expose a compatible row identity.
-/// PostgreSQL replica identity may use that primary key directly or request
-/// full old-row images, but alternative replica-identity indexes would
-/// identify rows differently from the destination key and would therefore
-/// apply updates and deletes incorrectly.
+/// BigQuery matches CDC rows by the destination table primary key, so the
+/// source table must always expose that key.
+/// PostgreSQL replica identity may either:
+/// - match the source primary key directly, or
+/// - request full old-row images (`FULL`), which still let us recover the
+///   source primary key for deletes and primary-key-changing updates.
+///
+/// Alternative replica-identity indexes are not compatible with BigQuery's
+/// destination key because BigQuery would deduplicate against a different row
+/// identity than the source publisher.
 fn validate_bigquery_replica_identity(
     replicated_table_schema: &ReplicatedTableSchema,
 ) -> EtlResult<()> {
@@ -1162,46 +1179,232 @@ where
     }
 }
 
-/// Builds a CDC delete row for BigQuery from either a full old row image or a
-/// replica-identity key image.
-fn bigquery_delete_row(
-    replicated_table_schema: &ReplicatedTableSchema,
-    old_table_row: OldTableRow,
+/// Builds a BigQuery CDC upsert row.
+fn bigquery_upsert_row(
+    mut table_row: TableRow,
     sequence_key: String,
 ) -> EtlResult<BigQueryTableRow> {
-    match old_table_row {
-        OldTableRow::Full(mut row) => {
-            row.values_mut().push(BigQueryOperationType::Delete.into_cell());
-            row.values_mut().push(Cell::String(sequence_key));
+    table_row.values_mut().push(BigQueryOperationType::Upsert.into_cell());
+    table_row.values_mut().push(Cell::String(sequence_key));
 
-            BigQueryTableRow::try_from(row)
+    BigQueryTableRow::try_from(table_row)
+}
+
+/// Builds one or two BigQuery CDC rows for an update.
+///
+/// BigQuery applies CDC rows by the destination primary key, so if the source
+/// update changes that key we must first delete the old key before upserting
+/// the new row.
+fn bigquery_update_rows(
+    replicated_table_schema: &ReplicatedTableSchema,
+    new_table_row: TableRow,
+    old_table_row: Option<OldTableRow>,
+    sequence_key: String,
+) -> EtlResult<Vec<BigQueryTableRow>> {
+    if old_table_row.is_none()
+        && matches!(replicated_table_schema.identity_type(), IdentityType::Full)
+    {
+        bail!(
+            ErrorKind::InvalidState,
+            "BigQuery full replica identity update requires an old row image",
+            format!(
+                "Table '{}' emitted an update without an old row image even though it uses FULL \
+                 replica identity",
+                replicated_table_schema.name()
+            )
+        );
+    }
+
+    let primary_key_changed = match old_table_row.as_ref() {
+        // PostgreSQL omits the old-side image only when the publisher
+        // determined it was unnecessary. For primary-key identity, that means
+        // the destination key did not change. `FULL` is handled above and must
+        // always carry an old row.
+        Some(old_table_row) => {
+            bigquery_primary_key_changed(replicated_table_schema, old_table_row, &new_table_row)?
         }
-        OldTableRow::Key(row) => {
-            let source_column_count = replicated_table_schema.column_schemas().count();
-            let identity_column_count = replicated_table_schema.identity_column_schemas().len();
-            if row.values().len() != identity_column_count {
+        None => false,
+    };
+
+    let mut rows = Vec::with_capacity(1 + usize::from(primary_key_changed));
+    if primary_key_changed {
+        rows.push(bigquery_delete_row(
+            replicated_table_schema,
+            old_table_row.expect("checked above"),
+            sequence_key.clone(),
+        )?);
+    }
+    rows.push(bigquery_upsert_row(new_table_row, sequence_key)?);
+
+    Ok(rows)
+}
+
+/// Returns whether an update changed the destination primary key.
+fn bigquery_primary_key_changed(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: &OldTableRow,
+    new_table_row: &TableRow,
+) -> EtlResult<bool> {
+    let column_count = replicated_table_schema.column_schemas().len();
+    if new_table_row.values().len() != column_count {
+        bail!(
+            ErrorKind::InvalidState,
+            "BigQuery full row image does not match the replicated schema",
+            format!(
+                "Expected {} values for table '{}', got {}",
+                column_count,
+                replicated_table_schema.name(),
+                new_table_row.values().len()
+            )
+        );
+    }
+
+    match old_table_row {
+        OldTableRow::Full(row) => {
+            if row.values().len() != column_count {
                 bail!(
                     ErrorKind::InvalidState,
-                    "BigQuery delete key image does not match replica identity",
+                    "BigQuery full row image does not match the replicated schema",
                     format!(
-                        "Expected {} key values for table '{}', got {}",
-                        identity_column_count,
+                        "Expected {} values for table '{}', got {}",
+                        column_count,
                         replicated_table_schema.name(),
                         row.values().len()
                     )
                 );
             }
 
-            let mut tagged_cells = Vec::new();
-            let mut identity_columns = replicated_table_schema.identity_column_schemas().peekable();
+            Ok(replicated_table_schema
+                .column_schemas()
+                .zip(row.values())
+                .zip(new_table_row.values())
+                .any(|((column_schema, old_value), new_value)| {
+                    column_schema.primary_key() && old_value != new_value
+                }))
+        }
+        OldTableRow::Key(row) => {
+            if !replicated_table_schema.identity_matches_primary_key() {
+                bail!(
+                    ErrorKind::InvalidState,
+                    "BigQuery key image does not match the source primary key",
+                    format!(
+                        "Table '{}' emitted a key image for replica identity {:?}, but BigQuery \
+                         rows are keyed by the source primary key",
+                        replicated_table_schema.name(),
+                        replicated_table_schema.identity_type()
+                    )
+                );
+            }
+
+            let primary_key_column_count =
+                replicated_table_schema.primary_key_column_schemas().len();
+            let old_key_values = row.values();
+            if old_key_values.len() != primary_key_column_count {
+                bail!(
+                    ErrorKind::InvalidState,
+                    "BigQuery key image does not match the source primary key",
+                    format!(
+                        "Expected {} key values for table '{}', got {}",
+                        primary_key_column_count,
+                        replicated_table_schema.name(),
+                        old_key_values.len()
+                    )
+                );
+            }
+
+            let mut new_primary_key_values = replicated_table_schema
+                .column_schemas()
+                .zip(new_table_row.values())
+                .filter(|(column_schema, _)| column_schema.primary_key())
+                .map(|(_, value)| value);
+
+            for old_value in old_key_values {
+                let new_value =
+                    new_primary_key_values.next().expect("validated primary-key column count");
+                if old_value != new_value {
+                    return Ok(true);
+                }
+            }
+
+            Ok(false)
+        }
+    }
+}
+
+/// Extracts tagged primary-key cells from an old row image.
+fn bigquery_primary_key_tagged_cells_from_old_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: OldTableRow,
+) -> EtlResult<Vec<(usize, Cell)>> {
+    match old_table_row {
+        OldTableRow::Full(row) => {
+            let column_count = replicated_table_schema.column_schemas().len();
+            let primary_key_column_count =
+                replicated_table_schema.primary_key_column_schemas().len();
+            if row.values().len() != column_count {
+                bail!(
+                    ErrorKind::InvalidState,
+                    "BigQuery full row image does not match the replicated schema",
+                    format!(
+                        "Expected {} values for table '{}', got {}",
+                        column_count,
+                        replicated_table_schema.name(),
+                        row.values().len()
+                    )
+                );
+            }
+
+            let mut tagged_cells = Vec::with_capacity(primary_key_column_count);
+            for (column_index, (column_schema, value)) in
+                replicated_table_schema.column_schemas().zip(row.into_values()).enumerate()
+            {
+                if column_schema.primary_key() {
+                    tagged_cells.push((column_index + 1, value));
+                }
+            }
+
+            Ok(tagged_cells)
+        }
+        OldTableRow::Key(row) => {
+            if !replicated_table_schema.identity_matches_primary_key() {
+                bail!(
+                    ErrorKind::InvalidState,
+                    "BigQuery key image does not match the source primary key",
+                    format!(
+                        "Table '{}' emitted a key image for replica identity {:?}, but BigQuery \
+                         rows are keyed by the source primary key",
+                        replicated_table_schema.name(),
+                        replicated_table_schema.identity_type()
+                    )
+                );
+            }
+
+            let primary_key_column_count =
+                replicated_table_schema.primary_key_column_schemas().len();
+            if row.values().len() != primary_key_column_count {
+                bail!(
+                    ErrorKind::InvalidState,
+                    "BigQuery delete key image does not match the source primary key",
+                    format!(
+                        "Expected {} key values for table '{}', got {}",
+                        primary_key_column_count,
+                        replicated_table_schema.name(),
+                        row.values().len()
+                    )
+                );
+            }
+
+            let mut tagged_cells = Vec::with_capacity(primary_key_column_count);
+            let mut primary_key_columns =
+                replicated_table_schema.primary_key_column_schemas().peekable();
             let mut key_values = row.into_values().into_iter();
             for (column_index, column_schema) in
                 replicated_table_schema.column_schemas().enumerate()
             {
-                if identity_columns.peek().is_some_and(|identity_column| {
-                    identity_column.ordinal_position == column_schema.ordinal_position
+                if primary_key_columns.peek().is_some_and(|primary_key_column| {
+                    primary_key_column.ordinal_position == column_schema.ordinal_position
                 }) {
-                    identity_columns.next();
+                    primary_key_columns.next();
                     let value = key_values.next().expect("validated key image length");
                     tagged_cells.push((column_index + 1, value));
                 }
@@ -1212,18 +1415,30 @@ fn bigquery_delete_row(
                     ErrorKind::InvalidState,
                     "BigQuery delete key image has leftover values",
                     format!(
-                        "Table '{}' key image contained more values than its replica identity",
+                        "Table '{}' key image contained more values than its primary key",
                         replicated_table_schema.name()
                     )
                 );
             }
 
-            tagged_cells.push((source_column_count + 1, BigQueryOperationType::Delete.into_cell()));
-            tagged_cells.push((source_column_count + 2, Cell::String(sequence_key)));
-
-            BigQueryTableRow::try_from_tagged_cells(tagged_cells)
+            Ok(tagged_cells)
         }
     }
+}
+
+/// Builds a CDC delete row for BigQuery from an old row image.
+fn bigquery_delete_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: OldTableRow,
+    sequence_key: String,
+) -> EtlResult<BigQueryTableRow> {
+    let source_column_count = replicated_table_schema.column_schemas().len();
+    let mut tagged_cells =
+        bigquery_primary_key_tagged_cells_from_old_row(replicated_table_schema, old_table_row)?;
+    tagged_cells.push((source_column_count + 1, BigQueryOperationType::Delete.into_cell()));
+    tagged_cells.push((source_column_count + 2, Cell::String(sequence_key)));
+
+    BigQueryTableRow::try_from_tagged_cells(tagged_cells)
 }
 
 /// Calculates the optimal number of batches for table copy operations.
@@ -1304,7 +1519,7 @@ fn split_table_rows(
 mod tests {
     use std::sync::Arc;
 
-    use etl::types::{ColumnSchema, IdentityMask, TableId, TableSchema, Type};
+    use etl::types::{CellNonOptional, ColumnSchema, IdentityMask, TableId, TableSchema, Type};
     use prost::Message;
 
     use super::*;
@@ -1786,5 +2001,153 @@ mod tests {
         // delete rows.
         assert!(!encoded.contains(&0x12));
         assert!(!encoded.contains(&0x18));
+    }
+
+    #[test]
+    fn bigquery_delete_full_row_omits_non_primary_key_source_columns() {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), Type::INT4, -1, 1, Some(1), false),
+                ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, false),
+                ColumnSchema::new("age".to_string(), Type::INT4, -1, 3, None, false),
+            ],
+        ));
+        let replicated_table_schema = ReplicatedTableSchema::from_masks(
+            table_schema,
+            etl::types::ReplicationMask::from_bytes(vec![1, 1, 1]),
+            IdentityMask::from_bytes(vec![1, 1, 1]),
+        );
+
+        let row = bigquery_delete_row(
+            &replicated_table_schema,
+            OldTableRow::Full(TableRow::new(vec![
+                Cell::I32(42),
+                Cell::String("alice".to_string()),
+                Cell::I32(7),
+            ])),
+            "lsn:1".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            row.debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(42)),
+                (4, CellNonOptional::String("DELETE".to_string())),
+                (5, CellNonOptional::String("lsn:1".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn bigquery_update_rows_emits_delete_before_upsert_when_primary_key_changes() {
+        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+
+        let rows = bigquery_update_rows(
+            &replicated_table_schema,
+            TableRow::new(vec![Cell::I32(2), Cell::String("updated".to_string())]),
+            Some(OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]))),
+            "lsn:1".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(1)),
+                (3, CellNonOptional::String("DELETE".to_string())),
+                (4, CellNonOptional::String("lsn:1".to_string())),
+            ]
+        );
+        assert_eq!(
+            rows[1].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(2)),
+                (2, CellNonOptional::String("updated".to_string())),
+                (3, CellNonOptional::String("UPSERT".to_string())),
+                (4, CellNonOptional::String("lsn:1".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn bigquery_update_rows_skips_delete_when_primary_key_is_unchanged() {
+        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+
+        let rows = bigquery_update_rows(
+            &replicated_table_schema,
+            TableRow::new(vec![Cell::I32(1), Cell::String("updated".to_string())]),
+            Some(OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]))),
+            "lsn:1".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(1)),
+                (2, CellNonOptional::String("updated".to_string())),
+                (3, CellNonOptional::String("UPSERT".to_string())),
+                (4, CellNonOptional::String("lsn:1".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn bigquery_update_rows_emits_delete_before_upsert_for_full_identity_primary_key_change() {
+        let replicated_table_schema = replicated_schema(IdentityType::Full);
+
+        let rows = bigquery_update_rows(
+            &replicated_table_schema,
+            TableRow::new(vec![Cell::I32(2), Cell::String("updated".to_string())]),
+            Some(OldTableRow::Full(TableRow::new(vec![
+                Cell::I32(1),
+                Cell::String("before".to_string()),
+            ]))),
+            "lsn:1".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(1)),
+                (3, CellNonOptional::String("DELETE".to_string())),
+                (4, CellNonOptional::String("lsn:1".to_string())),
+            ]
+        );
+        assert_eq!(
+            rows[1].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(2)),
+                (2, CellNonOptional::String("updated".to_string())),
+                (3, CellNonOptional::String("UPSERT".to_string())),
+                (4, CellNonOptional::String("lsn:1".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn bigquery_update_rows_rejects_full_identity_update_without_old_row() {
+        let replicated_table_schema = replicated_schema(IdentityType::Full);
+
+        let error = bigquery_update_rows(
+            &replicated_table_schema,
+            TableRow::new(vec![Cell::I32(1), Cell::String("updated".to_string())]),
+            None,
+            "lsn:1".to_string(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidState);
+        assert_eq!(
+            error.description(),
+            Some("BigQuery full replica identity update requires an old row image")
+        );
     }
 }

--- a/etl-destinations/src/bigquery/encoding.rs
+++ b/etl-destinations/src/bigquery/encoding.rs
@@ -81,6 +81,12 @@ impl BigQueryTableRow {
 
         Ok(BigQueryTableRow(validated_cells))
     }
+
+    /// Returns the tagged non-null cells for assertions in tests.
+    #[cfg(test)]
+    pub(super) fn debug_cells(&self) -> &[(u32, CellNonOptional)] {
+        &self.0
+    }
 }
 
 impl prost::Message for BigQueryTableRow {

--- a/etl-destinations/src/bigquery/test_utils.rs
+++ b/etl-destinations/src/bigquery/test_utils.rs
@@ -219,13 +219,16 @@ impl BigQueryDatabase {
         let mut attempts_remaining = BIGQUERY_QUERY_MAX_ATTEMPTS;
 
         loop {
-            let rows = self
+            let rows = match self
                 .client
                 .job()
                 .query(&self.project_id, QueryRequest::new(query.clone()))
                 .await
-                .unwrap()
-                .rows;
+            {
+                Ok(response) => response.rows,
+                Err(BQError::ResponseError { error }) if error.error.code == 404 => return None,
+                Err(err) => panic!("Failed to query BigQuery table: {err:?}"),
+            };
 
             if rows.is_some() || attempts_remaining == 1 {
                 return rows;

--- a/etl-destinations/src/bigquery/test_utils.rs
+++ b/etl-destinations/src/bigquery/test_utils.rs
@@ -3,7 +3,7 @@
 //! Provides a database wrapper for managing BigQuery datasets and constants for
 //! connecting to Google Cloud BigQuery in test environments.
 
-use std::{fmt, str::FromStr, time::Duration};
+use std::{fmt, path::Path, str::FromStr, time::Duration};
 
 use etl::{
     store::{schema::SchemaStore, state::StateStore},
@@ -57,16 +57,26 @@ pub const BIGQUERY_SA_KEY_PATH_ENV: &str = "TESTS_BIGQUERY_SA_KEY_PATH";
 ///
 /// Prints a warning and returns `true` when credentials are unavailable.
 pub fn skip_if_missing_bigquery_env_vars() -> bool {
-    let has_sa_key_path = std::env::var_os(BIGQUERY_SA_KEY_PATH_ENV).is_some();
+    let sa_key_path = std::env::var_os(BIGQUERY_SA_KEY_PATH_ENV);
     let has_project_id = std::env::var_os(BIGQUERY_PROJECT_ID_ENV).is_some();
-    if has_sa_key_path && has_project_id {
+    let has_sa_key_path = sa_key_path.is_some();
+    let has_sa_key_file = sa_key_path.as_ref().is_some_and(|path| Path::new(path).is_file());
+    if has_sa_key_file && has_project_id {
         return false;
     }
 
     let mut missing_env_vars = Vec::new();
     if !has_sa_key_path {
         missing_env_vars.push(BIGQUERY_SA_KEY_PATH_ENV);
+    } else if !has_sa_key_file {
+        eprintln!(
+            "skipping bigquery integration test: {BIGQUERY_SA_KEY_PATH_ENV} does not point to an \
+             existing file"
+        );
+
+        return true;
     }
+
     if !has_project_id {
         missing_env_vars.push(BIGQUERY_PROJECT_ID_ENV);
     }

--- a/etl-destinations/src/ducklake/METRICS.md
+++ b/etl-destinations/src/ducklake/METRICS.md
@@ -104,12 +104,13 @@ How to read it:
 
 - `task="flush"` with
   `reason="pending_inlined_data_bytes_threshold"` means the flush was
-  scheduled from sampled inline insert-data table size in a PostgreSQL-backed
-  DuckLake catalog.
+  scheduled from sampled inlined catalog-table size in a PostgreSQL-backed
+  DuckLake catalog. This includes both inlined inserts and inlined deletions.
 - `task="flush"` with `reason="pending_bytes_threshold"` means the flush was
-  scheduled because the fallback estimated pre-compression inline bytes
+  scheduled because the fallback estimated pre-compression inlined bytes
   crossed the configured threshold. The current heuristic assumes a 4:1
-  raw-to-parquet compression ratio.
+  raw-to-parquet compression ratio when direct catalog-size sampling is not
+  available.
 - `task="flush"` with `reason="pending_inserted_rows_threshold"` means the
   optional row-count threshold was enabled in code and fired before shutdown.
 - `task="scheduled_maintenance"` with `reason="merge_interval"` means the

--- a/etl-destinations/src/ducklake/batches.rs
+++ b/etl-destinations/src/ducklake/batches.rs
@@ -23,8 +23,8 @@ use etl::{
     error::{ErrorKind, EtlResult},
     etl_error,
     types::{
-        Cell, EventSequenceKey, OldTableRow, PartialTableRow, ReplicatedTableSchema, TableRow,
-        UpdatedTableRow,
+        Cell, EventSequenceKey, OldTableRow, PartialTableRow, ReplicatedTableSchema, SizeHint,
+        TableRow, UpdatedTableRow,
     },
 };
 use metrics::{counter, histogram};
@@ -164,15 +164,13 @@ impl TrackedTableMutation {
         EventSequenceKey::new(self.commit_lsn, self.tx_ordinal)
     }
 
-    /// Returns the row that will be upserted for this mutation, if any.
-    pub(super) fn upsert_row(&self) -> Option<&TableRow> {
+    /// Returns the approximate payload bytes that this mutation contributes to
+    /// inline-maintenance accounting.
+    pub(super) fn write_activity_size_hint(&self) -> u64 {
         match &self.mutation {
-            TableMutation::Insert(row) | TableMutation::Replace(row) => Some(row),
-            TableMutation::Update { new_row, .. } => match new_row {
-                UpdatedTableRow::Full(row) => Some(row),
-                UpdatedTableRow::Partial(_) => None,
-            },
-            TableMutation::Delete(_) => None,
+            TableMutation::Insert(row) | TableMutation::Replace(row) => row.size_hint() as u64,
+            TableMutation::Delete(row) => row.size_hint() as u64,
+            TableMutation::Update { new_row, .. } => new_row.size_hint() as u64,
         }
     }
 }
@@ -1108,16 +1106,14 @@ fn delete_predicate_from_row<'a>(
 ) -> EtlResult<String> {
     let row = row.into();
     let replicated_column_schemas: Vec<_> = replicated_table_schema.column_schemas().collect();
-
-    if !replicated_column_schemas
-        .iter()
-        .any(|column_schema| column_schema.primary_key_ordinal_position.is_some())
-    {
+    let identity_column_schemas: Vec<_> =
+        replicated_table_schema.identity_column_schemas().collect();
+    if identity_column_schemas.is_empty() {
         return Err(etl_error!(
             ErrorKind::InvalidState,
-            "DuckLake delete requires a primary key",
+            "DuckLake delete requires a replica identity",
             format!(
-                "Table '{}' has no replicated primary key columns",
+                "Table '{}' has no replicated replica-identity columns",
                 replicated_table_schema.name()
             )
         ));
@@ -1138,9 +1134,8 @@ fn delete_predicate_from_row<'a>(
                 ));
             }
 
-            let mut identity_columns = replicated_table_schema.identity_column_schemas().peekable();
-            let mut key_values =
-                Vec::with_capacity(replicated_table_schema.identity_column_schemas().len());
+            let mut identity_columns = identity_column_schemas.iter().copied().peekable();
+            let mut key_values = Vec::with_capacity(identity_column_schemas.len());
 
             for (column_schema, value) in replicated_column_schemas.iter().zip(row.values()) {
                 if identity_columns.peek().is_some_and(|identity_column| {
@@ -1154,22 +1149,20 @@ fn delete_predicate_from_row<'a>(
             key_values
         }
         DeletePredicateRowRef::Key(row) => {
-            let key_column_schemas: Vec<_> =
-                replicated_table_schema.identity_column_schemas().collect();
-            if row.values().len() != key_column_schemas.len() {
+            if row.values().len() != identity_column_schemas.len() {
                 return Err(etl_error!(
                     ErrorKind::InvalidState,
                     "DuckLake key image does not match replica identity",
                     format!(
                         "Expected {} key values for table '{}', got {}",
-                        key_column_schemas.len(),
+                        identity_column_schemas.len(),
                         replicated_table_schema.name(),
                         row.values().len()
                     )
                 ));
             }
 
-            key_column_schemas.into_iter().zip(row.values()).collect()
+            identity_column_schemas.iter().copied().zip(row.values()).collect()
         }
     };
 
@@ -2073,8 +2066,8 @@ fn maybe_fail_after_copy_batch_commit_for_tests(table_name: &str) -> EtlResult<(
 #[cfg(test)]
 mod tests {
     use etl::types::{
-        ColumnSchema, OldTableRow, PartialTableRow, ReplicatedTableSchema, TableId, TableName,
-        TableSchema, Type as PgType, UpdatedTableRow,
+        ColumnSchema, IdentityMask, OldTableRow, PartialTableRow, ReplicatedTableSchema,
+        ReplicationMask, TableId, TableName, TableSchema, Type as PgType, UpdatedTableRow,
     };
 
     use super::*;
@@ -2095,7 +2088,7 @@ mod tests {
     }
 
     #[test]
-    fn delete_predicate_from_row_uses_only_primary_key_columns() {
+    fn delete_predicate_from_row_uses_only_replica_identity_columns() {
         let replicated_table_schema = ReplicatedTableSchema::all(Arc::new(TableSchema::new(
             TableId::new(1),
             TableName::new("public".to_string(), "users".to_string()),
@@ -2112,6 +2105,78 @@ mod tests {
             delete_predicate_from_row(&replicated_table_schema, &row).unwrap(),
             "tenant_id = 7 AND id = 42"
         );
+    }
+
+    #[test]
+    fn delete_predicate_from_row_supports_alternative_identity_without_primary_key() {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), PgType::INT4, -1, 1, None, false),
+                ColumnSchema::new("email".to_string(), PgType::TEXT, -1, 2, None, false),
+                ColumnSchema::new("name".to_string(), PgType::TEXT, -1, 3, None, true),
+            ],
+        ));
+        let replicated_table_schema = ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            IdentityMask::from_bytes(vec![0, 1, 0]),
+        );
+        let row = TableRow::new(vec![
+            Cell::I32(7),
+            Cell::String("alice@example.com".to_string()),
+            Cell::String("alice".to_string()),
+        ]);
+
+        assert_eq!(
+            delete_predicate_from_row(&replicated_table_schema, &row).unwrap(),
+            "email = 'alice@example.com'"
+        );
+    }
+
+    #[test]
+    fn delete_predicate_from_row_uses_full_replica_identity_columns() {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), PgType::INT4, -1, 1, Some(1), false),
+                ColumnSchema::new("email".to_string(), PgType::TEXT, -1, 2, None, false),
+                ColumnSchema::new("name".to_string(), PgType::TEXT, -1, 3, None, true),
+            ],
+        ));
+        let replicated_table_schema = ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            IdentityMask::from_bytes(vec![1, 1, 1]),
+        );
+        let row = TableRow::new(vec![
+            Cell::I32(7),
+            Cell::String("alice@example.com".to_string()),
+            Cell::String("alice".to_string()),
+        ]);
+
+        assert_eq!(
+            delete_predicate_from_row(&replicated_table_schema, &row).unwrap(),
+            "id = 7 AND email = 'alice@example.com' AND name = 'alice'"
+        );
+    }
+
+    #[test]
+    fn delete_predicate_from_row_rejects_missing_replica_identity() {
+        let table_schema = Arc::new(make_schema());
+        let replicated_table_schema = ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            IdentityMask::from_bytes(vec![0, 0]),
+        );
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_string())]);
+
+        let error = delete_predicate_from_row(&replicated_table_schema, &row).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidState);
+        assert_eq!(error.description(), Some("DuckLake delete requires a replica identity"));
     }
 
     #[test]
@@ -2167,6 +2232,125 @@ mod tests {
             PreparedTableMutation::Update { assignments, predicate } => {
                 assert_eq!(assignments, &vec!["id = 1".to_string(), "name = 'after'".to_string()]);
                 assert_eq!(predicate, "id = 1");
+            }
+            PreparedTableMutation::Upsert(_) | PreparedTableMutation::Delete { .. } => {
+                panic!("expected update")
+            }
+        }
+    }
+
+    #[test]
+    fn prepare_table_mutations_update_uses_alternative_identity_key_for_changed_key_update() {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), PgType::INT4, -1, 1, Some(1), false),
+                ColumnSchema::new("email".to_string(), PgType::TEXT, -1, 2, None, false),
+                ColumnSchema::new("name".to_string(), PgType::TEXT, -1, 3, None, true),
+                ColumnSchema::new("payload".to_string(), PgType::TEXT, -1, 4, None, true),
+            ],
+        ));
+        let replicated_table_schema = ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            IdentityMask::from_bytes(vec![0, 1, 0, 0]),
+        );
+
+        let prepared = prepare_table_mutations(
+            &replicated_table_schema,
+            vec![TableMutation::Update {
+                delete_row: OldTableRow::Key(TableRow::new(vec![Cell::String(
+                    "alice@example.com".to_string(),
+                )])),
+                new_row: UpdatedTableRow::Partial(PartialTableRow::new(
+                    4,
+                    TableRow::new(vec![
+                        Cell::I32(1),
+                        Cell::String("alice@new.example.com".to_string()),
+                        Cell::String("ripe".to_string()),
+                    ]),
+                    vec![3],
+                )),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(prepared.len(), 1);
+        match &prepared[0] {
+            PreparedTableMutation::Update { assignments, predicate } => {
+                assert_eq!(
+                    assignments,
+                    &vec![
+                        "id = 1".to_string(),
+                        "email = 'alice@new.example.com'".to_string(),
+                        "name = 'ripe'".to_string(),
+                    ]
+                );
+                assert_eq!(predicate, "email = 'alice@example.com'");
+            }
+            PreparedTableMutation::Upsert(_) | PreparedTableMutation::Delete { .. } => {
+                panic!("expected update")
+            }
+        }
+    }
+
+    #[test]
+    fn prepare_table_mutations_update_uses_full_replica_identity_predicate() {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), PgType::INT4, -1, 1, Some(1), false),
+                ColumnSchema::new("email".to_string(), PgType::TEXT, -1, 2, None, false),
+                ColumnSchema::new("name".to_string(), PgType::TEXT, -1, 3, None, true),
+                ColumnSchema::new("payload".to_string(), PgType::TEXT, -1, 4, None, true),
+            ],
+        ));
+        let replicated_table_schema = ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            IdentityMask::from_bytes(vec![1, 1, 1, 1]),
+        );
+
+        let prepared = prepare_table_mutations(
+            &replicated_table_schema,
+            vec![TableMutation::Update {
+                delete_row: OldTableRow::Full(TableRow::new(vec![
+                    Cell::I32(1),
+                    Cell::String("alice@example.com".to_string()),
+                    Cell::String("seed".to_string()),
+                    Cell::String("toast".to_string()),
+                ])),
+                new_row: UpdatedTableRow::Partial(PartialTableRow::new(
+                    4,
+                    TableRow::new(vec![
+                        Cell::I32(1),
+                        Cell::String("alice@example.com".to_string()),
+                        Cell::String("grown".to_string()),
+                    ]),
+                    vec![3],
+                )),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(prepared.len(), 1);
+        match &prepared[0] {
+            PreparedTableMutation::Update { assignments, predicate } => {
+                assert_eq!(
+                    assignments,
+                    &vec![
+                        "id = 1".to_string(),
+                        "email = 'alice@example.com'".to_string(),
+                        "name = 'grown'".to_string(),
+                    ]
+                );
+                assert_eq!(
+                    predicate,
+                    "id = 1 AND email = 'alice@example.com' AND name = 'seed' AND payload = \
+                     'toast'"
+                );
             }
             PreparedTableMutation::Upsert(_) | PreparedTableMutation::Delete { .. } => {
                 panic!("expected update")

--- a/etl-destinations/src/ducklake/batches.rs
+++ b/etl-destinations/src/ducklake/batches.rs
@@ -1143,7 +1143,17 @@ fn delete_predicate_from_row<'a>(
                 if identity_columns.peek().is_some_and(|identity_column| {
                     identity_column.ordinal_position == column_schema.ordinal_position
                 }) {
-                    let identity_column = identity_columns.next().expect("peeked identity column");
+                    let Some(identity_column) = identity_columns.next() else {
+                        return Err(etl_error!(
+                            ErrorKind::InvalidState,
+                            "DuckLake replica identity schema is inconsistent",
+                            format!(
+                                "Table '{}' identity columns ended unexpectedly",
+                                replicated_table_schema.name()
+                            )
+                        ));
+                    };
+
                     key_values.push((identity_column, value));
                 }
             }
@@ -1292,7 +1302,7 @@ fn build_mutation_batch_identity(
                 delete_predicate_from_row(replicated_table_schema, delete_row)?.hash(&mut hasher);
                 match new_row {
                     UpdatedTableRow::Full(row) => hash_table_row_ref(&mut hasher, row),
-                    UpdatedTableRow::Partial(row) => hash_partial_table_row_ref(&mut hasher, row),
+                    UpdatedTableRow::Partial(row) => hash_partial_table_row_ref(&mut hasher, row)?,
                 }
             }
             TableMutation::Replace(row) => {
@@ -1416,7 +1426,7 @@ fn hash_table_row_ref(hasher: &mut BatchIdHasher, row: &TableRow) {
 }
 
 /// Hashes a partial row using column indexes and SQL literal forms.
-fn hash_partial_table_row_ref(hasher: &mut BatchIdHasher, row: &PartialTableRow) {
+fn hash_partial_table_row_ref(hasher: &mut BatchIdHasher, row: &PartialTableRow) -> EtlResult<()> {
     row.total_columns().hash(hasher);
     let mut missing_indexes = row.missing_column_indexes().iter().copied().peekable();
     let mut present_values = row.values().iter();
@@ -1427,12 +1437,27 @@ fn hash_partial_table_row_ref(hasher: &mut BatchIdHasher, row: &PartialTableRow)
             continue;
         }
 
-        let value = present_values
-            .next()
-            .expect("partial row present value count should match missing indexes");
+        let Some(value) = present_values.next() else {
+            return Err(etl_error!(
+                ErrorKind::InvalidState,
+                "DuckLake partial row shape is inconsistent",
+                format!("Partial row ended before replicated column index {}", column_index)
+            ));
+        };
+
         column_index.hash(hasher);
         cell_to_sql_literal_ref(value).hash(hasher);
     }
+
+    if present_values.next().is_some() {
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            "DuckLake partial row shape is inconsistent",
+            "Partial row contained more present values than its missing indexes allow"
+        ));
+    }
+
+    Ok(())
 }
 
 /// Returns whether the atomic batch marker already exists.

--- a/etl-destinations/src/ducklake/batches.rs
+++ b/etl-destinations/src/ducklake/batches.rs
@@ -170,7 +170,9 @@ impl TrackedTableMutation {
         match &self.mutation {
             TableMutation::Insert(row) | TableMutation::Replace(row) => row.size_hint() as u64,
             TableMutation::Delete(row) => row.size_hint() as u64,
-            TableMutation::Update { new_row, .. } => new_row.size_hint() as u64,
+            TableMutation::Update { delete_row, new_row } => {
+                (delete_row.size_hint() as u64).saturating_add(new_row.size_hint() as u64)
+            }
         }
     }
 }

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -182,49 +182,53 @@ where
     }
 }
 
+/// Validates that a replicated table schema can be applied to one DuckLake
+/// row-matching mutation.
+///
+/// DuckLake can stream inserts without replica identity, but update and delete
+/// paths need replicated replica-identity columns so the destination can match
+/// existing rows safely.
+fn validate_ducklake_replica_identity(
+    replicated_table_schema: &ReplicatedTableSchema,
+    operation: &'static str,
+) -> EtlResult<()> {
+    if replicated_table_schema.identity_column_schemas().len() == 0 {
+        let description = match operation {
+            "update" => "DuckLake update requires a replica identity",
+            "delete" => "DuckLake delete requires a replica identity",
+            _ => "DuckLake mutation requires a replica identity",
+        };
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            description,
+            format!(
+                "Table '{}' has no replicated replica-identity columns",
+                replicated_table_schema.name()
+            )
+        ));
+    }
+
+    Ok(())
+}
+
 impl<S> DuckLakeDestination<S>
 where
     S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
 {
-    /// Validates that the table exposes replicated replica-identity columns
-    /// for one row-matching mutation operation.
-    fn require_replica_identity(
-        replicated_table_schema: &ReplicatedTableSchema,
-        operation: &'static str,
-    ) -> EtlResult<()> {
-        if replicated_table_schema.identity_column_schemas().len() == 0 {
-            let description = match operation {
-                "update" => "DuckLake update requires a replica identity",
-                "delete" => "DuckLake delete requires a replica identity",
-                _ => "DuckLake mutation requires a replica identity",
-            };
-            return Err(etl_error!(
-                ErrorKind::InvalidState,
-                description,
-                format!(
-                    "Table '{}' has no replicated replica-identity columns",
-                    replicated_table_schema.name()
-                )
-            ));
-        }
-
-        Ok(())
-    }
-
     /// Builds a key-only row from a partial update row when PostgreSQL omits
     /// the old key image because the replica identity did not change.
     fn key_row_from_updated_partial_row(
         replicated_table_schema: &ReplicatedTableSchema,
         partial_row: &PartialTableRow,
     ) -> EtlResult<TableRow> {
-        let column_schemas: Vec<_> = replicated_table_schema.column_schemas().collect();
-        if partial_row.total_columns() != column_schemas.len() {
+        let column_count = replicated_table_schema.column_schemas().len();
+        if partial_row.total_columns() != column_count {
             return Err(etl_error!(
                 ErrorKind::InvalidState,
                 "DuckLake partial update row does not match schema",
                 format!(
                     "Expected {} replicated columns for table '{}', got {}",
-                    column_schemas.len(),
+                    column_count,
                     replicated_table_schema.name(),
                     partial_row.total_columns()
                 )
@@ -248,17 +252,15 @@ where
             ));
         }
 
-        Self::require_replica_identity(replicated_table_schema, "update")?;
+        validate_ducklake_replica_identity(replicated_table_schema, "update")?;
 
         let mut missing_indexes = partial_row.missing_column_indexes().iter().copied().peekable();
         let mut present_values = partial_row.values().iter();
-        let identity_column_schemas: Vec<_> =
-            replicated_table_schema.identity_column_schemas().collect();
+        let identity_column_count = replicated_table_schema.identity_column_schemas().len();
+        let mut identity_columns = replicated_table_schema.identity_column_schemas().peekable();
+        let mut key_values = Vec::with_capacity(identity_column_count);
 
-        let mut identity_columns = identity_column_schemas.iter().copied().peekable();
-        let mut key_values = Vec::with_capacity(identity_column_schemas.len());
-
-        for (column_index, column_schema) in column_schemas.iter().enumerate() {
+        for (column_index, column_schema) in replicated_table_schema.column_schemas().enumerate() {
             let is_identity = identity_columns.peek().is_some_and(|identity_column| {
                 identity_column.ordinal_position == column_schema.ordinal_position
             });
@@ -684,6 +686,10 @@ where
                         ));
                     }
                     Event::Update(update) => {
+                        validate_ducklake_replica_identity(
+                            &update.replicated_table_schema,
+                            "update",
+                        )?;
                         let table_id = update.replicated_table_schema.id();
                         let entry = table_id_to_mutations.entry(table_id).or_insert_with(|| {
                             (update.replicated_table_schema.clone(), Vec::new())
@@ -702,7 +708,6 @@ where
                         } else {
                             match table_row {
                                 UpdatedTableRow::Full(table_row) => {
-                                    Self::require_replica_identity(&entry.0, "update")?;
                                     debug!(
                                         "update event has no old row, deleting by replica \
                                          identity from new row"
@@ -737,11 +742,11 @@ where
                         }
                     }
                     Event::Delete(delete) => {
+                        validate_ducklake_replica_identity(
+                            &delete.replicated_table_schema,
+                            "delete",
+                        )?;
                         let Some(old_row) = delete.old_table_row else {
-                            Self::require_replica_identity(
-                                &delete.replicated_table_schema,
-                                "delete",
-                            )?;
                             return Err(etl_error!(
                                 ErrorKind::InvalidState,
                                 "DuckLake delete requires an old row image",

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -10,8 +10,6 @@ use std::{
     },
 };
 
-#[cfg(test)]
-use etl::types::Cell;
 use etl::{
     destination::{
         Destination,
@@ -188,6 +186,31 @@ impl<S> DuckLakeDestination<S>
 where
     S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
 {
+    /// Validates that the table exposes replicated replica-identity columns
+    /// for one row-matching mutation operation.
+    fn require_replica_identity(
+        replicated_table_schema: &ReplicatedTableSchema,
+        operation: &'static str,
+    ) -> EtlResult<()> {
+        if replicated_table_schema.identity_column_schemas().len() == 0 {
+            let description = match operation {
+                "update" => "DuckLake update requires a replica identity",
+                "delete" => "DuckLake delete requires a replica identity",
+                _ => "DuckLake mutation requires a replica identity",
+            };
+            return Err(etl_error!(
+                ErrorKind::InvalidState,
+                description,
+                format!(
+                    "Table '{}' has no replicated replica-identity columns",
+                    replicated_table_schema.name()
+                )
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Builds a key-only row from a partial update row when PostgreSQL omits
     /// the old key image because the replica identity did not change.
     fn key_row_from_updated_partial_row(
@@ -225,11 +248,15 @@ where
             ));
         }
 
+        Self::require_replica_identity(replicated_table_schema, "update")?;
+
         let mut missing_indexes = partial_row.missing_column_indexes().iter().copied().peekable();
         let mut present_values = partial_row.values().iter();
-        let mut identity_columns = replicated_table_schema.identity_column_schemas().peekable();
-        let mut key_values =
-            Vec::with_capacity(replicated_table_schema.identity_column_schemas().len());
+        let identity_column_schemas: Vec<_> =
+            replicated_table_schema.identity_column_schemas().collect();
+
+        let mut identity_columns = identity_column_schemas.iter().copied().peekable();
+        let mut key_values = Vec::with_capacity(identity_column_schemas.len());
 
         for (column_index, column_schema) in column_schemas.iter().enumerate() {
             let is_identity = identity_columns.peek().is_some_and(|identity_column| {
@@ -675,9 +702,10 @@ where
                         } else {
                             match table_row {
                                 UpdatedTableRow::Full(table_row) => {
+                                    Self::require_replica_identity(&entry.0, "update")?;
                                     debug!(
-                                        "update event has no old row, deleting by primary key \
-                                         from new row"
+                                        "update event has no old row, deleting by replica \
+                                         identity from new row"
                                     );
                                     mutations.push(TrackedTableMutation::new(
                                         update.start_lsn,
@@ -710,8 +738,19 @@ where
                     }
                     Event::Delete(delete) => {
                         let Some(old_row) = delete.old_table_row else {
-                            debug!("delete event has no old row, skipping");
-                            continue;
+                            Self::require_replica_identity(
+                                &delete.replicated_table_schema,
+                                "delete",
+                            )?;
+                            return Err(etl_error!(
+                                ErrorKind::InvalidState,
+                                "DuckLake delete requires an old row image",
+                                format!(
+                                    "Table '{}' emitted a delete without an old row despite \
+                                     exposing replica-identity columns",
+                                    delete.replicated_table_schema.name()
+                                )
+                            ));
                         };
                         let table_id = delete.replicated_table_schema.id();
                         let entry = table_id_to_mutations.entry(table_id).or_insert_with(|| {
@@ -1116,11 +1155,11 @@ fn table_write_activity_for_mutations(
     let mut write_activity = TableWriteActivity { table_name, approx_bytes: 0, inserted_rows: 0 };
 
     for tracked_mutation in tracked_mutations {
-        if let Some(row) = tracked_mutation.upsert_row() {
-            write_activity.approx_bytes =
-                write_activity.approx_bytes.saturating_add(row.size_hint() as u64);
-            write_activity.inserted_rows = write_activity.inserted_rows.saturating_add(1);
-        }
+        // This is only a fallback estimate for catalogs where we cannot sample
+        // actual inlined-table sizes directly.
+        write_activity.approx_bytes =
+            write_activity.approx_bytes.saturating_add(tracked_mutation.write_activity_size_hint());
+        write_activity.inserted_rows = write_activity.inserted_rows.saturating_add(1);
     }
 
     write_activity
@@ -1203,7 +1242,10 @@ mod tests {
     use duckdb::{Config, Connection};
     use etl::{
         store::{both::memory::MemoryStore, schema::SchemaStore},
-        types::{ColumnSchema, TableSchema, Type as PgType},
+        types::{
+            Cell, ColumnSchema, IdentityMask, OldTableRow, PartialTableRow, PgLsn, ReplicationMask,
+            SizeHint, TableRow, TableSchema, Type as PgType, UpdatedTableRow,
+        },
     };
     use pg_escape::{quote_identifier, quote_literal};
     use tempfile::TempDir;
@@ -1226,6 +1268,105 @@ mod tests {
                 ColumnSchema::new("name".to_string(), PgType::TEXT, -1, 2, None, true),
             ],
         )
+    }
+
+    fn make_alternative_identity_schema() -> ReplicatedTableSchema {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(2),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), PgType::INT4, -1, 1, Some(1), false),
+                ColumnSchema::new("email".to_string(), PgType::TEXT, -1, 2, None, false),
+                ColumnSchema::new("payload".to_string(), PgType::TEXT, -1, 3, None, true),
+            ],
+        ));
+
+        ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            IdentityMask::from_bytes(vec![0, 1, 0]),
+        )
+    }
+
+    fn make_missing_identity_schema() -> ReplicatedTableSchema {
+        let table_schema = Arc::new(make_schema(3, "public", "users"));
+
+        ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            IdentityMask::from_bytes(vec![0, 0]),
+        )
+    }
+
+    #[test]
+    fn table_write_activity_for_mutations_counts_partial_updates_and_deletes() {
+        let delete_row = OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]));
+        let partial_row = UpdatedTableRow::Partial(PartialTableRow::new(
+            2,
+            TableRow::new(vec![Cell::I32(1), Cell::String("grown".to_string())]),
+            vec![],
+        ));
+        let expected_bytes = delete_row.size_hint() as u64 + partial_row.size_hint() as u64;
+        let write_activity = table_write_activity_for_mutations(
+            "public_users".to_string(),
+            &[
+                TrackedTableMutation::new(
+                    PgLsn::from(100),
+                    PgLsn::from(100),
+                    0,
+                    TableMutation::Delete(delete_row),
+                ),
+                TrackedTableMutation::new(
+                    PgLsn::from(100),
+                    PgLsn::from(100),
+                    1,
+                    TableMutation::Update {
+                        delete_row: OldTableRow::Key(TableRow::new(vec![Cell::I32(1)])),
+                        new_row: partial_row,
+                    },
+                ),
+            ],
+        );
+
+        assert_eq!(write_activity.approx_bytes, expected_bytes);
+        assert_eq!(write_activity.inserted_rows, 2);
+    }
+
+    #[test]
+    fn key_row_from_updated_partial_row_uses_alternative_identity_columns() {
+        let replicated_table_schema = make_alternative_identity_schema();
+        let partial_row = PartialTableRow::new(
+            3,
+            TableRow::new(vec![Cell::I32(1), Cell::String("alice@example.com".to_string())]),
+            vec![2],
+        );
+
+        let key_row = DuckLakeDestination::<MemoryStore>::key_row_from_updated_partial_row(
+            &replicated_table_schema,
+            &partial_row,
+        )
+        .unwrap();
+
+        assert_eq!(key_row, TableRow::new(vec![Cell::String("alice@example.com".to_string())]));
+    }
+
+    #[test]
+    fn key_row_from_updated_partial_row_rejects_missing_replica_identity() {
+        let replicated_table_schema = make_missing_identity_schema();
+        let partial_row = PartialTableRow::new(
+            2,
+            TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_string())]),
+            vec![],
+        );
+
+        let error = DuckLakeDestination::<MemoryStore>::key_row_from_updated_partial_row(
+            &replicated_table_schema,
+            &partial_row,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidState);
+        assert_eq!(error.description(), Some("DuckLake update requires a replica identity"));
     }
 
     fn path_to_file_url(path: &Path) -> Url {

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -692,7 +692,9 @@ where
                     break;
                 }
 
-                let event = event_iter.next().unwrap();
+                let Some(event) = event_iter.next() else {
+                    break;
+                };
                 match event {
                     Event::Insert(insert) => {
                         let table_id = insert.replicated_table_schema.id();

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -1156,7 +1156,9 @@ fn table_write_activity_for_mutations(
 
     for tracked_mutation in tracked_mutations {
         // This is only a fallback estimate for catalogs where we cannot sample
-        // actual inlined-table sizes directly.
+        // actual inlined-table sizes directly. The optional row-threshold path
+        // is disabled today, so we treat each mutation as one unit of fallback
+        // activity to keep mutation-only streams visible to maintenance.
         write_activity.approx_bytes =
             write_activity.approx_bytes.saturating_add(tracked_mutation.write_activity_size_hint());
         write_activity.inserted_rows = write_activity.inserted_rows.saturating_add(1);
@@ -1301,12 +1303,15 @@ mod tests {
     #[test]
     fn table_write_activity_for_mutations_counts_partial_updates_and_deletes() {
         let delete_row = OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]));
+        let update_delete_row = OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]));
         let partial_row = UpdatedTableRow::Partial(PartialTableRow::new(
             2,
             TableRow::new(vec![Cell::I32(1), Cell::String("grown".to_string())]),
             vec![],
         ));
-        let expected_bytes = delete_row.size_hint() as u64 + partial_row.size_hint() as u64;
+        let expected_bytes = delete_row.size_hint() as u64
+            + update_delete_row.size_hint() as u64
+            + partial_row.size_hint() as u64;
         let write_activity = table_write_activity_for_mutations(
             "public_users".to_string(),
             &[
@@ -1320,10 +1325,7 @@ mod tests {
                     PgLsn::from(100),
                     PgLsn::from(100),
                     1,
-                    TableMutation::Update {
-                        delete_row: OldTableRow::Key(TableRow::new(vec![Cell::I32(1)])),
-                        new_row: partial_row,
-                    },
+                    TableMutation::Update { delete_row: update_delete_row, new_row: partial_row },
                 ),
             ],
         );

--- a/etl-destinations/src/ducklake/inline_size.rs
+++ b/etl-destinations/src/ducklake/inline_size.rs
@@ -73,15 +73,19 @@ fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
     let ducklake_table = quote_identifier("ducklake_table");
     let ducklake_inlined_data_tables = quote_identifier("ducklake_inlined_data_tables");
 
+    // DuckLake uses one inlined insert table per (table_id, schema_version),
+    // but one inlined delete table per table_id. We therefore sum every
+    // registered inlined data table for the current table and add the single
+    // deterministic delete-table relation size.
     format!(
-        r#"WITH target_table AS (
+        r"WITH target_table AS (
              SELECT table_id
              FROM {metadata_schema}.{ducklake_table}
              WHERE end_snapshot IS NULL AND table_name = $1
              LIMIT 1
          ),
          target_inline_tables AS (
-             SELECT table_name
+             SELECT DISTINCT table_name
              FROM {metadata_schema}.{ducklake_inlined_data_tables}
              WHERE table_id = (SELECT table_id FROM target_table)
          ),
@@ -114,7 +118,7 @@ fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
          )
          SELECT
              (SELECT total_bytes FROM inline_data_bytes)
-             + (SELECT total_bytes FROM inline_delete_bytes);"#
+             + (SELECT total_bytes FROM inline_delete_bytes);"
     )
 }
 

--- a/etl-destinations/src/ducklake/inline_size.rs
+++ b/etl-destinations/src/ducklake/inline_size.rs
@@ -8,13 +8,13 @@ use pg_escape::{quote_identifier, quote_literal};
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use url::Url;
 
-/// Pending inline insert-data bytes sampled from the Postgres DuckLake catalog.
+/// Pending inlined bytes sampled from the Postgres DuckLake catalog.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct DuckLakePendingInlineDataSizes {
-    pub(super) inlined_data_bytes: u64,
+    pub(super) inlined_bytes: u64,
 }
 
-/// Postgres-backed sampler for DuckLake inline insert-data table sizes.
+/// Postgres-backed sampler for DuckLake inlined catalog table sizes.
 #[derive(Clone)]
 pub(super) struct DuckLakePendingInlineSizeSampler {
     metadata_schema: String,
@@ -45,13 +45,13 @@ impl DuckLakePendingInlineSizeSampler {
         Ok(Some(Self { metadata_schema, pool }))
     }
 
-    /// Samples pending inline insert-data bytes for one DuckLake table.
+    /// Samples pending inlined bytes for one DuckLake table.
     pub(super) async fn sample_table(
         &self,
         table_name: &str,
     ) -> EtlResult<DuckLakePendingInlineDataSizes> {
         let sql = pending_inline_data_bytes_query(&self.metadata_schema);
-        let inlined_data_bytes: i64 =
+        let inlined_bytes: i64 =
             sqlx::query_scalar(&sql).bind(table_name).fetch_one(&self.pool).await.map_err(
                 |source| {
                     etl_error!(
@@ -62,12 +62,11 @@ impl DuckLakePendingInlineSizeSampler {
                 },
             )?;
 
-        Ok(DuckLakePendingInlineDataSizes { inlined_data_bytes: inlined_data_bytes.max(0) as u64 })
+        Ok(DuckLakePendingInlineDataSizes { inlined_bytes: inlined_bytes.max(0) as u64 })
     }
 }
 
-/// Returns the PostgreSQL query that measures one table's inline insert-data
-/// size.
+/// Returns the PostgreSQL query that measures one table's pending inlined size.
 fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
     let metadata_schema_literal = quote_literal(metadata_schema);
     let metadata_schema = quote_identifier(metadata_schema);
@@ -81,20 +80,41 @@ fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
              WHERE end_snapshot IS NULL AND table_name = $1
              LIMIT 1
          ),
-         target_inline_table AS (
+         target_inline_tables AS (
              SELECT table_name
              FROM {metadata_schema}.{ducklake_inlined_data_tables}
              WHERE table_id = (SELECT table_id FROM target_table)
-             LIMIT 1
+         ),
+         inline_data_bytes AS (
+             SELECT COALESCE(
+                 SUM(
+                     pg_total_relation_size(
+                         to_regclass(
+                             format('%I.%I', {metadata_schema_literal}, table_name)
+                         )
+                     )
+                 ),
+                 0
+             ) AS total_bytes
+             FROM target_inline_tables
+         ),
+         inline_delete_bytes AS (
+             SELECT COALESCE(
+                 pg_total_relation_size(
+                     to_regclass(
+                         format(
+                             '%I.%I',
+                             {metadata_schema_literal},
+                             format('ducklake_inlined_delete_%s', (SELECT table_id FROM target_table))
+                         )
+                     )
+                 ),
+                 0
+             ) AS total_bytes
          )
-         SELECT COALESCE(
-             pg_total_relation_size(
-                 to_regclass(
-                     format('%I.%I', {metadata_schema_literal}, (SELECT table_name FROM target_inline_table))
-                 )
-             ),
-             0
-         );"#
+         SELECT
+             (SELECT total_bytes FROM inline_data_bytes)
+             + (SELECT total_bytes FROM inline_delete_bytes);"#
     )
 }
 
@@ -108,7 +128,9 @@ mod tests {
 
         assert!(sql.contains("ducklake_table"));
         assert!(sql.contains("ducklake_inlined_data_tables"));
+        assert!(sql.contains("ducklake_inlined_delete_%s"));
         assert!(sql.contains("duck'lake"));
         assert!(sql.contains(r#"format('%I.%I', 'duck''lake'"#));
+        assert!(sql.contains("SUM("));
     }
 }

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -42,8 +42,7 @@ use crate::ducklake::{
 const MAINTENANCE_POOL_SIZE: u32 = 1;
 /// Poll interval for checking per-table inline flush thresholds.
 const MAINTENANCE_FLUSH_POLL_INTERVAL: Duration = Duration::from_secs(30);
-/// Pending inline insert-data bytes threshold that triggers a background inline
-/// flush.
+/// Pending inlined bytes threshold that triggers a background inline flush.
 const MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD: u64 = 10_000_000;
 /// Estimated ratio from raw row payload to compressed parquet bytes.
 const PARQUET_COMPRESSION_RATIO_ESTIMATE: u64 = 4;
@@ -263,7 +262,7 @@ impl TableMaintenanceState {
         self.last_write_at = Some(now);
     }
 
-    /// Records one sampled inline insert-data snapshot for this table.
+    /// Records one sampled inlined-data snapshot for this table.
     fn record_pending_inline_data_sizes(
         &mut self,
         sampled_at: Instant,
@@ -292,7 +291,7 @@ impl TableMaintenanceState {
             && self.current_pending_inline_data_sizes().is_none()
     }
 
-    /// Returns the latest inline insert-data sample covering the current dirty
+    /// Returns the latest inlined-data sample covering the current dirty
     /// period.
     fn current_pending_inline_data_sizes(&self) -> Option<DuckLakePendingInlineDataSizes> {
         let sizes = self.latest_pending_inline_data_sizes?;
@@ -319,7 +318,7 @@ impl TableMaintenanceState {
         pending_rows_threshold: Option<u64>,
     ) -> Option<MaintenanceReason> {
         if let Some(sizes) = self.current_pending_inline_data_sizes() {
-            return (sizes.inlined_data_bytes
+            return (sizes.inlined_bytes
                 >= (MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD
                     * PARQUET_COMPRESSION_RATIO_ESTIMATE))
                 .then_some(MaintenanceReason::PendingInlinedDataBytesThreshold);
@@ -1514,7 +1513,7 @@ mod tests {
         state.record_pending_inline_data_sizes(
             now + Duration::from_secs(1),
             DuckLakePendingInlineDataSizes {
-                inlined_data_bytes: MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD
+                inlined_bytes: MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD
                     * PARQUET_COMPRESSION_RATIO_ESTIMATE,
             },
         );
@@ -1533,7 +1532,7 @@ mod tests {
         state.record_pending_inline_data_sizes(
             now + Duration::from_secs(1),
             DuckLakePendingInlineDataSizes {
-                inlined_data_bytes: MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD - 1,
+                inlined_bytes: MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD - 1,
             },
         );
 

--- a/etl-destinations/src/iceberg/core.rs
+++ b/etl-destinations/src/iceberg/core.rs
@@ -15,8 +15,8 @@ use etl::{
     state::destination_metadata::DestinationTableMetadata,
     store::state::StateStore,
     types::{
-        Cell, ColumnSchema, Event, IdentityType, ReplicatedTableSchema, TableId, TableName,
-        TableRow, Type, generate_sequence_number,
+        Cell, ColumnSchema, Event, IdentityType, OldTableRow, ReplicatedTableSchema, TableId,
+        TableName, TableRow, Type, generate_sequence_number,
     },
 };
 use tokio::{sync::Mutex, task::JoinSet};
@@ -288,7 +288,9 @@ where
                     break;
                 }
 
-                let event = events_iter.next().unwrap();
+                let Some(event) = events_iter.next() else {
+                    break;
+                };
                 match event {
                     Event::Insert(mut insert) => {
                         let sequence_key = insert.event_sequence_key().to_string();
@@ -342,7 +344,7 @@ where
                                 )
                             ));
                         };
-                        if old_table_row.is_key() {
+                        let OldTableRow::Full(mut old_table_row) = old_table_row else {
                             return Err(etl_error!(
                                 ErrorKind::InvalidState,
                                 "Iceberg delete requires a full old row image",
@@ -352,8 +354,7 @@ where
                                     delete.replicated_table_schema.name()
                                 )
                             ));
-                        }
-                        let mut old_table_row = old_table_row.into_full().expect("checked above");
+                        };
                         old_table_row.values_mut().push(IcebergOperationType::Delete.into());
                         old_table_row.values_mut().push(Cell::String(sequence_key));
 

--- a/etl-destinations/src/iceberg/core.rs
+++ b/etl-destinations/src/iceberg/core.rs
@@ -302,6 +302,7 @@ where
                         entry.1.push(insert.table_row);
                     }
                     Event::Update(update) => {
+                        validate_iceberg_replica_identity(&update.replicated_table_schema)?;
                         let sequence_key = update.event_sequence_key().to_string();
                         let mut table_row = match update.updated_table_row {
                             etl::types::UpdatedTableRow::Full(row) => row,
@@ -328,10 +329,18 @@ where
                         entry.1.push(table_row);
                     }
                     Event::Delete(delete) => {
+                        validate_iceberg_replica_identity(&delete.replicated_table_schema)?;
                         let sequence_key = delete.event_sequence_key().to_string();
                         let Some(old_table_row) = delete.old_table_row else {
-                            debug!("delete event has no row, skipping");
-                            continue;
+                            return Err(etl_error!(
+                                ErrorKind::InvalidState,
+                                "Iceberg delete requires an old row image",
+                                format!(
+                                    "Table '{}' emitted a delete without an old row image even \
+                                     though Iceberg requires FULL replica identity.",
+                                    delete.replicated_table_schema.name()
+                                )
+                            ));
                         };
                         if old_table_row.is_key() {
                             return Err(etl_error!(

--- a/etl-destinations/tests/bigquery_pipeline.rs
+++ b/etl-destinations/tests/bigquery_pipeline.rs
@@ -416,7 +416,7 @@ async fn table_primary_key_update_rewrites_row() {
         .unwrap();
     event_notify.notified().await;
 
-    let updated_id = 10i32;
+    let updated_id = 10i64;
     let updated_name = "user_10".to_string();
     let updated_age = 10i32;
     let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;

--- a/etl-destinations/tests/bigquery_pipeline.rs
+++ b/etl-destinations/tests/bigquery_pipeline.rs
@@ -368,6 +368,80 @@ async fn table_subsequent_updates() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn table_primary_key_update_rewrites_row() {
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+
+    let bigquery_database = setup_bigquery_database().await;
+
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
+    let destination = TestDestinationWrapper::wrap(raw_destination);
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_state_notify = store
+        .notify_on_table_state_type(
+            database_schema.users_schema().id,
+            TableReplicationPhaseType::Ready,
+        )
+        .await;
+
+    pipeline.start().await.unwrap();
+
+    users_state_notify.notified().await;
+
+    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    database
+        .insert_values(
+            database_schema.users_schema().name.clone(),
+            &["name", "age"],
+            &[&"user_1", &1],
+        )
+        .await
+        .unwrap();
+    event_notify.notified().await;
+
+    let updated_id = 10i32;
+    let updated_name = "user_10".to_string();
+    let updated_age = 10i32;
+    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    database
+        .update_values_where(
+            database_schema.users_schema().name.clone(),
+            &["id", "name", "age"],
+            &[&updated_id, &updated_name, &updated_age],
+            &["id"],
+            &["1"],
+            "",
+        )
+        .await
+        .unwrap();
+    event_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let users_rows =
+        bigquery_database.query_table(database_schema.users_schema().name).await.unwrap();
+    let parsed_users_rows = parse_bigquery_table_rows::<BigQueryUser>(users_rows);
+    assert_eq!(parsed_users_rows, vec![BigQueryUser::new(10, "user_10", 10),]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn table_truncate_with_batching() {
     if skip_if_missing_bigquery_env_vars() {
         return;

--- a/etl-destinations/tests/bigquery_pipeline.rs
+++ b/etl-destinations/tests/bigquery_pipeline.rs
@@ -13,7 +13,9 @@ use etl::{
         test_destination_wrapper::TestDestinationWrapper,
         test_schema::{TableSelection, insert_mock_data, setup_test_database_schema},
     },
-    types::{EventType, PgNumeric, PipelineId},
+    types::{
+        Cell, Event, EventType, OldTableRow, PgNumeric, PipelineId, TableRow, UpdatedTableRow,
+    },
 };
 use etl_destinations::bigquery::test_utils::{
     setup_bigquery_database, skip_if_missing_bigquery_env_vars,
@@ -36,9 +38,39 @@ fn install_crypto_provider() {
 }
 
 use crate::support::bigquery::{
-    BigQueryOrder, BigQueryUser, NonNullableColsScalar, NullableColsArray, NullableColsScalar,
-    parse_bigquery_table_rows,
+    BigQueryOrder, BigQueryReplicaIdentityRow, BigQueryUser, NonNullableColsScalar,
+    NullableColsArray, NullableColsScalar, parse_bigquery_table_rows,
 };
+
+const REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES: usize = 8192;
+
+fn data_events(events: Vec<Event>) -> Vec<Event> {
+    events
+        .into_iter()
+        .filter(|event| matches!(event, Event::Insert(_) | Event::Update(_) | Event::Delete(_)))
+        .collect()
+}
+
+fn find_update_event(events: &[Event], update_index: usize) -> &etl::types::UpdateEvent {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            Event::Update(update) => Some(update),
+            _ => None,
+        })
+        .nth(update_index)
+        .expect("expected update event")
+}
+
+fn find_delete_event(events: &[Event]) -> &etl::types::DeleteEvent {
+    events
+        .iter()
+        .find_map(|event| match event {
+            Event::Delete(delete) => Some(delete),
+            _ => None,
+        })
+        .expect("expected delete event")
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn table_copy_and_streaming_with_restart() {
@@ -378,6 +410,14 @@ async fn table_primary_key_update_rewrites_row() {
 
     let database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    database
+        .insert_values(
+            database_schema.users_schema().name.clone(),
+            &["name", "age"],
+            &[&"user_1", &1],
+        )
+        .await
+        .unwrap();
 
     let bigquery_database = setup_bigquery_database().await;
 
@@ -405,21 +445,14 @@ async fn table_primary_key_update_rewrites_row() {
 
     users_state_notify.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
-    database
-        .insert_values(
-            database_schema.users_schema().name.clone(),
-            &["name", "age"],
-            &[&"user_1", &1],
-        )
-        .await
-        .unwrap();
-    event_notify.notified().await;
+    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
 
+    // With default primary-key replica identity, changing the source primary
+    // key is a valid PostgreSQL shape: the update carries an old key row plus
+    // a full new row image.
     let updated_id = 10i64;
     let updated_name = "user_10".to_string();
     let updated_age = 10i32;
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
     database
         .update_values_where(
             database_schema.users_schema().name.clone(),
@@ -431,14 +464,328 @@ async fn table_primary_key_update_rewrites_row() {
         )
         .await
         .unwrap();
+
     event_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
+
+    let events = data_events(destination.get_events().await);
+    assert_eq!(events.len(), 1);
+    let update = find_update_event(&events, 0);
+    assert_eq!(update.old_table_row, Some(OldTableRow::Key(TableRow::new(vec![Cell::I64(1)]))));
+    assert_eq!(
+        update.updated_table_row,
+        UpdatedTableRow::Full(TableRow::new(vec![
+            Cell::I64(updated_id),
+            Cell::String(updated_name.clone()),
+            Cell::I32(updated_age),
+        ]))
+    );
 
     let users_rows =
         bigquery_database.query_table(database_schema.users_schema().name).await.unwrap();
     let parsed_users_rows = parse_bigquery_table_rows::<BigQueryUser>(users_rows);
     assert_eq!(parsed_users_rows, vec![BigQueryUser::new(10, "user_10", 10),]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_full_replica_identity_update_preserves_unchanged_toasted_columns() {
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = spawn_source_database().await;
+    let bigquery_database = setup_bigquery_database().await;
+    let table_name = test_table_name("full_replica_identity_users");
+    let table_id = database
+        .create_table(
+            table_name.clone(),
+            true,
+            &[("name", "text not null"), ("large_text", "text not null")],
+        )
+        .await
+        .unwrap();
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[
+                TableModification::AlterColumn {
+                    name: "large_text",
+                    alteration: "set storage external",
+                },
+                TableModification::ReplicaIdentity { value: "full" },
+            ],
+        )
+        .await
+        .unwrap();
+
+    let initial_large_text = "a".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
+    database
+        .insert_values(
+            table_name.clone(),
+            &["name", "large_text"],
+            &[&"alice", &initial_large_text],
+        )
+        .await
+        .unwrap();
+
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
+    let destination = TestDestinationWrapper::wrap(raw_destination);
+
+    let publication_name = "test_pub_full_replica_identity".to_string();
+    database
+        .create_publication(&publication_name, std::slice::from_ref(&table_name))
+        .await
+        .expect("Failed to create publication");
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name,
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    table_ready_notify.notified().await;
+
+    // With REPLICA IDENTITY FULL, PostgreSQL sends a full old row for updates.
+    // That means unchanged external TOAST values can be reconstructed and the
+    // destination should receive a full new row image.
+    let updated_name = "alicia".to_string();
+    let update_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+
+    database
+        .update_values_where(table_name.clone(), &["name"], &[&updated_name], &["id"], &["1"], "")
+        .await
+        .unwrap();
+
+    update_notify.notified().await;
+
+    let delete_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+
+    database.delete_values(table_name.clone(), &["id"], &["1"], "").await.unwrap();
+
+    delete_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let events = data_events(destination.get_events().await);
+    assert_eq!(events.len(), 2);
+    let update = find_update_event(&events, 0);
+    assert_eq!(
+        update.old_table_row,
+        Some(OldTableRow::Full(TableRow::new(vec![
+            Cell::I64(1),
+            Cell::String("alice".to_string()),
+            Cell::String(initial_large_text.clone()),
+        ])))
+    );
+    assert_eq!(
+        update.updated_table_row,
+        UpdatedTableRow::Full(TableRow::new(vec![
+            Cell::I64(1),
+            Cell::String(updated_name.clone()),
+            Cell::String(initial_large_text.clone()),
+        ]))
+    );
+    let delete = find_delete_event(&events);
+    assert_eq!(
+        delete.old_table_row,
+        Some(OldTableRow::Full(TableRow::new(vec![
+            Cell::I64(1),
+            Cell::String(updated_name),
+            Cell::String(initial_large_text),
+        ])))
+    );
+
+    let table_rows = bigquery_database.query_table(table_name).await;
+    assert!(table_rows.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_alternative_replica_identity_errors_cleanly() {
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = spawn_source_database().await;
+    let bigquery_database = setup_bigquery_database().await;
+    let table_name = test_table_name("alternative_replica_identity_users");
+    let table_id = database
+        .create_table(
+            table_name.clone(),
+            true,
+            &[("email", "text not null"), ("name", "text not null")],
+        )
+        .await
+        .unwrap();
+
+    database
+        .insert_values(table_name.clone(), &["email", "name"], &[&"alice@example.com", &"alice"])
+        .await
+        .unwrap();
+
+    let index_name = format!("{}_replica_identity_idx", table_name.name);
+    database
+        .run_sql(&format!(
+            "create unique index {index_name} on {} (email)",
+            table_name.as_quoted_identifier(),
+        ))
+        .await
+        .unwrap();
+    let replica_identity_value = format!("using index {index_name}");
+    database
+        .alter_table(
+            table_name.clone(),
+            &[TableModification::ReplicaIdentity { value: &replica_identity_value }],
+        )
+        .await
+        .unwrap();
+
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
+    let destination = TestDestinationWrapper::wrap(raw_destination);
+
+    let publication_name = "test_pub_alternative_replica_identity".to_string();
+    database
+        .create_publication(&publication_name, std::slice::from_ref(&table_name))
+        .await
+        .expect("Failed to create publication");
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name,
+        store.clone(),
+        destination.clone(),
+    );
+
+    // PostgreSQL can validly publish USING INDEX key rows here, but BigQuery
+    // only supports source primary-key or FULL replica identity.
+    let table_error_notify =
+        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Errored).await;
+
+    pipeline.start().await.unwrap();
+
+    table_error_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_state = store.get_table_replication_state(table_id).await.unwrap();
+    assert!(matches!(table_state, Some(TableReplicationPhase::Errored { .. })));
+    assert!(destination.get_events().await.is_empty());
+    assert!(bigquery_database.query_table(table_name).await.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_partial_update_rows_error_cleanly_for_bigquery() {
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = spawn_source_database().await;
+    let bigquery_database = setup_bigquery_database().await;
+    let table_name = test_table_name("partial_update_rows_users");
+    let table_id = database
+        .create_table(
+            table_name.clone(),
+            true,
+            &[("name", "text not null"), ("large_text", "text not null")],
+        )
+        .await
+        .unwrap();
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[TableModification::AlterColumn {
+                name: "large_text",
+                alteration: "set storage external",
+            }],
+        )
+        .await
+        .unwrap();
+
+    let initial_large_text = "a".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
+    database
+        .insert_values(
+            table_name.clone(),
+            &["name", "large_text"],
+            &[&"alice", &initial_large_text],
+        )
+        .await
+        .unwrap();
+
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
+    let destination = TestDestinationWrapper::wrap(raw_destination);
+
+    let publication_name = "test_pub_partial_update_rows".to_string();
+    database
+        .create_publication(&publication_name, std::slice::from_ref(&table_name))
+        .await
+        .expect("Failed to create publication");
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name,
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    table_ready_notify.notified().await;
+
+    // With default primary-key replica identity, updating a non-key column
+    // while leaving an external TOAST value unchanged is a valid PostgreSQL
+    // shape: no old row plus a partial new row. BigQuery should reject that
+    // cleanly instead of trying to upsert a sparse row.
+    let table_error_notify =
+        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Errored).await;
+
+    database
+        .update_values_where(table_name.clone(), &["name"], &[&"alicia"], &["id"], &["1"], "")
+        .await
+        .unwrap();
+
+    table_error_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_state = store.get_table_replication_state(table_id).await.unwrap();
+    assert!(matches!(table_state, Some(TableReplicationPhase::Errored { .. })));
+    assert!(destination.get_events().await.is_empty());
+
+    let table_rows = bigquery_database.query_table(table_name).await.unwrap();
+    let parsed_table_rows = parse_bigquery_table_rows::<BigQueryReplicaIdentityRow>(table_rows);
+    assert_eq!(
+        parsed_table_rows,
+        vec![BigQueryReplicaIdentityRow::new(1, "alice", &initial_large_text),]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/etl-destinations/tests/bigquery_pipeline.rs
+++ b/etl-destinations/tests/bigquery_pipeline.rs
@@ -22,7 +22,7 @@ use etl_destinations::bigquery::test_utils::{
 };
 use etl_postgres::tokio::test_utils::TableModification;
 use etl_telemetry::tracing::init_test_tracing;
-use rand::random;
+use rand::{Rng, distr::Alphanumeric, random};
 use tokio::time::sleep;
 
 /// Ensures crypto provider is only initialized once.
@@ -38,11 +38,15 @@ fn install_crypto_provider() {
 }
 
 use crate::support::bigquery::{
-    BigQueryOrder, BigQueryReplicaIdentityRow, BigQueryUser, NonNullableColsScalar,
-    NullableColsArray, NullableColsScalar, parse_bigquery_table_rows,
+    BigQueryOrder, BigQueryUser, NonNullableColsScalar, NullableColsArray, NullableColsScalar,
+    parse_bigquery_table_rows,
 };
 
 const REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES: usize = 8192;
+
+fn generate_random_ascii_string(length: usize) -> String {
+    rand::rng().sample_iter(&Alphanumeric).take(length).map(char::from).collect()
+}
 
 fn data_events(events: Vec<Event>) -> Vec<Event> {
     events
@@ -523,7 +527,7 @@ async fn table_full_replica_identity_update_preserves_unchanged_toasted_columns(
         .await
         .unwrap();
 
-    let initial_large_text = "a".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
+    let initial_large_text = generate_random_ascii_string(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
     database
         .insert_values(
             table_name.clone(),
@@ -611,181 +615,6 @@ async fn table_full_replica_identity_update_preserves_unchanged_toasted_columns(
 
     let table_rows = bigquery_database.query_table(table_name).await;
     assert!(table_rows.is_none());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn table_alternative_replica_identity_errors_cleanly() {
-    if skip_if_missing_bigquery_env_vars() {
-        return;
-    }
-
-    init_test_tracing();
-    install_crypto_provider();
-
-    let database = spawn_source_database().await;
-    let bigquery_database = setup_bigquery_database().await;
-    let table_name = test_table_name("alternative_replica_identity_users");
-    let table_id = database
-        .create_table(
-            table_name.clone(),
-            true,
-            &[("email", "text not null"), ("name", "text not null")],
-        )
-        .await
-        .unwrap();
-
-    database
-        .insert_values(table_name.clone(), &["email", "name"], &[&"alice@example.com", &"alice"])
-        .await
-        .unwrap();
-
-    let index_name = format!("{}_replica_identity_idx", table_name.name);
-    database
-        .run_sql(&format!(
-            "create unique index {index_name} on {} (email)",
-            table_name.as_quoted_identifier(),
-        ))
-        .await
-        .unwrap();
-    let replica_identity_value = format!("using index {index_name}");
-    database
-        .alter_table(
-            table_name.clone(),
-            &[TableModification::ReplicaIdentity { value: &replica_identity_value }],
-        )
-        .await
-        .unwrap();
-
-    let store = NotifyingStore::new();
-    let pipeline_id: PipelineId = random();
-    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
-    let destination = TestDestinationWrapper::wrap(raw_destination);
-
-    let publication_name = "test_pub_alternative_replica_identity".to_string();
-    database
-        .create_publication(&publication_name, std::slice::from_ref(&table_name))
-        .await
-        .expect("Failed to create publication");
-
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name,
-        store.clone(),
-        destination.clone(),
-    );
-
-    // PostgreSQL can validly publish USING INDEX key rows here, but BigQuery
-    // only supports source primary-key or FULL replica identity.
-    let table_error_notify =
-        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Errored).await;
-
-    pipeline.start().await.unwrap();
-
-    table_error_notify.notified().await;
-
-    pipeline.shutdown_and_wait().await.unwrap();
-
-    let table_state = store.get_table_replication_state(table_id).await.unwrap();
-    assert!(matches!(table_state, Some(TableReplicationPhase::Errored { .. })));
-    assert!(destination.get_events().await.is_empty());
-    assert!(bigquery_database.query_table(table_name).await.is_none());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn table_partial_update_rows_error_cleanly_for_bigquery() {
-    if skip_if_missing_bigquery_env_vars() {
-        return;
-    }
-
-    init_test_tracing();
-    install_crypto_provider();
-
-    let database = spawn_source_database().await;
-    let bigquery_database = setup_bigquery_database().await;
-    let table_name = test_table_name("partial_update_rows_users");
-    let table_id = database
-        .create_table(
-            table_name.clone(),
-            true,
-            &[("name", "text not null"), ("large_text", "text not null")],
-        )
-        .await
-        .unwrap();
-
-    database
-        .alter_table(
-            table_name.clone(),
-            &[TableModification::AlterColumn {
-                name: "large_text",
-                alteration: "set storage external",
-            }],
-        )
-        .await
-        .unwrap();
-
-    let initial_large_text = "a".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
-    database
-        .insert_values(
-            table_name.clone(),
-            &["name", "large_text"],
-            &[&"alice", &initial_large_text],
-        )
-        .await
-        .unwrap();
-
-    let store = NotifyingStore::new();
-    let pipeline_id: PipelineId = random();
-    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
-    let destination = TestDestinationWrapper::wrap(raw_destination);
-
-    let publication_name = "test_pub_partial_update_rows".to_string();
-    database
-        .create_publication(&publication_name, std::slice::from_ref(&table_name))
-        .await
-        .expect("Failed to create publication");
-
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name,
-        store.clone(),
-        destination.clone(),
-    );
-
-    let table_ready_notify =
-        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
-
-    pipeline.start().await.unwrap();
-
-    table_ready_notify.notified().await;
-
-    // With default primary-key replica identity, updating a non-key column
-    // while leaving an external TOAST value unchanged is a valid PostgreSQL
-    // shape: no old row plus a partial new row. BigQuery should reject that
-    // cleanly instead of trying to upsert a sparse row.
-    let table_error_notify =
-        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Errored).await;
-
-    database
-        .update_values_where(table_name.clone(), &["name"], &[&"alicia"], &["id"], &["1"], "")
-        .await
-        .unwrap();
-
-    table_error_notify.notified().await;
-
-    pipeline.shutdown_and_wait().await.unwrap();
-
-    let table_state = store.get_table_replication_state(table_id).await.unwrap();
-    assert!(matches!(table_state, Some(TableReplicationPhase::Errored { .. })));
-    assert!(destination.get_events().await.is_empty());
-
-    let table_rows = bigquery_database.query_table(table_name).await.unwrap();
-    let parsed_table_rows = parse_bigquery_table_rows::<BigQueryReplicaIdentityRow>(table_rows);
-    assert_eq!(
-        parsed_table_rows,
-        vec![BigQueryReplicaIdentityRow::new(1, "alice", &initial_large_text),]
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/etl-destinations/tests/ducklake_destination.rs
+++ b/etl-destinations/tests/ducklake_destination.rs
@@ -37,8 +37,9 @@ use etl::{
     error::ErrorKind,
     store::{both::memory::MemoryStore, schema::SchemaStore},
     types::{
-        Cell, ColumnSchema, Event, OldTableRow, PgLsn, ReplicatedTableSchema, TableId, TableName,
-        TableRow, TableSchema, Type as PgType, UpdatedTableRow,
+        Cell, ColumnSchema, DeleteEvent, Event, IdentityMask, OldTableRow, PartialTableRow, PgLsn,
+        ReplicatedTableSchema, ReplicationMask, TableId, TableName, TableRow, TableSchema,
+        Type as PgType, UpdatedTableRow,
     },
 };
 use etl_destinations::ducklake::{DuckLakeDestination, table_name_to_ducklake_table_name};
@@ -1044,11 +1045,197 @@ async fn write_events_with_old_row_update() {
     assert_eq!(name, "Gadget");
 }
 
+/// Partial update rows should execute through DuckLake and preserve the latest
+/// value when the same row is updated multiple times in order.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_events_with_partial_updates() {
+    use etl::types::UpdateEvent;
+
+    let dir = make_test_dir("write_events_with_partial_updates");
+    let catalog = dir.join("catalog.ducklake");
+    let data = dir.join("data");
+    std::fs::create_dir_all(&data).unwrap();
+
+    let catalog_url = path_to_file_url(&catalog);
+    let data_url = path_to_file_url(&data);
+
+    let schema = make_schema(37, "public", "partial_inventory");
+    let replicated_schema = make_replicated_table_schema(&schema);
+    let table_name = table_name_to_ducklake_table_name(&schema.name).unwrap();
+
+    let store = MemoryStore::new();
+    store.store_table_schema(schema).await.unwrap();
+
+    let destination = DuckLakeDestination::new(
+        catalog_url.clone(),
+        data_url.clone(),
+        1,
+        None,
+        None,
+        None,
+        None,
+        store,
+    )
+    .await
+    .unwrap();
+
+    destination
+        .write_table_rows(
+            &replicated_schema,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("seed".to_string())])],
+        )
+        .await
+        .unwrap();
+
+    let lsn = PgLsn::from(425u64);
+    destination
+        .write_events(vec![
+            Event::Update(UpdateEvent {
+                start_lsn: lsn,
+                commit_lsn: lsn,
+                tx_ordinal: 0,
+                replicated_table_schema: replicated_schema.clone(),
+                updated_table_row: UpdatedTableRow::Partial(PartialTableRow::new(
+                    2,
+                    TableRow::new(vec![Cell::I32(1), Cell::String("grown".to_string())]),
+                    vec![],
+                )),
+                old_table_row: Some(OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]))),
+            }),
+            Event::Update(UpdateEvent {
+                start_lsn: lsn,
+                commit_lsn: lsn,
+                tx_ordinal: 1,
+                replicated_table_schema: replicated_schema.clone(),
+                updated_table_row: UpdatedTableRow::Partial(PartialTableRow::new(
+                    2,
+                    TableRow::new(vec![Cell::I32(1), Cell::String("ripe".to_string())]),
+                    vec![],
+                )),
+                old_table_row: Some(OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]))),
+            }),
+        ])
+        .await
+        .unwrap();
+
+    let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
+    assert_eq!(count_rows(&conn, &table_name), 1);
+    assert_eq!(count_streaming_progress_rows(&conn, &table_name), 1);
+    assert_eq!(read_streaming_progress(&conn, &table_name), Some((425, 1)));
+
+    let name: String = conn
+        .query_row(
+            &format!(
+                "SELECT name FROM {}.{} WHERE id = 1",
+                quote_identifier("lake"),
+                quote_identifier(&table_name)
+            ),
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(name, "ripe");
+}
+
+/// Missing replica identity should fail mutations clearly instead of silently
+/// skipping them.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_events_without_replica_identity_rejects_mutations() {
+    use etl::types::UpdateEvent;
+
+    let dir = make_test_dir("write_events_without_replica_identity_rejects_mutations");
+    let catalog = dir.join("catalog.ducklake");
+    let data = dir.join("data");
+    std::fs::create_dir_all(&data).unwrap();
+
+    let catalog_url = path_to_file_url(&catalog);
+    let data_url = path_to_file_url(&data);
+
+    let table_schema = Arc::new(make_schema(40, "public", "missing_identity_inventory"));
+    let replicated_schema = ReplicatedTableSchema::from_masks(
+        Arc::clone(&table_schema),
+        ReplicationMask::all(&table_schema),
+        IdentityMask::from_bytes(vec![0, 0]),
+    );
+    let table_name = table_name_to_ducklake_table_name(&table_schema.name).unwrap();
+
+    let store = MemoryStore::new();
+    store.store_table_schema(table_schema.as_ref().clone()).await.unwrap();
+
+    let destination = DuckLakeDestination::new(
+        catalog_url.clone(),
+        data_url.clone(),
+        1,
+        None,
+        None,
+        None,
+        None,
+        store,
+    )
+    .await
+    .unwrap();
+
+    destination
+        .write_table_rows(
+            &replicated_schema,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("seed".to_string())])],
+        )
+        .await
+        .unwrap();
+
+    let update_lsn = PgLsn::from(450u64);
+    let update_error = destination
+        .write_events(vec![Event::Update(UpdateEvent {
+            start_lsn: update_lsn,
+            commit_lsn: update_lsn,
+            tx_ordinal: 0,
+            replicated_table_schema: replicated_schema.clone(),
+            updated_table_row: UpdatedTableRow::Full(TableRow::new(vec![
+                Cell::I32(1),
+                Cell::String("grown".to_string()),
+            ])),
+            old_table_row: None,
+        })])
+        .await
+        .unwrap_err();
+    assert_eq!(update_error.kind(), ErrorKind::InvalidState);
+    assert_eq!(update_error.description(), Some("DuckLake update requires a replica identity"));
+
+    let delete_lsn = PgLsn::from(451u64);
+    let delete_error = destination
+        .write_events(vec![Event::Delete(DeleteEvent {
+            start_lsn: delete_lsn,
+            commit_lsn: delete_lsn,
+            tx_ordinal: 0,
+            replicated_table_schema: replicated_schema.clone(),
+            old_table_row: None,
+        })])
+        .await
+        .unwrap_err();
+    assert_eq!(delete_error.kind(), ErrorKind::InvalidState);
+    assert_eq!(delete_error.description(), Some("DuckLake delete requires a replica identity"));
+
+    let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
+    assert_eq!(count_rows(&conn, &table_name), 1);
+    let name: String = conn
+        .query_row(
+            &format!(
+                "SELECT name FROM {}.{} WHERE id = 1",
+                quote_identifier("lake"),
+                quote_identifier(&table_name)
+            ),
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(name, "seed");
+}
+
 /// Replaying the same CDC batch should be a no-op after the progress row is
 /// committed.
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events_replay_is_idempotent() {
-    use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
+    use etl::types::{InsertEvent, PgLsn, UpdateEvent};
 
     let dir = make_test_dir("write_events_replay_is_idempotent");
     let catalog = dir.join("catalog.ducklake");

--- a/etl-destinations/tests/support/bigquery.rs
+++ b/etl-destinations/tests/support/bigquery.rs
@@ -58,6 +58,31 @@ impl From<TableRow> for BigQueryOrder {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BigQueryReplicaIdentityRow {
+    id: i32,
+    name: String,
+    large_text: String,
+}
+
+impl BigQueryReplicaIdentityRow {
+    pub fn new(id: i32, name: &str, large_text: &str) -> Self {
+        Self { id, name: name.to_owned(), large_text: large_text.to_owned() }
+    }
+}
+
+impl From<TableRow> for BigQueryReplicaIdentityRow {
+    fn from(value: TableRow) -> Self {
+        let columns = value.columns.unwrap();
+
+        BigQueryReplicaIdentityRow {
+            id: parse_table_cell(columns[0].clone()).unwrap(),
+            name: parse_table_cell(columns[1].clone()).unwrap(),
+            large_text: parse_table_cell(columns[2].clone()).unwrap(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct NullableColsScalar {
     id: i32,

--- a/etl-postgres/src/types/schema.rs
+++ b/etl-postgres/src/types/schema.rs
@@ -565,6 +565,14 @@ impl IdentityMask {
 /// - [`IdentityType::Full`] means the whole replicated row is the old-row key.
 /// - [`IdentityType::Missing`] means updates and deletes do not have a usable
 ///   row identity.
+///
+/// Equivalence is established structurally from the current replicated schema
+/// columns, not from the raw PostgreSQL mode byte or from an index OID. In
+/// practice that means a `USING INDEX` identity is treated as
+/// [`IdentityType::PrimaryKey`] whenever it resolves to the same current
+/// columns as the primary key. This is the semantic question destinations care
+/// about, and it remains stable across supported DDL evolution because ETL
+/// keeps rebuilding the runtime schema from schema-change messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IdentityType {
     /// The full replicated row is the row identity.
@@ -776,7 +784,13 @@ impl ReplicatedTableSchema {
     ///
     /// This is the semantic question destinations usually care about. A table
     /// configured with `REPLICA IDENTITY USING INDEX` can still return `true`
-    /// here if the chosen index is the primary-key index.
+    /// here if the chosen index resolves to the same current columns as the
+    /// primary key.
+    ///
+    /// This comparison is structural over the runtime schema masks, not a
+    /// direct comparison of PostgreSQL identity modes or index OIDs. Because
+    /// ETL tracks DDL/schema changes, that gives the intended notion of
+    /// primary-key equivalence across schema evolution.
     pub fn identity_matches_primary_key(&self) -> bool {
         self.identity_mask.as_slice().iter().eq(Self::primary_key_identity_mask(
             &self.table_schema,
@@ -921,6 +935,11 @@ impl ReplicatedTableSchema {
     ///
     /// In the case when a primary key is made up of all the table columns, the
     /// identity will be marked as [`IdentityType::PrimaryKey`].
+    ///
+    /// The inference is structural: if the identity mask selects the same
+    /// current replicated columns as the primary key mask, the result is
+    /// [`IdentityType::PrimaryKey`] even if the original source mode might
+    /// have been `USING INDEX`.
     fn infer_identity_type(
         table_schema: &TableSchema,
         replication_mask: &ReplicationMask,

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -291,6 +291,19 @@ pub(crate) fn parse_event_from_commit_message(
 }
 
 /// Returns the set of column names to replicate from a relation message.
+///
+/// PostgreSQL pgoutput emits relation columns by iterating the relation
+/// `TupleDesc` in physical `pg_attribute.attnum` order and skipping columns
+/// that are not published.
+///
+/// This function intentionally returns a [`HashSet`]: mask membership is built
+/// by column name, and PostgreSQL requires live column names to be unique
+/// within one table schema version. Relation-message order is therefore not
+/// needed to decide which columns are included. The order matters later, when
+/// tuple data is decoded, because tuple fields are sent in the same order as
+/// the relation message. Applying the name-based masks to ETL's stored,
+/// `attnum`-ordered [`TableSchema`] creates the [`ReplicatedTableSchema`] view
+/// used for positional tuple decoding.
 pub(crate) fn parse_replicated_column_names(
     relation_body: &protocol::RelationBody,
 ) -> EtlResult<HashSet<String>> {
@@ -309,7 +322,11 @@ pub(crate) fn parse_replicated_column_names(
 /// key-column membership on each [`RelationBody`] column. For
 /// `REPLICA IDENTITY FULL`, every replicated column belongs to the old-row
 /// identity. Otherwise the low bit of the column flags marks identity
-/// membership.
+/// membership. The column order is the same `attnum` order described in
+/// [`parse_replicated_column_names`]. This returns names because identity-mask
+/// membership is also name-based; tuple interpretation relies on the resulting
+/// replicated schema preserving relation-message order after the masks are
+/// applied.
 pub(crate) fn parse_replica_identity_column_names(
     relation_body: &protocol::RelationBody,
 ) -> EtlResult<HashSet<String>> {
@@ -356,30 +373,25 @@ pub(crate) fn parse_event_from_insert_message(
 
 /// Converts a Postgres update message into an [`UpdateEvent`].
 ///
-/// Update events have two distinct row images with different semantics.
-///
-/// The old row image may be either [`OldTableRow::Full`] or
-/// [`OldTableRow::Key`], depending on the table's `REPLICA IDENTITY` setting
-/// and on whether PostgreSQL needed to send an old-side image at all:
+/// This function preserves pgoutput's update tuple markers:
 ///
 /// - `REPLICA IDENTITY FULL` emits `old_tuple`, which we decode as
-///   [`OldTableRow::Full`].
-/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` may emit `key_tuple`, which
-///   we decode as [`OldTableRow::Key`]. PostgreSQL does this when the replica
-///   identity changed, or when it still needs the old identity values (for
-///   example because a replica-identity column is externally stored).
-/// - Otherwise PostgreSQL emits no old-side tuple at all and `old_table_row`
-///   stays `None`.
+///   [`OldTableRow::Full`] for every published update.
+/// - `REPLICA IDENTITY DEFAULT` with a primary key and `USING INDEX` may emit
+///   `key_tuple`, which we decode as [`OldTableRow::Key`]. PostgreSQL does this
+///   when any replica-identity column changed, or when a replica-identity
+///   column has external data that must be available from the old tuple.
+/// - `REPLICA IDENTITY DEFAULT` with a primary key and `USING INDEX` otherwise
+///   emit no old-side tuple and `old_table_row` stays `None`.
+/// - `REPLICA IDENTITY NOTHING`, and `DEFAULT` without a primary key, do not
+///   produce published update messages when the table publishes updates. The
+///   source `UPDATE` is rejected before pgoutput emits an event.
+/// - `REPLICA IDENTITY FULL` updates with no old row are not emitted by
+///   PostgreSQL pgoutput.
 ///
-/// The new row image is always decoded from the update's new tuple and becomes
-/// [`UpdatedTableRow::Full`] when every column value is known, or
-/// [`UpdatedTableRow::Partial`] when PostgreSQL emits `UnchangedToast` fields
-/// that cannot be reconstructed from the available old-row image.
-///
-/// The shared key-row decoder only normalizes PostgreSQL's key-image tuple into
-/// a dense row containing replica-identity columns in replicated table order.
-/// The update-specific semantics live here: the old row is auxiliary data that
-/// is consulted only to resolve missing new-row values.
+/// The new tuple is decoded separately. `UnchangedToast` values are recovered
+/// from the old-side row image when possible; otherwise the result is
+/// [`UpdatedTableRow::Partial`].
 pub(crate) fn parse_event_from_update_message(
     replicated_table_schema: ReplicatedTableSchema,
     start_lsn: PgLsn,
@@ -390,9 +402,9 @@ pub(crate) fn parse_event_from_update_message(
     // PostgreSQL can attach either a full old tuple (`old_tuple`) or only the
     // replica-identity columns (`key_tuple`) to an update. If neither is
     // present, the publisher determined that no old-side image was required
-    // for this update. We preserve that shape in `OldTableRow`. The new tuple
-    // is decoded separately below, where the old row acts only as a source for
-    // resolving `UnchangedToast`.
+    // for this key-based replica-identity update. We preserve that shape in
+    // `OldTableRow`. The new tuple is decoded separately below, where the old
+    // row acts only as a source for resolving `UnchangedToast`.
     let is_key = update_body.old_tuple().is_none();
     let old_tuple = update_body.old_tuple().or(update_body.key_tuple());
 
@@ -440,23 +452,19 @@ pub(crate) fn parse_event_from_update_message(
 
 /// Converts a Postgres delete message into a [`DeleteEvent`].
 ///
-/// Delete events carry only an old row image.
-///
-/// That old image may be either [`OldTableRow::Full`] or [`OldTableRow::Key`],
-/// depending on the table's `REPLICA IDENTITY` setting:
+/// Delete messages carry only an old-side row image:
 ///
 /// - `REPLICA IDENTITY FULL` emits `old_tuple`, which we decode as
 ///   [`OldTableRow::Full`].
-/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` emit `key_tuple`, which we
-///   decode as [`OldTableRow::Key`].
-/// - valid publications cannot emit deletes for `REPLICA IDENTITY NOTHING`, and
-///   published deletes should always carry an old-side tuple. A missing old row
-///   is therefore preserved defensively as an invalid upstream absence.
+/// - `REPLICA IDENTITY DEFAULT` with a primary key and `USING INDEX` emit
+///   `key_tuple`, which we decode as [`OldTableRow::Key`].
+/// - `REPLICA IDENTITY NOTHING`, and `DEFAULT` without a primary key, do not
+///   produce published delete messages when the table publishes deletes. The
+///   source `DELETE` is rejected before pgoutput emits an event.
 ///
-/// Unlike updates, delete handling does not need any additional reconstruction
-/// step for a new row, so this function simply preserves PostgreSQL's old-row
-/// semantics after normalizing any key tuple into a dense key row in
-/// replicated table order.
+/// PostgreSQL pgoutput sends an old-side tuple for every published delete. This
+/// decoder preserves that tuple shape, normalizing key tuples into dense
+/// replica-identity rows in replicated table order.
 pub(crate) fn parse_event_from_delete_message(
     replicated_table_schema: ReplicatedTableSchema,
     start_lsn: PgLsn,
@@ -464,9 +472,9 @@ pub(crate) fn parse_event_from_delete_message(
     tx_ordinal: u64,
     delete_body: &protocol::DeleteBody,
 ) -> EtlResult<DeleteEvent> {
-    // Published delete messages should always carry an old-side image.
-    // PostgreSQL sends either the full old row or only the replica-identity
-    // columns, and we preserve that shape here.
+    // Published delete messages carry an old-side image. PostgreSQL sends
+    // either the full old row or only the replica-identity columns, and we
+    // preserve that shape here.
     let is_key = delete_body.old_tuple().is_none();
     let old_tuple = delete_body.old_tuple().or(delete_body.key_tuple());
 
@@ -602,7 +610,7 @@ fn convert_update_tuple_to_updated_table_row(
         });
         let old_value = old_row_resolver.value_for_column(is_identity)?;
         if is_identity {
-            let _ = identity_columns.next().expect("peeked identity column");
+            let _ = identity_columns.next();
         }
         match convert_tuple_data_to_cell(index, column_schema, tuple_data, old_value)? {
             ConvertedTupleCell::Present(value) if partial_row => {
@@ -620,9 +628,9 @@ fn convert_update_tuple_to_updated_table_row(
                     present_values.append(&mut full_values);
                     partial_row = true;
                 }
-                // Missing indexes stay in replicated-column order so
-                // destinations can align the sparse row against the attached
-                // replicated schema without guessing positions.
+                // Missing indexes stay in replicated-column order so consumers
+                // can align the sparse row against the attached replicated
+                // schema without guessing positions.
                 missing_column_indexes.push(index);
             }
         }
@@ -805,7 +813,13 @@ fn convert_full_width_key_tuple_to_row(
             continue;
         }
 
-        let identity_column = identity_columns.next().expect("peeked identity column");
+        let Some(identity_column) = identity_columns.next() else {
+            bail!(
+                ErrorKind::ConversionError,
+                "Replica-identity tuple shape does not match schema",
+                "Replica-identity column iterator ended unexpectedly"
+            );
+        };
         let ConvertedTupleCell::Present(value) =
             convert_tuple_data_to_cell(i, identity_column, tuple_data, None)?
         else {

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -360,8 +360,18 @@ pub(crate) fn parse_event_from_insert_message(
 ///
 /// The old row image may be either [`OldTableRow::Full`] or
 /// [`OldTableRow::Key`], depending on the table's `REPLICA IDENTITY` setting
-/// and on whether PostgreSQL needed to send an old-side image at all. The new
-/// row image is always decoded from the update's new tuple and becomes
+/// and on whether PostgreSQL needed to send an old-side image at all:
+///
+/// - `REPLICA IDENTITY FULL` emits `old_tuple`, which we decode as
+///   [`OldTableRow::Full`].
+/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` may emit `key_tuple`, which
+///   we decode as [`OldTableRow::Key`]. PostgreSQL does this when the replica
+///   identity changed, or when it still needs the old identity values (for
+///   example because a replica-identity column is externally stored).
+/// - Otherwise PostgreSQL emits no old-side tuple at all and `old_table_row`
+///   stays `None`.
+///
+/// The new row image is always decoded from the update's new tuple and becomes
 /// [`UpdatedTableRow::Full`] when every column value is known, or
 /// [`UpdatedTableRow::Partial`] when PostgreSQL emits `UnchangedToast` fields
 /// that cannot be reconstructed from the available old-row image.
@@ -378,9 +388,11 @@ pub(crate) fn parse_event_from_update_message(
     update_body: &protocol::UpdateBody,
 ) -> EtlResult<UpdateEvent> {
     // PostgreSQL can attach either a full old tuple (`old_tuple`) or only the
-    // replica-identity columns (`key_tuple`) to an update. We preserve that
-    // shape in `OldTableRow`. The new tuple is decoded separately below, where
-    // the old row acts only as a source for resolving `UnchangedToast`.
+    // replica-identity columns (`key_tuple`) to an update. If neither is
+    // present, the publisher determined that no old-side image was required
+    // for this update. We preserve that shape in `OldTableRow`. The new tuple
+    // is decoded separately below, where the old row acts only as a source for
+    // resolving `UnchangedToast`.
     let is_key = update_body.old_tuple().is_none();
     let old_tuple = update_body.old_tuple().or(update_body.key_tuple());
 
@@ -431,10 +443,20 @@ pub(crate) fn parse_event_from_update_message(
 /// Delete events carry only an old row image.
 ///
 /// That old image may be either [`OldTableRow::Full`] or [`OldTableRow::Key`],
-/// depending on the table's `REPLICA IDENTITY` setting. Unlike updates, delete
-/// handling does not need any additional reconstruction step for a new row, so
-/// this function simply preserves PostgreSQL's old-row semantics after
-/// normalizing any key tuple into a dense key row in replicated table order.
+/// depending on the table's `REPLICA IDENTITY` setting:
+///
+/// - `REPLICA IDENTITY FULL` emits `old_tuple`, which we decode as
+///   [`OldTableRow::Full`].
+/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` emit `key_tuple`, which we
+///   decode as [`OldTableRow::Key`].
+/// - valid publications cannot emit deletes for `REPLICA IDENTITY NOTHING`, and
+///   published deletes should always carry an old-side tuple. A missing old row
+///   is therefore preserved defensively as an invalid upstream absence.
+///
+/// Unlike updates, delete handling does not need any additional reconstruction
+/// step for a new row, so this function simply preserves PostgreSQL's old-row
+/// semantics after normalizing any key tuple into a dense key row in
+/// replicated table order.
 pub(crate) fn parse_event_from_delete_message(
     replicated_table_schema: ReplicatedTableSchema,
     start_lsn: PgLsn,
@@ -442,8 +464,9 @@ pub(crate) fn parse_event_from_delete_message(
     tx_ordinal: u64,
     delete_body: &protocol::DeleteBody,
 ) -> EtlResult<DeleteEvent> {
-    // Delete messages carry only an old-side image. PostgreSQL may send either
-    // the full old row or only the replica-identity columns.
+    // Published delete messages should always carry an old-side image.
+    // PostgreSQL sends either the full old row or only the replica-identity
+    // columns, and we preserve that shape here.
     let is_key = delete_body.old_tuple().is_none();
     let old_tuple = delete_body.old_tuple().or(delete_body.key_tuple());
 
@@ -924,21 +947,30 @@ fn convert_tuple_data_to_cell(
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
     use etl_postgres::types::{ColumnSchema, IdentityType, ReplicationMask};
-    use postgres_replication::protocol::TupleData;
+    use postgres_replication::protocol::{LogicalReplicationMessage, TupleData};
     use tokio_postgres::types::Type;
 
     use super::{
         IdentityMessage, convert_tuple_to_row, convert_update_tuple_to_updated_table_row,
-        normalize_key_tuple_to_row,
+        normalize_key_tuple_to_row, parse_event_from_delete_message,
+        parse_event_from_update_message,
     };
     use crate::{
         error::ErrorKind,
         types::{
-            Cell, OldTableRow, PartialTableRow, ReplicatedTableSchema, TableId, TableName,
-            TableRow, TableSchema, UpdatedTableRow,
+            Cell, DeleteEvent, OldTableRow, PartialTableRow, PgLsn, ReplicatedTableSchema, TableId,
+            TableName, TableRow, TableSchema, UpdateEvent, UpdatedTableRow,
         },
     };
+
+    #[derive(Clone, Copy)]
+    enum TestTupleData<'a> {
+        Null,
+        UnchangedToast,
+        Text(&'a str),
+    }
 
     fn event_schema(columns: Vec<ColumnSchema>) -> ReplicatedTableSchema {
         let table_schema = Arc::new(TableSchema::new(
@@ -948,6 +980,162 @@ mod tests {
         ));
 
         ReplicatedTableSchema::all(Arc::clone(&table_schema))
+    }
+
+    fn composite_primary_key_schema() -> ReplicatedTableSchema {
+        event_schema(vec![
+            ColumnSchema::new("id".to_string(), Type::INT8, -1, 1, Some(2), false),
+            ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, false),
+            ColumnSchema::new("surname".to_string(), Type::TEXT, -1, 3, Some(1), false),
+            ColumnSchema::new("city".to_string(), Type::TEXT, -1, 4, None, false),
+            ColumnSchema::new("large_text".to_string(), Type::TEXT, -1, 5, None, false),
+        ])
+    }
+
+    fn alternative_identity_schema() -> ReplicatedTableSchema {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(43),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), Type::INT8, -1, 1, Some(2), false),
+                ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, false),
+                ColumnSchema::new("surname".to_string(), Type::TEXT, -1, 3, Some(1), false),
+                ColumnSchema::new("city".to_string(), Type::TEXT, -1, 4, None, false),
+            ],
+        ));
+
+        ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            etl_postgres::types::IdentityMask::from_bytes(vec![0, 1, 1, 0]),
+        )
+    }
+
+    fn full_identity_schema() -> ReplicatedTableSchema {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(44),
+            TableName::new("public".to_string(), "users".to_string()),
+            vec![
+                ColumnSchema::new("id".to_string(), Type::INT8, -1, 1, Some(2), false),
+                ColumnSchema::new("name".to_string(), Type::TEXT, -1, 2, None, false),
+                ColumnSchema::new("surname".to_string(), Type::TEXT, -1, 3, Some(1), false),
+                ColumnSchema::new("city".to_string(), Type::TEXT, -1, 4, None, false),
+            ],
+        ));
+
+        ReplicatedTableSchema::from_masks(
+            Arc::clone(&table_schema),
+            ReplicationMask::all(&table_schema),
+            etl_postgres::types::IdentityMask::from_bytes(vec![1, 1, 1, 1]),
+        )
+    }
+
+    fn encode_tuple(buf: &mut Vec<u8>, tuple_data: &[TestTupleData<'_>]) {
+        buf.extend_from_slice(&(i16::try_from(tuple_data.len()).unwrap()).to_be_bytes());
+
+        for cell in tuple_data {
+            match cell {
+                TestTupleData::Null => buf.push(b'n'),
+                TestTupleData::UnchangedToast => buf.push(b'u'),
+                TestTupleData::Text(value) => {
+                    buf.push(b't');
+                    buf.extend_from_slice(&(i32::try_from(value.len()).unwrap()).to_be_bytes());
+                    buf.extend_from_slice(value.as_bytes());
+                }
+            }
+        }
+    }
+
+    fn parse_update_body_from_parts(
+        rel_id: u32,
+        old_tuple: Option<&[TestTupleData<'_>]>,
+        key_tuple: Option<&[TestTupleData<'_>]>,
+        new_tuple: &[TestTupleData<'_>],
+    ) -> postgres_replication::protocol::UpdateBody {
+        let mut bytes = Vec::new();
+        bytes.push(b'U');
+        bytes.extend_from_slice(&rel_id.to_be_bytes());
+
+        match (old_tuple, key_tuple) {
+            (Some(old_tuple), None) => {
+                bytes.push(b'O');
+                encode_tuple(&mut bytes, old_tuple);
+            }
+            (None, Some(key_tuple)) => {
+                bytes.push(b'K');
+                encode_tuple(&mut bytes, key_tuple);
+            }
+            (None, None) => {}
+            (Some(_), Some(_)) => panic!("update body cannot contain both old and key tuples"),
+        }
+
+        bytes.push(b'N');
+        encode_tuple(&mut bytes, new_tuple);
+
+        let message = LogicalReplicationMessage::parse(&Bytes::from(bytes)).unwrap();
+        let LogicalReplicationMessage::Update(body) = message else {
+            panic!("expected update body");
+        };
+
+        body
+    }
+
+    fn parse_delete_body_from_parts(
+        rel_id: u32,
+        old_tuple: Option<&[TestTupleData<'_>]>,
+        key_tuple: Option<&[TestTupleData<'_>]>,
+    ) -> postgres_replication::protocol::DeleteBody {
+        let mut bytes = Vec::new();
+        bytes.push(b'D');
+        bytes.extend_from_slice(&rel_id.to_be_bytes());
+
+        match (old_tuple, key_tuple) {
+            (Some(old_tuple), None) => {
+                bytes.push(b'O');
+                encode_tuple(&mut bytes, old_tuple);
+            }
+            (None, Some(key_tuple)) => {
+                bytes.push(b'K');
+                encode_tuple(&mut bytes, key_tuple);
+            }
+            (None, None) => panic!("delete body requires either old or key tuple"),
+            (Some(_), Some(_)) => panic!("delete body cannot contain both old and key tuples"),
+        }
+
+        let message = LogicalReplicationMessage::parse(&Bytes::from(bytes)).unwrap();
+        let LogicalReplicationMessage::Delete(body) = message else {
+            panic!("expected delete body");
+        };
+
+        body
+    }
+
+    fn parse_update_event(
+        replicated_table_schema: ReplicatedTableSchema,
+        update_body: &postgres_replication::protocol::UpdateBody,
+    ) -> UpdateEvent {
+        parse_event_from_update_message(
+            replicated_table_schema,
+            PgLsn::from(10),
+            PgLsn::from(20),
+            0,
+            update_body,
+        )
+        .unwrap()
+    }
+
+    fn parse_delete_event(
+        replicated_table_schema: ReplicatedTableSchema,
+        delete_body: &postgres_replication::protocol::DeleteBody,
+    ) -> DeleteEvent {
+        parse_event_from_delete_message(
+            replicated_table_schema,
+            PgLsn::from(10),
+            PgLsn::from(20),
+            0,
+            delete_body,
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1147,5 +1335,201 @@ mod tests {
         let row = normalize_key_tuple_to_row(&replicated_table_schema, &tuple_data).unwrap();
 
         assert_eq!(row, TableRow::new(vec![Cell::I64(1), Cell::String("smith".to_string())]));
+    }
+
+    #[test]
+    fn parse_event_from_update_message_preserves_absent_old_row_for_non_identity_change() {
+        let replicated_table_schema = composite_primary_key_schema();
+        let update_body = parse_update_body_from_parts(
+            42,
+            None,
+            None,
+            &[
+                TestTupleData::Text("1"),
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smith"),
+                TestTupleData::Text("vienna"),
+                TestTupleData::Text("toast"),
+            ],
+        );
+
+        let event = parse_update_event(replicated_table_schema, &update_body);
+
+        assert_eq!(event.old_table_row, None);
+        assert_eq!(
+            event.updated_table_row,
+            UpdatedTableRow::Full(TableRow::new(vec![
+                Cell::I64(1),
+                Cell::String("alice".to_string()),
+                Cell::String("smith".to_string()),
+                Cell::String("vienna".to_string()),
+                Cell::String("toast".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn parse_event_from_update_message_marks_unrecoverable_toast_as_partial_without_old_row() {
+        let replicated_table_schema = composite_primary_key_schema();
+        let update_body = parse_update_body_from_parts(
+            42,
+            None,
+            None,
+            &[
+                TestTupleData::Text("1"),
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smith"),
+                TestTupleData::Text("vienna"),
+                TestTupleData::UnchangedToast,
+            ],
+        );
+
+        let event = parse_update_event(replicated_table_schema, &update_body);
+
+        assert_eq!(event.old_table_row, None);
+        assert_eq!(
+            event.updated_table_row,
+            UpdatedTableRow::Partial(PartialTableRow::new(
+                5,
+                TableRow::new(vec![
+                    Cell::I64(1),
+                    Cell::String("alice".to_string()),
+                    Cell::String("smith".to_string()),
+                    Cell::String("vienna".to_string()),
+                ]),
+                vec![4],
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_event_from_update_message_preserves_key_tuple_for_identity_change() {
+        let replicated_table_schema = composite_primary_key_schema();
+        let update_body = parse_update_body_from_parts(
+            42,
+            None,
+            Some(&[
+                TestTupleData::Text("1"),
+                TestTupleData::Null,
+                TestTupleData::Text("smith"),
+                TestTupleData::Null,
+                TestTupleData::Null,
+            ]),
+            &[
+                TestTupleData::Text("1"),
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smithers"),
+                TestTupleData::Text("rome"),
+                TestTupleData::Text("toast"),
+            ],
+        );
+
+        let event = parse_update_event(replicated_table_schema, &update_body);
+
+        assert_eq!(
+            event.old_table_row,
+            Some(OldTableRow::Key(TableRow::new(vec![
+                Cell::I64(1),
+                Cell::String("smith".to_string()),
+            ])))
+        );
+    }
+
+    #[test]
+    fn parse_event_from_update_message_preserves_key_tuple_when_old_identity_is_still_sent() {
+        let replicated_table_schema = alternative_identity_schema();
+        let update_body = parse_update_body_from_parts(
+            43,
+            None,
+            Some(&[
+                TestTupleData::Null,
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smith"),
+                TestTupleData::Null,
+            ]),
+            &[
+                TestTupleData::Text("1"),
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smith"),
+                TestTupleData::Text("vienna"),
+            ],
+        );
+
+        let event = parse_update_event(replicated_table_schema, &update_body);
+
+        assert_eq!(
+            event.old_table_row,
+            Some(OldTableRow::Key(TableRow::new(vec![
+                Cell::String("alice".to_string()),
+                Cell::String("smith".to_string()),
+            ])))
+        );
+        assert_eq!(
+            event.updated_table_row,
+            UpdatedTableRow::Full(TableRow::new(vec![
+                Cell::I64(1),
+                Cell::String("alice".to_string()),
+                Cell::String("smith".to_string()),
+                Cell::String("vienna".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn parse_event_from_update_message_preserves_full_old_tuple_for_full_identity() {
+        let replicated_table_schema = full_identity_schema();
+        let update_body = parse_update_body_from_parts(
+            44,
+            Some(&[
+                TestTupleData::Text("1"),
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smith"),
+                TestTupleData::Text("rome"),
+            ]),
+            None,
+            &[
+                TestTupleData::Text("1"),
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smith"),
+                TestTupleData::Text("vienna"),
+            ],
+        );
+
+        let event = parse_update_event(replicated_table_schema, &update_body);
+
+        assert_eq!(
+            event.old_table_row,
+            Some(OldTableRow::Full(TableRow::new(vec![
+                Cell::I64(1),
+                Cell::String("alice".to_string()),
+                Cell::String("smith".to_string()),
+                Cell::String("rome".to_string()),
+            ])))
+        );
+    }
+
+    #[test]
+    fn parse_event_from_delete_message_preserves_key_tuple_for_delete() {
+        let replicated_table_schema = alternative_identity_schema();
+        let delete_body = parse_delete_body_from_parts(
+            43,
+            None,
+            Some(&[
+                TestTupleData::Null,
+                TestTupleData::Text("alice"),
+                TestTupleData::Text("smith"),
+                TestTupleData::Null,
+            ]),
+        );
+
+        let event = parse_delete_event(replicated_table_schema, &delete_body);
+
+        assert_eq!(
+            event.old_table_row,
+            Some(OldTableRow::Key(TableRow::new(vec![
+                Cell::String("alice".to_string()),
+                Cell::String("smith".to_string()),
+            ])))
+        );
     }
 }

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -317,13 +317,13 @@ pub(crate) fn parse_replica_identity_column_names(
         protocol::ReplicaIdentity::Full => relation_body
             .columns()
             .iter()
-            .map(|column| column.name().map(std::string::ToString::to_string))
+            .map(|column| column.name().map(ToString::to_string))
             .collect::<Result<HashSet<String>, _>>()?,
         _ => relation_body
             .columns()
             .iter()
             .filter(|column| column.flags() & 1 == 1)
-            .map(|column| column.name().map(std::string::ToString::to_string))
+            .map(|column| column.name().map(ToString::to_string))
             .collect::<Result<HashSet<String>, _>>()?,
     };
 

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1824,11 +1824,22 @@ where
             return Ok(HandleMessageResult::no_event());
         }
 
+        // We extract the columns from the message that are needed to build the masks.
+        // The masks themselves are built by name, so relation-message order is
+        // not needed to decide membership: PostgreSQL live column names are
+        // unique within a table schema version. The order matters after the
+        // masks are applied: PostgreSQL writes RELATION columns and tuple data
+        // in the same physical `pg_attribute.attnum` order, skipping
+        // unpublished columns. Because stored TableSchema values use that same
+        // order, ReplicatedTableSchema becomes the positional view used to
+        // decode later tuple payloads.
         let replicated_columns = parse_replicated_column_names(message)?;
+        let identity_columns = parse_replica_identity_column_names(message)?;
 
         info!(
             table_id = %table_id,
             replicated_columns = ?replicated_columns,
+            identity_columns = ?identity_columns,
             "received relation message, building replication mask"
         );
 
@@ -1846,15 +1857,12 @@ where
         )
         .await?;
         let replication_mask = ReplicationMask::try_build(&table_schema, &replicated_columns)?;
-        let identity_columns = parse_replica_identity_column_names(message)?;
         let identity_mask = IdentityMask::try_build(&table_schema, &identity_columns)?;
 
         let replicated_table_schema =
             ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask);
 
         self.shared_table_cache.note_ready(table_id, replicated_table_schema.clone()).await;
-
-        // Build the event schema and emit a Relation event.
 
         let relation_event = RelationEvent {
             start_lsn,

--- a/etl/src/types/event.rs
+++ b/etl/src/types/event.rs
@@ -89,10 +89,29 @@ impl InsertEvent {
 ///
 /// [`UpdateEvent`] represents an existing row being modified.
 ///
+/// Destination authors should read this event as:
+///
+/// - [`UpdateEvent::updated_table_row`] is the new row state that PostgreSQL
+///   exposed after the update.
+/// - [`UpdateEvent::old_table_row`] is auxiliary old-side data that PostgreSQL
+///   may or may not include, depending on replica-identity semantics.
+///
 /// The new row may be full or partial depending on whether all column values
 /// are known after decoding `UnchangedToast` fields. The optional old row is
-/// either a full old image or a key-only image, depending on PostgreSQL
-/// replica-identity semantics.
+/// either a full old image, a key-only image, or absent, depending on
+/// PostgreSQL replica-identity semantics:
+///
+/// - `REPLICA IDENTITY FULL` yields a full old row.
+/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` may yield a key-only row.
+/// - updates that do not require an old-side image carry no old row.
+///
+/// Two details matter when implementing destinations:
+///
+/// - [`OldTableRow::Key`] contains replica-identity columns only. That is not
+///   necessarily the source primary key.
+/// - `old_table_row == None` on an update does not mean "missing identity" or
+///   "invalid event". For valid `pgoutput` streams it usually means PostgreSQL
+///   determined that no old-side tuple needed to be logged.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct UpdateEvent {
@@ -105,8 +124,17 @@ pub struct UpdateEvent {
     /// The replicated table schema for this event.
     pub replicated_table_schema: ReplicatedTableSchema,
     /// New row data after the update.
+    ///
+    /// [`UpdatedTableRow::Full`] means ETL knows every replicated column value.
+    /// [`UpdatedTableRow::Partial`] means some replicated columns were emitted
+    /// by PostgreSQL as `UnchangedToast` and could not be reconstructed
+    /// safely.
     pub updated_table_row: UpdatedTableRow,
     /// Previous row data before the update, when PostgreSQL emitted one.
+    ///
+    /// For `REPLICA IDENTITY FULL`, this should be a full row image. For
+    /// `DEFAULT` or `USING INDEX`, this may be a key image or may be absent
+    /// entirely when PostgreSQL did not need to log an old-side tuple.
     pub old_table_row: Option<OldTableRow>,
 }
 
@@ -121,8 +149,19 @@ impl UpdateEvent {
 ///
 /// [`DeleteEvent`] represents a row being removed from a table.
 ///
-/// The old row image is either a full old row or a key-only row depending on
-/// PostgreSQL replica-identity semantics.
+/// Unlike updates, deletes carry only old-side data. Destinations should treat
+/// [`DeleteEvent::old_table_row`] as the payload used to identify the removed
+/// source row.
+///
+/// The optional old row follows PostgreSQL replica-identity semantics:
+///
+/// - `REPLICA IDENTITY FULL` yields a full old row.
+/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` yield a key-only row.
+/// - valid publications do not emit deletes without an old row; `None` is
+///   preserved defensively for invalid upstream states.
+///
+/// [`OldTableRow::Key`] again means replica-identity columns only, not
+/// necessarily the table's primary key.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct DeleteEvent {
@@ -135,6 +174,11 @@ pub struct DeleteEvent {
     /// The replicated table schema for this event.
     pub replicated_table_schema: ReplicatedTableSchema,
     /// Data from the deleted row.
+    ///
+    /// For supported PostgreSQL publications, deletes should carry either a
+    /// full old row or a key-only old row. `None` is preserved only
+    /// defensively and should be treated as an unsafe, unmatchable delete by
+    /// destinations.
     pub old_table_row: Option<OldTableRow>,
 }
 

--- a/etl/src/types/event.rs
+++ b/etl/src/types/event.rs
@@ -62,7 +62,7 @@ impl CommitEvent {
 /// Row insertion event from Postgres logical replication.
 ///
 /// [`InsertEvent`] represents a new row being added to a table. It contains
-/// the complete row data for insertion into the destination system.
+/// the complete row data for the inserted source row.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct InsertEvent {
@@ -89,29 +89,19 @@ impl InsertEvent {
 ///
 /// [`UpdateEvent`] represents an existing row being modified.
 ///
-/// Destination authors should read this event as:
+/// The updated row is the authoritative post-update payload. The old row, when
+/// present, is auxiliary context from PostgreSQL's replica identity and may be
+/// a full old image or only replica-identity columns.
 ///
-/// - [`UpdateEvent::updated_table_row`] is the new row state that PostgreSQL
-///   exposed after the update.
-/// - [`UpdateEvent::old_table_row`] is auxiliary old-side data that PostgreSQL
-///   may or may not include, depending on replica-identity semantics.
+/// A few details matter for consumers:
 ///
-/// The new row may be full or partial depending on whether all column values
-/// are known after decoding `UnchangedToast` fields. The optional old row is
-/// either a full old image, a key-only image, or absent, depending on
-/// PostgreSQL replica-identity semantics:
-///
-/// - `REPLICA IDENTITY FULL` yields a full old row.
-/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` may yield a key-only row.
-/// - updates that do not require an old-side image carry no old row.
-///
-/// Two details matter when implementing destinations:
-///
+/// - `old_table_row == None` is valid for updates under key-based replica
+///   identities when PostgreSQL determines no old-side tuple is needed.
 /// - [`OldTableRow::Key`] contains replica-identity columns only. That is not
 ///   necessarily the source primary key.
-/// - `old_table_row == None` on an update does not mean "missing identity" or
-///   "invalid event". For valid `pgoutput` streams it usually means PostgreSQL
-///   determined that no old-side tuple needed to be logged.
+/// - [`UpdatedTableRow::Partial`] can occur when PostgreSQL emits
+///   `UnchangedToast` for columns ETL cannot reconstruct from the available
+///   old-side row image.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct UpdateEvent {
@@ -128,13 +118,13 @@ pub struct UpdateEvent {
     /// [`UpdatedTableRow::Full`] means ETL knows every replicated column value.
     /// [`UpdatedTableRow::Partial`] means some replicated columns were emitted
     /// by PostgreSQL as `UnchangedToast` and could not be reconstructed
-    /// safely.
+    /// safely from the old-side row image.
     pub updated_table_row: UpdatedTableRow,
     /// Previous row data before the update, when PostgreSQL emitted one.
     ///
-    /// For `REPLICA IDENTITY FULL`, this should be a full row image. For
-    /// `DEFAULT` or `USING INDEX`, this may be a key image or may be absent
-    /// entirely when PostgreSQL did not need to log an old-side tuple.
+    /// For `REPLICA IDENTITY FULL`, this is a full row image. For `DEFAULT`
+    /// with a primary key or `USING INDEX`, this may be a key image or may be
+    /// absent entirely when PostgreSQL did not need to log an old-side tuple.
     pub old_table_row: Option<OldTableRow>,
 }
 
@@ -149,19 +139,14 @@ impl UpdateEvent {
 ///
 /// [`DeleteEvent`] represents a row being removed from a table.
 ///
-/// Unlike updates, deletes carry only old-side data. Destinations should treat
-/// [`DeleteEvent::old_table_row`] as the payload used to identify the removed
+/// Unlike updates, deletes carry only old-side data.
+/// [`DeleteEvent::old_table_row`] is the payload used to identify the removed
 /// source row.
 ///
-/// The optional old row follows PostgreSQL replica-identity semantics:
-///
-/// - `REPLICA IDENTITY FULL` yields a full old row.
-/// - `REPLICA IDENTITY DEFAULT` and `USING INDEX` yield a key-only row.
-/// - valid publications do not emit deletes without an old row; `None` is
-///   preserved defensively for invalid upstream states.
-///
-/// [`OldTableRow::Key`] again means replica-identity columns only, not
-/// necessarily the table's primary key.
+/// PostgreSQL pgoutput sends an old-side tuple for every published delete:
+/// [`OldTableRow::Full`] for `REPLICA IDENTITY FULL`, otherwise
+/// [`OldTableRow::Key`] for key-based replica identity. The field remains
+/// optional at the Rust API boundary for malformed or non-pgoutput inputs.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct DeleteEvent {
@@ -173,12 +158,7 @@ pub struct DeleteEvent {
     pub tx_ordinal: u64,
     /// The replicated table schema for this event.
     pub replicated_table_schema: ReplicatedTableSchema,
-    /// Data from the deleted row.
-    ///
-    /// For supported PostgreSQL publications, deletes should carry either a
-    /// full old row or a key-only old row. `None` is preserved only
-    /// defensively and should be treated as an unsafe, unmatchable delete by
-    /// destinations.
+    /// Old-side payload from the deleted row.
     pub old_table_row: Option<OldTableRow>,
 }
 
@@ -222,6 +202,14 @@ impl TruncateEvent {
 /// stream. It is emitted when a RELATION message is received, containing the
 /// current replication mask for the table. This event notifies downstream
 /// consumers about which columns are being replicated for a table.
+///
+/// PostgreSQL emits relation-message columns in `pg_attribute.attnum` order,
+/// skipping unpublished columns, and sends tuple data in that same order. The
+/// masks are built by unique column name, so ordering is not needed for mask
+/// membership. Applying those masks to ETL's `attnum`-ordered stored table
+/// schema creates a [`ReplicatedTableSchema`] whose column order matches the
+/// tuple payloads. Event conversion can then decode row values by
+/// replicated-column position.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub struct RelationEvent {

--- a/etl/src/types/table_row.rs
+++ b/etl/src/types/table_row.rs
@@ -178,9 +178,18 @@ impl SizeHint for UpdatedTableRow {
 
 /// Old-row image carried by logical replication for updates and deletes.
 ///
-/// PostgreSQL either sends a full old tuple (`REPLICA IDENTITY FULL`) or only
-/// the replica-identity columns. Key rows are stored densely in replicated
-/// table-column order after filtering to just the identity columns.
+/// This enum preserves the old-side tuple shape that PostgreSQL exposed to the
+/// replication stream:
+///
+/// - [`OldTableRow::Full`] means PostgreSQL emitted a full old tuple. In
+///   practice this is the `REPLICA IDENTITY FULL` case.
+/// - [`OldTableRow::Key`] means PostgreSQL emitted only the replica-identity
+///   columns.
+///
+/// Key rows are stored densely in replicated table-column order after
+/// filtering to just the identity columns. They are therefore not necessarily
+/// the table's primary key; they represent whatever the source table exposed as
+/// replica identity.
 #[derive(Debug, PartialEq)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(Clone))]
 pub enum OldTableRow {

--- a/etl/tests/pipeline_replica_identity.rs
+++ b/etl/tests/pipeline_replica_identity.rs
@@ -189,12 +189,12 @@ async fn run_replica_identity_scenario(
             ))
             .await
             .unwrap();
+        let replica_identity_value = format!("using index {}", quote_identifier(&index_name));
         database
-            .run_sql(&format!(
-                "alter table {} replica identity using index {}",
-                table_name.as_quoted_identifier(),
-                quote_identifier(&index_name),
-            ))
+            .alter_table(
+                table_name.clone(),
+                &[TableModification::ReplicaIdentity { value: &replica_identity_value }],
+            )
             .await
             .unwrap();
     } else {

--- a/etl/tests/pipeline_replica_identity.rs
+++ b/etl/tests/pipeline_replica_identity.rs
@@ -428,6 +428,15 @@ async fn full_replica_identity_with_composite_primary_key_preserves_full_old_row
 
     let toast_update = find_update_event(&events, 1);
     assert_eq!(
+        toast_update.updated_table_row,
+        UpdatedTableRow::Full(full_row(
+            INITIAL_NAME,
+            INITIAL_SURNAME,
+            UPDATED_CITY,
+            &result.updated_large_text,
+        ))
+    );
+    assert_eq!(
         toast_update.old_table_row,
         Some(OldTableRow::Full(full_row(
             INITIAL_NAME,
@@ -438,6 +447,15 @@ async fn full_replica_identity_with_composite_primary_key_preserves_full_old_row
     );
 
     let identity_update = find_update_event(&events, 2);
+    assert_eq!(
+        identity_update.updated_table_row,
+        UpdatedTableRow::Full(full_row(
+            INITIAL_NAME,
+            UPDATED_SURNAME_IDENTITY,
+            UPDATED_CITY,
+            &result.final_large_text,
+        ))
+    );
     assert_eq!(
         identity_update.old_table_row,
         Some(OldTableRow::Full(full_row(

--- a/etl/tests/replication.rs
+++ b/etl/tests/replication.rs
@@ -455,12 +455,12 @@ async fn run_raw_replica_identity_scenario(
                 ))
                 .await
                 .unwrap();
+            let replica_identity_value = format!("using index {}", quote_identifier(&index_name));
             database
-                .run_sql(&format!(
-                    "alter table {} replica identity using index {}",
-                    quoted_table_name,
-                    quote_identifier(&index_name),
-                ))
+                .alter_table(
+                    table_name.clone(),
+                    &[TableModification::ReplicaIdentity { value: &replica_identity_value }],
+                )
                 .await
                 .unwrap();
         }

--- a/etl/tests/replication.rs
+++ b/etl/tests/replication.rs
@@ -20,7 +20,7 @@ use etl_postgres::{
 };
 use etl_telemetry::tracing::init_test_tracing;
 use futures::StreamExt;
-use pg_escape::quote_identifier;
+use pg_escape::{quote_identifier, quote_literal};
 use postgres_replication::{
     LogicalReplicationStream,
     protocol::{LogicalReplicationMessage, ReplicationMessage},
@@ -257,6 +257,273 @@ async fn collect_stream_markers(
     }
 
     markers
+}
+
+const REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES: usize = 8192;
+const REPLICA_IDENTITY_INITIAL_ID: i64 = 1;
+const REPLICA_IDENTITY_INITIAL_NAME: &str = "alice";
+const REPLICA_IDENTITY_INITIAL_SURNAME: &str = "smith";
+const REPLICA_IDENTITY_INITIAL_CITY: &str = "rome";
+const REPLICA_IDENTITY_UPDATED_CITY: &str = "vienna";
+const REPLICA_IDENTITY_UPDATED_NAME: &str = "alicia";
+const REPLICA_IDENTITY_UPDATED_SURNAME: &str = "smithers";
+
+#[derive(Clone, Copy)]
+enum ReplicaIdentityMode {
+    Default,
+    Full,
+    UsingIndex,
+}
+
+impl ReplicaIdentityMode {
+    fn identity_update_sql(self, table_name: &str, final_large_text: &str) -> String {
+        match self {
+            Self::UsingIndex => format!(
+                "update {table_name} set name = {}, large_text = {} where id = {} and surname = {}",
+                quote_literal(REPLICA_IDENTITY_UPDATED_NAME),
+                quote_literal(final_large_text),
+                REPLICA_IDENTITY_INITIAL_ID,
+                quote_literal(REPLICA_IDENTITY_INITIAL_SURNAME),
+            ),
+            Self::Default | Self::Full => format!(
+                "update {table_name} set surname = {}, large_text = {} where id = {} and surname \
+                 = {}",
+                quote_literal(REPLICA_IDENTITY_UPDATED_SURNAME),
+                quote_literal(final_large_text),
+                REPLICA_IDENTITY_INITIAL_ID,
+                quote_literal(REPLICA_IDENTITY_INITIAL_SURNAME),
+            ),
+        }
+    }
+
+    fn delete_sql(self, table_name: &str) -> String {
+        match self {
+            Self::UsingIndex => format!(
+                "delete from {table_name} where id = {} and name = {} and surname = {}",
+                REPLICA_IDENTITY_INITIAL_ID,
+                quote_literal(REPLICA_IDENTITY_UPDATED_NAME),
+                quote_literal(REPLICA_IDENTITY_INITIAL_SURNAME),
+            ),
+            Self::Default | Self::Full => format!(
+                "delete from {table_name} where id = {} and surname = {}",
+                REPLICA_IDENTITY_INITIAL_ID,
+                quote_literal(REPLICA_IDENTITY_UPDATED_SURNAME),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ObservedTupleCell {
+    Null,
+    UnchangedToast,
+    Text(String),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ObservedChangeMessage {
+    Update {
+        key_tuple: Option<Vec<ObservedTupleCell>>,
+        old_tuple: Option<Vec<ObservedTupleCell>>,
+        new_tuple: Vec<ObservedTupleCell>,
+    },
+    Delete {
+        key_tuple: Option<Vec<ObservedTupleCell>>,
+        old_tuple: Option<Vec<ObservedTupleCell>>,
+    },
+}
+
+fn observed_tuple_cells(tuple: &postgres_replication::protocol::Tuple) -> Vec<ObservedTupleCell> {
+    tuple
+        .tuple_data()
+        .iter()
+        .map(|cell| match cell {
+            postgres_replication::protocol::TupleData::Null => ObservedTupleCell::Null,
+            postgres_replication::protocol::TupleData::UnchangedToast => {
+                ObservedTupleCell::UnchangedToast
+            }
+            postgres_replication::protocol::TupleData::Text(bytes) => {
+                ObservedTupleCell::Text(std::str::from_utf8(bytes).unwrap().to_string())
+            }
+            postgres_replication::protocol::TupleData::Binary(_) => {
+                panic!("unexpected binary tuple data in test")
+            }
+        })
+        .collect()
+}
+
+async fn collect_update_delete_messages(
+    stream: LogicalReplicationStream,
+    expected_count: usize,
+) -> Vec<ObservedChangeMessage> {
+    let mut messages = Vec::with_capacity(expected_count);
+
+    pin!(stream);
+    while messages.len() < expected_count {
+        let event = timeout(Duration::from_secs(10), stream.next())
+            .await
+            .expect("timed out while waiting for logical replication data")
+            .expect("logical replication stream ended unexpectedly")
+            .expect("failed to decode logical replication data");
+
+        let ReplicationMessage::XLogData(event) = event else {
+            continue;
+        };
+
+        match event.data() {
+            LogicalReplicationMessage::Update(update) => {
+                messages.push(ObservedChangeMessage::Update {
+                    key_tuple: update.key_tuple().map(observed_tuple_cells),
+                    old_tuple: update.old_tuple().map(observed_tuple_cells),
+                    new_tuple: observed_tuple_cells(update.new_tuple()),
+                });
+            }
+            LogicalReplicationMessage::Delete(delete) => {
+                messages.push(ObservedChangeMessage::Delete {
+                    key_tuple: delete.key_tuple().map(observed_tuple_cells),
+                    old_tuple: delete.old_tuple().map(observed_tuple_cells),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    messages
+}
+
+struct RawReplicaIdentityScenarioResult {
+    changes: Vec<ObservedChangeMessage>,
+}
+
+async fn run_raw_replica_identity_scenario(
+    replica_identity: ReplicaIdentityMode,
+) -> RawReplicaIdentityScenarioResult {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let table_name = test_table_name("raw_replica_identity");
+    let quoted_table_name = table_name.as_quoted_identifier();
+    database
+        .create_table(
+            table_name.clone(),
+            false,
+            &[
+                ("id", "bigint not null"),
+                ("name", "text not null"),
+                ("surname", "text not null"),
+                ("city", "text not null"),
+                ("large_text", "text not null"),
+            ],
+        )
+        .await
+        .unwrap();
+
+    database
+        .run_sql(&format!("alter table {quoted_table_name} add primary key (surname, id)"))
+        .await
+        .unwrap();
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[TableModification::AlterColumn {
+                name: "large_text",
+                alteration: "set storage external",
+            }],
+        )
+        .await
+        .unwrap();
+
+    match replica_identity {
+        ReplicaIdentityMode::Default => {}
+        ReplicaIdentityMode::Full => {
+            database
+                .alter_table(
+                    table_name.clone(),
+                    &[TableModification::ReplicaIdentity { value: "full" }],
+                )
+                .await
+                .unwrap();
+        }
+        ReplicaIdentityMode::UsingIndex => {
+            let index_name = format!("{}_replica_identity_idx", table_name.name);
+            database
+                .run_sql(&format!(
+                    "create unique index {} on {} (surname, name)",
+                    quote_identifier(&index_name),
+                    quoted_table_name,
+                ))
+                .await
+                .unwrap();
+            database
+                .run_sql(&format!(
+                    "alter table {} replica identity using index {}",
+                    quoted_table_name,
+                    quote_identifier(&index_name),
+                ))
+                .await
+                .unwrap();
+        }
+    }
+
+    let publication_name = "raw_replica_identity_pub";
+    database.create_publication(publication_name, std::slice::from_ref(&table_name)).await.unwrap();
+
+    let client = PgReplicationClient::connect(database.config.clone()).await.unwrap();
+    let slot_name = test_slot_name("raw_replica_identity_slot");
+    let slot = client.create_slot(&slot_name).await.unwrap();
+    let stream = client
+        .start_logical_replication(publication_name, &slot_name, slot.consistent_point)
+        .await
+        .unwrap();
+
+    let initial_large_text = "a".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
+    let updated_large_text = "b".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
+    let final_large_text = "c".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES);
+
+    database
+        .run_sql(&format!(
+            "insert into {quoted_table_name} (id, name, surname, city, large_text) values ({}, \
+             {}, {}, {}, {})",
+            REPLICA_IDENTITY_INITIAL_ID,
+            quote_literal(REPLICA_IDENTITY_INITIAL_NAME),
+            quote_literal(REPLICA_IDENTITY_INITIAL_SURNAME),
+            quote_literal(REPLICA_IDENTITY_INITIAL_CITY),
+            quote_literal(&initial_large_text),
+        ))
+        .await
+        .unwrap();
+
+    database
+        .run_sql(&format!(
+            "update {quoted_table_name} set city = {} where id = {} and surname = {}",
+            quote_literal(REPLICA_IDENTITY_UPDATED_CITY),
+            REPLICA_IDENTITY_INITIAL_ID,
+            quote_literal(REPLICA_IDENTITY_INITIAL_SURNAME),
+        ))
+        .await
+        .unwrap();
+
+    database
+        .run_sql(&format!(
+            "update {quoted_table_name} set large_text = {} where id = {} and surname = {}",
+            quote_literal(&updated_large_text),
+            REPLICA_IDENTITY_INITIAL_ID,
+            quote_literal(REPLICA_IDENTITY_INITIAL_SURNAME),
+        ))
+        .await
+        .unwrap();
+
+    database
+        .run_sql(&replica_identity.identity_update_sql(&quoted_table_name, &final_large_text))
+        .await
+        .unwrap();
+
+    database.run_sql(&replica_identity.delete_sql(&quoted_table_name)).await.unwrap();
+
+    let changes = collect_update_delete_messages(stream, 4).await;
+
+    RawReplicaIdentityScenarioResult { changes }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1809,5 +2076,197 @@ async fn table_copy_stream_with_ctid_partition() {
     assert_eq!(
         total_rows, expected_rows as u64,
         "total rows across all partitions should match inserted rows"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pgoutput_default_replica_identity_uses_replica_identity_not_primary_key() {
+    let result = run_raw_replica_identity_scenario(ReplicaIdentityMode::Default).await;
+
+    assert_eq!(
+        result.changes,
+        vec![
+            ObservedChangeMessage::Update {
+                key_tuple: None,
+                old_tuple: None,
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::UnchangedToast,
+                ],
+            },
+            ObservedChangeMessage::Update {
+                key_tuple: None,
+                old_tuple: None,
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("b".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ],
+            },
+            ObservedChangeMessage::Update {
+                key_tuple: Some(vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Null,
+                ]),
+                old_tuple: None,
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smithers".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("c".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ],
+            },
+            ObservedChangeMessage::Delete {
+                key_tuple: Some(vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Text("smithers".to_string()),
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Null,
+                ]),
+                old_tuple: None,
+            },
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pgoutput_using_index_replica_identity_tracks_alternative_identity_columns() {
+    let result = run_raw_replica_identity_scenario(ReplicaIdentityMode::UsingIndex).await;
+
+    assert_eq!(
+        result.changes,
+        vec![
+            ObservedChangeMessage::Update {
+                key_tuple: None,
+                old_tuple: None,
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::UnchangedToast,
+                ],
+            },
+            ObservedChangeMessage::Update {
+                key_tuple: None,
+                old_tuple: None,
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("b".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ],
+            },
+            ObservedChangeMessage::Update {
+                key_tuple: Some(vec![
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Null,
+                ]),
+                old_tuple: None,
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alicia".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("c".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ],
+            },
+            ObservedChangeMessage::Delete {
+                key_tuple: Some(vec![
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Text("alicia".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Null,
+                    ObservedTupleCell::Null,
+                ]),
+                old_tuple: None,
+            },
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pgoutput_full_replica_identity_always_sends_full_old_rows() {
+    let result = run_raw_replica_identity_scenario(ReplicaIdentityMode::Full).await;
+
+    assert_eq!(
+        result.changes,
+        vec![
+            ObservedChangeMessage::Update {
+                key_tuple: None,
+                old_tuple: Some(vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("rome".to_string()),
+                    ObservedTupleCell::Text("a".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ]),
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::UnchangedToast,
+                ],
+            },
+            ObservedChangeMessage::Update {
+                key_tuple: None,
+                old_tuple: Some(vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("a".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ]),
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("b".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ],
+            },
+            ObservedChangeMessage::Update {
+                key_tuple: None,
+                old_tuple: Some(vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smith".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("b".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ]),
+                new_tuple: vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smithers".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("c".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ],
+            },
+            ObservedChangeMessage::Delete {
+                key_tuple: None,
+                old_tuple: Some(vec![
+                    ObservedTupleCell::Text("1".to_string()),
+                    ObservedTupleCell::Text("alice".to_string()),
+                    ObservedTupleCell::Text("smithers".to_string()),
+                    ObservedTupleCell::Text("vienna".to_string()),
+                    ObservedTupleCell::Text("c".repeat(REPLICA_IDENTITY_LARGE_TEXT_SIZE_BYTES),),
+                ]),
+            },
+        ]
     );
 }


### PR DESCRIPTION
## Summary
- fix DuckLake mutation propagation by counting mutation-only workloads correctly for maintenance and inline-data flushing
- align the event-conversion layer with PostgreSQL `pgoutput` replica-identity semantics
- add regression coverage around DuckLake partial updates, deletes, and replica-identity behavior

## Problem
Production DuckLake workloads were observing updates and deletes that appeared to stop propagating. The main issue was that mutation-only traffic was undercounted for DuckLake maintenance, so partial updates and deletes could stay inline without contributing enough activity to trigger the normal flush/materialization path.

While debugging that, I also re-validated the PostgreSQL logical replication semantics we rely on for old-row handling:
- `REPLICA IDENTITY FULL` sends an old full tuple
- `REPLICA IDENTITY DEFAULT` / `USING INDEX` send an old key tuple only when PostgreSQL needs one
- non-identity updates can legitimately arrive without an old row
- published `UPDATE` / `DELETE` without usable replica identity are invalid at the publisher

## What changed
### DuckLake
- count partial updates and deletes in mutation write-activity accounting instead of only mutations with an upsert row
- include inlined delete-side bytes when sampling pending inline data
- keep row-matching logic based on replica identity, including alternative-key and `FULL` cases
- fail clearly when a mutation needs replica identity but no usable identity is available

### Event conversion / semantics
- document the real `pgoutput` old-row semantics directly in the conversion layer
- preserve the distinction between:
  - full old rows
  - key-only old rows
  - absent old rows for updates where PostgreSQL did not need to send one

## Tests in this PR
- DuckLake partial update coverage
- DuckLake mutation-without-replica-identity rejection coverage
- conversion-layer coverage for old full rows, old key rows, and absent old rows

## Validation
Validated against:
- PostgreSQL logical replication docs and PostgreSQL source for `heap_update`, `heap_delete`, `ExtractReplicaIdentity`, and logical replication message writing
- DuckLake data inlining and constraints docs

Local checks run:
- `./scripts/fmt-check`
- focused `cargo nextest run` coverage for DuckLake mutation paths
- focused `cargo nextest run` coverage for replica-identity parsing and raw `pgoutput` semantics