### PR TITLE
ref(tests): Improve tests and clean up unused utils

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,6 @@
 - Prefer one-way integration tests: perform the source-side writes first, wait for the expected notifications, then call `shutdown_and_wait()` immediately before assertions.
 - Avoid asserting destination state while the pipeline is still running unless the test is specifically about in-flight behavior or recovery during active replication.
 - For `TestDestinationWrapper`, prefer asserting against the cumulative event history from `get_events()`. Use `clear_events()` only when restarting the pipeline or when a test intentionally needs to discard earlier history and assert on a new phase in isolation.
-- Use `get_events_deduped()` only for replay/idempotence scenarios where duplicate wrapper observations are expected and the test is asserting logical equivalence rather than delivery history.
 - When asserting CDC event shapes, only expect combinations that PostgreSQL can actually emit for the table's replica identity mode. In particular, distinguish between `FULL`, primary-key identity, and `USING INDEX`, and remember that partial update rows only occur for update new-tuples.
 
 ## Review Checklist

--- a/etl/src/test_utils/event.rs
+++ b/etl/src/test_utils/event.rs
@@ -51,51 +51,6 @@ pub fn group_events_by_type_and_table_id(
     grouped
 }
 
-pub fn check_events_count(events: &[Event], conditions: Vec<(EventType, u64)>) -> bool {
-    let grouped_events = group_events_by_type(events);
-
-    conditions.into_iter().all(|(event_type, count)| {
-        grouped_events.get(&event_type).is_some_and(|inner| inner.len() == count as usize)
-    })
-}
-
-/// Compares two events for equality in test contexts.
-///
-/// This function compares events based on their key fields, ignoring LSN values
-/// since those may vary between pipeline runs.
-fn events_equal(a: &Event, b: &Event) -> bool {
-    match (a, b) {
-        (Event::Begin(a), Event::Begin(b)) => a == b,
-        (Event::Commit(a), Event::Commit(b)) => a == b,
-        (Event::Truncate(a), Event::Truncate(b)) => {
-            if a.options != b.options || a.truncated_tables.len() != b.truncated_tables.len() {
-                return false;
-            }
-
-            // Compare table IDs of truncated tables
-            let a_ids: Vec<_> = a.truncated_tables.iter().map(ReplicatedTableSchema::id).collect();
-            let b_ids: Vec<_> = b.truncated_tables.iter().map(ReplicatedTableSchema::id).collect();
-
-            a_ids == b_ids
-        }
-        (Event::Insert(a), Event::Insert(b)) => {
-            a.replicated_table_schema.id() == b.replicated_table_schema.id()
-                && a.table_row == b.table_row
-        }
-        (Event::Update(a), Event::Update(b)) => {
-            a.replicated_table_schema.id() == b.replicated_table_schema.id()
-                && a.updated_table_row == b.updated_table_row
-                && a.old_table_row == b.old_table_row
-        }
-        (Event::Delete(a), Event::Delete(b)) => {
-            a.replicated_table_schema.id() == b.replicated_table_schema.id()
-                && a.old_table_row == b.old_table_row
-        }
-        (Event::Unsupported, Event::Unsupported) => true,
-        _ => false,
-    }
-}
-
 /// Checks if the combined count of events and table rows meets the expected
 /// counts.
 ///
@@ -140,29 +95,4 @@ pub fn check_all_events_count(
             event_count + table_row_count >= *expected_count
         }
     })
-}
-
-/// Returns a new Vec of events with duplicates removed.
-///
-/// Row-level events (Insert, Update, Delete) are de-duplicated by comparing key
-/// fields, ignoring LSN values that may vary between pipeline runs. Non-row
-/// events (Begin, Commit, Relation, Truncate, Unsupported) are also
-/// de-duplicated using the same equality comparison.
-///
-/// The first occurrence of each event is kept and subsequent duplicates are
-/// dropped.
-///
-/// The rationale for having this method is that the pipeline doesn't guarantee
-/// exactly once delivery, thus in some tests we might have to exclude
-/// duplicates while performing assertions.
-pub fn deduplicate_events(events: &[Event]) -> Vec<Event> {
-    let mut result: Vec<Event> = Vec::with_capacity(events.len());
-
-    for event in events.iter().cloned() {
-        if !result.iter().any(|existing| events_equal(existing, &event)) {
-            result.push(event);
-        }
-    }
-
-    result
 }

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -93,13 +93,18 @@ impl Inner {
     }
 }
 
-/// A state store that notifies listeners about changes to table states.
+/// In-memory store that notifies tests about state and schema changes.
+///
+/// Notification helpers only observe changes that happen after registration.
+/// Register the returned [`TimedNotify`] before starting the producer that is
+/// expected to satisfy it.
 #[derive(Clone)]
 pub struct NotifyingStore {
     inner: Arc<RwLock<Inner>>,
 }
 
 impl NotifyingStore {
+    /// Creates an empty notifying store.
     pub fn new() -> Self {
         let inner = Inner {
             table_replication_states: Arc::new(BTreeMap::new()),
@@ -115,12 +120,13 @@ impl NotifyingStore {
         Self { inner: Arc::new(RwLock::new(inner)) }
     }
 
-    /// Returns all table replication states.
+    /// Returns the current table replication states.
     pub async fn get_table_replication_states(&self) -> TableReplicationStates {
         let inner = self.inner.read().await;
         Arc::clone(&inner.table_replication_states)
     }
 
+    /// Returns the latest schema snapshot stored for each table.
     pub async fn get_latest_table_schemas(&self) -> HashMap<TableId, TableSchema> {
         let inner = self.inner.read().await;
 
@@ -134,6 +140,7 @@ impl NotifyingStore {
             .collect()
     }
 
+    /// Returns all stored schema snapshots grouped by table.
     pub async fn get_table_schemas(&self) -> HashMap<TableId, Vec<(SnapshotId, TableSchema)>> {
         let inner = self.inner.read().await;
 
@@ -151,8 +158,8 @@ impl NotifyingStore {
             .collect()
     }
 
-    /// Registers a notification that fires when a table reaches a specific
-    /// state type after this method is called.
+    /// Registers a notification that fires when a future state update reaches
+    /// the expected table state type.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the expected state is not reached. This
@@ -169,8 +176,8 @@ impl NotifyingStore {
         TimedNotify::new(notify)
     }
 
-    /// Registers a notification that fires when a table state matches a custom
-    /// condition after this method is called.
+    /// Registers a notification that fires when a future state update matches a
+    /// custom condition.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the condition is not met. This prevents tests
@@ -186,8 +193,8 @@ impl NotifyingStore {
         TimedNotify::new(notify)
     }
 
-    /// Registers a notification that fires when a table has stored at least the
-    /// expected number of schema snapshots after this method is called.
+    /// Registers a notification that fires when a future schema write brings a
+    /// table to at least the expected number of stored snapshots.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the expected schema count is not reached. This
@@ -204,6 +211,8 @@ impl NotifyingStore {
         TimedNotify::new(notify)
     }
 
+    /// Resets one table to [`TableReplicationPhase::Init`] and clears its state
+    /// history.
     pub async fn reset_table_state(&self, table_id: TableId) -> EtlResult<()> {
         let mut inner = self.inner.write().await;
         inner.table_state_history.remove(&table_id);
@@ -262,7 +271,7 @@ impl StateStore for NotifyingStore {
 
         let states = Arc::make_mut(&mut inner.table_replication_states);
         for (table_id, state) in updates {
-            // Store the current state in history before updating
+            // Store the current state in history before updating.
             if let Some(current_state) = states.get(&table_id).cloned() {
                 inner
                     .table_state_history
@@ -286,7 +295,7 @@ impl StateStore for NotifyingStore {
     ) -> EtlResult<TableReplicationPhase> {
         let mut inner = self.inner.write().await;
 
-        // Get the previous state from history
+        // Get the previous state from history.
         let previous_state =
             inner.table_state_history.get_mut(&table_id).and_then(Vec::pop).ok_or_else(|| {
                 etl_error!(
@@ -295,7 +304,7 @@ impl StateStore for NotifyingStore {
                 )
             })?;
 
-        // Update the current state to the previous state
+        // Update the current state to the previous state.
         Arc::make_mut(&mut inner.table_replication_states).insert(table_id, previous_state.clone());
         inner.check_conditions();
 

--- a/etl/src/test_utils/test_destination_wrapper.rs
+++ b/etl/src/test_utils/test_destination_wrapper.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     error::EtlResult,
     test_utils::{
-        event::{EventCondition, check_all_events_count, check_events_count, deduplicate_events},
+        event::{EventCondition, check_all_events_count, group_events_by_type},
         notify::TimedNotify,
     },
     types::{Event, EventType, TableRow},
@@ -46,7 +46,7 @@ struct Inner<D> {
 
 impl<D> Inner<D> {
     fn check_conditions(&mut self) {
-        // Check event conditions
+        // Check event conditions.
         let events = self.events.clone();
         self.event_conditions.retain(|(condition, notify)| {
             let should_retain = !condition(&events);
@@ -56,7 +56,7 @@ impl<D> Inner<D> {
             should_retain
         });
 
-        // Check table row conditions
+        // Check table row conditions.
         let table_rows = self.table_rows.clone();
         self.table_row_conditions.retain(|(condition, notify)| {
             let should_retain = !condition(&table_rows);
@@ -66,7 +66,7 @@ impl<D> Inner<D> {
             should_retain
         });
 
-        // Check combined conditions
+        // Check combined conditions.
         let events = self.events.clone();
         let table_rows = self.table_rows.clone();
         self.combined_conditions.retain(|(condition, notify)| {
@@ -82,12 +82,13 @@ impl<D> Inner<D> {
 /// Test wrapper for [`Destination`] implementations that tracks all operations.
 ///
 /// [`TestDestinationWrapper`] wraps any destination implementation and records
-/// all method calls and data flowing through it. This enables test assertions
-/// on the behavior of ETL pipelines without requiring complex destination
-/// setup.
+/// all rows, events, truncations, and shutdown calls flowing through it. This
+/// enables test assertions on pipeline behavior without requiring complex
+/// destination setup.
 ///
-/// The wrapper supports waiting for specific conditions to be met, making it
-/// ideal for testing asynchronous ETL operations with deterministic assertions.
+/// Notification helpers only observe writes that happen after registration.
+/// Register the returned [`TimedNotify`] before starting the producer that is
+/// expected to satisfy it.
 #[derive(Clone)]
 pub struct TestDestinationWrapper<D> {
     inner: Arc<RwLock<Inner<D>>>,
@@ -109,8 +110,8 @@ impl<D: fmt::Debug> fmt::Debug for TestDestinationWrapper<D> {
 impl<D> TestDestinationWrapper<D> {
     /// Creates a new test wrapper around any destination implementation.
     ///
-    /// The wrapper will track all method calls and data operations performed
-    /// on the destination, enabling comprehensive testing and verification.
+    /// The wrapper forwards every operation to the wrapped destination and
+    /// keeps an in-memory history for assertions.
     pub fn wrap(destination: D) -> Self {
         let inner = Inner {
             wrapped_destination: destination,
@@ -127,25 +128,18 @@ impl<D> TestDestinationWrapper<D> {
         Self { inner: Arc::new(RwLock::new(inner)) }
     }
 
-    /// Get all table rows that have been written
+    /// Returns all table rows written through the wrapper.
     pub async fn get_table_rows(&self) -> HashMap<TableId, Vec<TableRow>> {
         self.inner.read().await.table_rows.clone()
     }
 
-    /// Get all events that have been written
+    /// Returns all events written through the wrapper.
     pub async fn get_events(&self) -> Vec<Event> {
         self.inner.read().await.events.clone()
     }
 
-    /// Get all events that have been written, de-duplicated by full event
-    /// equality.
-    pub async fn get_events_deduped(&self) -> Vec<Event> {
-        let events = self.inner.read().await.events.clone();
-        deduplicate_events(&events)
-    }
-
-    /// Registers a notification that fires when events match a specific
-    /// condition after this method is called.
+    /// Registers a notification that fires when future events match a
+    /// condition.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the condition is not met. This prevents tests
@@ -161,35 +155,25 @@ impl<D> TestDestinationWrapper<D> {
         TimedNotify::new(notify)
     }
 
-    /// Registers a notification that fires when a specific number of events of
-    /// given types are received.
+    /// Registers a notification that fires when future events exactly match the
+    /// requested per-type counts.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the expected event count is not reached. This
     /// prevents tests from hanging indefinitely.
     pub async fn wait_for_events_count(&self, conditions: Vec<(EventType, u64)>) -> TimedNotify {
-        self.notify_on_events(move |events| check_events_count(events, conditions.clone())).await
-    }
-
-    /// Registers a notification that fires when a specific number of events of
-    /// given types are received after de-duplicating.
-    ///
-    /// Returns a [`TimedNotify`] that will automatically timeout after the
-    /// specified timeout if the expected event count is not reached. This
-    /// prevents tests from hanging indefinitely.
-    pub async fn wait_for_events_count_deduped(
-        &self,
-        conditions: Vec<(EventType, u64)>,
-    ) -> TimedNotify {
         self.notify_on_events(move |events| {
-            let deduped = deduplicate_events(events);
-            check_events_count(&deduped, conditions.clone())
+            let grouped_events = group_events_by_type(events);
+
+            conditions.iter().all(|(event_type, count)| {
+                grouped_events.get(event_type).is_some_and(|inner| inner.len() == *count as usize)
+            })
         })
         .await
     }
 
-    /// Registers a notification that fires when event conditions are met after
-    /// this method is called.
+    /// Registers a notification that fires when future events and table rows
+    /// satisfy all requested conditions.
     ///
     /// Supports two condition types:
     /// - [`EventCondition::Any`]: counts events across all tables
@@ -213,20 +197,24 @@ impl<D> TestDestinationWrapper<D> {
         TimedNotify::new(notify)
     }
 
+    /// Clears the recorded table rows without touching the wrapped destination.
     pub async fn clear_table_rows(&self) {
         let mut inner = self.inner.write().await;
         inner.table_rows.clear();
     }
 
+    /// Clears the recorded events without touching the wrapped destination.
     pub async fn clear_events(&self) {
         let mut inner = self.inner.write().await;
         inner.events.clear();
     }
 
+    /// Returns whether the table was truncated through the wrapper.
     pub async fn was_table_truncated(&self, table_id: TableId) -> bool {
         self.inner.read().await.truncated_tables.contains(&table_id)
     }
 
+    /// Returns how many times [`Destination::write_table_rows`] was called.
     pub async fn write_table_rows_called(&self) -> u64 {
         self.inner.read().await.write_table_rows_called
     }

--- a/etl/tests/pipeline.rs
+++ b/etl/tests/pipeline.rs
@@ -609,8 +609,10 @@ async fn publication_changes_are_correctly_handled() {
 
     // Insert one row in each table and wait for two insert events.
     let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+
     database.insert_values(table_1.clone(), &["value"], &[&1]).await.unwrap();
     database.insert_values(table_2.clone(), &["value"], &[&1]).await.unwrap();
+
     inserts_notify.notified().await;
 
     // Drop table_2 so it's no longer part of the publication.
@@ -626,6 +628,17 @@ async fn publication_changes_are_correctly_handled() {
     // dropping of a table doesn't cause issues with the pipeline since the
     // change is picked up on pipeline restart.
     pipeline.shutdown_and_wait().await.unwrap();
+
+    // The destination should have the insert event for each original table
+    // before the restart.
+    let events = destination.get_events().await;
+    let grouped = group_events_by_type_and_table_id(&events);
+    let table_1_inserts = grouped.get(&(EventType::Insert, table_1_id)).cloned().unwrap();
+    assert_eq!(table_1_inserts.len(), 1);
+    let table_2_inserts = grouped.get(&(EventType::Insert, table_2_id)).cloned().unwrap();
+    assert_eq!(table_2_inserts.len(), 1);
+
+    destination.clear_events().await;
 
     // Create table_3 which is going to be added to the publication.
     let table_3 = test_table_name("table_3");
@@ -649,10 +662,8 @@ async fn publication_changes_are_correctly_handled() {
 
     table_3_ready_notify.notified().await;
 
-    // Insert one row in table_1 and wait for it. (We wait for 4 inserts since it
-    // keeps the previous ones).
-    let inserts_notify =
-        destination.wait_for_events_count_deduped(vec![(EventType::Insert, 4)]).await;
+    // Insert one row in table_1 and table_3 and wait for the new events.
+    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
 
     database.insert_values(table_1.clone(), &["value"], &[&2]).await.unwrap();
     database.insert_values(table_3.clone(), &["value"], &[&1]).await.unwrap();
@@ -673,16 +684,11 @@ async fn publication_changes_are_correctly_handled() {
     let slot_state = database.get_replication_slot_state(&table_2_slot_name).await.unwrap();
     assert_eq!(slot_state, None, "Table sync slot for removed table should be deleted");
 
-    // The destination should have the 2 events of the first table, the 1 event of
-    // the removed table and the 1 event of the new table.
-    // Use de-duplicated events for assertions to be robust to potential duplicates
-    // on restart where confirmed_flush_lsn may not have been stored.
-    let events = destination.get_events_deduped().await;
+    // The destination should have the new event for table_1 and table_3.
+    let events = destination.get_events().await;
     let grouped = group_events_by_type_and_table_id(&events);
     let table_1_inserts = grouped.get(&(EventType::Insert, table_1_id)).cloned().unwrap();
-    assert_eq!(table_1_inserts.len(), 2);
-    let table_2_inserts = grouped.get(&(EventType::Insert, table_2_id)).cloned().unwrap();
-    assert_eq!(table_2_inserts.len(), 1);
+    assert_eq!(table_1_inserts.len(), 1);
     let table_3_inserts = grouped.get(&(EventType::Insert, table_3_id)).cloned().unwrap();
     assert_eq!(table_3_inserts.len(), 1);
 }


### PR DESCRIPTION
## Summary

- Remove the deduped event test helpers now that raw event assertions are stable.
- Update `publication_changes_are_correctly_handled` to assert pre-restart events, clear recorded events, then assert only post-restart events.
- Inline event count waiting logic into `TestDestinationWrapper::wait_for_events_count`.
- Clarify `TestDestinationWrapper` and `NotifyingStore` docs, especially that notification helpers only observe future changes after registration.

## Verification

- `./scripts/fmt`
- `cargo nextest run -p etl --all-features publication_changes_are_correctly_handled`
- `cargo clippy -p etl --all-targets --all-features -- -D warnings`
