### PR TITLE
refactor(ducklake): switch metrics sampler to pg connection instead of duckdb connection

### DIFF
--- a/etl-destinations/Cargo.toml
+++ b/etl-destinations/Cargo.toml
@@ -83,7 +83,7 @@ uuid = { workspace = true, optional = true, features = ["v4"] }
 [dev-dependencies]
 duckdb = { workspace = true, features = ["bundled", "json", "parquet"] }
 etl = { workspace = true, features = ["test-utils"] }
-etl-postgres = { workspace = true, features = ["test-utils"] }
+etl-postgres = { workspace = true, features = ["test-utils", "tokio"] }
 etl-telemetry = { workspace = true }
 tempfile = { workspace = true }
 

--- a/etl-destinations/src/ducklake/METRICS.md
+++ b/etl-destinations/src/ducklake/METRICS.md
@@ -11,8 +11,8 @@ The metrics fall into four groups:
   emitted by the background maintenance worker with the primary reason and
   outcome for each maintenance attempt.
 - table-health samples: histograms recorded by a background sampler every
-  30 seconds on a dedicated DuckDB pool of size 1. They describe the current
-  shape of tables known to the current destination instance.
+  30 seconds from the PostgreSQL DuckLake metadata catalog. They describe the
+  current shape of tables known to the current destination instance.
 - catalog-backlog gauges: current global snapshot and deletion backlog in the
   attached DuckLake catalog.
 

--- a/etl-destinations/src/ducklake/client.rs
+++ b/etl-destinations/src/ducklake/client.rs
@@ -36,15 +36,12 @@ static NEXT_CONNECTION_INIT_ID: AtomicU64 = AtomicU64::new(1);
 pub(super) const FOREGROUND_QUERY_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 /// Timeout applied to each maintenance DuckLake blocking operation.
 pub(super) const MAINTENANCE_QUERY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
-/// Timeout applied to each background DuckLake metrics query.
-pub(super) const METRICS_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Timeout class applied to one DuckDB blocking operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum DuckDbBlockingOperationKind {
     Foreground,
     Maintenance,
-    Metrics,
 }
 
 impl DuckDbBlockingOperationKind {
@@ -52,7 +49,6 @@ impl DuckDbBlockingOperationKind {
         match self {
             Self::Foreground => "foreground",
             Self::Maintenance => "maintenance",
-            Self::Metrics => "metrics",
         }
     }
 
@@ -60,7 +56,6 @@ impl DuckDbBlockingOperationKind {
         match self {
             Self::Foreground => FOREGROUND_QUERY_TIMEOUT,
             Self::Maintenance => MAINTENANCE_QUERY_TIMEOUT,
-            Self::Metrics => METRICS_QUERY_TIMEOUT,
         }
     }
 }
@@ -563,7 +558,6 @@ mod tests {
     fn duckdb_blocking_operation_kind_timeouts() {
         assert_eq!(DuckDbBlockingOperationKind::Foreground.timeout(), FOREGROUND_QUERY_TIMEOUT);
         assert_eq!(DuckDbBlockingOperationKind::Maintenance.timeout(), MAINTENANCE_QUERY_TIMEOUT);
-        assert_eq!(DuckDbBlockingOperationKind::Metrics.timeout(), METRICS_QUERY_TIMEOUT);
     }
 
     #[tokio::test]

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -30,13 +30,14 @@ use etl::{
 use metrics::gauge;
 use parking_lot::Mutex;
 use pg_escape::quote_identifier;
+use sqlx::{PgPool, postgres::PgPoolOptions};
 #[cfg(feature = "test-utils")]
 use tokio::sync::oneshot;
 use tokio::{
     sync::{OwnedRwLockReadGuard, OwnedSemaphorePermit, RwLock, Semaphore},
     task::JoinSet,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 use url::Url;
 
 use crate::{
@@ -73,6 +74,29 @@ use crate::{
     },
     table_name::try_stringify_table_name,
 };
+
+/// Shared Postgres metadata pool size for DuckLake background samplers.
+///
+/// One connection is enough because inline-size sampling and metrics sampling
+/// are both best-effort background reads and can safely serialize.
+const DUCKLAKE_METADATA_PG_POOL_SIZE: u32 = 1;
+
+/// Builds the shared Postgres metadata pool used by background samplers.
+fn build_ducklake_metadata_pg_pool(catalog_url: &Url) -> EtlResult<PgPool> {
+    PgPoolOptions::new()
+        .max_connections(DUCKLAKE_METADATA_PG_POOL_SIZE)
+        .min_connections(0)
+        .acquire_timeout(std::time::Duration::from_secs(5))
+        .idle_timeout(Some(std::time::Duration::from_secs(30)))
+        .connect_lazy(catalog_url.as_str())
+        .map_err(|source| {
+            etl_error!(
+                ErrorKind::ConfigError,
+                "DuckLake metadata pool configuration failed",
+                source: source
+            )
+        })
+}
 
 /// Returns whether a DuckLake DDL error indicates another transaction already
 /// created the requested table.
@@ -319,8 +343,8 @@ where
 
     /// Creates a new DuckLake destination.
     ///
-    /// - `catalog_url`: DuckLake catalog location. Use a PostgreSQL URL (`postgres://user:pass@localhost:5432/mydb`)
-    ///   or a local file URL (`file:///tmp/catalog.ducklake`).
+    /// - `catalog_url`: DuckLake catalog location. Use a PostgreSQL URL
+    ///   (`postgres://user:pass@localhost:5432/mydb`).
     /// - `data_path`: Where Parquet files are stored. Use a local file URL (`file:///tmp/lake_data`)
     ///   or a cloud URL (`s3://bucket/prefix/`, `gs://bucket/prefix/`).
     /// - `pool_size`: Number of warm DuckDB connections maintained in the pool.
@@ -357,6 +381,14 @@ where
         store: S,
     ) -> EtlResult<Self> {
         register_metrics();
+
+        if !matches!(catalog_url.scheme(), "postgres" | "postgresql") {
+            return Err(etl_error!(
+                ErrorKind::ConfigError,
+                "DuckLake destination requires a PostgreSQL catalog URL",
+                format!("unsupported catalog URL scheme `{}`", catalog_url.scheme())
+            ));
+        }
 
         if pool_size == 0 {
             return Err(etl_error!(
@@ -421,30 +453,23 @@ where
             },
         )
         .await?;
-        let pending_inline_size_sampler =
-            if matches!(catalog_url.scheme(), "postgres" | "postgresql") {
-                match run_duckdb_blocking(
+        let metadata_schema = match metadata_schema {
+            Some(metadata_schema) => metadata_schema,
+            None => {
+                run_duckdb_blocking(
                     Arc::clone(&pool),
                     Arc::clone(&blocking_slots),
                     DuckDbBlockingOperationKind::Foreground,
                     resolve_ducklake_metadata_schema_blocking,
                 )
-                .await
-                {
-                    Ok(metadata_schema) => {
-                        DuckLakePendingInlineSizeSampler::new(&catalog_url, metadata_schema)?
-                    }
-                    Err(error) => {
-                        warn!(
-                            error = ?error,
-                            "ducklake inline-size sampler initialization skipped"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
+                .await?
+            }
+        };
+        let metadata_pg_pool = build_ducklake_metadata_pg_pool(&catalog_url)?;
+        let pending_inline_size_sampler = Some(DuckLakePendingInlineSizeSampler::new(
+            metadata_schema.clone(),
+            metadata_pg_pool.clone(),
+        ));
         let created_tables = Arc::default();
         let checkpoint_gate = Arc::new(RwLock::new(()));
         let inline_flush_requested = Arc::new(AtomicBool::new(false));
@@ -488,12 +513,8 @@ where
         );
         destination.metrics_sampler = Arc::new(
             spawn_ducklake_metrics_sampler(
-                DuckLakeConnectionManager {
-                    setup_plan: Arc::clone(&setup_plan),
-                    disable_extension_autoload,
-                    #[cfg(feature = "test-utils")]
-                    open_count: Arc::new(AtomicUsize::new(0)),
-                },
+                metadata_schema,
+                metadata_pg_pool,
                 Arc::clone(&created_tables),
                 destination
                     .maintenance_worker
@@ -1218,25 +1239,29 @@ pub fn table_name_to_ducklake_table_name(table_name: &TableName) -> EtlResult<Du
 #[cfg(test)]
 mod tests {
     use std::{
+        env,
         path::{Path, PathBuf},
         time::Instant,
     };
 
     use duckdb::{Config, Connection};
     use etl::{
+        config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig},
         store::{both::memory::MemoryStore, schema::SchemaStore},
         types::{ColumnSchema, TableSchema, Type as PgType},
     };
+    use etl_postgres::tokio::test_utils::PgDatabase;
     use pg_escape::{quote_identifier, quote_literal};
     use tempfile::TempDir;
+    use tokio_postgres::Client;
     use url::Url;
+    use uuid::Uuid;
 
     use super::*;
     use crate::ducklake::{
+        config::catalog_conninfo_from_url,
         maintenance::flush_table_inlined_data,
-        metrics::{
-            query_catalog_maintenance_metrics_blocking, query_table_storage_metrics_blocking,
-        },
+        metrics::{query_catalog_maintenance_metrics, query_table_storage_metrics},
     };
 
     fn make_schema(table_id: u32, schema: &str, table: &str) -> TableSchema {
@@ -1252,6 +1277,44 @@ mod tests {
 
     fn path_to_file_url(path: &Path) -> Url {
         Url::from_file_path(path).expect("failed to convert path to file url")
+    }
+
+    fn local_pg_connection_config(database_name: String) -> PgConnectionConfig {
+        PgConnectionConfig {
+            host: env::var("TESTS_DATABASE_HOST").expect("TESTS_DATABASE_HOST must be set"),
+            port: env::var("TESTS_DATABASE_PORT")
+                .expect("TESTS_DATABASE_PORT must be set")
+                .parse()
+                .expect("TESTS_DATABASE_PORT must be a valid port number"),
+            name: database_name,
+            username: env::var("TESTS_DATABASE_USERNAME")
+                .expect("TESTS_DATABASE_USERNAME must be set"),
+            password: env::var("TESTS_DATABASE_PASSWORD").ok().map(Into::into),
+            tls: TlsConfig { trusted_root_certs: String::new(), enabled: false },
+            keepalive: TcpKeepaliveConfig::default(),
+        }
+    }
+
+    async fn create_catalog_database() -> (PgDatabase<Client>, Url) {
+        let database_name = Uuid::new_v4().to_string();
+        let host = env::var("TESTS_DATABASE_HOST").expect("TESTS_DATABASE_HOST must be set");
+        let port = env::var("TESTS_DATABASE_PORT")
+            .expect("TESTS_DATABASE_PORT must be set")
+            .parse()
+            .expect("TESTS_DATABASE_PORT must be a valid port number");
+        let username =
+            env::var("TESTS_DATABASE_USERNAME").expect("TESTS_DATABASE_USERNAME must be set");
+        let password = env::var("TESTS_DATABASE_PASSWORD").ok();
+        let database = PgDatabase::new(local_pg_connection_config(database_name.clone())).await;
+
+        let mut catalog_url = Url::parse("postgres://localhost").expect("failed to parse base url");
+        catalog_url.set_host(Some(&host)).expect("failed to set catalog host");
+        catalog_url.set_port(Some(port)).expect("failed to set catalog port");
+        catalog_url.set_username(&username).expect("failed to set catalog username");
+        catalog_url.set_password(password.as_deref()).expect("failed to set catalog password");
+        catalog_url.set_path(&database_name);
+
+        (database, catalog_url)
     }
 
     fn current_vendored_extension_dir() -> Option<PathBuf> {
@@ -1316,10 +1379,12 @@ mod tests {
 
     fn open_lake_conn(catalog: &Url, data: &Url) -> Connection {
         let conn = open_verification_connection();
+        let catalog_attach_target =
+            catalog_conninfo_from_url(catalog).expect("invalid catalog url");
         conn.execute_batch(&format!(
             "{} ATTACH {} AS {} (DATA_PATH {});",
             ducklake_load_sql(),
-            quote_literal(&format!("ducklake:{}", catalog.as_str())),
+            quote_literal(&format!("ducklake:{catalog_attach_target}")),
             quote_identifier(LAKE_CATALOG),
             quote_literal(data.as_str()),
         ))
@@ -1404,8 +1469,8 @@ mod tests {
     #[tokio::test]
     async fn query_table_storage_metrics_reads_ducklake_metadata() {
         let dir = TempDir::new().expect("failed to create temp dir");
-        let catalog = path_to_file_url(&dir.path().join("catalog.ducklake"));
         let data = path_to_file_url(&dir.path().join("data"));
+        let (_catalog_database, catalog) = create_catalog_database().await;
         let store = MemoryStore::new();
         let schema = make_schema(1, "public", "users");
         let replicated_table_schema = ReplicatedTableSchema::all(Arc::new(schema.clone()));
@@ -1438,12 +1503,18 @@ mod tests {
             .expect("failed to write rows");
 
         let conn = open_lake_conn_when_table_visible(&catalog, &data, &table_name).await;
+        let metadata_schema = resolve_ducklake_metadata_schema_blocking(&conn)
+            .expect("failed to resolve metadata schema");
+        let metadata_pg_pool =
+            build_ducklake_metadata_pg_pool(&catalog).expect("failed to create metadata pool");
         let _rows_flushed = flush_table_inlined_data(&conn, &table_name)
             .expect("failed to materialize inlined rows for storage metrics test");
         let deadline = Instant::now() + Duration::from_secs(10);
         let metrics = loop {
-            let metrics = query_table_storage_metrics_blocking(&conn, &table_name)
-                .expect("failed to query storage metrics");
+            let metrics =
+                query_table_storage_metrics(&metadata_pg_pool, &metadata_schema, &table_name)
+                    .await
+                    .expect("failed to query storage metrics");
             if metrics.active_data_files >= 1 {
                 break metrics;
             }
@@ -1463,8 +1534,8 @@ mod tests {
     #[tokio::test]
     async fn query_catalog_maintenance_metrics_reports_active_data_files_total() {
         let dir = TempDir::new().expect("failed to create temp dir");
-        let catalog = path_to_file_url(&dir.path().join("catalog.ducklake"));
         let data = path_to_file_url(&dir.path().join("data"));
+        let (_catalog_database, catalog) = create_catalog_database().await;
         let store = MemoryStore::new();
         let schema = make_schema(1, "public", "users");
         let replicated_table_schema = ReplicatedTableSchema::all(Arc::new(schema.clone()));
@@ -1497,11 +1568,16 @@ mod tests {
             .expect("failed to write rows");
 
         let conn = open_lake_conn_when_table_visible(&catalog, &data, &table_name).await;
+        let metadata_schema = resolve_ducklake_metadata_schema_blocking(&conn)
+            .expect("failed to resolve metadata schema");
+        let metadata_pg_pool =
+            build_ducklake_metadata_pg_pool(&catalog).expect("failed to create metadata pool");
         let _rows_flushed = flush_table_inlined_data(&conn, &table_name)
             .expect("failed to materialize inlined rows for catalog metrics test");
         let deadline = Instant::now() + Duration::from_secs(10);
         let metrics = loop {
-            let metrics = query_catalog_maintenance_metrics_blocking(&conn)
+            let metrics = query_catalog_maintenance_metrics(&metadata_pg_pool, &metadata_schema)
+                .await
                 .expect("failed to query catalog maintenance metrics");
             if metrics.active_data_files_total >= 1 {
                 break metrics;
@@ -1519,8 +1595,8 @@ mod tests {
     #[tokio::test]
     async fn query_catalog_maintenance_metrics_reads_ducklake_metadata() {
         let dir = TempDir::new().expect("failed to create temp dir");
-        let catalog = path_to_file_url(&dir.path().join("catalog.ducklake"));
         let data = path_to_file_url(&dir.path().join("data"));
+        let (_catalog_database, catalog) = create_catalog_database().await;
         let store = MemoryStore::new();
         let schema = make_schema(1, "public", "users");
         let replicated_table_schema = ReplicatedTableSchema::all(Arc::new(schema.clone()));
@@ -1557,7 +1633,12 @@ mod tests {
         drop(destination);
 
         let conn = open_lake_conn_when_table_visible(&catalog, &data, &table_name).await;
-        let metrics = query_catalog_maintenance_metrics_blocking(&conn)
+        let metadata_schema = resolve_ducklake_metadata_schema_blocking(&conn)
+            .expect("failed to resolve metadata schema");
+        let metadata_pg_pool =
+            build_ducklake_metadata_pg_pool(&catalog).expect("failed to create metadata pool");
+        let metrics = query_catalog_maintenance_metrics(&metadata_pg_pool, &metadata_schema)
+            .await
             .expect("failed to query catalog maintenance metrics");
 
         assert!(metrics.active_data_files_total >= 0);

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -1264,6 +1264,8 @@ mod tests {
         metrics::{query_catalog_maintenance_metrics, query_table_storage_metrics},
     };
 
+    const POSTGRES_SCANNER_EXTENSION_FILE: &str = "postgres_scanner.duckdb_extension";
+
     fn make_schema(table_id: u32, schema: &str, table: &str) -> TableSchema {
         TableSchema::new(
             TableId::new(table_id),
@@ -1337,8 +1339,9 @@ mod tests {
         for root in candidate_roots {
             let extension_dir = root.join("1.5.2").join(platform_dir);
             let ducklake_extension = extension_dir.join("ducklake.duckdb_extension");
+            let postgres_scanner_extension = extension_dir.join(POSTGRES_SCANNER_EXTENSION_FILE);
 
-            if ducklake_extension.is_file() {
+            if ducklake_extension.is_file() && postgres_scanner_extension.is_file() {
                 return Some(extension_dir);
             }
         }
@@ -1370,11 +1373,17 @@ mod tests {
     fn ducklake_load_sql() -> String {
         if let Some(extension_dir) = current_vendored_extension_dir() {
             let ducklake_extension = extension_dir.join("ducklake.duckdb_extension");
+            let postgres_scanner_extension = extension_dir.join(POSTGRES_SCANNER_EXTENSION_FILE);
 
-            return format!("LOAD {};", quote_literal(&ducklake_extension.display().to_string()),);
+            return format!(
+                "LOAD {}; LOAD {};",
+                quote_literal(&ducklake_extension.display().to_string()),
+                quote_literal(&postgres_scanner_extension.display().to_string()),
+            );
         }
 
-        "INSTALL ducklake; LOAD ducklake;".to_string()
+        "INSTALL ducklake; LOAD ducklake; INSTALL postgres_scanner; LOAD postgres_scanner;"
+            .to_string()
     }
 
     fn open_lake_conn(catalog: &Url, data: &Url) -> Connection {
@@ -1466,7 +1475,7 @@ mod tests {
         assert!(!is_create_table_conflict(&error, "public_orders"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn query_table_storage_metrics_reads_ducklake_metadata() {
         let dir = TempDir::new().expect("failed to create temp dir");
         let data = path_to_file_url(&dir.path().join("data"));
@@ -1531,7 +1540,7 @@ mod tests {
         assert_eq!(metrics.deleted_rows, 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn query_catalog_maintenance_metrics_reports_active_data_files_total() {
         let dir = TempDir::new().expect("failed to create temp dir");
         let data = path_to_file_url(&dir.path().join("data"));
@@ -1592,7 +1601,7 @@ mod tests {
         assert!(metrics.active_data_files_total >= 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn query_catalog_maintenance_metrics_reads_ducklake_metadata() {
         let dir = TempDir::new().expect("failed to create temp dir");
         let data = path_to_file_url(&dir.path().join("data"));

--- a/etl-destinations/src/ducklake/inline_size.rs
+++ b/etl-destinations/src/ducklake/inline_size.rs
@@ -1,12 +1,9 @@
-use std::time::Duration;
-
 use etl::{
     error::{ErrorKind, EtlResult},
     etl_error,
 };
 use pg_escape::{quote_identifier, quote_literal};
-use sqlx::{PgPool, postgres::PgPoolOptions};
-use url::Url;
+use sqlx::PgPool;
 
 /// Pending inline insert-data bytes sampled from the Postgres DuckLake catalog.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -22,27 +19,9 @@ pub(super) struct DuckLakePendingInlineSizeSampler {
 }
 
 impl DuckLakePendingInlineSizeSampler {
-    /// Builds a sampler for PostgreSQL-backed DuckLake catalogs.
-    pub(super) fn new(catalog_url: &Url, metadata_schema: String) -> EtlResult<Option<Self>> {
-        if !matches!(catalog_url.scheme(), "postgres" | "postgresql") {
-            return Ok(None);
-        }
-
-        let pool = PgPoolOptions::new()
-            .max_connections(1)
-            .min_connections(0)
-            .acquire_timeout(Duration::from_secs(5))
-            .idle_timeout(Some(Duration::from_secs(30)))
-            .connect_lazy(catalog_url.as_str())
-            .map_err(|source| {
-                etl_error!(
-                    ErrorKind::ConfigError,
-                    "DuckLake inline-size sampler configuration failed",
-                    source: source
-                )
-            })?;
-
-        Ok(Some(Self { metadata_schema, pool }))
+    /// Builds a sampler backed by the shared DuckLake metadata pool.
+    pub(super) fn new(metadata_schema: String, pool: PgPool) -> Self {
+        Self { metadata_schema, pool }
     }
 
     /// Samples pending inline insert-data bytes for one DuckLake table.

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -1193,18 +1193,10 @@ fn rewrite_table_data_files(conn: &duckdb::Connection, table_name: &str) -> EtlR
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use etl_telemetry::metrics::init_metrics_handle;
 
     use super::*;
-    use crate::ducklake::{
-        client::{
-            DuckDbBlockingOperationKind, DuckLakeConnectionManager, build_warm_ducklake_pool,
-            run_duckdb_blocking,
-        },
-        metrics::register_metrics,
-    };
+    use crate::ducklake::metrics::register_metrics;
 
     fn maintenance_duration_count(
         rendered: &str,

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -1196,7 +1196,9 @@ mod tests {
     use etl_telemetry::metrics::init_metrics_handle;
 
     use super::*;
-    use crate::ducklake::{client::build_warm_ducklake_pool, metrics::register_metrics};
+    #[cfg(feature = "test-utils")]
+    use crate::ducklake::client::build_warm_ducklake_pool;
+    use crate::ducklake::metrics::register_metrics;
 
     fn maintenance_duration_count(
         rendered: &str,

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -1196,7 +1196,7 @@ mod tests {
     use etl_telemetry::metrics::init_metrics_handle;
 
     use super::*;
-    use crate::ducklake::metrics::register_metrics;
+    use crate::ducklake::{client::build_warm_ducklake_pool, metrics::register_metrics};
 
     fn maintenance_duration_count(
         rendered: &str,

--- a/etl-destinations/src/ducklake/metrics.rs
+++ b/etl-destinations/src/ducklake/metrics.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashSet,
-    sync::{Arc, Once, OnceLock},
+    sync::{Arc, Once},
 };
 
 use chrono::Utc;
@@ -11,8 +11,9 @@ use etl::{
 use metrics::{Unit, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use parking_lot::Mutex;
 use pg_escape::{quote_identifier, quote_literal};
+use sqlx::PgPool;
 use tokio::{
-    sync::{Semaphore, mpsc, watch},
+    sync::{mpsc, watch},
     task::JoinHandle,
     time::{Duration, Instant, MissedTickBehavior},
 };
@@ -20,10 +21,7 @@ use tracing::{info, warn};
 
 use crate::ducklake::{
     DuckLakeTableName, LAKE_CATALOG,
-    client::{
-        DuckDbBlockingOperationKind, DuckLakeConnectionManager, LazyDuckLakePool,
-        format_query_error_detail, run_duckdb_blocking,
-    },
+    client::format_query_error_detail,
     maintenance::{
         TableMaintenanceNotification, TableMetricsSample, send_maintenance_notification,
     },
@@ -34,8 +32,6 @@ static REGISTER_METRICS: Once = Once::new();
 /// Files smaller than this are usually too small to be efficient in object
 /// storage.
 pub(super) const SMALL_FILE_SIZE_BYTES: i64 = 5_000_000; // 5MB
-/// Dedicated pool size for background DuckLake metrics sampling.
-const METRICS_POOL_SIZE: u32 = 1;
 /// Frequency of background DuckLake metrics sampling.
 const METRICS_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -334,15 +330,17 @@ pub(crate) fn register_metrics() {
     });
 }
 
-/// Spawns the periodic DuckLake sampler task with lazy pool initialization.
+/// Spawns the periodic DuckLake sampler task on the shared metadata pool.
 pub(super) fn spawn_ducklake_metrics_sampler(
-    manager: DuckLakeConnectionManager,
+    metadata_schema: String,
+    metadata_pg_pool: PgPool,
     created_tables: Arc<Mutex<HashSet<DuckLakeTableName>>>,
     maintenance_notification_tx: mpsc::Sender<TableMaintenanceNotification>,
 ) -> EtlResult<DuckLakeMetricsSampler> {
     let (shutdown_tx, shutdown_rx) = watch::channel(());
     let handle = tokio::spawn(run_ducklake_metrics_sampler(
-        manager,
+        metadata_schema,
+        metadata_pg_pool,
         created_tables,
         maintenance_notification_tx,
         shutdown_rx,
@@ -351,14 +349,14 @@ pub(super) fn spawn_ducklake_metrics_sampler(
     Ok(DuckLakeMetricsSampler { shutdown_tx, handle: Mutex::new(handle.into()) })
 }
 
-/// Periodically samples DuckLake metadata on a dedicated connection pool.
+/// Periodically samples DuckLake metadata from PostgreSQL.
 async fn run_ducklake_metrics_sampler(
-    manager: DuckLakeConnectionManager,
+    metadata_schema: String,
+    metadata_pg_pool: PgPool,
     created_tables: Arc<Mutex<HashSet<DuckLakeTableName>>>,
     maintenance_notification_tx: mpsc::Sender<TableMaintenanceNotification>,
     mut shutdown_rx: watch::Receiver<()>,
 ) {
-    let mut lazy_pool = LazyDuckLakePool::new(manager, METRICS_POOL_SIZE, "metrics");
     let mut interval =
         tokio::time::interval_at(Instant::now() + METRICS_POLL_INTERVAL, METRICS_POLL_INTERVAL);
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -371,16 +369,8 @@ async fn run_ducklake_metrics_sampler(
                 break;
             }
             _ = interval.tick() => {
-                let pool = match lazy_pool.get_or_init_pool().await {
-                    Ok(pool) => pool,
-                    Err(error) => {
-                        warn!(error = ?error, "ducklake metrics pool initialization failed");
-                        continue;
-                    }
-                };
-                let blocking_slots = lazy_pool.blocking_slots();
                 if let Err(error) =
-                    record_catalog_maintenance_metrics(Arc::clone(&pool), Arc::clone(&blocking_slots)).await
+                    record_catalog_maintenance_metrics(&metadata_pg_pool, &metadata_schema).await
                 {
                     warn!(error = ?error, "ducklake catalog maintenance metrics collection failed");
                 }
@@ -397,8 +387,8 @@ async fn run_ducklake_metrics_sampler(
                     }
 
                     if let Err(error) = record_table_storage_metrics(
-                        Arc::clone(&pool),
-                        Arc::clone(&blocking_slots),
+                        &metadata_pg_pool,
+                        &metadata_schema,
                         table_name.clone(),
                         &maintenance_notification_tx,
                     )
@@ -418,16 +408,24 @@ async fn run_ducklake_metrics_sampler(
 
 /// Samples storage health for one table without affecting the write path.
 async fn record_table_storage_metrics(
-    pool: Arc<r2d2::Pool<DuckLakeConnectionManager>>,
-    blocking_slots: Arc<Semaphore>,
+    metadata_pg_pool: &PgPool,
+    metadata_schema: &str,
     table_name: DuckLakeTableName,
     maintenance_notification_tx: &mpsc::Sender<TableMaintenanceNotification>,
 ) -> EtlResult<()> {
-    let metrics = query_table_storage_metrics(pool, blocking_slots, table_name.clone()).await?;
-    let active_data_files = metrics.active_data_files.max(0) as f64;
-    let active_data_bytes = metrics.active_data_bytes.max(0) as f64;
-    let active_delete_files = metrics.active_delete_files.max(0) as f64;
-    let active_delete_bytes = metrics.active_delete_bytes.max(0) as f64;
+    let metrics =
+        query_table_storage_metrics(metadata_pg_pool, metadata_schema, &table_name).await?;
+    let DuckLakeTableStorageMetrics {
+        active_data_files,
+        active_data_bytes,
+        active_delete_files,
+        active_delete_bytes,
+        ..
+    } = &metrics;
+    let active_data_files = (*active_data_files).max(0) as f64;
+    let active_data_bytes = (*active_data_bytes).max(0) as f64;
+    let active_delete_files = (*active_delete_files).max(0) as f64;
+    let active_delete_bytes = (*active_delete_bytes).max(0) as f64;
     let small_file_ratio = metrics.small_file_ratio();
     let average_data_file_size_bytes = metrics.average_data_file_size_bytes();
     let deleted_row_ratio = metrics.deleted_row_ratio();
@@ -455,57 +453,128 @@ async fn record_table_storage_metrics(
 
 /// Samples global snapshot and deletion backlog gauges.
 async fn record_catalog_maintenance_metrics(
-    pool: Arc<r2d2::Pool<DuckLakeConnectionManager>>,
-    blocking_slots: Arc<Semaphore>,
+    metadata_pg_pool: &PgPool,
+    metadata_schema: &str,
 ) -> EtlResult<()> {
-    let metrics = query_catalog_maintenance_metrics(pool, blocking_slots).await?;
-    gauge!(ETL_DUCKLAKE_ACTIVE_DATA_FILES_TOTAL).set(metrics.active_data_files_total.max(0) as f64);
-    gauge!(ETL_DUCKLAKE_SNAPSHOTS_TOTAL).set(metrics.snapshots_total.max(0) as f64);
-    gauge!(ETL_DUCKLAKE_OLDEST_SNAPSHOT_AGE_SECONDS)
-        .set(metrics.oldest_snapshot_age_seconds.max(0) as f64);
+    let metrics = query_catalog_maintenance_metrics(metadata_pg_pool, metadata_schema).await?;
+    let DuckLakeCatalogMaintenanceMetrics {
+        active_data_files_total,
+        snapshots_total,
+        oldest_snapshot_age_seconds,
+        files_scheduled_for_deletion_total,
+        files_scheduled_for_deletion_bytes,
+        oldest_scheduled_deletion_age_seconds,
+    } = metrics;
+    gauge!(ETL_DUCKLAKE_ACTIVE_DATA_FILES_TOTAL).set(active_data_files_total.max(0) as f64);
+    gauge!(ETL_DUCKLAKE_SNAPSHOTS_TOTAL).set(snapshots_total.max(0) as f64);
+    gauge!(ETL_DUCKLAKE_OLDEST_SNAPSHOT_AGE_SECONDS).set(oldest_snapshot_age_seconds.max(0) as f64);
     gauge!(ETL_DUCKLAKE_FILES_SCHEDULED_FOR_DELETION_TOTAL)
-        .set(metrics.files_scheduled_for_deletion_total.max(0) as f64);
+        .set(files_scheduled_for_deletion_total.max(0) as f64);
     gauge!(ETL_DUCKLAKE_FILES_SCHEDULED_FOR_DELETION_BYTES)
-        .set(metrics.files_scheduled_for_deletion_bytes.max(0) as f64);
+        .set(files_scheduled_for_deletion_bytes.max(0) as f64);
     gauge!(ETL_DUCKLAKE_OLDEST_SCHEDULED_DELETION_AGE_SECONDS)
-        .set(metrics.oldest_scheduled_deletion_age_seconds.max(0) as f64);
+        .set(oldest_scheduled_deletion_age_seconds.max(0) as f64);
 
     Ok(())
 }
 
 /// Returns table-level storage health from the DuckLake metadata tables.
-async fn query_table_storage_metrics(
-    pool: Arc<r2d2::Pool<DuckLakeConnectionManager>>,
-    blocking_slots: Arc<Semaphore>,
-    table_name: DuckLakeTableName,
-) -> EtlResult<DuckLakeTableStorageMetrics> {
-    let table_name_for_query = table_name.clone();
-    run_duckdb_blocking(pool, blocking_slots, DuckDbBlockingOperationKind::Metrics, move |conn| {
-        query_table_storage_metrics_blocking(conn, &table_name_for_query)
-    })
-    .await
-}
-
-/// Returns table-level storage health from the DuckLake metadata tables.
-pub(super) fn query_table_storage_metrics_blocking(
-    conn: &duckdb::Connection,
+pub(super) async fn query_table_storage_metrics(
+    metadata_pg_pool: &PgPool,
+    metadata_schema: &str,
     table_name: &str,
 ) -> EtlResult<DuckLakeTableStorageMetrics> {
-    let metadata_namespace = ducklake_metadata_namespace(conn)?;
-    let sql = format!(
+    let sql = table_storage_metrics_query(metadata_schema);
+    let (
+        active_data_files,
+        active_data_bytes,
+        small_data_files,
+        active_data_rows,
+        active_delete_files,
+        active_delete_bytes,
+        deleted_rows,
+    ): (i64, i64, i64, i64, i64, i64, i64) =
+        sqlx::query_as(&sql).bind(table_name).fetch_one(metadata_pg_pool).await.map_err(
+            |source| {
+                etl_error!(
+                    ErrorKind::DestinationQueryFailed,
+                    "DuckLake table storage metrics query failed",
+                    format!("table={table_name}, metadata_schema={metadata_schema}"),
+                    source: source
+                )
+            },
+        )?;
+
+    Ok(DuckLakeTableStorageMetrics {
+        active_data_files,
+        active_data_bytes,
+        small_data_files,
+        active_data_rows,
+        active_delete_files,
+        active_delete_bytes,
+        deleted_rows,
+    })
+}
+
+/// Returns global maintenance backlog metrics from the DuckLake metadata
+/// tables.
+pub(super) async fn query_catalog_maintenance_metrics(
+    metadata_pg_pool: &PgPool,
+    metadata_schema: &str,
+) -> EtlResult<DuckLakeCatalogMaintenanceMetrics> {
+    let sql = catalog_maintenance_metrics_query(metadata_schema);
+    let now_epoch_ms = Utc::now().timestamp_millis();
+    let (
+        active_data_files_total,
+        snapshots_total,
+        oldest_snapshot_epoch_ms,
+        files_scheduled_for_deletion_total,
+        files_scheduled_for_deletion_bytes,
+        oldest_scheduled_deletion_epoch_ms,
+    ): (i64, i64, Option<i64>, i64, i64, Option<i64>) =
+        sqlx::query_as(&sql).fetch_one(metadata_pg_pool).await.map_err(|source| {
+            etl_error!(
+                ErrorKind::DestinationQueryFailed,
+                "DuckLake catalog maintenance metrics query failed",
+                format!("metadata_schema={metadata_schema}"),
+                source: source
+            )
+        })?;
+
+    Ok(DuckLakeCatalogMaintenanceMetrics {
+        active_data_files_total,
+        snapshots_total,
+        oldest_snapshot_age_seconds: epoch_age_seconds(now_epoch_ms, oldest_snapshot_epoch_ms),
+        files_scheduled_for_deletion_total,
+        files_scheduled_for_deletion_bytes,
+        oldest_scheduled_deletion_age_seconds: epoch_age_seconds(
+            now_epoch_ms,
+            oldest_scheduled_deletion_epoch_ms,
+        ),
+    })
+}
+
+/// Returns the SQL query used to sample table-level storage health.
+fn table_storage_metrics_query(metadata_schema: &str) -> String {
+    let metadata_schema = quote_identifier(metadata_schema);
+    let ducklake_table = quote_identifier("ducklake_table");
+    let ducklake_data_file = quote_identifier("ducklake_data_file");
+    let ducklake_delete_file = quote_identifier("ducklake_delete_file");
+
+    format!(
         r#"WITH target_table AS (
              SELECT table_id
-             FROM {metadata_namespace}.ducklake_table
-             WHERE end_snapshot IS NULL AND table_name = {}
+             FROM {metadata_schema}.{ducklake_table}
+             WHERE end_snapshot IS NULL AND table_name = $1
              LIMIT 1
          ),
          data_stats AS (
              SELECT
                  COUNT(*) AS active_data_files,
                  COALESCE(SUM(file_size_bytes), 0) AS active_data_bytes,
-                 COALESCE(SUM(CASE WHEN file_size_bytes < {} THEN 1 ELSE 0 END), 0) AS small_data_files,
+                 COALESCE(SUM(CASE WHEN file_size_bytes < {SMALL_FILE_SIZE_BYTES} THEN 1 ELSE 0 END), 0) AS small_data_files,
                  COALESCE(SUM(record_count), 0) AS active_data_rows
-             FROM {metadata_namespace}.ducklake_data_file
+             FROM {metadata_schema}.{ducklake_data_file}
              WHERE end_snapshot IS NULL AND table_id = (SELECT table_id FROM target_table)
          ),
          delete_stats AS (
@@ -513,7 +582,7 @@ pub(super) fn query_table_storage_metrics_blocking(
                  COUNT(*) AS active_delete_files,
                  COALESCE(SUM(file_size_bytes), 0) AS active_delete_bytes,
                  COALESCE(SUM(delete_count), 0) AS deleted_rows
-             FROM {metadata_namespace}.ducklake_delete_file
+             FROM {metadata_schema}.{ducklake_delete_file}
              WHERE end_snapshot IS NULL AND table_id = (SELECT table_id FROM target_table)
          )
          SELECT
@@ -524,72 +593,37 @@ pub(super) fn query_table_storage_metrics_blocking(
              active_delete_files,
              active_delete_bytes,
              deleted_rows
-         FROM data_stats CROSS JOIN delete_stats;"#,
-        quote_literal(table_name),
-        SMALL_FILE_SIZE_BYTES,
-    );
-
-    conn.query_row(&sql, [], |row| {
-        Ok(DuckLakeTableStorageMetrics {
-            active_data_files: row.get(0)?,
-            active_data_bytes: row.get(1)?,
-            small_data_files: row.get(2)?,
-            active_data_rows: row.get(3)?,
-            active_delete_files: row.get(4)?,
-            active_delete_bytes: row.get(5)?,
-            deleted_rows: row.get(6)?,
-        })
-    })
-    .map_err(|e| {
-        etl_error!(
-            ErrorKind::DestinationQueryFailed,
-            "DuckLake table storage metrics query failed",
-            format_query_error_detail(&sql, &e),
-            source: e
-        )
-    })
-}
-
-/// Returns global maintenance backlog metrics from the DuckLake metadata
-/// tables.
-async fn query_catalog_maintenance_metrics(
-    pool: Arc<r2d2::Pool<DuckLakeConnectionManager>>,
-    blocking_slots: Arc<Semaphore>,
-) -> EtlResult<DuckLakeCatalogMaintenanceMetrics> {
-    run_duckdb_blocking(
-        pool,
-        blocking_slots,
-        DuckDbBlockingOperationKind::Metrics,
-        query_catalog_maintenance_metrics_blocking,
+         FROM data_stats CROSS JOIN delete_stats;"#
     )
-    .await
 }
 
-/// Returns global maintenance backlog metrics from the DuckLake metadata
-/// tables.
-pub(super) fn query_catalog_maintenance_metrics_blocking(
-    conn: &duckdb::Connection,
-) -> EtlResult<DuckLakeCatalogMaintenanceMetrics> {
-    let metadata_namespace = ducklake_metadata_namespace(conn)?;
-    let sql = format!(
+/// Returns the SQL query used to sample global DuckLake catalog backlog.
+fn catalog_maintenance_metrics_query(metadata_schema: &str) -> String {
+    let metadata_schema = quote_identifier(metadata_schema);
+    let ducklake_data_file = quote_identifier("ducklake_data_file");
+    let ducklake_snapshot = quote_identifier("ducklake_snapshot");
+    let ducklake_files_scheduled_for_deletion =
+        quote_identifier("ducklake_files_scheduled_for_deletion");
+
+    format!(
         r#"WITH active_data_file_stats AS (
              SELECT COUNT(*) AS active_data_files_total
-             FROM {metadata_namespace}.ducklake_data_file
+             FROM {metadata_schema}.{ducklake_data_file}
              WHERE end_snapshot IS NULL
          ),
          snapshot_stats AS (
              SELECT
                  COUNT(*) AS snapshots_total,
                  MIN(epoch_ms(snapshot_time)) AS oldest_snapshot_epoch_ms
-             FROM {metadata_namespace}.ducklake_snapshot
+             FROM {metadata_schema}.{ducklake_snapshot}
          ),
          scheduled_deletion_stats AS (
              SELECT
                  COUNT(*) AS files_scheduled_for_deletion_total,
                  COALESCE(SUM(data_files.file_size_bytes), 0) AS files_scheduled_for_deletion_bytes,
                  MIN(epoch_ms(scheduled.schedule_start)) AS oldest_scheduled_deletion_epoch_ms
-             FROM {metadata_namespace}.ducklake_files_scheduled_for_deletion AS scheduled
-             LEFT JOIN {metadata_namespace}.ducklake_data_file AS data_files USING (data_file_id)
+             FROM {metadata_schema}.{ducklake_files_scheduled_for_deletion} AS scheduled
+             LEFT JOIN {metadata_schema}.{ducklake_data_file} AS data_files USING (data_file_id)
          )
          SELECT
              active_data_files_total,
@@ -601,32 +635,7 @@ pub(super) fn query_catalog_maintenance_metrics_blocking(
          FROM active_data_file_stats
          CROSS JOIN snapshot_stats
          CROSS JOIN scheduled_deletion_stats;"#
-    );
-    let now_epoch_ms = Utc::now().timestamp_millis();
-
-    conn.query_row(&sql, [], |row| {
-        let oldest_snapshot_epoch_ms = row.get::<_, Option<i64>>(2)?;
-        let oldest_scheduled_deletion_epoch_ms = row.get::<_, Option<i64>>(5)?;
-        Ok(DuckLakeCatalogMaintenanceMetrics {
-            active_data_files_total: row.get(0)?,
-            snapshots_total: row.get(1)?,
-            oldest_snapshot_age_seconds: epoch_age_seconds(now_epoch_ms, oldest_snapshot_epoch_ms),
-            files_scheduled_for_deletion_total: row.get(3)?,
-            files_scheduled_for_deletion_bytes: row.get(4)?,
-            oldest_scheduled_deletion_age_seconds: epoch_age_seconds(
-                now_epoch_ms,
-                oldest_scheduled_deletion_epoch_ms,
-            ),
-        })
-    })
-    .map_err(|e| {
-        etl_error!(
-            ErrorKind::DestinationQueryFailed,
-            "DuckLake catalog maintenance metrics query failed",
-            format_query_error_detail(&sql, &e),
-            source: e
-        )
-    })
+    )
 }
 
 fn epoch_age_seconds(now_epoch_ms: i64, oldest_epoch_ms: Option<i64>) -> i64 {
@@ -663,61 +672,28 @@ pub(super) fn resolve_ducklake_metadata_schema_blocking(
     })
 }
 
-/// Returns the fully-qualified hidden DuckLake metadata namespace.
-fn ducklake_metadata_namespace(conn: &duckdb::Connection) -> EtlResult<String> {
-    static METADATA_NAMESPACE: OnceLock<String> = OnceLock::new();
-
-    if let Some(namespace) = METADATA_NAMESPACE.get() {
-        return Ok(namespace.clone());
-    }
-
-    let namespace = resolve_ducklake_metadata_namespace(conn)?;
-    let _ = METADATA_NAMESPACE.set(namespace.clone());
-    Ok(namespace)
-}
-
-/// Resolves the schema that DuckLake uses inside its hidden metadata catalog.
-fn resolve_ducklake_metadata_namespace(conn: &duckdb::Connection) -> EtlResult<String> {
-    let metadata_catalog = format!("__ducklake_metadata_{LAKE_CATALOG}");
-    let table_schema = resolve_ducklake_metadata_schema_blocking(conn)?;
-
-    Ok(format!("{}.{}", quote_identifier(&metadata_catalog), quote_identifier(&table_schema),))
-}
-
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "test-utils")]
-    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
-    use std::{collections::HashSet, sync::Arc};
-
     use super::*;
 
-    #[cfg(feature = "test-utils")]
-    #[tokio::test]
-    async fn spawn_ducklake_metrics_sampler_initializes_pool_lazily() {
-        let open_count = Arc::new(AtomicUsize::new(0));
-        let (maintenance_notification_tx, _maintenance_notification_rx) = mpsc::channel(1);
-        let sampler = spawn_ducklake_metrics_sampler(
-            DuckLakeConnectionManager {
-                setup_plan: Arc::new(crate::ducklake::config::DuckLakeSetupPlan::default()),
-                disable_extension_autoload: cfg!(target_os = "linux"),
-                open_count: Arc::clone(&open_count),
-            },
-            Arc::new(Mutex::new(HashSet::new())),
-            maintenance_notification_tx,
-        )
-        .expect("failed to spawn metrics sampler");
+    #[test]
+    fn table_storage_metrics_query_qualifies_metadata_tables() {
+        let sql = table_storage_metrics_query("duck'lake");
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(sql.contains("ducklake_table"));
+        assert!(sql.contains("ducklake_data_file"));
+        assert!(sql.contains("ducklake_delete_file"));
+        assert!(sql.contains(r#""duck'lake""#));
+        assert!(sql.contains("table_name = $1"));
+    }
 
-        assert_eq!(
-            open_count.load(AtomicOrdering::Relaxed),
-            0,
-            "metrics sampler should not warm its pool before the first poll"
-        );
+    #[test]
+    fn catalog_maintenance_metrics_query_qualifies_metadata_tables() {
+        let sql = catalog_maintenance_metrics_query("duck'lake");
 
-        sampler.shutdown_tx.send(()).expect("metrics sampler shutdown channel should stay open");
-        let handle = sampler.handle.lock().take().expect("metrics sampler handle should exist");
-        handle.await.expect("metrics sampler should shut down cleanly");
+        assert!(sql.contains("ducklake_data_file"));
+        assert!(sql.contains("ducklake_snapshot"));
+        assert!(sql.contains("ducklake_files_scheduled_for_deletion"));
+        assert!(sql.contains(r#""duck'lake""#));
     }
 }

--- a/etl-destinations/src/ducklake/metrics.rs
+++ b/etl-destinations/src/ducklake/metrics.rs
@@ -570,18 +570,18 @@ fn table_storage_metrics_query(metadata_schema: &str) -> String {
          ),
          data_stats AS (
              SELECT
-                 COUNT(*) AS active_data_files,
-                 COALESCE(SUM(file_size_bytes), 0) AS active_data_bytes,
-                 COALESCE(SUM(CASE WHEN file_size_bytes < {SMALL_FILE_SIZE_BYTES} THEN 1 ELSE 0 END), 0) AS small_data_files,
-                 COALESCE(SUM(record_count), 0) AS active_data_rows
+                 COUNT(*)::BIGINT AS active_data_files,
+                 COALESCE(SUM(file_size_bytes), 0)::BIGINT AS active_data_bytes,
+                 COALESCE(SUM(CASE WHEN file_size_bytes < {SMALL_FILE_SIZE_BYTES} THEN 1 ELSE 0 END), 0)::BIGINT AS small_data_files,
+                 COALESCE(SUM(record_count), 0)::BIGINT AS active_data_rows
              FROM {metadata_schema}.{ducklake_data_file}
              WHERE end_snapshot IS NULL AND table_id = (SELECT table_id FROM target_table)
          ),
          delete_stats AS (
              SELECT
-                 COUNT(*) AS active_delete_files,
-                 COALESCE(SUM(file_size_bytes), 0) AS active_delete_bytes,
-                 COALESCE(SUM(delete_count), 0) AS deleted_rows
+                 COUNT(*)::BIGINT AS active_delete_files,
+                 COALESCE(SUM(file_size_bytes), 0)::BIGINT AS active_delete_bytes,
+                 COALESCE(SUM(delete_count), 0)::BIGINT AS deleted_rows
              FROM {metadata_schema}.{ducklake_delete_file}
              WHERE end_snapshot IS NULL AND table_id = (SELECT table_id FROM target_table)
          )
@@ -607,21 +607,21 @@ fn catalog_maintenance_metrics_query(metadata_schema: &str) -> String {
 
     format!(
         r#"WITH active_data_file_stats AS (
-             SELECT COUNT(*) AS active_data_files_total
+             SELECT COUNT(*)::BIGINT AS active_data_files_total
              FROM {metadata_schema}.{ducklake_data_file}
              WHERE end_snapshot IS NULL
          ),
          snapshot_stats AS (
              SELECT
-                 COUNT(*) AS snapshots_total,
-                 MIN(epoch_ms(snapshot_time)) AS oldest_snapshot_epoch_ms
+                 COUNT(*)::BIGINT AS snapshots_total,
+                 MIN((EXTRACT(EPOCH FROM snapshot_time) * 1000)::BIGINT) AS oldest_snapshot_epoch_ms
              FROM {metadata_schema}.{ducklake_snapshot}
          ),
          scheduled_deletion_stats AS (
              SELECT
-                 COUNT(*) AS files_scheduled_for_deletion_total,
-                 COALESCE(SUM(data_files.file_size_bytes), 0) AS files_scheduled_for_deletion_bytes,
-                 MIN(epoch_ms(scheduled.schedule_start)) AS oldest_scheduled_deletion_epoch_ms
+                 COUNT(*)::BIGINT AS files_scheduled_for_deletion_total,
+                 COALESCE(SUM(data_files.file_size_bytes), 0)::BIGINT AS files_scheduled_for_deletion_bytes,
+                 MIN((EXTRACT(EPOCH FROM scheduled.schedule_start) * 1000)::BIGINT) AS oldest_scheduled_deletion_epoch_ms
              FROM {metadata_schema}.{ducklake_files_scheduled_for_deletion} AS scheduled
              LEFT JOIN {metadata_schema}.{ducklake_data_file} AS data_files USING (data_file_id)
          )

--- a/etl-destinations/tests/ducklake_destination.rs
+++ b/etl-destinations/tests/ducklake_destination.rs
@@ -1,8 +1,7 @@
 //! Integration tests for the DuckLake destination.
 //!
-//! These tests use a local DuckDB-backed DuckLake catalog (a `.ducklake`
-//! metadata file + a local Parquet data directory). No PostgreSQL or cloud
-//! storage account is required.
+//! These tests use a PostgreSQL-backed DuckLake catalog with a local Parquet
+//! data directory.
 //!
 //! Run with `-- --nocapture` to see the paths printed for each test:
 //!
@@ -15,7 +14,7 @@
 //! ```
 //! duckdb :memory: -c "
 //!   LOAD '/absolute/path/to/ducklake.duckdb_extension';
-//!   ATTACH 'ducklake:file:///path/printed/catalog.ducklake' AS lake
+//!   ATTACH 'ducklake:postgres:host=... dbname=... user=...' AS lake
 //!     (DATA_PATH 'file:///path/printed/data');
 //!   SELECT * FROM lake.public_users;
 //! "
@@ -23,12 +22,7 @@
 
 #[cfg(feature = "test-utils")]
 use std::sync::LazyLock;
-use std::{
-    f64::consts::PI,
-    path::{Path, PathBuf},
-    sync::Arc,
-    time::Duration,
-};
+use std::{f64::consts::PI, path::Path, sync::Arc, time::Duration};
 
 use chrono::NaiveDate;
 use duckdb::Connection;
@@ -54,28 +48,13 @@ use pg_escape::{quote_identifier, quote_literal};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use url::Url;
 
-use crate::support::ducklake::{ducklake_load_sql, open_verification_connection};
+use crate::support::ducklake::{
+    catalog_attach_target, create_test_lake, ducklake_load_sql, open_verification_connection,
+    path_to_file_url,
+};
 
 // ── helpers
 // ───────────────────────────────────────────────────────────────────
-
-/// Creates a persistent temp directory named after the test and prints its
-/// path. Returns the directory path (kept on disk after the test completes).
-fn make_test_dir(test_name: &str) -> PathBuf {
-    let dir = tempfile::Builder::new()
-        .prefix(&format!("etl_ducklake_{test_name}_"))
-        .tempdir()
-        .expect("failed to create temp dir")
-        .keep(); // `into_path` prevents auto-cleanup on drop
-
-    println!("[{test_name}] catalog : {}", dir.join("catalog.ducklake").display());
-    println!("[{test_name}] data    : {}", dir.join("data").display());
-    dir
-}
-
-fn path_to_file_url(path: &Path) -> Url {
-    Url::from_file_path(path).expect("failed to convert path to file url")
-}
 
 #[cfg(feature = "test-utils")]
 static DUCKLAKE_TEST_HOOKS_GUARD: LazyLock<Arc<Semaphore>> =
@@ -124,10 +103,11 @@ fn make_replicated_table_schema(schema: &TableSchema) -> ReplicatedTableSchema {
 /// checkpoint mismatch while another connection is still flushing).
 fn try_open_lake_conn(catalog: &Url, data: &Url) -> Result<Connection, duckdb::Error> {
     let conn = open_verification_connection();
+    let catalog_attach_target = catalog_attach_target(catalog);
     conn.execute_batch(&format!(
         "{} ATTACH {} AS {} (DATA_PATH {});",
         ducklake_load_sql(),
-        quote_literal(&format!("ducklake:{}", catalog.as_str())),
+        quote_literal(&format!("ducklake:{catalog_attach_target}")),
         quote_identifier("lake"),
         quote_literal(data.as_str())
     ))?;
@@ -281,13 +261,9 @@ fn checkpoint_lake(catalog: &Url, data: &Url) {
 /// DuckLake catalog using a separate DuckDB connection.
 #[tokio::test(flavor = "multi_thread")]
 async fn write_table_rows_basic() {
-    let dir = make_test_dir("write_table_rows_basic");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_table_rows_basic").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(1);
     let schema = make_schema(1, "public", "users");
@@ -342,13 +318,10 @@ async fn write_table_rows_basic() {
 /// Small copy batches should remain inlined after the caller returns.
 #[tokio::test(flavor = "multi_thread")]
 async fn write_table_rows_small_batch_stays_inlined_after_return() {
-    let dir = make_test_dir("write_table_rows_small_batch_stays_inlined_after_return");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_table_rows_small_batch_stays_inlined_after_return").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
+    let data = lake.data_dir.clone();
 
     let _table_id = TableId::new(16);
     let schema = make_schema(16, "public", "copy_flush");
@@ -392,14 +365,18 @@ async fn write_table_rows_small_batch_stays_inlined_after_return() {
 /// `pool_size = 0` should fail fast with a configuration error.
 #[tokio::test(flavor = "multi_thread")]
 async fn ducklake_rejects_zero_pool_size() {
-    let dir = make_test_dir("ducklake_rejects_zero_pool_size");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
+    let data_dir = tempfile::Builder::new()
+        .prefix("etl_ducklake_zero_pool_size_")
+        .tempdir()
+        .expect("failed to create temp dir")
+        .keep()
+        .join("data");
+    std::fs::create_dir_all(&data_dir).expect("failed to create data dir");
 
     let err = DuckLakeDestination::new(
-        path_to_file_url(&catalog),
-        path_to_file_url(&data),
+        Url::parse("postgres://ducklake@localhost/test_catalog")
+            .expect("failed to parse catalog url"),
+        path_to_file_url(&data_dir),
         0,
         None,
         None,
@@ -414,20 +391,49 @@ async fn ducklake_rejects_zero_pool_size() {
     assert_eq!(err.kind(), ErrorKind::ConfigError);
 }
 
+/// Non-Postgres DuckLake catalogs should be rejected up front.
+#[tokio::test(flavor = "multi_thread")]
+async fn ducklake_rejects_non_postgres_catalog_url() {
+    let file_catalog = tempfile::Builder::new()
+        .prefix("etl_ducklake_file_catalog_")
+        .tempdir()
+        .expect("failed to create file catalog dir")
+        .keep()
+        .join("catalog.ducklake");
+    let data_dir = tempfile::Builder::new()
+        .prefix("etl_ducklake_non_postgres_catalog_")
+        .tempdir()
+        .expect("failed to create temp data dir")
+        .keep()
+        .join("data");
+    std::fs::create_dir_all(&data_dir).expect("failed to create data dir");
+
+    let err = DuckLakeDestination::new(
+        path_to_file_url(&file_catalog),
+        path_to_file_url(&data_dir),
+        1,
+        None,
+        None,
+        None,
+        None,
+        MemoryStore::new(),
+    )
+    .await
+    .err()
+    .expect("file-backed catalogs should be rejected");
+
+    assert_eq!(err.kind(), ErrorKind::ConfigError);
+}
+
 /// Repeated writes should reuse the warm pooled DuckDB connection.
 #[cfg(feature = "test-utils")]
 #[tokio::test(flavor = "multi_thread")]
 async fn write_table_rows_reuses_warm_pooled_connection() {
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
-
-    let dir = make_test_dir("write_table_rows_reuses_warm_pooled_connection");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_table_rows_reuses_warm_pooled_connection").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(21);
     let schema = make_schema(21, "public", "pooled_copy");
@@ -481,14 +487,10 @@ async fn write_table_rows_reuses_warm_pooled_connection() {
 async fn write_table_rows_replaces_broken_pooled_connection_after_retry() {
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
-
-    let dir = make_test_dir("write_table_rows_replaces_broken_pooled_connection_after_retry");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake =
+        create_test_lake("write_table_rows_replaces_broken_pooled_connection_after_retry").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(22);
     let schema = make_schema(22, "public", "pooled_retry");
@@ -544,14 +546,10 @@ async fn write_table_rows_replaces_broken_pooled_connection_after_retry() {
 async fn write_table_rows_retry_after_post_commit_failure_is_idempotent() {
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
-
-    let dir = make_test_dir("write_table_rows_retry_after_post_commit_failure_is_idempotent");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake =
+        create_test_lake("write_table_rows_retry_after_post_commit_failure_is_idempotent").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(13);
     let schema = make_schema(13, "public", "copy_retry");
@@ -598,13 +596,9 @@ async fn write_table_rows_retry_after_post_commit_failure_is_idempotent() {
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_same_table_copy_batches_complete() {
     init_test_tracing();
-    let dir = make_test_dir("concurrent_same_table_copy_batches_complete");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("concurrent_same_table_copy_batches_complete").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(14);
     let schema = make_schema(14, "public", "parallel_copy");
@@ -728,13 +722,9 @@ async fn concurrent_same_table_copy_batches_complete() {
 /// `write_table_rows` with an empty slice still creates the table schema.
 #[tokio::test(flavor = "multi_thread")]
 async fn write_table_rows_empty_creates_table() {
-    let dir = make_test_dir("write_table_rows_empty");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_table_rows_empty").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(2);
     let schema = make_schema(2, "public", "events");
@@ -768,13 +758,9 @@ async fn write_table_rows_empty_creates_table() {
 /// `truncate_table` deletes all rows while leaving the table schema intact.
 #[tokio::test(flavor = "multi_thread")]
 async fn truncate_clears_rows() {
-    let dir = make_test_dir("truncate_clears_rows");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("truncate_clears_rows").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(3);
     let schema = make_schema(3, "public", "logs");
@@ -832,13 +818,9 @@ async fn truncate_clears_rows() {
 /// Truncation should clear copy markers so the same rows can be copied again.
 #[tokio::test(flavor = "multi_thread")]
 async fn truncate_clears_copy_markers_for_recopy() {
-    let dir = make_test_dir("truncate_clears_copy_markers_for_recopy");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("truncate_clears_copy_markers_for_recopy").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(15);
     let schema = make_schema(15, "public", "recopy_logs");
@@ -880,14 +862,9 @@ async fn truncate_clears_copy_markers_for_recopy() {
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events() {
     use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
-
-    let dir = make_test_dir("write_events");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(4);
     let schema = make_schema(4, "public", "products");
@@ -974,14 +951,10 @@ async fn write_events() {
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events_small_batch_stays_inlined_after_return() {
     use etl::types::{InsertEvent, PgLsn};
-
-    let dir = make_test_dir("write_events_small_batch_stays_inlined_after_return");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_small_batch_stays_inlined_after_return").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
+    let data = lake.data_dir.clone();
 
     let _table_id = TableId::new(17);
     let schema = make_schema(17, "public", "cdc_flush");
@@ -1031,14 +1004,9 @@ async fn write_events_small_batch_stays_inlined_after_return() {
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events_with_old_row_update() {
     use etl::types::{InsertEvent, PgLsn, UpdateEvent};
-
-    let dir = make_test_dir("write_events_with_old_row_update");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_with_old_row_update").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(8);
     let schema = make_schema(8, "public", "inventory");
@@ -1112,14 +1080,9 @@ async fn write_events_with_old_row_update() {
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events_replay_is_idempotent() {
     use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
-
-    let dir = make_test_dir("write_events_replay_is_idempotent");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_replay_is_idempotent").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(9);
     let schema = make_schema(9, "public", "orders");
@@ -1211,14 +1174,10 @@ async fn write_events_replay_is_idempotent() {
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events_same_commit_lsn_higher_tx_ordinal_still_applies() {
     use etl::types::{InsertEvent, UpdateEvent};
-
-    let dir = make_test_dir("write_events_same_commit_lsn_higher_tx_ordinal_still_applies");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake =
+        create_test_lake("write_events_same_commit_lsn_higher_tx_ordinal_still_applies").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(18);
     let schema = make_schema(18, "public", "tx_ordinal_progress");
@@ -1293,14 +1252,9 @@ async fn write_events_same_commit_lsn_higher_tx_ordinal_still_applies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events_restart_overlap_rebatches_only_pending_suffix() {
     use etl::types::InsertEvent;
-
-    let dir = make_test_dir("write_events_restart_overlap_rebatches_only_pending_suffix");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_restart_overlap_rebatches_only_pending_suffix").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(19);
     let schema = make_schema(19, "public", "restart_overlap_progress");
@@ -1415,14 +1369,9 @@ async fn write_events_reuses_one_staging_table_per_atomic_batch() {
 
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
-
-    let dir = make_test_dir("write_events_reuses_one_staging_table_per_atomic_batch");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_reuses_one_staging_table_per_atomic_batch").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(19);
     let schema = make_schema(19, "public", "staging_reuse");
@@ -1505,13 +1454,10 @@ async fn write_events_reuses_one_staging_table_per_atomic_batch() {
 /// Parquet files.
 #[tokio::test(flavor = "multi_thread")]
 async fn applied_batches_table_uses_data_inlining() {
-    let dir = make_test_dir("applied_batches_table_uses_data_inlining");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("applied_batches_table_uses_data_inlining").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
+    let data = lake.data_dir.clone();
 
     let _table_id = TableId::new(13);
     let schema = make_schema(13, "public", "audit");
@@ -1553,14 +1499,9 @@ async fn applied_batches_table_uses_data_inlining() {
 #[tokio::test(flavor = "multi_thread")]
 async fn write_events_mixed_multi_table_batches() {
     use etl::types::{DeleteEvent, InsertEvent, PgLsn, UpdateEvent};
-
-    let dir = make_test_dir("write_events_mixed_multi_table_batches");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_mixed_multi_table_batches").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id_a = TableId::new(10);
     let _table_id_b = TableId::new(11);
@@ -1693,14 +1634,11 @@ async fn write_events_truncate_retry_after_post_commit_failure_is_idempotent() {
 
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
-
-    let dir = make_test_dir("write_events_truncate_retry_after_post_commit_failure_is_idempotent");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake =
+        create_test_lake("write_events_truncate_retry_after_post_commit_failure_is_idempotent")
+            .await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(16);
     let schema = make_schema(16, "public", "truncate_retries");
@@ -1792,14 +1730,9 @@ async fn write_events_retry_after_post_commit_failure_is_idempotent() {
 
     let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
     reset_ducklake_test_hooks();
-
-    let dir = make_test_dir("write_events_retry_after_post_commit_failure_is_idempotent");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_retry_after_post_commit_failure_is_idempotent").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(12);
     let schema = make_schema(12, "public", "payments");
@@ -1894,13 +1827,9 @@ async fn write_events_retry_after_post_commit_failure_is_idempotent() {
 /// Concurrent async callers should serialize cleanly behind one DuckDB slot.
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_writes_with_single_slot_complete() {
-    let dir = make_test_dir("concurrent_writes_single_slot");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("concurrent_writes_single_slot").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id_a = TableId::new(6);
     let _table_id_b = TableId::new(7);
@@ -1968,13 +1897,9 @@ async fn concurrent_writes_with_single_slot_complete() {
 /// Verifies that common Postgres types survive the write → read cycle.
 #[tokio::test(flavor = "multi_thread")]
 async fn type_mapping_round_trip() {
-    let dir = make_test_dir("type_mapping");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("type_mapping").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(5);
     let schema = make_rich_schema(5);

--- a/etl-destinations/tests/ducklake_destination.rs
+++ b/etl-destinations/tests/ducklake_destination.rs
@@ -22,12 +22,7 @@
 
 #[cfg(feature = "test-utils")]
 use std::sync::LazyLock;
-use std::{
-    f64::consts::PI,
-    path::{Path, PathBuf},
-    sync::Arc,
-    time::Duration,
-};
+use std::{f64::consts::PI, path::Path, sync::Arc, time::Duration};
 
 use chrono::NaiveDate;
 use duckdb::Connection;
@@ -61,20 +56,6 @@ use crate::support::ducklake::{
 
 // ── helpers
 // ───────────────────────────────────────────────────────────────────
-
-/// Creates a persistent temp directory named after the test and prints its
-/// path. Returns the directory path (kept on disk after the test completes).
-fn make_test_dir(test_name: &str) -> PathBuf {
-    let dir = tempfile::Builder::new()
-        .prefix(&format!("etl_ducklake_{test_name}_"))
-        .tempdir()
-        .expect("failed to create temp dir")
-        .keep(); // `into_path` prevents auto-cleanup on drop
-
-    println!("[{test_name}] catalog : {}", dir.join("catalog.ducklake").display());
-    println!("[{test_name}] data    : {}", dir.join("data").display());
-    dir
-}
 
 #[cfg(feature = "test-utils")]
 static DUCKLAKE_TEST_HOOKS_GUARD: LazyLock<Arc<Semaphore>> =
@@ -1101,13 +1082,9 @@ async fn write_events_with_old_row_update() {
 async fn write_events_with_partial_updates() {
     use etl::types::UpdateEvent;
 
-    let dir = make_test_dir("write_events_with_partial_updates");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_with_partial_updates").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let schema = make_schema(37, "public", "partial_inventory");
     let replicated_schema = make_replicated_table_schema(&schema);
@@ -1193,13 +1170,9 @@ async fn write_events_with_partial_updates() {
 async fn write_events_without_replica_identity_rejects_mutations() {
     use etl::types::UpdateEvent;
 
-    let dir = make_test_dir("write_events_without_replica_identity_rejects_mutations");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_without_replica_identity_rejects_mutations").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let table_schema = Arc::new(make_schema(40, "public", "missing_identity_inventory"));
     let replicated_schema = ReplicatedTableSchema::from_masks(
@@ -1287,13 +1260,9 @@ async fn write_events_without_replica_identity_rejects_mutations() {
 async fn write_events_replay_is_idempotent() {
     use etl::types::{InsertEvent, PgLsn, UpdateEvent};
 
-    let dir = make_test_dir("write_events_replay_is_idempotent");
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).unwrap();
-
-    let catalog_url = path_to_file_url(&catalog);
-    let data_url = path_to_file_url(&data);
+    let lake = create_test_lake("write_events_replay_is_idempotent").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let _table_id = TableId::new(9);
     let schema = make_schema(9, "public", "orders");

--- a/etl-destinations/tests/ducklake_pipeline.rs
+++ b/etl-destinations/tests/ducklake_pipeline.rs
@@ -1,9 +1,7 @@
 //! End-to-end integration tests for DuckLake using a real ETL [`Pipeline`].
 //!
-//! These tests use a local DuckDB-backed DuckLake catalog and verify the final
+//! These tests use a PostgreSQL-backed DuckLake catalog and verify the final
 //! table contents by querying DuckLake directly through DuckDB.
-
-use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
 use etl::{
@@ -23,42 +21,17 @@ use pg_escape::{quote_identifier, quote_literal};
 use rand::random;
 use url::Url;
 
-use crate::support::ducklake::{ducklake_load_sql, open_verification_connection};
-
-/// Creates a persistent temp directory named after the test and prints its
-/// path. Returns the directory path kept on disk after the test completes.
-fn make_test_dir(test_name: &str) -> PathBuf {
-    let dir = tempfile::Builder::new()
-        .prefix(&format!("etl_ducklake_{test_name}_"))
-        .tempdir()
-        .expect("failed to create temp dir")
-        .keep();
-
-    println!("[{test_name}] catalog : {}", dir.join("catalog.ducklake").display());
-    println!("[{test_name}] data    : {}", dir.join("data").display());
-
-    dir
-}
-
-fn path_to_file_url(path: &Path) -> Url {
-    Url::from_file_path(path).expect("failed to convert path to file url")
-}
-
-fn make_lake_urls(test_name: &str) -> (Url, Url) {
-    let dir = make_test_dir(test_name);
-    let catalog = dir.join("catalog.ducklake");
-    let data = dir.join("data");
-    std::fs::create_dir_all(&data).expect("failed to create DuckLake data dir");
-
-    (path_to_file_url(&catalog), path_to_file_url(&data))
-}
+use crate::support::ducklake::{
+    catalog_attach_target, create_test_lake, ducklake_load_sql, open_verification_connection,
+};
 
 fn open_lake_conn(catalog: &Url, data: &Url) -> Connection {
     let conn = open_verification_connection();
+    let catalog_attach_target = catalog_attach_target(catalog);
     conn.execute_batch(&format!(
         "{} ATTACH {} AS {} (DATA_PATH {});",
         ducklake_load_sql(),
-        quote_literal(&format!("ducklake:{}", catalog.as_str())),
+        quote_literal(&format!("ducklake:{catalog_attach_target}")),
         quote_identifier("lake"),
         quote_literal(data.as_str())
     ))
@@ -149,7 +122,9 @@ async fn table_copy_and_streaming_with_restart() {
 
     let mut database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::Both).await;
-    let (catalog_url, data_url) = make_lake_urls("table_copy_and_streaming_with_restart");
+    let lake = create_test_lake("table_copy_and_streaming_with_restart").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let users_table_name = table_name_to_ducklake_table_name(&database_schema.users_schema().name)
         .expect("failed to build DuckLake users table name");
@@ -266,7 +241,9 @@ async fn table_insert_update_delete() {
 
     let database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
-    let (catalog_url, data_url) = make_lake_urls("table_insert_update_delete");
+    let lake = create_test_lake("table_insert_update_delete").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let users_table_name = table_name_to_ducklake_table_name(&database_schema.users_schema().name)
         .expect("failed to build DuckLake users table name");
@@ -376,7 +353,9 @@ async fn cdc_streaming_with_truncate() {
 
     let mut database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::Both).await;
-    let (catalog_url, data_url) = make_lake_urls("cdc_streaming_with_truncate");
+    let lake = create_test_lake("cdc_streaming_with_truncate").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
 
     let users_table_name = table_name_to_ducklake_table_name(&database_schema.users_schema().name)
         .expect("failed to build DuckLake users table name");

--- a/etl-destinations/tests/support/ducklake.rs
+++ b/etl-destinations/tests/support/ducklake.rs
@@ -1,14 +1,33 @@
 #![allow(dead_code)]
 
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use duckdb::{Config, Connection};
+use etl::config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig};
+use etl_postgres::tokio::test_utils::PgDatabase;
 use pg_escape::quote_literal;
+use tokio_postgres::{
+    Client, Config as PgConfig,
+    config::{Host, SslMode},
+};
+use url::Url;
+use uuid::Uuid;
 
 const DUCKDB_EXTENSION_VERSION: &str = "1.5.2";
 const DUCKLAKE_EXTENSION_FILE: &str = "ducklake.duckdb_extension";
 const JSON_EXTENSION_FILE: &str = "json.duckdb_extension";
 const PARQUET_EXTENSION_FILE: &str = "parquet.duckdb_extension";
+
+pub struct DuckLakeTestEnv {
+    _catalog_database: PgDatabase<Client>,
+    pub catalog_url: Url,
+    pub data_dir: PathBuf,
+    pub data_url: Url,
+}
 
 fn current_vendored_extension_dir() -> Option<PathBuf> {
     let platform_dir = match (std::env::consts::OS, std::env::consts::ARCH) {
@@ -78,4 +97,149 @@ pub fn ducklake_load_sql() -> String {
 
     "INSTALL ducklake; LOAD ducklake; INSTALL json; LOAD json; INSTALL parquet; LOAD parquet;"
         .to_string()
+}
+
+pub async fn create_test_lake(test_name: &str) -> DuckLakeTestEnv {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("etl_ducklake_{test_name}_"))
+        .tempdir()
+        .expect("failed to create temp dir")
+        .keep();
+    let data_dir = dir.join("data");
+    std::fs::create_dir_all(&data_dir).expect("failed to create DuckLake data dir");
+
+    let (catalog_database, catalog_url) = create_catalog_database().await;
+    let data_url = path_to_file_url(&data_dir);
+
+    println!("[{test_name}] catalog : {catalog_url}");
+    println!("[{test_name}] data    : {}", data_dir.display());
+
+    DuckLakeTestEnv { _catalog_database: catalog_database, catalog_url, data_dir, data_url }
+}
+
+pub fn catalog_attach_target(catalog_url: &Url) -> String {
+    match catalog_url.scheme() {
+        "postgres" | "postgresql" => postgres_catalog_attach_target(catalog_url),
+        scheme => panic!("unsupported DuckLake catalog URL scheme `{scheme}`"),
+    }
+}
+
+pub fn path_to_file_url(path: &Path) -> Url {
+    Url::from_file_path(path).expect("failed to convert path to file url")
+}
+
+async fn create_catalog_database() -> (PgDatabase<Client>, Url) {
+    let database_name = Uuid::new_v4().to_string();
+    let host = env::var("TESTS_DATABASE_HOST").expect("TESTS_DATABASE_HOST must be set");
+    let port = env::var("TESTS_DATABASE_PORT")
+        .expect("TESTS_DATABASE_PORT must be set")
+        .parse()
+        .expect("TESTS_DATABASE_PORT must be a valid port number");
+    let username =
+        env::var("TESTS_DATABASE_USERNAME").expect("TESTS_DATABASE_USERNAME must be set");
+    let password = env::var("TESTS_DATABASE_PASSWORD").ok();
+    let database = PgDatabase::new(local_pg_connection_config(database_name.clone())).await;
+
+    let mut catalog_url = Url::parse("postgres://localhost").expect("failed to parse base url");
+    catalog_url.set_host(Some(&host)).expect("failed to set catalog host");
+    catalog_url.set_port(Some(port)).expect("failed to set catalog port");
+    catalog_url.set_username(&username).expect("failed to set catalog username");
+    catalog_url.set_password(password.as_deref()).expect("failed to set catalog password");
+    catalog_url.set_path(&database_name);
+
+    (database, catalog_url)
+}
+
+fn local_pg_connection_config(database_name: String) -> PgConnectionConfig {
+    PgConnectionConfig {
+        host: env::var("TESTS_DATABASE_HOST").expect("TESTS_DATABASE_HOST must be set"),
+        port: env::var("TESTS_DATABASE_PORT")
+            .expect("TESTS_DATABASE_PORT must be set")
+            .parse()
+            .expect("TESTS_DATABASE_PORT must be a valid port number"),
+        name: database_name,
+        username: env::var("TESTS_DATABASE_USERNAME").expect("TESTS_DATABASE_USERNAME must be set"),
+        password: env::var("TESTS_DATABASE_PASSWORD").ok().map(Into::into),
+        tls: TlsConfig { trusted_root_certs: String::new(), enabled: false },
+        keepalive: TcpKeepaliveConfig::default(),
+    }
+}
+
+fn postgres_catalog_attach_target(catalog_url: &Url) -> String {
+    let config =
+        PgConfig::from_str(catalog_url.as_str()).expect("failed to parse Postgres catalog url");
+    let mut parts = Vec::new();
+
+    let hosts = serialize_hosts(config.get_hosts());
+    if !hosts.is_empty() {
+        push_conninfo_pair(&mut parts, "host", &hosts);
+    }
+
+    let ports = config
+        .get_ports()
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    if !ports.is_empty() {
+        push_conninfo_pair(&mut parts, "port", &ports);
+    }
+
+    if let Some(dbname) = config.get_dbname() {
+        push_conninfo_pair(&mut parts, "dbname", dbname);
+    }
+    if let Some(user) = config.get_user() {
+        push_conninfo_pair(&mut parts, "user", user);
+    }
+    if let Some(password) = config.get_password() {
+        let password = std::str::from_utf8(password).expect("catalog password must be valid utf-8");
+        push_conninfo_pair(&mut parts, "password", password);
+    }
+    if config.get_ssl_mode() != SslMode::Prefer {
+        parts.push(format!("sslmode={}", ssl_mode_to_str(config.get_ssl_mode())));
+    }
+
+    format!("postgres:{}", parts.join(" "))
+}
+
+fn serialize_hosts(hosts: &[Host]) -> String {
+    let mut values = Vec::with_capacity(hosts.len());
+    for host in hosts {
+        match host {
+            Host::Tcp(host) => values.push(host.clone()),
+            #[cfg(unix)]
+            Host::Unix(path) => values.push(
+                path.to_str().expect("catalog unix socket path must be valid utf-8").to_owned(),
+            ),
+        }
+    }
+
+    values.join(",")
+}
+
+fn push_conninfo_pair(parts: &mut Vec<String>, key: &str, value: &str) {
+    parts.push(format!("{key}={}", quote_libpq_conninfo_value(value)));
+}
+
+fn quote_libpq_conninfo_value(value: &str) -> String {
+    let mut quoted = String::from("'");
+    for ch in value.chars() {
+        if matches!(ch, '\'' | '\\') {
+            quoted.push('\\');
+        }
+        quoted.push(ch);
+    }
+    quoted.push('\'');
+    quoted
+}
+
+fn ssl_mode_to_str(ssl_mode: SslMode) -> &'static str {
+    match ssl_mode {
+        SslMode::Disable => "disable",
+        SslMode::Prefer => "prefer",
+        SslMode::Require => "require",
+        SslMode::VerifyCa => "verify-ca",
+        SslMode::VerifyFull => "verify-full",
+        _ => panic!("unsupported sslmode"),
+    }
 }

--- a/etl-destinations/tests/support/ducklake.rs
+++ b/etl-destinations/tests/support/ducklake.rs
@@ -19,8 +19,7 @@ use uuid::Uuid;
 
 const DUCKDB_EXTENSION_VERSION: &str = "1.5.2";
 const DUCKLAKE_EXTENSION_FILE: &str = "ducklake.duckdb_extension";
-const JSON_EXTENSION_FILE: &str = "json.duckdb_extension";
-const PARQUET_EXTENSION_FILE: &str = "parquet.duckdb_extension";
+const POSTGRES_SCANNER_EXTENSION_FILE: &str = "postgres_scanner.duckdb_extension";
 
 pub struct DuckLakeTestEnv {
     _catalog_database: PgDatabase<Client>,
@@ -49,10 +48,9 @@ fn current_vendored_extension_dir() -> Option<PathBuf> {
     for root in candidate_roots {
         let extension_dir = root.join(DUCKDB_EXTENSION_VERSION).join(platform_dir);
         let ducklake_extension = extension_dir.join(DUCKLAKE_EXTENSION_FILE);
-        let json_extension = extension_dir.join(JSON_EXTENSION_FILE);
-        let parquet_extension = extension_dir.join(PARQUET_EXTENSION_FILE);
+        let postgres_scanner_extension = extension_dir.join(POSTGRES_SCANNER_EXTENSION_FILE);
 
-        if ducklake_extension.is_file() && json_extension.is_file() && parquet_extension.is_file() {
+        if ducklake_extension.is_file() && postgres_scanner_extension.is_file() {
             return Some(extension_dir);
         }
     }
@@ -84,18 +82,17 @@ pub fn open_verification_connection() -> Connection {
 pub fn ducklake_load_sql() -> String {
     if let Some(extension_dir) = current_vendored_extension_dir() {
         let ducklake_extension = extension_dir.join(DUCKLAKE_EXTENSION_FILE);
-        let json_extension = extension_dir.join(JSON_EXTENSION_FILE);
-        let parquet_extension = extension_dir.join(PARQUET_EXTENSION_FILE);
+        let postgres_scanner_extension = extension_dir.join(POSTGRES_SCANNER_EXTENSION_FILE);
 
         return format!(
-            "LOAD {}; LOAD {}; LOAD {};",
+            "LOAD {}; LOAD {}; LOAD json; LOAD parquet;",
             quote_literal(&ducklake_extension.display().to_string()),
-            quote_literal(&json_extension.display().to_string()),
-            quote_literal(&parquet_extension.display().to_string()),
+            quote_literal(&postgres_scanner_extension.display().to_string()),
         );
     }
 
-    "INSTALL ducklake; LOAD ducklake; INSTALL json; LOAD json; INSTALL parquet; LOAD parquet;"
+    "INSTALL ducklake; LOAD ducklake; INSTALL json; LOAD json; INSTALL parquet; LOAD parquet; \
+     INSTALL postgres_scanner; LOAD postgres_scanner;"
         .to_string()
 }
 

--- a/etl-examples/src/bin/ducklake.rs
+++ b/etl-examples/src/bin/ducklake.rs
@@ -94,9 +94,7 @@ struct DbArgs {
 
 #[derive(Debug, Args)]
 struct DuckLakeArgs {
-    /// DuckLake catalog URL (e.g., postgres://user:pass@host/db or file:///tmp/catalog.ducklake)
-    ///
-    /// Plain local paths are accepted and converted to absolute `file://` URLs.
+    /// DuckLake catalog URL (e.g., postgres://user:pass@host/db)
     #[arg(long, value_parser = parse_ducklake_url)]
     catalog_url: Url,
     /// Local directory or S3 / S3-compatible URI for Parquet files (e.g., file:///tmp/lake_data or s3://bucket/)


### PR DESCRIPTION
The main goal of this refactor is to avoid taking one blocking slot on a duckdb connection. Having something async compliant will be better if we have high contention on duckdb blocking connections