### PR TITLE
feat(core): Add background cleanup of outdated table schemas

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -92,10 +92,10 @@ Each write-like method receives an async result handle. The intent is different 
 Persists pipeline state so replication can resume after restarts. Three traits work together:
 
 - **StateStore**: Tracks replication phase per table and destination table metadata
-- **SchemaStore**: Stores versioned table schema information (columns, types, primary keys, snapshot IDs)
+- **SchemaStore**: Stores versioned table schema information (columns, types, primary keys, snapshot IDs) and prunes obsolete schema versions after acknowledged progress
 - **CleanupStore**: Removes stored state when a table is dropped from the publication
 
-`StateStore` and `SchemaStore` use a cache-first pattern: reads hit an in-memory cache, writes go to both the cache and persistent storage.
+`StateStore` and `SchemaStore` use a cache-first pattern: reads hit an in-memory cache, writes go to both the cache and persistent storage. Schema pruning follows the same rule for implementations with durable storage: obsolete versions are removed from both the cache and the persistent store.
 
 ## Delivery Guarantees
 

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -249,7 +249,7 @@ Multiple events in the same transaction share the same `commit_lsn` but have dif
 
 ## Why Persist State?
 
-ETL persists replication state (schemas, progress, mappings) for recovery.
+ETL persists replication state (schemas, progress, destination table metadata) for recovery.
 
 ### Without Persistence
 
@@ -267,7 +267,7 @@ ETL stores:
 |-------|---------|
 | Replication phase | Know whether to copy or stream for each table |
 | Table schemas | Validate incoming data against expected schema |
-| Table mappings | Route events to correct downstream tables |
+| Destination table metadata | Route events to correct downstream tables |
 
 On restart, ETL loads this state and resumes from where it left off.
 

--- a/docs/explanation/traits.md
+++ b/docs/explanation/traits.md
@@ -42,7 +42,8 @@ See [Event Types](events.md) for details on the events received by `write_events
 
 ## SchemaStore
 
-Stores table schema information (column names, types, primary keys).
+Stores versioned table schema information (column names, types, primary keys,
+and snapshot IDs).
 
 ```rust
 pub trait SchemaStore {
@@ -50,6 +51,7 @@ pub trait SchemaStore {
     fn get_table_schemas(&self) -> impl Future<Output = EtlResult<Vec<Arc<TableSchema>>>> + Send;
     fn load_table_schemas(&self) -> impl Future<Output = EtlResult<usize>> + Send;
     fn store_table_schema(&self, table_schema: TableSchema) -> impl Future<Output = EtlResult<Arc<TableSchema>>> + Send;
+    fn prune_table_schemas(&self, current_snapshot_ids: HashMap<TableId, SnapshotId>) -> impl Future<Output = EtlResult<u64>> + Send;
 }
 ```
 
@@ -61,6 +63,7 @@ pub trait SchemaStore {
 | `get_table_schemas()` | Returns all cached schemas |
 | `load_table_schemas()` | Loads schemas from persistent storage into cache. Call once at startup. Returns the number of schemas loaded |
 | `store_table_schema()` | Saves a schema version to both cache and persistent storage and returns the cached `Arc` |
+| `prune_table_schemas()` | Removes schema versions older than the current snapshot for each table. Implementations with both cache and persistent storage must prune both |
 
 ## StateStore
 
@@ -101,10 +104,10 @@ Destination table metadata connects source table IDs to destination state, inclu
 
 | Method | Purpose |
 |--------|---------|
-| `get_destination_table_metadata()` | Returns destination metadata for a source table from cache |
-| `get_applied_destination_table_metadata()` | Returns destination metadata only when the destination schema is fully applied |
-| `load_destination_tables_metadata()` | Loads destination metadata from persistent storage into cache |
-| `store_destination_table_metadata()` | Saves destination metadata to both cache and persistent storage |
+| `get_destination_table_metadata()` | Returns destination table metadata for a source table from cache |
+| `get_applied_destination_table_metadata()` | Returns destination table metadata only when the destination schema is fully applied |
+| `load_destination_tables_metadata()` | Loads destination table metadata from persistent storage into cache |
+| `store_destination_table_metadata()` | Saves destination table metadata to both cache and persistent storage |
 
 ### Table Replication Phases
 
@@ -133,7 +136,7 @@ pub trait CleanupStore {
 
 | Method | Purpose |
 |--------|---------|
-| `cleanup_table_state()` | Deletes all stored state for a table: replication state, schema versions, and destination metadata. Does not modify destination tables |
+| `cleanup_table_state()` | Deletes all stored state for a table: replication state, schema versions, and destination table metadata. Does not modify destination tables |
 
 ## Combining Traits
 

--- a/docs/explanation/traits.md
+++ b/docs/explanation/traits.md
@@ -51,7 +51,7 @@ pub trait SchemaStore {
     fn get_table_schemas(&self) -> impl Future<Output = EtlResult<Vec<Arc<TableSchema>>>> + Send;
     fn load_table_schemas(&self) -> impl Future<Output = EtlResult<usize>> + Send;
     fn store_table_schema(&self, table_schema: TableSchema) -> impl Future<Output = EtlResult<Arc<TableSchema>>> + Send;
-    fn prune_table_schemas(&self, current_snapshot_ids: HashMap<TableId, SnapshotId>) -> impl Future<Output = EtlResult<u64>> + Send;
+    fn prune_table_schemas(&self, table_ids: HashSet<TableId>, confirmed_flush_lsn: PgLsn) -> impl Future<Output = EtlResult<u64>> + Send;
 }
 ```
 
@@ -63,7 +63,7 @@ pub trait SchemaStore {
 | `get_table_schemas()` | Returns all cached schemas |
 | `load_table_schemas()` | Loads schemas from persistent storage into cache. Call once at startup. Returns the number of schemas loaded |
 | `store_table_schema()` | Saves a schema version to both cache and persistent storage and returns the cached `Arc` |
-| `prune_table_schemas()` | Removes schema versions older than the current snapshot for each table. Implementations with both cache and persistent storage must prune both |
+| `prune_table_schemas()` | For the supplied table IDs, preserves the newest schema version at or before the confirmed flush LSN and removes older versions. Implementations with both cache and persistent storage must prune both |
 
 ## StateStore
 

--- a/docs/explanation/traits.md
+++ b/docs/explanation/traits.md
@@ -51,7 +51,7 @@ pub trait SchemaStore {
     fn get_table_schemas(&self) -> impl Future<Output = EtlResult<Vec<Arc<TableSchema>>>> + Send;
     fn load_table_schemas(&self) -> impl Future<Output = EtlResult<usize>> + Send;
     fn store_table_schema(&self, table_schema: TableSchema) -> impl Future<Output = EtlResult<Arc<TableSchema>>> + Send;
-    fn prune_table_schemas(&self, table_ids: HashSet<TableId>, confirmed_flush_lsn: PgLsn) -> impl Future<Output = EtlResult<u64>> + Send;
+    fn prune_table_schemas(&self, table_schema_retentions: HashMap<TableId, TableSchemaRetention>) -> impl Future<Output = EtlResult<u64>> + Send;
 }
 ```
 
@@ -63,7 +63,7 @@ pub trait SchemaStore {
 | `get_table_schemas()` | Returns all cached schemas |
 | `load_table_schemas()` | Loads schemas from persistent storage into cache. Call once at startup. Returns the number of schemas loaded |
 | `store_table_schema()` | Saves a schema version to both cache and persistent storage and returns the cached `Arc` |
-| `prune_table_schemas()` | For the supplied table IDs, preserves the newest schema version at or before the confirmed flush LSN and removes older versions. Implementations with both cache and persistent storage must prune both |
+| `prune_table_schemas()` | For the supplied per-table retention boundaries, preserves the newest schema version at or before each retention LSN and removes older versions. Implementations with both cache and persistent storage must prune both |
 
 ## StateStore
 

--- a/docs/guides/custom-implementations.md
+++ b/docs/guides/custom-implementations.md
@@ -49,9 +49,9 @@ tracing-subscriber = "0.3"
 
 Create `src/custom_store.rs`. A store must implement three traits (see [Extension Points](../explanation/traits.md) for full details):
 
-- `SchemaStore` - Table schema storage and retrieval
-- `StateStore` - Replication progress and destination metadata tracking
-- `CleanupStore` - Metadata cleanup when tables leave the publication
+- `SchemaStore` - Versioned table schema storage, retrieval, and pruning
+- `StateStore` - Replication progress and destination table metadata tracking
+- `CleanupStore` - Store cleanup when tables leave the publication
 
 ```rust
 use std::collections::{BTreeMap, HashMap};
@@ -127,6 +127,25 @@ impl SchemaStore for CustomStore {
             .schemas
             .insert(snapshot_id, Arc::clone(&schema));
         Ok(schema)
+    }
+
+    async fn prune_table_schemas(
+        &self,
+        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+    ) -> EtlResult<u64> {
+        let mut tables = self.tables.lock().await;
+        let mut removed_count = 0u64;
+
+        for (table_id, entry) in tables.iter_mut() {
+            if let Some(current_snapshot_id) = current_snapshot_ids.get(table_id) {
+                let before_count = entry.schemas.len();
+                entry.schemas.retain(|snapshot_id, _| snapshot_id >= current_snapshot_id);
+                removed_count = removed_count
+                    .saturating_add(before_count.saturating_sub(entry.schemas.len()) as u64);
+            }
+        }
+
+        Ok(removed_count)
     }
 }
 

--- a/docs/guides/custom-implementations.md
+++ b/docs/guides/custom-implementations.md
@@ -54,7 +54,7 @@ Create `src/custom_store.rs`. A store must implement three traits (see [Extensio
 - `CleanupStore` - Store cleanup when tables leave the publication
 
 ```rust
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -64,7 +64,7 @@ use etl::state::{
     AppliedDestinationTableMetadata, DestinationTableMetadata, TableReplicationPhase,
 };
 use etl::store::{CleanupStore, SchemaStore, StateStore, TableReplicationStates};
-use etl::types::{SnapshotId, TableId, TableSchema};
+use etl::types::{PgLsn, SnapshotId, TableId, TableSchema};
 
 #[derive(Debug, Clone, Default)]
 struct TableEntry {
@@ -131,18 +131,32 @@ impl SchemaStore for CustomStore {
 
     async fn prune_table_schemas(
         &self,
-        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+        table_ids: HashSet<TableId>,
+        confirmed_flush_lsn: PgLsn,
     ) -> EtlResult<u64> {
         let mut tables = self.tables.lock().await;
+        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
         let mut removed_count = 0u64;
 
         for (table_id, entry) in tables.iter_mut() {
-            if let Some(current_snapshot_id) = current_snapshot_ids.get(table_id) {
-                let before_count = entry.schemas.len();
-                entry.schemas.retain(|snapshot_id, _| snapshot_id >= current_snapshot_id);
-                removed_count = removed_count
-                    .saturating_add(before_count.saturating_sub(entry.schemas.len()) as u64);
+            if !table_ids.contains(table_id) {
+                continue;
             }
+
+            let retained_snapshot_id = entry
+                .schemas
+                .keys()
+                .filter(|snapshot_id| **snapshot_id <= confirmed_flush_snapshot_id)
+                .max()
+                .copied();
+            let Some(retained_snapshot_id) = retained_snapshot_id else {
+                continue;
+            };
+
+            let before_count = entry.schemas.len();
+            entry.schemas.retain(|snapshot_id, _| *snapshot_id >= retained_snapshot_id);
+            removed_count =
+                removed_count.saturating_add(before_count.saturating_sub(entry.schemas.len()) as u64);
         }
 
         Ok(removed_count)

--- a/docs/guides/custom-implementations.md
+++ b/docs/guides/custom-implementations.md
@@ -54,7 +54,7 @@ Create `src/custom_store.rs`. A store must implement three traits (see [Extensio
 - `CleanupStore` - Store cleanup when tables leave the publication
 
 ```rust
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -64,7 +64,8 @@ use etl::state::{
     AppliedDestinationTableMetadata, DestinationTableMetadata, TableReplicationPhase,
 };
 use etl::store::{CleanupStore, SchemaStore, StateStore, TableReplicationStates};
-use etl::types::{PgLsn, SnapshotId, TableId, TableSchema};
+use etl::store::schema::TableSchemaRetention;
+use etl::types::{SnapshotId, TableId, TableSchema};
 
 #[derive(Debug, Clone, Default)]
 struct TableEntry {
@@ -131,22 +132,21 @@ impl SchemaStore for CustomStore {
 
     async fn prune_table_schemas(
         &self,
-        table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: PgLsn,
+        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> EtlResult<u64> {
         let mut tables = self.tables.lock().await;
-        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
         let mut removed_count = 0u64;
 
         for (table_id, entry) in tables.iter_mut() {
-            if !table_ids.contains(table_id) {
+            let Some(retention) = table_schema_retentions.get(table_id) else {
                 continue;
-            }
+            };
+            let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
 
             let retained_snapshot_id = entry
                 .schemas
                 .keys()
-                .filter(|snapshot_id| **snapshot_id <= confirmed_flush_snapshot_id)
+                .filter(|snapshot_id| **snapshot_id <= retention_snapshot_id)
                 .max()
                 .copied();
             let Some(retained_snapshot_id) = retained_snapshot_id else {

--- a/etl-api/src/db/pipelines.rs
+++ b/etl-api/src/db/pipelines.rs
@@ -243,8 +243,8 @@ pub async fn delete_pipeline_source_state(
     source_connection: &mut PgConnection,
     pipeline_id: i64,
 ) -> Result<(), PipelinesDbError> {
-    // Delete state, schema, and destination metadata from the source database, only
-    // if ETL tables exist.
+    // Delete state, schema, and destination table metadata from the source
+    // database, only if ETL tables exist.
     if health::etl_tables_present(&mut *source_connection).await? {
         state::delete_replication_state_for_all_tables(&mut *source_connection, pipeline_id)
             .await?;

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -1117,7 +1117,7 @@ async fn rollback_tables_with_full_reset_succeeds() {
     .await
     .unwrap();
 
-    // Insert destination metadata for this table
+    // Insert destination table metadata for this table.
     sqlx::query(
         "insert into etl.destination_tables_metadata (pipeline_id, table_id, \
          destination_table_id, snapshot_id, schema_status, replication_mask) values ($1, $2, \
@@ -1184,7 +1184,7 @@ async fn rollback_tables_with_full_reset_succeeds() {
     .unwrap();
     assert_eq!(schema_count_after, 1);
 
-    // Verify destination metadata was not deleted.
+    // Verify destination table metadata was not deleted.
     let metadata_count_after: i64 = sqlx::query_scalar(
         "select count(*) from etl.destination_tables_metadata where pipeline_id = $1 and table_id \
          = $2",
@@ -1220,7 +1220,7 @@ async fn rollback_to_init_keeps_schemas_and_metadata() {
     )
     .await;
 
-    // Insert table schema and mapping
+    // Insert table schema and destination table metadata.
     let table_schema_id: i64 = sqlx::query_scalar(
         "insert into etl.table_schemas (pipeline_id, table_id, schema_name, table_name) values \
          ($1, $2, 'test', 'test_users') returning id",
@@ -1279,7 +1279,7 @@ async fn rollback_to_init_keeps_schemas_and_metadata() {
     .unwrap();
     assert_eq!(schema_count, 1);
 
-    // Verify destination metadata was not deleted.
+    // Verify destination table metadata was not deleted.
     let metadata_count: i64 = sqlx::query_scalar(
         "select count(*) from etl.destination_tables_metadata where pipeline_id = $1 and table_id \
          = $2",
@@ -1316,7 +1316,7 @@ async fn rollback_to_non_starting_state_keeps_schemas_and_metadata() {
     )
     .await;
 
-    // Insert table schema and mapping
+    // Insert table schema and destination table metadata.
     let table_schema_id: i64 = sqlx::query_scalar(
         "insert into etl.table_schemas (pipeline_id, table_id, schema_name, table_name) values \
          ($1, $2, 'test', 'test_users') returning id",
@@ -1375,7 +1375,7 @@ async fn rollback_to_non_starting_state_keeps_schemas_and_metadata() {
     .unwrap();
     assert_eq!(schema_count, 1);
 
-    // Verify destination metadata was NOT deleted
+    // Verify destination table metadata was NOT deleted.
     let metadata_count: i64 = sqlx::query_scalar(
         "select count(*) from etl.destination_tables_metadata where pipeline_id = $1 and table_id \
          = $2",

--- a/etl-destinations/src/bigquery/core.rs
+++ b/etl-destinations/src/bigquery/core.rs
@@ -172,7 +172,7 @@ struct Inner {
 ///
 /// Designed for high concurrency with minimal locking:
 /// - Configuration and client are accessible without locks
-/// - Only caches and state mappings require synchronization
+/// - Only caches and destination table metadata require synchronization
 /// - Multiple write operations can execute concurrently
 #[derive(Debug, Clone)]
 pub struct BigQueryDestination<S> {
@@ -465,7 +465,8 @@ where
         inner.created_tables.insert(table_id.clone());
     }
 
-    /// Retrieves the current sequenced table ID from the destination metadata.
+    /// Retrieves the current sequenced table ID from the destination table
+    /// metadata.
     async fn get_sequenced_bigquery_table_id(
         &self,
         table_id: &TableId,
@@ -508,7 +509,7 @@ where
             .create_or_replace_view(&self.dataset_id, view_name, &target_table_id.to_string())
             .await?;
 
-        // We insert/overwrite the new (view -> sequenced bigquery table id) mapping
+        // We insert/overwrite the cached view target.
         inner.created_views.insert(view_name.clone(), target_table_id.clone());
 
         debug!(
@@ -606,7 +607,7 @@ where
         let table_id = new_replicated_table_schema.id();
         let new_snapshot_id = new_replicated_table_schema.inner().snapshot_id;
 
-        // Get current applied destination metadata. If the table is still in
+        // Get current applied destination table metadata. If the table is still in
         // `Applying`, the state store surfaces that as an error.
         let Some(metadata) =
             self.state_store.get_applied_destination_table_metadata(table_id).await?
@@ -987,9 +988,9 @@ where
 
             // We need to determine the current sequenced table ID for this table.
             //
-            // If no mapping exists, it means the table was never created in BigQuery (e.g.,
-            // due to validation errors during copy). In this case, we skip the
-            // truncate since there's nothing to truncate.
+            // If no destination table metadata exists, it means the table was never created
+            // in BigQuery (e.g., due to validation errors during copy). In this
+            // case, we skip the truncate since there's nothing to truncate.
             let Some(sequenced_bigquery_table_id) =
                 self.get_sequenced_bigquery_table_id(&table_id).await?
             else {
@@ -1049,13 +1050,14 @@ where
             // - Table created, but view update failed -> in this case the system will still
             //   point to table 'n', so the restart will reprocess events on table 'n', the
             //   table 'n + 1' will be recreated and the view will be updated to point to
-            //   the new table. No mappings are changed.
-            // - Table created, view updated, but mapping update failed -> in this case the
-            //   system will still point to table 'n' but the customer will see the empty
-            //   state of table 'n + 1' until the system heals. Healing happens when the
-            //   system is restarted, the mapping points to 'n' meaning that events will be
-            //   reprocessed and applied on table 'n' and then once the truncate is
-            //   successfully processed, the system should be consistent.
+            //   the new table. No destination table metadata is changed.
+            // - Table created, view updated, but destination table metadata update failed
+            //   -> in this case the system will still point to table 'n' but the customer
+            //   will see the empty state of table 'n + 1' until the system heals. Healing
+            //   happens when the system is restarted, the destination table metadata points
+            //   to 'n' meaning that events will be reprocessed and applied on table 'n' and
+            //   then once the truncate is successfully processed, the system should be
+            //   consistent.
 
             info!(
                 table_id = table_id.0,

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -409,6 +409,54 @@ where
     Ok(result.rows_affected())
 }
 
+/// Deletes obsolete table schema versions for a pipeline.
+///
+/// For each current table snapshot, deletes schema versions for that table
+/// with an older `snapshot_id`. Schema versions at or after the current
+/// snapshot are left untouched. Column rows are removed by the
+/// `table_columns.table_schema_id` `ON DELETE CASCADE` constraint, and the
+/// single `DELETE` statement is atomic in PostgreSQL.
+pub async fn delete_obsolete_table_schema_versions<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+    current_snapshot_ids: &HashMap<TableId, SnapshotId>,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    if current_snapshot_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut table_ids = Vec::with_capacity(current_snapshot_ids.len());
+    let mut snapshot_ids = Vec::with_capacity(current_snapshot_ids.len());
+    for (table_id, snapshot_id) in current_snapshot_ids {
+        table_ids.push(SqlxTableId(table_id.into_inner()));
+        snapshot_ids.push(snapshot_id.to_pg_lsn_string());
+    }
+
+    let result = sqlx::query(
+        r#"
+        with current_snapshots as (
+            select *
+            from unnest($2::oid[], $3::pg_lsn[]) as cs(table_id, current_snapshot_id)
+        )
+        delete from etl.table_schemas ts
+        using current_snapshots cs
+        where ts.pipeline_id = $1
+          and ts.table_id = cs.table_id
+          and ts.snapshot_id < cs.current_snapshot_id
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(table_ids)
+    .bind(snapshot_ids)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
 /// Builds a [`ColumnSchema`] from a database row.
 ///
 /// Assumes all required fields are present in the row after appropriate joins.

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sqlx::{
     PgExecutor, PgPool, Row,
@@ -411,46 +411,47 @@ where
 
 /// Deletes obsolete table schema versions for a pipeline.
 ///
-/// For each current table snapshot, deletes schema versions for that table
-/// with an older `snapshot_id`. Schema versions at or after the current
-/// snapshot are left untouched. Column rows are removed by the
-/// `table_columns.table_schema_id` `ON DELETE CASCADE` constraint, and the
+/// For each table, finds the newest schema version at or before
+/// `confirmed_flush_lsn` and deletes older schema versions. Versions at or
+/// after that retained snapshot are left untouched. Column rows are removed by
+/// the `table_columns.table_schema_id` `ON DELETE CASCADE` constraint, and the
 /// single `DELETE` statement is atomic in PostgreSQL.
 pub async fn delete_obsolete_table_schema_versions<'c, E>(
     executor: E,
     pipeline_id: i64,
-    current_snapshot_ids: &HashMap<TableId, SnapshotId>,
+    table_ids: &HashSet<TableId>,
+    confirmed_flush_lsn: SnapshotId,
 ) -> Result<u64, sqlx::Error>
 where
     E: PgExecutor<'c>,
 {
-    if current_snapshot_ids.is_empty() {
+    if table_ids.is_empty() {
         return Ok(0);
     }
 
-    let mut table_ids = Vec::with_capacity(current_snapshot_ids.len());
-    let mut snapshot_ids = Vec::with_capacity(current_snapshot_ids.len());
-    for (table_id, snapshot_id) in current_snapshot_ids {
-        table_ids.push(SqlxTableId(table_id.into_inner()));
-        snapshot_ids.push(snapshot_id.to_pg_lsn_string());
-    }
+    let table_ids =
+        table_ids.iter().map(|table_id| SqlxTableId(table_id.into_inner())).collect::<Vec<_>>();
 
     let result = sqlx::query(
         r#"
-        with current_snapshots as (
-            select *
-            from unnest($2::oid[], $3::pg_lsn[]) as cs(table_id, current_snapshot_id)
+        with retained_snapshots as (
+            select ts.table_id, max(ts.snapshot_id) as retained_snapshot_id
+            from etl.table_schemas ts
+            where ts.pipeline_id = $1
+              and ts.table_id = any($2::oid[])
+              and ts.snapshot_id <= $3::pg_lsn
+            group by ts.table_id
         )
         delete from etl.table_schemas ts
-        using current_snapshots cs
+        using retained_snapshots rs
         where ts.pipeline_id = $1
-          and ts.table_id = cs.table_id
-          and ts.snapshot_id < cs.current_snapshot_id
+          and ts.table_id = rs.table_id
+          and ts.snapshot_id < rs.retained_snapshot_id
         "#,
     )
     .bind(pipeline_id)
     .bind(table_ids)
-    .bind(snapshot_ids)
+    .bind(confirmed_flush_lsn.to_pg_lsn_string())
     .execute(executor)
     .await?;
 

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -4,7 +4,7 @@ use sqlx::{
     PgExecutor, PgPool, Row,
     postgres::{PgRow, types::Oid as SqlxTableId},
 };
-use tokio_postgres::types::Type as PgType;
+use tokio_postgres::types::{PgLsn, Type as PgType};
 
 use crate::types::{ColumnSchema, SnapshotId, TableId, TableName, TableSchema};
 
@@ -420,7 +420,7 @@ pub async fn delete_obsolete_table_schema_versions<'c, E>(
     executor: E,
     pipeline_id: i64,
     table_ids: &HashSet<TableId>,
-    confirmed_flush_lsn: SnapshotId,
+    confirmed_flush_lsn: PgLsn,
 ) -> Result<u64, sqlx::Error>
 where
     E: PgExecutor<'c>,
@@ -451,7 +451,7 @@ where
     )
     .bind(pipeline_id)
     .bind(table_ids)
-    .bind(confirmed_flush_lsn.to_pg_lsn_string())
+    .bind(confirmed_flush_lsn.to_string())
     .execute(executor)
     .await?;
 

--- a/etl-postgres/src/replication/schema.rs
+++ b/etl-postgres/src/replication/schema.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use sqlx::{
     PgExecutor, PgPool, Row,
@@ -411,35 +411,44 @@ where
 
 /// Deletes obsolete table schema versions for a pipeline.
 ///
-/// For each table, finds the newest schema version at or before
-/// `confirmed_flush_lsn` and deletes older schema versions. Versions at or
+/// For each table, finds the newest schema version at or before that table's
+/// retention LSN and deletes older schema versions. Versions at or
 /// after that retained snapshot are left untouched. Column rows are removed by
 /// the `table_columns.table_schema_id` `ON DELETE CASCADE` constraint, and the
 /// single `DELETE` statement is atomic in PostgreSQL.
 pub async fn delete_obsolete_table_schema_versions<'c, E>(
     executor: E,
     pipeline_id: i64,
-    table_ids: &HashSet<TableId>,
-    confirmed_flush_lsn: PgLsn,
+    retention_lsns: &HashMap<TableId, PgLsn>,
 ) -> Result<u64, sqlx::Error>
 where
     E: PgExecutor<'c>,
 {
-    if table_ids.is_empty() {
+    if retention_lsns.is_empty() {
         return Ok(0);
     }
 
-    let table_ids =
-        table_ids.iter().map(|table_id| SqlxTableId(table_id.into_inner())).collect::<Vec<_>>();
+    let mut table_ids = Vec::with_capacity(retention_lsns.len());
+    let mut retention_lsn_values = Vec::with_capacity(retention_lsns.len());
+    for (table_id, retention_lsn) in retention_lsns {
+        table_ids.push(SqlxTableId(table_id.into_inner()));
+        retention_lsn_values.push(retention_lsn.to_string());
+    }
 
     let result = sqlx::query(
         r#"
-        with retained_snapshots as (
+        with cleanup_retentions as (
+            select table_id, retention_lsn::pg_lsn as retention_lsn
+            from unnest($2::oid[], $3::text[])
+                as cleanup(table_id, retention_lsn)
+        ),
+        retained_snapshots as (
             select ts.table_id, max(ts.snapshot_id) as retained_snapshot_id
             from etl.table_schemas ts
+            join cleanup_retentions cleanup
+              on cleanup.table_id = ts.table_id
             where ts.pipeline_id = $1
-              and ts.table_id = any($2::oid[])
-              and ts.snapshot_id <= $3::pg_lsn
+              and ts.snapshot_id <= cleanup.retention_lsn
             group by ts.table_id
         )
         delete from etl.table_schemas ts
@@ -451,7 +460,7 @@ where
     )
     .bind(pipeline_id)
     .bind(table_ids)
-    .bind(confirmed_flush_lsn.to_string())
+    .bind(retention_lsn_values)
     .execute(executor)
     .await?;
 

--- a/etl-postgres/src/replication/state.rs
+++ b/etl-postgres/src/replication/state.rs
@@ -165,7 +165,7 @@ pub async fn rollback_replication_state(
 ///
 /// Removes all existing state entries for the table (including history) and
 /// creates a new Init entry, effectively restarting replication from scratch.
-/// Table mappings and schemas are preserved for use on restart.
+/// Destination table metadata and schemas are preserved for use on restart.
 pub async fn reset_replication_state(
     conn: &mut sqlx::PgConnection,
     pipeline_id: i64,

--- a/etl-replicator/src/error_reporting.rs
+++ b/etl-replicator/src/error_reporting.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use etl::{
     error::{EtlError, EtlResult},
@@ -170,6 +170,13 @@ where
 
     async fn store_table_schema(&self, table_schema: TableSchema) -> EtlResult<Arc<TableSchema>> {
         self.inner.store_table_schema(table_schema).await
+    }
+
+    async fn prune_table_schemas(
+        &self,
+        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+    ) -> EtlResult<u64> {
+        self.inner.prune_table_schemas(current_snapshot_ids).await
     }
 }
 

--- a/etl-replicator/src/error_reporting.rs
+++ b/etl-replicator/src/error_reporting.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 
 use etl::{
     error::{EtlError, EtlResult},
@@ -11,7 +11,7 @@ use etl::{
         schema::SchemaStore,
         state::{StateStore, TableReplicationStates},
     },
-    types::{SnapshotId, TableId, TableSchema},
+    types::{PgLsn, SnapshotId, TableId, TableSchema},
 };
 use tracing::info;
 
@@ -174,9 +174,10 @@ where
 
     async fn prune_table_schemas(
         &self,
-        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+        table_ids: HashSet<TableId>,
+        confirmed_flush_lsn: PgLsn,
     ) -> EtlResult<u64> {
-        self.inner.prune_table_schemas(current_snapshot_ids).await
+        self.inner.prune_table_schemas(table_ids, confirmed_flush_lsn).await
     }
 }
 

--- a/etl-replicator/src/error_reporting.rs
+++ b/etl-replicator/src/error_reporting.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use etl::{
     error::{EtlError, EtlResult},
@@ -8,10 +8,10 @@ use etl::{
     },
     store::{
         cleanup::CleanupStore,
-        schema::SchemaStore,
+        schema::{SchemaStore, TableSchemaRetention},
         state::{StateStore, TableReplicationStates},
     },
-    types::{PgLsn, SnapshotId, TableId, TableSchema},
+    types::{SnapshotId, TableId, TableSchema},
 };
 use tracing::info;
 
@@ -174,10 +174,9 @@ where
 
     async fn prune_table_schemas(
         &self,
-        table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: PgLsn,
+        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> EtlResult<u64> {
-        self.inner.prune_table_schemas(table_ids, confirmed_flush_lsn).await
+        self.inner.prune_table_schemas(table_schema_retentions).await
     }
 }
 

--- a/etl/README.md
+++ b/etl/README.md
@@ -21,8 +21,8 @@ The ETL core implements a pipeline architecture that replicates data from Postgr
 - **Table Sync Worker**: Handles initial copying of existing table data and processes CDC events until it has caught up
   to the apply worker
 - **State Store**: Stores the state of the pipeline
-- **Schema Store**: Stores the table schemas of the tables involved in the replication
-- **Cleanup Store**: Provides atomic cleanup primitives that delete stored state, schema, and mappings for tables removed from a publication (does not touch destination data)
+- **Schema Store**: Stores versioned table schemas and prunes obsolete schema versions after acknowledged progress
+- **Cleanup Store**: Provides atomic cleanup primitives that delete stored state, schema, and destination table metadata for tables removed from a publication (does not touch destination data)
 
 ### Information Flow
 

--- a/etl/src/conversions/event.rs
+++ b/etl/src/conversions/event.rs
@@ -319,7 +319,7 @@ pub(crate) fn parse_replicated_column_names(
 /// Returns the set of relation-message key column names.
 ///
 /// PostgreSQL exposes replica-identity mode on the relation itself and
-/// key-column membership on each [`RelationBody`] column. For
+/// key-column membership on each [`protocol::RelationBody`] column. For
 /// `REPLICA IDENTITY FULL`, every replicated column belongs to the old-row
 /// identity. Otherwise the low bit of the column flags marks identity
 /// membership. The column order is the same `attnum` order described in

--- a/etl/src/error.rs
+++ b/etl/src/error.rs
@@ -416,7 +416,7 @@ where
 /// Creates an [`EtlError`] from a vector of errors for aggregation.
 ///
 /// If the vector contains exactly one error, returns that error directly
-/// without wrapping it in the [`ErrorRepr::Many`] variant.
+/// without wrapping it in the `ErrorRepr::Many` variant.
 impl<E> From<Vec<E>> for EtlError
 where
     E: Into<EtlError>,

--- a/etl/src/failpoints.rs
+++ b/etl/src/failpoints.rs
@@ -16,8 +16,6 @@ pub const START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP: &str =
 pub const START_TABLE_SYNC_DURING_DATA_SYNC_FP: &str = "start_table_sync.during_data_sync_fp";
 pub const SEND_STATUS_UPDATE_FP: &str = "send_status_update_fp";
 pub const FORCE_SCHEMA_CLEANUP_FP: &str = "force_schema_cleanup_fp";
-pub const FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP: &str =
-    "force_schema_cleanup_confirmed_flush_lsn_fp";
 
 /// Executes a configurable failpoint for testing error scenarios.
 ///

--- a/etl/src/failpoints.rs
+++ b/etl/src/failpoints.rs
@@ -16,6 +16,8 @@ pub const START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP: &str =
 pub const START_TABLE_SYNC_DURING_DATA_SYNC_FP: &str = "start_table_sync.during_data_sync_fp";
 pub const SEND_STATUS_UPDATE_FP: &str = "send_status_update_fp";
 pub const FORCE_SCHEMA_CLEANUP_FP: &str = "force_schema_cleanup_fp";
+pub const FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP: &str =
+    "force_schema_cleanup_confirmed_flush_lsn_fp";
 
 /// Executes a configurable failpoint for testing error scenarios.
 ///

--- a/etl/src/failpoints.rs
+++ b/etl/src/failpoints.rs
@@ -15,12 +15,13 @@ pub const START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP: &str =
     "start_table_sync.before_data_sync_slot_creation_fp";
 pub const START_TABLE_SYNC_DURING_DATA_SYNC_FP: &str = "start_table_sync.during_data_sync_fp";
 pub const SEND_STATUS_UPDATE_FP: &str = "send_status_update_fp";
+pub const FORCE_SCHEMA_CLEANUP_FP: &str = "force_schema_cleanup_fp";
 
 /// Executes a configurable failpoint for testing error scenarios.
 ///
 /// When the failpoint is active, and it's set to return an error, this function
-/// generates an [`EtlError`] with the specified retry policy. The retry
-/// behavior can be controlled through the failpoint parameter:
+/// generates an [`crate::error::EtlError`] with the specified retry policy. The
+/// retry behavior can be controlled through the failpoint parameter:
 ///
 /// - `"no_retry"` - Creates an error that should not be retried
 /// - `"manual_retry"` - Creates an error requiring manual intervention

--- a/etl/src/metrics.rs
+++ b/etl/src/metrics.rs
@@ -20,6 +20,9 @@ pub const ETL_STATUS_UPDATES_TOTAL: &str = "etl_status_updates_total";
 pub const ETL_STATUS_UPDATES_SKIPPED_TOTAL: &str = "etl_status_updates_skipped_total";
 pub const ETL_SCHEMA_CLEANUPS_TOTAL: &str = "etl_schema_cleanups_total";
 pub const ETL_SCHEMA_CLEANUP_ERRORS_TOTAL: &str = "etl_schema_cleanup_errors_total";
+pub const ETL_SCHEMA_CLEANUP_TABLES_TOTAL: &str = "etl_schema_cleanup_tables_total";
+pub const ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL: &str =
+    "etl_schema_cleanup_pruned_versions_total";
 pub const ETL_DDL_SCHEMA_CHANGES_TOTAL: &str = "etl_ddl_schema_changes_total";
 pub const ETL_DDL_SCHEMA_CHANGE_COLUMNS: &str = "etl_ddl_schema_change_columns";
 pub const ETL_ROW_SIZE_BYTES: &str = "etl_row_size_bytes";
@@ -159,6 +162,20 @@ pub(crate) fn register_metrics() {
             ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
             Unit::Count,
             "Total number of asynchronous schema cleanup errors, labeled by worker_type."
+        );
+
+        describe_counter!(
+            ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
+            Unit::Count,
+            "Total number of tables considered by asynchronous schema cleanup tasks, labeled by \
+             worker_type."
+        );
+
+        describe_counter!(
+            ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL,
+            Unit::Count,
+            "Total number of obsolete schema versions pruned by asynchronous schema cleanup \
+             tasks, labeled by worker_type."
         );
 
         describe_counter!(

--- a/etl/src/metrics.rs
+++ b/etl/src/metrics.rs
@@ -18,6 +18,8 @@ pub const ETL_EVENTS_PROCESSED_TOTAL: &str = "etl_events_processed_total";
 pub const ETL_REPLICATION_MESSAGES_TOTAL: &str = "etl_replication_messages_total";
 pub const ETL_STATUS_UPDATES_TOTAL: &str = "etl_status_updates_total";
 pub const ETL_STATUS_UPDATES_SKIPPED_TOTAL: &str = "etl_status_updates_skipped_total";
+pub const ETL_SCHEMA_CLEANUPS_TOTAL: &str = "etl_schema_cleanups_total";
+pub const ETL_SCHEMA_CLEANUP_ERRORS_TOTAL: &str = "etl_schema_cleanup_errors_total";
 pub const ETL_DDL_SCHEMA_CHANGES_TOTAL: &str = "etl_ddl_schema_changes_total";
 pub const ETL_DDL_SCHEMA_CHANGE_COLUMNS: &str = "etl_ddl_schema_change_columns";
 pub const ETL_ROW_SIZE_BYTES: &str = "etl_row_size_bytes";
@@ -145,6 +147,18 @@ pub(crate) fn register_metrics() {
             Unit::Count,
             "Total number of status updates skipped due to throttling, labeled by \
              status_update_type."
+        );
+
+        describe_counter!(
+            ETL_SCHEMA_CLEANUPS_TOTAL,
+            Unit::Count,
+            "Total number of asynchronous schema cleanup tasks completed, labeled by worker_type."
+        );
+
+        describe_counter!(
+            ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
+            Unit::Count,
+            "Total number of asynchronous schema cleanup errors, labeled by worker_type."
         );
 
         describe_counter!(

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -32,12 +32,13 @@ use postgres_replication::{
 use tokio::{
     pin,
     sync::{Semaphore, watch},
+    task::JoinSet,
 };
 use tokio_postgres::types::PgLsn;
 use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "failpoints")]
-use crate::failpoints::{SEND_STATUS_UPDATE_FP, etl_fail_point_active};
+use crate::failpoints::{FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP, etl_fail_point_active};
 use crate::{
     bail,
     concurrency::{
@@ -64,11 +65,12 @@ use crate::{
     metrics::{
         ACTION_LABEL, COMMAND_TAG_LABEL, DESTINATION_LABEL, ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
         ETL_DDL_SCHEMA_CHANGE_COLUMNS, ETL_DDL_SCHEMA_CHANGES_TOTAL, ETL_EVENTS_PROCESSED_TOTAL,
-        ETL_REPLICATION_MESSAGES_TOTAL, ETL_TRANSACTION_DURATION_SECONDS, ETL_TRANSACTION_SIZE,
-        ETL_TRANSACTIONS_TOTAL, OUTCOME_LABEL, WORKER_TYPE_LABEL,
+        ETL_REPLICATION_MESSAGES_TOTAL, ETL_SCHEMA_CLEANUP_ERRORS_TOTAL, ETL_SCHEMA_CLEANUPS_TOTAL,
+        ETL_TRANSACTION_DURATION_SECONDS, ETL_TRANSACTION_SIZE, ETL_TRANSACTIONS_TOTAL,
+        OUTCOME_LABEL, WORKER_TYPE_LABEL,
     },
     replication::{
-        EventsStream, SharedTableCache, StatusUpdateType,
+        EventsStream, SharedTableCache, StatusUpdateResult, StatusUpdateType,
         client::{PgReplicationClient, PostgresConnectionUpdate},
     },
     state::table::{TableReplicationError, TableReplicationPhase, TableReplicationPhaseType},
@@ -100,6 +102,13 @@ const KEEP_ALIVE_DEADLINE_FRACTION: f64 = 0.6;
 /// deadline at that scale would make the apply loop spin sending forced keep
 /// alives, which is not operationally useful. We clamp to `100ms`.
 const MIN_KEEP_ALIVE_DEADLINE_DURATION: Duration = Duration::from_millis(100);
+/// Minimum interval between best-effort schema cleanup tasks during normal
+/// replication.
+///
+/// Cleanup is checked after status updates and depends only on when cleanup was
+/// last scheduled. The interval keeps the status-update hot path cheap while
+/// bounding how long stale schema versions normally remain in storage.
+const SCHEMA_CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
 
 /// Type of worker driving the apply loop.
 #[derive(Debug, Copy, Clone)]
@@ -400,6 +409,10 @@ struct ApplyLoopState {
     /// can always resolve the latest schema version whose snapshot is less
     /// than or equal to the worker's start point.
     bootstrap_snapshot_id: SnapshotId,
+    /// Time at which a schema cleanup task was last scheduled.
+    last_schema_cleanup_at: Option<Instant>,
+    /// Background schema cleanup tasks owned by this apply loop.
+    schema_cleanup_tasks: JoinSet<()>,
 }
 
 impl ApplyLoopState {
@@ -425,6 +438,8 @@ impl ApplyLoopState {
             exit_intent: None,
             processing_paused: false,
             bootstrap_snapshot_id,
+            last_schema_cleanup_at: Some(Instant::now()),
+            schema_cleanup_tasks: JoinSet::new(),
         }
     }
 
@@ -521,6 +536,28 @@ impl ApplyLoopState {
         } else {
             self.replication_progress.last_flush_lsn
         }
+    }
+
+    /// Returns `true` when cleanup should run.
+    fn should_cleanup_schemas(&self) -> bool {
+        #[cfg(feature = "failpoints")]
+        if etl_fail_point_active(FORCE_SCHEMA_CLEANUP_FP) {
+            return true;
+        }
+
+        self.last_schema_cleanup_at.is_none_or(|last_schema_cleanup_at| {
+            last_schema_cleanup_at.elapsed() >= SCHEMA_CLEANUP_INTERVAL
+        })
+    }
+
+    /// Marks a schema cleanup task as scheduled.
+    fn mark_schema_cleanup_scheduled(&mut self) {
+        self.last_schema_cleanup_at = Some(Instant::now());
+    }
+
+    /// Returns `true` if any schema cleanup task is still running.
+    fn has_schema_cleanup_tasks(&self) -> bool {
+        !self.schema_cleanup_tasks.is_empty()
     }
 
     /// Returns true if the apply loop is in the middle of processing a
@@ -725,7 +762,19 @@ where
             state,
         };
 
-        apply_loop.run(replication_client, start_lsn).await
+        apply_loop.run_with_teardown(replication_client, start_lsn).await
+    }
+
+    /// Runs the apply loop and performs teardown work before returning.
+    async fn run_with_teardown(
+        &mut self,
+        replication_client: PgReplicationClient,
+        start_lsn: PgLsn,
+    ) -> EtlResult<ApplyLoopResult> {
+        let result = self.run(replication_client, start_lsn).await;
+        self.drain_schema_cleanup_tasks().await;
+
+        result
     }
 
     /// Runs the main event processing loop.
@@ -763,21 +812,21 @@ where
                 return Ok(self.finish_shutdown());
             }
 
-            let result = match &self.state.shutdown_state {
+            let iteration_result = match &self.state.shutdown_state {
                 ShutdownState::NoShutdown => {
                     self.run_active_iteration(
                         events_stream.as_mut(),
                         &replication_client,
                         &mut connection_updates_rx,
                     )
-                    .await?
+                    .await
                 }
                 ShutdownState::DrainingForShutdown => {
                     self.run_draining_shutdown_iteration(
                         events_stream.as_mut(),
                         &mut connection_updates_rx,
                     )
-                    .await?
+                    .await
                 }
                 ShutdownState::WaitingForPrimaryKeepAlive { acked_flush_lsn } => {
                     self.run_shutdown_wait_iteration(
@@ -785,9 +834,10 @@ where
                         &mut connection_updates_rx,
                         *acked_flush_lsn,
                     )
-                    .await?
+                    .await
                 }
             };
+            let result = iteration_result?;
 
             if let Some(result) = result {
                 return Ok(result);
@@ -802,9 +852,10 @@ where
     /// 1. Shutdown requests.
     /// 2. PostgreSQL connection lifecycle updates.
     /// 3. Pending destination flush results.
-    /// 4. Batch flush deadline expiry.
-    /// 5. Incoming replication messages.
-    /// 6. Periodic heartbeats once the computed keep alive deadline expires.
+    /// 4. Completed background schema cleanup tasks.
+    /// 5. Batch flush deadline expiry.
+    /// 6. Incoming replication messages.
+    /// 7. Periodic heartbeats once the computed keep alive deadline expires.
     ///
     /// PostgreSQL normally sends keep alives at roughly half of
     /// `wal_sender_timeout`. We wait a little longer than that before
@@ -849,13 +900,18 @@ where
                     .await?;
             }
 
-            // PRIORITY 4: Handle batch flush timer expiry.
+            // PRIORITY 4: Observe completed background schema cleanup tasks.
+            cleanup_result = self.state.schema_cleanup_tasks.join_next(), if self.state.has_schema_cleanup_tasks() => {
+                self.handle_schema_cleanup_task_result(cleanup_result);
+            }
+
+            // PRIORITY 5: Handle batch flush timer expiry.
             // This prevents buffered work from waiting forever when traffic is low.
             _ = Self::wait_for_batch_deadline(self.state.flush_deadline), if self.state.can_wait_for_deadline() => {
                 self.flush_batch("flush deadline reached").await?;
             }
 
-            // PRIORITY 5: Process incoming replication messages from PostgreSQL.
+            // PRIORITY 6: Process incoming replication messages from PostgreSQL.
             // New WAL messages are only accepted while the loop is still actively ingesting.
             maybe_message = events_stream.next(), if self.state.can_process_messages() => {
                 self.handle_stream_message(
@@ -866,7 +922,7 @@ where
                 .await?;
             }
 
-            // PRIORITY 6: Emit a periodic status update once the computed keep alive deadline
+            // PRIORITY 7: Emit a periodic status update once the computed keep alive deadline
             // expires. This intentionally resends the same effective flush LSN so PostgreSQL keeps
             // the standby connection open during long stalls, including cases where the loop is
             // paused behind an in-flight flush and therefore not making visible progress yet. This
@@ -906,8 +962,9 @@ where
     /// Priority order:
     /// 1. PostgreSQL connection lifecycle updates.
     /// 2. Pending destination flush results.
-    /// 3. Batch flush deadline expiry.
-    /// 4. Periodic keep alive status updates.
+    /// 3. Completed background schema cleanup tasks.
+    /// 4. Batch flush deadline expiry.
+    /// 5. Periodic keep alive status updates.
     ///
     /// After the selected branch runs, the loop advances idle syncing state.
     /// Once buffered or in-flight destination work is resolved, it sends the
@@ -932,12 +989,17 @@ where
                     .await?;
             }
 
-            // PRIORITY 3: Handle batch flush timer expiry.
+            // PRIORITY 3: Observe completed background schema cleanup tasks.
+            cleanup_result = self.state.schema_cleanup_tasks.join_next(), if self.state.has_schema_cleanup_tasks() => {
+                self.handle_schema_cleanup_task_result(cleanup_result);
+            }
+
+            // PRIORITY 4: Handle batch flush timer expiry.
             _ = Self::wait_for_batch_deadline(self.state.flush_deadline), if self.state.can_wait_for_deadline() => {
                 self.flush_batch("flush deadline reached during shutdown drain").await?;
             }
 
-            // PRIORITY 4: Emit a periodic status update while shutdown is draining.
+            // PRIORITY 5: Emit a periodic status update while shutdown is draining.
             _ = Self::wait_for_keep_alive_deadline(self.state.keep_alive_deadline) => {
                 self.send_status_update(
                     events_stream.as_mut(),
@@ -972,7 +1034,8 @@ where
     /// Priority order:
     /// 1. PostgreSQL connection lifecycle updates.
     /// 2. PostgreSQL keepalives that may acknowledge `acked_flush_lsn`.
-    /// 3. Periodic keep alive status updates.
+    /// 3. Completed background schema cleanup tasks.
+    /// 4. Periodic keep alive status updates.
     ///
     /// Once the acknowledgement arrives, unresolved work causes
     /// [`ApplyLoopResult::Paused`]; otherwise the recorded exit result may be
@@ -1003,7 +1066,12 @@ where
                 }
             }
 
-            // PRIORITY 3: Resend a heartbeat once the computed keep alive deadline expires while
+            // PRIORITY 3: Observe completed background schema cleanup tasks.
+            cleanup_result = self.state.schema_cleanup_tasks.join_next(), if self.state.has_schema_cleanup_tasks() => {
+                self.handle_schema_cleanup_task_result(cleanup_result);
+            }
+
+            // PRIORITY 4: Resend a heartbeat once the computed keep alive deadline expires while
             // shutdown is waiting for the primary keep alive acknowledgement barrier. This is a
             // last-resort safeguard for cases where PostgreSQL keep alives stop reaching the loop,
             // for example because the source has gone quiet, the stream is backpressured, or the
@@ -1297,7 +1365,7 @@ where
         force: bool,
         status_update_type: StatusUpdateType,
     ) -> EtlResult<()> {
-        events_stream
+        let status_update_result = events_stream
             .as_mut()
             .stream_mut()
             .send_status_update(
@@ -1306,7 +1374,95 @@ where
                 force,
                 status_update_type,
             )
-            .await
+            .await?;
+
+        if let StatusUpdateResult::Sent = status_update_result {
+            self.maybe_spawn_schema_cleanup().await;
+        }
+
+        Ok(())
+    }
+
+    /// Spawns a best-effort cleanup task for obsolete schema versions.
+    async fn maybe_spawn_schema_cleanup(&mut self) {
+        if !self.state.should_cleanup_schemas() {
+            return;
+        }
+
+        if self.state.has_schema_cleanup_tasks() {
+            return;
+        }
+
+        let current_snapshot_ids = self.shared_table_cache.snapshot_ids().await;
+        if current_snapshot_ids.is_empty() {
+            return;
+        }
+
+        self.state.mark_schema_cleanup_scheduled();
+
+        let schema_store = self.schema_store.clone();
+        let worker_type = self.worker_context.worker_type();
+
+        self.state.schema_cleanup_tasks.spawn(async move {
+            match schema_store.prune_table_schemas(current_snapshot_ids).await {
+                Ok(deleted_count) => {
+                    counter!(
+                        ETL_SCHEMA_CLEANUPS_TOTAL,
+                        WORKER_TYPE_LABEL => worker_type.as_str(),
+                    )
+                    .increment(1);
+
+                    if deleted_count > 0 {
+                        info!(
+                            %worker_type,
+                            deleted_count,
+                            "completed obsolete table schema cleanup"
+                        );
+                    }
+                }
+                Err(err) => {
+                    counter!(
+                        ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
+                        WORKER_TYPE_LABEL => worker_type.as_str(),
+                    )
+                    .increment(1);
+
+                    error!(
+                        %worker_type,
+                        error = %err,
+                        "failed to clean up obsolete table schemas"
+                    );
+                }
+            }
+        });
+    }
+
+    /// Records the result of a completed background schema cleanup task.
+    fn handle_schema_cleanup_task_result(
+        &self,
+        cleanup_result: Option<Result<(), tokio::task::JoinError>>,
+    ) {
+        if let Some(Err(err)) = cleanup_result {
+            let worker_type = self.worker_context.worker_type();
+            counter!(
+                ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
+                WORKER_TYPE_LABEL => worker_type.as_str(),
+            )
+            .increment(1);
+
+            error!(
+                %worker_type,
+                error = %err,
+                "schema cleanup task failed before completing"
+            );
+        }
+    }
+
+    /// Joins all background schema cleanup tasks before the apply loop exits.
+    async fn drain_schema_cleanup_tasks(&mut self) {
+        while let Some(cleanup_result) = self.state.schema_cleanup_tasks.join_next().await {
+            self.handle_schema_cleanup_task_result(Some(cleanup_result));
+        }
     }
 
     /// Waits for the pending flush result, if any.
@@ -1731,7 +1887,6 @@ where
 
             return Err(err);
         }
-
         // The next post-DDL DML will cause pgoutput to synthesize a fresh `RELATION`
         // message for this table. Record the new snapshot and clear any cached
         // mask now so relation handling rebuilds it from the schema version we
@@ -3150,4 +3305,57 @@ async fn get_replicated_table_schema(
     };
 
     Ok(replicated_table_schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply_loop_state() -> ApplyLoopState {
+        let start_lsn = PgLsn::from(100u64);
+        let replication_progress =
+            ReplicationProgress { last_received_lsn: start_lsn, last_flush_lsn: start_lsn };
+
+        ApplyLoopState::new(
+            replication_progress,
+            Duration::from_secs(1),
+            SnapshotId::from(start_lsn),
+        )
+    }
+
+    #[test]
+    fn schema_cleanup_waits_for_interval_before_first_trigger() {
+        let state = apply_loop_state();
+
+        assert!(!state.should_cleanup_schemas());
+    }
+
+    #[test]
+    fn schema_cleanup_uses_interval_after_first_trigger() {
+        let mut state = apply_loop_state();
+
+        state.mark_schema_cleanup_scheduled();
+
+        assert!(!state.should_cleanup_schemas());
+
+        state.last_schema_cleanup_at =
+            Some(Instant::now() - SCHEMA_CLEANUP_INTERVAL - Duration::from_secs(1));
+
+        assert!(state.should_cleanup_schemas());
+    }
+
+    #[test]
+    fn schema_cleanup_does_not_depend_on_status_update_type() {
+        let mut state = apply_loop_state();
+
+        state.mark_schema_cleanup_scheduled();
+
+        for _status_update_type in [
+            StatusUpdateType::KeepAlive,
+            StatusUpdateType::PeriodicKeepAlive,
+            StatusUpdateType::ShutdownFlush,
+        ] {
+            assert!(!state.should_cleanup_schemas());
+        }
+    }
 }

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1376,24 +1376,29 @@ where
             )
             .await?;
 
-        if let StatusUpdateResult::Sent = status_update_result {
-            self.maybe_spawn_schema_cleanup().await;
+        // If we sent a status update, we check if we can perform schema cleanup for old
+        // table schema snapshots.
+        if let StatusUpdateResult::Sent { flush_lsn } = status_update_result {
+            self.maybe_spawn_schema_cleanup(flush_lsn).await;
         }
 
         Ok(())
     }
 
     /// Spawns a best-effort cleanup task for obsolete schema versions.
-    async fn maybe_spawn_schema_cleanup(&mut self) {
+    async fn maybe_spawn_schema_cleanup(&mut self, flush_lsn: PgLsn) {
         if !self.state.should_cleanup_schemas() {
             return;
         }
 
-        if self.state.has_schema_cleanup_tasks() {
-            return;
-        }
+        // Gate cleanup by flushed progress because restart can replay WAL after
+        // the last durable flush lsn. A schema snapshot newer than that point
+        // may still be needed to decode replayed row changes, even if the live
+        // relation cache has already advanced to it.
+        let flush_lsn: SnapshotId = flush_lsn.into();
+        let mut current_snapshot_ids = self.shared_table_cache.snapshot_ids().await;
+        current_snapshot_ids.retain(|_, snapshot_id| *snapshot_id <= flush_lsn);
 
-        let current_snapshot_ids = self.shared_table_cache.snapshot_ids().await;
         if current_snapshot_ids.is_empty() {
             return;
         }

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -438,7 +438,7 @@ impl ApplyLoopState {
             exit_intent: None,
             processing_paused: false,
             bootstrap_snapshot_id,
-            last_schema_cleanup_at: Some(Instant::now()),
+            last_schema_cleanup_at: None,
             schema_cleanup_tasks: JoinSet::new(),
         }
     }

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -227,7 +227,7 @@ impl ShutdownState {
 ///
 /// Contains all state and dependencies needed by the apply worker to coordinate
 /// with table sync workers and manage table lifecycle transitions.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ApplyWorkerContext<S, D> {
     /// Unique identifier for the pipeline.
     pub(crate) pipeline_id: PipelineId,
@@ -256,7 +256,7 @@ pub(crate) struct ApplyWorkerContext<S, D> {
 ///
 /// Contains state and dependencies needed by a table sync worker to track
 /// its synchronization progress and coordinate with the apply worker.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct TableSyncWorkerContext<S> {
     /// Unique identifier for the table being synchronized.
     pub(crate) table_id: TableId,
@@ -271,7 +271,7 @@ pub(crate) struct TableSyncWorkerContext<S> {
 /// This enum replaces the [`ApplyLoopHook`] trait, providing direct access to
 /// worker-specific resources and enabling different behavior based on the
 /// worker type at various points in the replication cycle.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum WorkerContext<S, D> {
     /// Context for the apply worker.
     Apply(ApplyWorkerContext<S, D>),
@@ -358,6 +358,25 @@ impl HandleMessageResult {
     }
 }
 
+/// Running schema cleanup marker.
+///
+/// Finishing the marker schedules the next cleanup deadline. This keeps the
+/// deadline mutex private while allowing a cleanup run to reset it after it
+/// either finishes or decides not to spawn background work.
+#[derive(Debug)]
+struct SchemaCleanupRun {
+    /// Shared cleanup deadline owned by [`ApplyLoopState`].
+    deadline: Arc<Mutex<Option<Instant>>>,
+}
+
+impl SchemaCleanupRun {
+    /// Schedules the next cleanup after the current run finishes.
+    async fn finish(self) {
+        let mut deadline = self.deadline.lock().await;
+        *deadline = Some(Instant::now() + SCHEMA_CLEANUP_INTERVAL);
+    }
+}
+
 /// Mutable runtime state that evolves throughout the apply loop.
 #[derive(Debug)]
 struct ApplyLoopState {
@@ -414,29 +433,11 @@ struct ApplyLoopState {
     slot_name: String,
     /// Shared schema cleanup deadline.
     ///
-    /// `None` means a cleanup task is already running. The background cleanup
-    /// task resets this after it finishes.
+    /// `None` means a cleanup run has claimed the deadline. The run resets this
+    /// after it either finishes or decides not to spawn background work.
     schema_cleanup_deadline: Arc<Mutex<Option<Instant>>>,
     /// Background schema cleanup task owned by this apply loop.
     schema_cleanup_task: Option<JoinHandle<()>>,
-}
-
-/// Running schema cleanup marker.
-///
-/// Finishing the marker schedules the next cleanup deadline. This keeps the
-/// deadline mutex private while allowing the background task to reset it.
-#[derive(Debug)]
-struct SchemaCleanupRun {
-    /// Shared cleanup deadline owned by [`ApplyLoopState`].
-    deadline: Arc<Mutex<Option<Instant>>>,
-}
-
-impl SchemaCleanupRun {
-    /// Schedules the next cleanup after the current run finishes.
-    async fn finish(self) {
-        let mut deadline = self.deadline.lock().await;
-        *deadline = Some(Instant::now() + SCHEMA_CLEANUP_INTERVAL);
-    }
 }
 
 impl ApplyLoopState {
@@ -574,13 +575,12 @@ impl ApplyLoopState {
     /// Tries to mark schema cleanup as running if the deadline has elapsed.
     async fn try_start_schema_cleanup(&self) -> Option<SchemaCleanupRun> {
         let mut schema_cleanup_deadline = self.schema_cleanup_deadline.lock().await;
-        let Some(deadline) = *schema_cleanup_deadline else {
-            return None;
-        };
+        let deadline = (*schema_cleanup_deadline)?;
 
         #[cfg(feature = "failpoints")]
         if etl_fail_point_active(FORCE_SCHEMA_CLEANUP_FP) {
             *schema_cleanup_deadline = None;
+
             return Some(SchemaCleanupRun { deadline: Arc::clone(&self.schema_cleanup_deadline) });
         }
 
@@ -589,6 +589,7 @@ impl ApplyLoopState {
         }
 
         *schema_cleanup_deadline = None;
+
         Some(SchemaCleanupRun { deadline: Arc::clone(&self.schema_cleanup_deadline) })
     }
 
@@ -607,7 +608,7 @@ impl ApplyLoopState {
 
     /// Takes the schema cleanup task if it has finished.
     fn take_finished_schema_cleanup_task(&mut self) -> Option<JoinHandle<()>> {
-        if self.schema_cleanup_task.as_ref().is_some_and(|task| task.is_finished()) {
+        if self.schema_cleanup_task.as_ref().is_some_and(tokio::task::JoinHandle::is_finished) {
             self.schema_cleanup_task.take()
         } else {
             None
@@ -921,10 +922,9 @@ where
     /// 1. Shutdown requests.
     /// 2. PostgreSQL connection lifecycle updates.
     /// 3. Pending destination flush results.
-    /// 4. Completed background schema cleanup tasks.
-    /// 5. Batch flush deadline expiry.
-    /// 6. Incoming replication messages.
-    /// 7. Periodic heartbeats once the computed keep alive deadline expires.
+    /// 4. Batch flush deadline expiry.
+    /// 5. Incoming replication messages.
+    /// 6. Periodic heartbeats once the computed keep alive deadline expires.
     ///
     /// PostgreSQL normally sends keep alives at roughly half of
     /// `wal_sender_timeout`. We wait a little longer than that before
@@ -1092,8 +1092,7 @@ where
     /// Priority order:
     /// 1. PostgreSQL connection lifecycle updates.
     /// 2. PostgreSQL keepalives that may acknowledge `acked_flush_lsn`.
-    /// 3. Completed background schema cleanup tasks.
-    /// 4. Periodic keep alive status updates.
+    /// 3. Periodic keep alive status updates.
     ///
     /// Once the acknowledgement arrives, unresolved work causes
     /// [`ApplyLoopResult::Paused`]; otherwise the recorded exit result may be
@@ -1438,13 +1437,15 @@ where
         Ok(())
     }
 
-    /// Spawns a best-effort task that prunes obsolete schema versions.
+    /// Attempts to spawn a best-effort task that prunes obsolete schema
+    /// versions.
     ///
-    /// Cleanup is interval-gated on the status-update path, but the task reads
-    /// the slot's actual `confirmed_flush_lsn` before deleting anything. This
-    /// avoids using the optimistic status update boundary, which is acceptable
-    /// for replaying data but can break decoding if schema versions are pruned
-    /// before PostgreSQL stores the acknowledgement.
+    /// Cleanup is interval-gated on the status-update path, but the loop reads
+    /// the slot's actual `confirmed_flush_lsn` and determines table ownership
+    /// before spawning the pruning task. This avoids using the optimistic
+    /// status update boundary, which is acceptable for replaying data but
+    /// can break decoding if schema versions are pruned before PostgreSQL
+    /// stores the acknowledgement.
     async fn maybe_spawn_schema_cleanup(&mut self) -> EtlResult<()> {
         self.collect_finished_schema_cleanup_task().await;
 
@@ -1456,51 +1457,59 @@ where
             return Ok(());
         };
 
-        let schema_store = self.schema_store.clone();
-        let pg_connection = self.config.pg_connection.clone();
-        let slot_name = self.state.slot_name().to_owned();
-        let shared_table_cache = self.shared_table_cache.clone();
         let worker_type = self.worker_context.worker_type();
-        let worker_context = self.worker_context.clone();
 
-        let cleanup_fut = async move {
-            let confirmed_flush_lsn =
-                match Self::get_actual_confirmed_flush_lsn(pg_connection, &slot_name).await {
-                    Ok(confirmed_flush_lsn) => confirmed_flush_lsn,
-                    Err(err) => {
-                        warn!(
-                            %worker_type,
-                            error = %err,
-                            "skipping schema cleanup because slot progress could not be confirmed"
-                        );
+        // We load the confirmed flush lsn from the slot that is being used by this
+        // apply loop.
+        let confirmed_flush_lsn = match self.get_actual_confirmed_flush_lsn().await {
+            Ok(confirmed_flush_lsn) => confirmed_flush_lsn,
+            Err(err) => {
+                warn!(
+                    %worker_type,
+                    error = %err,
+                    "skipping schema cleanup because slot progress could not be confirmed"
+                );
 
-                        return;
-                    }
-                };
+                schema_cleanup_run.finish().await;
 
-            let table_ids = match Self::get_schema_cleanup_table_ids(
-                &worker_context,
-                &shared_table_cache,
-                confirmed_flush_lsn,
-            )
-            .await
-            {
-                Ok(table_ids) => table_ids,
-                Err(err) => {
-                    error!(
-                        %worker_type,
-                        error = %err,
-                        "failed to determine schema cleanup ownership"
-                    );
-
-                    return;
-                }
-            };
-
-            if table_ids.is_empty() {
-                return;
+                return Ok(());
             }
+        };
 
+        // We get the table ids that this apply loop instance takes care of and we try
+        // to prune their old table schemas based on the confirmed flush lsn.
+        let table_ids = match self.get_schema_cleanup_table_ids(confirmed_flush_lsn).await {
+            Ok(table_ids) => table_ids,
+            Err(err) => {
+                error!(
+                    %worker_type,
+                    error = %err,
+                    "failed to determine schema cleanup ownership"
+                );
+
+                schema_cleanup_run.finish().await;
+
+                return Ok(());
+            }
+        };
+
+        // If there are no tables to try to prune, we don't want to attempt it.
+        if table_ids.is_empty() {
+            schema_cleanup_run.finish().await;
+
+            return Ok(());
+        }
+
+        let schema_store = self.schema_store.clone();
+
+        // At this point we know all table ids to check for pruning, so we can offload
+        // this to a background task to not stall the worker. This is fine since
+        // we know that the frontier is frozen at confirmed flush lsn, so this
+        // task can take its time to do the job, without ever interfering
+        // with the apply loop. Also, no more than one pruning task can occur at the
+        // same time within an apply loop instance, so this makes this even
+        // safer.
+        let cleanup_fut = async move {
             match schema_store.prune_table_schemas(table_ids, confirmed_flush_lsn).await {
                 Ok(deleted_count) => {
                     counter!(
@@ -1530,13 +1539,14 @@ where
                         "failed to clean up obsolete table schemas"
                     );
                 }
-            }
+            };
         };
 
-        self.state.set_schema_cleanup_task(tokio::spawn(async move {
+        let cleanup_task = tokio::spawn(async move {
             cleanup_fut.await;
             schema_cleanup_run.finish().await;
-        }));
+        });
+        self.state.set_schema_cleanup_task(cleanup_task);
 
         Ok(())
     }
@@ -1548,39 +1558,33 @@ where
     /// acknowledgement. Schema cleanup is different because deleting a schema
     /// that may still be needed on replay can stop decoding, so cleanup reads
     /// `confirmed_flush_lsn` from the replication slot.
-    async fn get_actual_confirmed_flush_lsn(
-        pg_connection: PgConnectionConfig,
-        slot_name: &str,
-    ) -> EtlResult<PgLsn> {
-        let replication_client = PgReplicationClient::connect(pg_connection).await?;
-        let slot = replication_client.get_slot(&slot_name).await?;
+    async fn get_actual_confirmed_flush_lsn(&self) -> EtlResult<PgLsn> {
+        let replication_client =
+            PgReplicationClient::connect(self.config.pg_connection.clone()).await?;
+        let slot = replication_client.get_slot(&self.state.slot_name).await?;
 
         Ok(slot.confirmed_flush_lsn)
     }
 
     /// Returns table ids this worker may clean up at the confirmed LSN.
     ///
-    /// The shared cache is used only to find active tables. The schema store
-    /// computes the retained snapshot for each table from the confirmed flush
-    /// LSN before deleting anything.
+    /// The shared cache is used only to find active tables, and the worker's
+    /// normal ownership check decides which of those tables can be considered.
+    /// The schema store computes the retained snapshot for each table from the
+    /// confirmed flush LSN before deleting anything.
     async fn get_schema_cleanup_table_ids(
-        worker_context: &WorkerContext<S, D>,
-        shared_table_cache: &SharedTableCache,
+        &self,
         confirmed_flush_lsn: PgLsn,
     ) -> EtlResult<HashSet<TableId>> {
-        let active_table_ids = shared_table_cache.active_table_ids().await;
+        let active_table_ids = self.shared_table_cache.active_table_ids().await;
         let mut table_ids = HashSet::with_capacity(active_table_ids.len());
 
         for table_id in active_table_ids {
             // Only prune snapshots for tables this worker would apply at this
             // flush position. This keeps table sync workers limited to their
             // assigned table while preserving apply worker ownership rules.
-            let should_apply_changes = Self::should_apply_changes_for_context(
-                worker_context,
-                table_id,
-                confirmed_flush_lsn,
-            )
-            .await?;
+            let should_apply_changes =
+                self.should_apply_changes(table_id, confirmed_flush_lsn).await?;
 
             if should_apply_changes {
                 table_ids.insert(table_id);
@@ -2410,17 +2414,7 @@ where
         table_id: TableId,
         remote_final_lsn: PgLsn,
     ) -> EtlResult<bool> {
-        Self::should_apply_changes_for_context(&self.worker_context, table_id, remote_final_lsn)
-            .await
-    }
-
-    /// Determines whether a worker context owns changes for a table.
-    async fn should_apply_changes_for_context(
-        worker_context: &WorkerContext<S, D>,
-        table_id: TableId,
-        remote_final_lsn: PgLsn,
-    ) -> EtlResult<bool> {
-        match worker_context {
+        match &self.worker_context {
             WorkerContext::Apply(ctx) => {
                 apply_worker::should_apply_changes(ctx, table_id, remote_final_lsn).await
             }

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -17,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use etl_config::shared::{PgConnectionConfig, PipelineConfig};
+use etl_config::shared::PipelineConfig;
 use etl_postgres::{
     replication::slots::EtlReplicationSlot,
     types::{

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -8,7 +8,7 @@
 //! cycle.
 
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     fmt::{Display, Formatter},
     future::Future,
     pin::Pin,
@@ -66,16 +66,20 @@ use crate::{
     metrics::{
         ACTION_LABEL, COMMAND_TAG_LABEL, DESTINATION_LABEL, ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
         ETL_DDL_SCHEMA_CHANGE_COLUMNS, ETL_DDL_SCHEMA_CHANGES_TOTAL, ETL_EVENTS_PROCESSED_TOTAL,
-        ETL_REPLICATION_MESSAGES_TOTAL, ETL_SCHEMA_CLEANUP_ERRORS_TOTAL, ETL_SCHEMA_CLEANUPS_TOTAL,
-        ETL_TRANSACTION_DURATION_SECONDS, ETL_TRANSACTION_SIZE, ETL_TRANSACTIONS_TOTAL,
-        OUTCOME_LABEL, WORKER_TYPE_LABEL,
+        ETL_REPLICATION_MESSAGES_TOTAL, ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
+        ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL, ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
+        ETL_SCHEMA_CLEANUPS_TOTAL, ETL_TRANSACTION_DURATION_SECONDS, ETL_TRANSACTION_SIZE,
+        ETL_TRANSACTIONS_TOTAL, OUTCOME_LABEL, WORKER_TYPE_LABEL,
     },
     replication::{
         EventsStream, SharedTableCache, StatusUpdateResult, StatusUpdateType,
         client::{PgReplicationClient, PostgresConnectionUpdate},
     },
     state::table::{TableReplicationError, TableReplicationPhase, TableReplicationPhaseType},
-    store::{schema::SchemaStore, state::StateStore},
+    store::{
+        schema::{SchemaStore, TableSchemaRetention},
+        state::StateStore,
+    },
     types::{Event, PipelineId, RelationEvent, SizeHint},
     workers::{TableSyncWorker, TableSyncWorkerPool, TableSyncWorkerState},
 };
@@ -1476,47 +1480,62 @@ where
             }
         };
 
-        // We get the table ids that this apply loop instance takes care of and we try
-        // to prune their old table schemas based on the confirmed flush lsn.
-        let table_ids = match self.get_schema_cleanup_table_ids(confirmed_flush_lsn).await {
-            Ok(table_ids) => table_ids,
-            Err(err) => {
-                error!(
-                    %worker_type,
-                    error = %err,
-                    "failed to determine schema cleanup ownership"
-                );
+        // We get the table retention boundaries that this apply loop instance
+        // can safely prune up to. The map is frozen before the background task
+        // is spawned, so any concurrent progress can only make this cleanup
+        // conservative.
+        let table_schema_retentions =
+            match self.get_table_schema_retentions(confirmed_flush_lsn).await {
+                Ok(table_schema_retentions) => table_schema_retentions,
+                Err(err) => {
+                    error!(
+                        %worker_type,
+                        error = %err,
+                        "failed to determine schema cleanup ownership"
+                    );
 
-                schema_cleanup_run.finish().await;
+                    schema_cleanup_run.finish().await;
 
-                return Ok(());
-            }
-        };
+                    return Ok(());
+                }
+            };
 
         // If there are no tables to try to prune, we don't want to attempt it.
-        if table_ids.is_empty() {
+        if table_schema_retentions.is_empty() {
             schema_cleanup_run.finish().await;
 
             return Ok(());
         }
 
         let schema_store = self.schema_store.clone();
+        let table_count = table_schema_retentions.len() as u64;
 
-        // At this point we know all table ids to check for pruning, so we can offload
-        // this to a background task to not stall the worker. This is fine since
-        // we know that the frontier is frozen at confirmed flush lsn, so this
-        // task can take its time to do the job, without ever interfering
-        // with the apply loop. Also, no more than one pruning task can occur at the
-        // same time within an apply loop instance, so this makes this even
-        // safer.
+        // At this point we know the retention boundaries to check for pruning,
+        // so we can offload this to a background task to not stall the worker.
+        // This is fine since those boundaries are frozen, so this task can take
+        // its time to do the job without interfering with the apply loop. Also,
+        // no more than one pruning task can occur at the same time within an
+        // apply loop instance, so this makes this even safer.
         let cleanup_fut = async move {
-            match schema_store.prune_table_schemas(table_ids, confirmed_flush_lsn).await {
+            match schema_store.prune_table_schemas(table_schema_retentions).await {
                 Ok(deleted_count) => {
                     counter!(
                         ETL_SCHEMA_CLEANUPS_TOTAL,
                         WORKER_TYPE_LABEL => worker_type.as_str(),
                     )
                     .increment(1);
+
+                    counter!(
+                        ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
+                        WORKER_TYPE_LABEL => worker_type.as_str(),
+                    )
+                    .increment(table_count);
+
+                    counter!(
+                        ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL,
+                        WORKER_TYPE_LABEL => worker_type.as_str(),
+                    )
+                    .increment(deleted_count);
 
                     if deleted_count > 0 {
                         info!(
@@ -1566,18 +1585,19 @@ where
         Ok(slot.confirmed_flush_lsn)
     }
 
-    /// Returns table ids this worker may clean up at the confirmed LSN.
+    /// Returns schema retention boundaries for tables this worker may clean up.
     ///
     /// The shared cache is used only to find active tables, and the worker's
     /// normal ownership check decides which of those tables can be considered.
-    /// The schema store computes the retained snapshot for each table from the
-    /// confirmed flush LSN before deleting anything.
-    async fn get_schema_cleanup_table_ids(
+    /// A table's cleanup boundary is capped both by the slot's confirmed flush
+    /// LSN and by the earliest destination metadata snapshot that may still be
+    /// needed.
+    async fn get_table_schema_retentions(
         &self,
         confirmed_flush_lsn: PgLsn,
-    ) -> EtlResult<HashSet<TableId>> {
+    ) -> EtlResult<HashMap<TableId, TableSchemaRetention>> {
         let active_table_ids = self.shared_table_cache.active_table_ids().await;
-        let mut table_ids = HashSet::with_capacity(active_table_ids.len());
+        let mut table_schema_retentions = HashMap::with_capacity(active_table_ids.len());
 
         for table_id in active_table_ids {
             // Only prune snapshots for tables this worker would apply at this
@@ -1586,12 +1606,48 @@ where
             let should_apply_changes =
                 self.should_apply_changes(table_id, confirmed_flush_lsn).await?;
 
-            if should_apply_changes {
-                table_ids.insert(table_id);
+            if !should_apply_changes {
+                continue;
             }
+
+            // We try to load the destination table metadata to see if it is referencing a
+            // snapshot id that would be cleaned up if we were to just use the
+            // confirmed flush lsn as the boundary.
+            //
+            // If there is no metadata, we play it safe and skip the pruning for this table.
+            let Some(destination_table_metadata) =
+                self.schema_store.get_destination_table_metadata(table_id).await?
+            else {
+                debug!(
+                    %table_id,
+                    "skipping schema cleanup for table without destination metadata"
+                );
+
+                continue;
+            };
+
+            // We take the earliest snapshot id that is still needed by the destination
+            // table metadata.
+            let destination_retention_snapshot_id = destination_table_metadata
+                .previous_snapshot_id
+                .unwrap_or(destination_table_metadata.snapshot_id)
+                .min(destination_table_metadata.snapshot_id);
+
+            // We determine whether the confirmed flush lsn or the snapshot id is the new
+            // retention limit. We could use a normal PgLsn type for handling
+            // this, but to make the implementation
+            //
+            let retention = if confirmed_flush_lsn <= destination_retention_snapshot_id.into_inner()
+            {
+                TableSchemaRetention::ConfirmedFlushLsn(confirmed_flush_lsn)
+            } else {
+                TableSchemaRetention::SnapshotId(destination_retention_snapshot_id)
+            };
+
+            table_schema_retentions.insert(table_id, retention);
         }
 
-        Ok(table_ids)
+        Ok(table_schema_retentions)
     }
 
     /// Records the result of a completed background schema cleanup task.

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -612,7 +612,7 @@ impl ApplyLoopState {
 
     /// Takes the schema cleanup task if it has finished.
     fn take_finished_schema_cleanup_task(&mut self) -> Option<JoinHandle<()>> {
-        if self.schema_cleanup_task.as_ref().is_some_and(tokio::task::JoinHandle::is_finished) {
+        if self.schema_cleanup_task.as_ref().is_some_and(JoinHandle::is_finished) {
             self.schema_cleanup_task.take()
         } else {
             None

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -39,10 +39,7 @@ use tokio_postgres::types::PgLsn;
 use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "failpoints")]
-use crate::failpoints::{
-    FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP, FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP,
-    etl_fail_point_active,
-};
+use crate::failpoints::{FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP, etl_fail_point_active};
 use crate::{
     bail,
     concurrency::{
@@ -845,6 +842,7 @@ where
         start_lsn: PgLsn,
     ) -> EtlResult<ApplyLoopResult> {
         let result = self.run(replication_client, start_lsn).await;
+
         self.drain_schema_cleanup_task().await;
 
         result
@@ -1433,8 +1431,8 @@ where
 
         // If we sent a status update, we check if we can perform schema cleanup for old
         // table schema snapshots.
-        if let StatusUpdateResult::Sent { flush_lsn } = status_update_result {
-            self.maybe_spawn_schema_cleanup(flush_lsn).await?;
+        if let StatusUpdateResult::Sent = status_update_result {
+            self.maybe_spawn_schema_cleanup().await?;
         }
 
         Ok(())
@@ -1447,7 +1445,7 @@ where
     /// avoids using the optimistic status update boundary, which is acceptable
     /// for replaying data but can break decoding if schema versions are pruned
     /// before PostgreSQL stores the acknowledgement.
-    async fn maybe_spawn_schema_cleanup(&mut self, reported_flush_lsn: PgLsn) -> EtlResult<()> {
+    async fn maybe_spawn_schema_cleanup(&mut self) -> EtlResult<()> {
         self.collect_finished_schema_cleanup_task().await;
 
         if self.state.has_schema_cleanup_task() {
@@ -1466,25 +1464,19 @@ where
         let worker_context = self.worker_context.clone();
 
         let cleanup_fut = async move {
-            let confirmed_flush_lsn = match Self::get_actual_confirmed_flush_lsn(
-                pg_connection,
-                &slot_name,
-                reported_flush_lsn,
-            )
-            .await
-            {
-                Ok(confirmed_flush_lsn) => confirmed_flush_lsn,
-                Err(err) => {
-                    warn!(
-                        %worker_type,
-                        %reported_flush_lsn,
-                        error = %err,
-                        "skipping schema cleanup because slot progress could not be confirmed"
-                    );
+            let confirmed_flush_lsn =
+                match Self::get_actual_confirmed_flush_lsn(pg_connection, &slot_name).await {
+                    Ok(confirmed_flush_lsn) => confirmed_flush_lsn,
+                    Err(err) => {
+                        warn!(
+                            %worker_type,
+                            error = %err,
+                            "skipping schema cleanup because slot progress could not be confirmed"
+                        );
 
-                    return;
-                }
-            };
+                        return;
+                    }
+                };
 
             let table_ids = match Self::get_schema_cleanup_table_ids(
                 &worker_context,
@@ -1559,13 +1551,7 @@ where
     async fn get_actual_confirmed_flush_lsn(
         pg_connection: PgConnectionConfig,
         slot_name: &str,
-        reported_flush_lsn: PgLsn,
     ) -> EtlResult<PgLsn> {
-        #[cfg(feature = "failpoints")]
-        if etl_fail_point_active(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP) {
-            return Ok(reported_flush_lsn);
-        }
-
         let replication_client = PgReplicationClient::connect(pg_connection).await?;
         let slot = replication_client.get_slot(&slot_name).await?;
 

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1635,8 +1635,7 @@ where
 
             // We determine whether the confirmed flush lsn or the snapshot id is the new
             // retention limit. We could use a normal PgLsn type for handling
-            // this, but to make the implementation
-            //
+            // this, but to make the implementation more explicit we use an enum.
             let retention = if confirmed_flush_lsn <= destination_retention_snapshot_id.into_inner()
             {
                 TableSchemaRetention::ConfirmedFlushLsn(confirmed_flush_lsn)

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -1509,7 +1509,7 @@ where
                 return;
             }
 
-            match schema_store.prune_table_schemas(table_ids, confirmed_flush_lsn.into()).await {
+            match schema_store.prune_table_schemas(table_ids, confirmed_flush_lsn).await {
                 Ok(deleted_count) => {
                     counter!(
                         ETL_SCHEMA_CLEANUPS_TOTAL,

--- a/etl/src/replication/apply.rs
+++ b/etl/src/replication/apply.rs
@@ -8,6 +8,7 @@
 //! cycle.
 
 use std::{
+    collections::HashSet,
     fmt::{Display, Formatter},
     future::Future,
     pin::Pin,
@@ -16,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use etl_config::shared::PipelineConfig;
+use etl_config::shared::{PgConnectionConfig, PipelineConfig};
 use etl_postgres::{
     replication::slots::EtlReplicationSlot,
     types::{
@@ -31,14 +32,17 @@ use postgres_replication::{
 };
 use tokio::{
     pin,
-    sync::{Semaphore, watch},
-    task::JoinSet,
+    sync::{Mutex, Semaphore, watch},
+    task::JoinHandle,
 };
 use tokio_postgres::types::PgLsn;
 use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "failpoints")]
-use crate::failpoints::{FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP, etl_fail_point_active};
+use crate::failpoints::{
+    FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP, FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP,
+    etl_fail_point_active,
+};
 use crate::{
     bail,
     concurrency::{
@@ -105,9 +109,9 @@ const MIN_KEEP_ALIVE_DEADLINE_DURATION: Duration = Duration::from_millis(100);
 /// Minimum interval between best-effort schema cleanup tasks during normal
 /// replication.
 ///
-/// Cleanup is checked after status updates and depends only on when cleanup was
-/// last scheduled. The interval keeps the status-update hot path cheap while
-/// bounding how long stale schema versions normally remain in storage.
+/// Cleanup is considered only after status updates, because those are the
+/// points where the slot's confirmed flush LSN may have advanced. The next
+/// deadline is scheduled when the previous cleanup task finishes.
 const SCHEMA_CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
 
 /// Type of worker driving the apply loop.
@@ -226,7 +230,7 @@ impl ShutdownState {
 ///
 /// Contains all state and dependencies needed by the apply worker to coordinate
 /// with table sync workers and manage table lifecycle transitions.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct ApplyWorkerContext<S, D> {
     /// Unique identifier for the pipeline.
     pub(crate) pipeline_id: PipelineId,
@@ -255,7 +259,7 @@ pub(crate) struct ApplyWorkerContext<S, D> {
 ///
 /// Contains state and dependencies needed by a table sync worker to track
 /// its synchronization progress and coordinate with the apply worker.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct TableSyncWorkerContext<S> {
     /// Unique identifier for the table being synchronized.
     pub(crate) table_id: TableId,
@@ -270,7 +274,7 @@ pub(crate) struct TableSyncWorkerContext<S> {
 /// This enum replaces the [`ApplyLoopHook`] trait, providing direct access to
 /// worker-specific resources and enabling different behavior based on the
 /// worker type at various points in the replication cycle.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum WorkerContext<S, D> {
     /// Context for the apply worker.
     Apply(ApplyWorkerContext<S, D>),
@@ -409,10 +413,33 @@ struct ApplyLoopState {
     /// can always resolve the latest schema version whose snapshot is less
     /// than or equal to the worker's start point.
     bootstrap_snapshot_id: SnapshotId,
-    /// Time at which a schema cleanup task was last scheduled.
-    last_schema_cleanup_at: Option<Instant>,
-    /// Background schema cleanup tasks owned by this apply loop.
-    schema_cleanup_tasks: JoinSet<()>,
+    /// Replication slot name used by this loop.
+    slot_name: String,
+    /// Shared schema cleanup deadline.
+    ///
+    /// `None` means a cleanup task is already running. The background cleanup
+    /// task resets this after it finishes.
+    schema_cleanup_deadline: Arc<Mutex<Option<Instant>>>,
+    /// Background schema cleanup task owned by this apply loop.
+    schema_cleanup_task: Option<JoinHandle<()>>,
+}
+
+/// Running schema cleanup marker.
+///
+/// Finishing the marker schedules the next cleanup deadline. This keeps the
+/// deadline mutex private while allowing the background task to reset it.
+#[derive(Debug)]
+struct SchemaCleanupRun {
+    /// Shared cleanup deadline owned by [`ApplyLoopState`].
+    deadline: Arc<Mutex<Option<Instant>>>,
+}
+
+impl SchemaCleanupRun {
+    /// Schedules the next cleanup after the current run finishes.
+    async fn finish(self) {
+        let mut deadline = self.deadline.lock().await;
+        *deadline = Some(Instant::now() + SCHEMA_CLEANUP_INTERVAL);
+    }
 }
 
 impl ApplyLoopState {
@@ -421,6 +448,7 @@ impl ApplyLoopState {
         replication_progress: ReplicationProgress,
         keep_alive_deadline_duration: Duration,
         bootstrap_snapshot_id: SnapshotId,
+        slot_name: String,
     ) -> Self {
         Self {
             last_commit_end_lsn: None,
@@ -438,8 +466,11 @@ impl ApplyLoopState {
             exit_intent: None,
             processing_paused: false,
             bootstrap_snapshot_id,
-            last_schema_cleanup_at: None,
-            schema_cleanup_tasks: JoinSet::new(),
+            slot_name,
+            schema_cleanup_deadline: Arc::new(Mutex::new(Some(
+                Instant::now() + SCHEMA_CLEANUP_INTERVAL,
+            ))),
+            schema_cleanup_task: None,
         }
     }
 
@@ -466,6 +497,11 @@ impl ApplyLoopState {
     /// state.
     fn bootstrap_snapshot_id(&self) -> SnapshotId {
         self.bootstrap_snapshot_id
+    }
+
+    /// Returns the replication slot name used by this loop.
+    fn slot_name(&self) -> &str {
+        &self.slot_name
     }
 
     /// Sets the batch flush deadline, if not already set.
@@ -538,26 +574,63 @@ impl ApplyLoopState {
         }
     }
 
-    /// Returns `true` when cleanup should run.
-    fn should_cleanup_schemas(&self) -> bool {
+    /// Tries to mark schema cleanup as running if the deadline has elapsed.
+    async fn try_start_schema_cleanup(&self) -> Option<SchemaCleanupRun> {
+        let mut schema_cleanup_deadline = self.schema_cleanup_deadline.lock().await;
+        let Some(deadline) = *schema_cleanup_deadline else {
+            return None;
+        };
+
         #[cfg(feature = "failpoints")]
         if etl_fail_point_active(FORCE_SCHEMA_CLEANUP_FP) {
-            return true;
+            *schema_cleanup_deadline = None;
+            return Some(SchemaCleanupRun { deadline: Arc::clone(&self.schema_cleanup_deadline) });
         }
 
-        self.last_schema_cleanup_at.is_none_or(|last_schema_cleanup_at| {
-            last_schema_cleanup_at.elapsed() >= SCHEMA_CLEANUP_INTERVAL
-        })
+        if Instant::now() < deadline {
+            return None;
+        }
+
+        *schema_cleanup_deadline = None;
+        Some(SchemaCleanupRun { deadline: Arc::clone(&self.schema_cleanup_deadline) })
     }
 
-    /// Marks a schema cleanup task as scheduled.
-    fn mark_schema_cleanup_scheduled(&mut self) {
-        self.last_schema_cleanup_at = Some(Instant::now());
+    /// Moves the schema cleanup deadline into the past for tests.
+    #[cfg(test)]
+    async fn expire_schema_cleanup_deadline(&self) {
+        let mut schema_cleanup_deadline = self.schema_cleanup_deadline.lock().await;
+        *schema_cleanup_deadline =
+            Some(Instant::now() - SCHEMA_CLEANUP_INTERVAL - Duration::from_secs(1));
     }
 
-    /// Returns `true` if any schema cleanup task is still running.
-    fn has_schema_cleanup_tasks(&self) -> bool {
-        !self.schema_cleanup_tasks.is_empty()
+    /// Returns `true` if a schema cleanup task is still recorded.
+    fn has_schema_cleanup_task(&self) -> bool {
+        self.schema_cleanup_task.is_some()
+    }
+
+    /// Takes the schema cleanup task if it has finished.
+    fn take_finished_schema_cleanup_task(&mut self) -> Option<JoinHandle<()>> {
+        if self.schema_cleanup_task.as_ref().is_some_and(|task| task.is_finished()) {
+            self.schema_cleanup_task.take()
+        } else {
+            None
+        }
+    }
+
+    /// Takes the schema cleanup task, whether it has finished or not.
+    fn take_schema_cleanup_task(&mut self) -> Option<JoinHandle<()>> {
+        self.schema_cleanup_task.take()
+    }
+
+    /// Sets the currently running schema cleanup task.
+    fn set_schema_cleanup_task(&mut self, task: JoinHandle<()>) {
+        self.schema_cleanup_task = Some(task);
+    }
+
+    /// Schedules schema cleanup again after the configured interval.
+    async fn reset_schema_cleanup_deadline(&self) {
+        let mut schema_cleanup_deadline = self.schema_cleanup_deadline.lock().await;
+        *schema_cleanup_deadline = Some(Instant::now() + SCHEMA_CLEANUP_INTERVAL);
     }
 
     /// Returns true if the apply loop is in the middle of processing a
@@ -657,8 +730,6 @@ impl ApplyLoopState {
 /// [`ApplyLoop`] encapsulates the apply loop's immutable dependencies plus its
 /// mutable runtime state.
 pub(crate) struct ApplyLoop<S, D> {
-    /// Unique identifier for the pipeline.
-    pipeline_id: PipelineId,
     /// Shared immutable configuration.
     config: Arc<PipelineConfig>,
     /// Schema store for table schemas.
@@ -741,14 +812,16 @@ where
         let initial_progress =
             ReplicationProgress { last_received_lsn: start_lsn, last_flush_lsn: start_lsn };
 
+        let slot_name: String = worker_type.build_etl_replication_slot(pipeline_id).try_into()?;
+
         let state = ApplyLoopState::new(
             initial_progress,
             keep_alive_deadline_duration,
             bootstrap_snapshot_id,
+            slot_name,
         );
 
         let mut apply_loop = Self {
-            pipeline_id,
             config: Arc::clone(&config),
             schema_store,
             destination,
@@ -772,7 +845,7 @@ where
         start_lsn: PgLsn,
     ) -> EtlResult<ApplyLoopResult> {
         let result = self.run(replication_client, start_lsn).await;
-        self.drain_schema_cleanup_tasks().await;
+        self.drain_schema_cleanup_task().await;
 
         result
     }
@@ -783,14 +856,12 @@ where
         replication_client: PgReplicationClient,
         start_lsn: PgLsn,
     ) -> EtlResult<ApplyLoopResult> {
-        let slot_name: String = self
-            .worker_context
-            .worker_type()
-            .build_etl_replication_slot(self.pipeline_id)
-            .try_into()?;
-
         let logical_replication_stream = replication_client
-            .start_logical_replication(&self.config.publication_name, &slot_name, start_lsn)
+            .start_logical_replication(
+                &self.config.publication_name,
+                self.state.slot_name(),
+                start_lsn,
+            )
             .await?;
 
         let events_stream = EventsStream::wrap(logical_replication_stream);
@@ -900,18 +971,13 @@ where
                     .await?;
             }
 
-            // PRIORITY 4: Observe completed background schema cleanup tasks.
-            cleanup_result = self.state.schema_cleanup_tasks.join_next(), if self.state.has_schema_cleanup_tasks() => {
-                self.handle_schema_cleanup_task_result(cleanup_result);
-            }
-
-            // PRIORITY 5: Handle batch flush timer expiry.
+            // PRIORITY 4: Handle batch flush timer expiry.
             // This prevents buffered work from waiting forever when traffic is low.
             _ = Self::wait_for_batch_deadline(self.state.flush_deadline), if self.state.can_wait_for_deadline() => {
                 self.flush_batch("flush deadline reached").await?;
             }
 
-            // PRIORITY 6: Process incoming replication messages from PostgreSQL.
+            // PRIORITY 5: Process incoming replication messages from PostgreSQL.
             // New WAL messages are only accepted while the loop is still actively ingesting.
             maybe_message = events_stream.next(), if self.state.can_process_messages() => {
                 self.handle_stream_message(
@@ -922,7 +988,7 @@ where
                 .await?;
             }
 
-            // PRIORITY 7: Emit a periodic status update once the computed keep alive deadline
+            // PRIORITY 6: Emit a periodic status update once the computed keep alive deadline
             // expires. This intentionally resends the same effective flush LSN so PostgreSQL keeps
             // the standby connection open during long stalls, including cases where the loop is
             // paused behind an in-flight flush and therefore not making visible progress yet. This
@@ -962,9 +1028,8 @@ where
     /// Priority order:
     /// 1. PostgreSQL connection lifecycle updates.
     /// 2. Pending destination flush results.
-    /// 3. Completed background schema cleanup tasks.
-    /// 4. Batch flush deadline expiry.
-    /// 5. Periodic keep alive status updates.
+    /// 3. Batch flush deadline expiry.
+    /// 4. Periodic keep alive status updates.
     ///
     /// After the selected branch runs, the loop advances idle syncing state.
     /// Once buffered or in-flight destination work is resolved, it sends the
@@ -989,17 +1054,12 @@ where
                     .await?;
             }
 
-            // PRIORITY 3: Observe completed background schema cleanup tasks.
-            cleanup_result = self.state.schema_cleanup_tasks.join_next(), if self.state.has_schema_cleanup_tasks() => {
-                self.handle_schema_cleanup_task_result(cleanup_result);
-            }
-
-            // PRIORITY 4: Handle batch flush timer expiry.
+            // PRIORITY 3: Handle batch flush timer expiry.
             _ = Self::wait_for_batch_deadline(self.state.flush_deadline), if self.state.can_wait_for_deadline() => {
                 self.flush_batch("flush deadline reached during shutdown drain").await?;
             }
 
-            // PRIORITY 5: Emit a periodic status update while shutdown is draining.
+            // PRIORITY 4: Emit a periodic status update while shutdown is draining.
             _ = Self::wait_for_keep_alive_deadline(self.state.keep_alive_deadline) => {
                 self.send_status_update(
                     events_stream.as_mut(),
@@ -1066,12 +1126,7 @@ where
                 }
             }
 
-            // PRIORITY 3: Observe completed background schema cleanup tasks.
-            cleanup_result = self.state.schema_cleanup_tasks.join_next(), if self.state.has_schema_cleanup_tasks() => {
-                self.handle_schema_cleanup_task_result(cleanup_result);
-            }
-
-            // PRIORITY 4: Resend a heartbeat once the computed keep alive deadline expires while
+            // PRIORITY 3: Resend a heartbeat once the computed keep alive deadline expires while
             // shutdown is waiting for the primary keep alive acknowledgement barrier. This is a
             // last-resort safeguard for cases where PostgreSQL keep alives stop reaching the loop,
             // for example because the source has gone quiet, the stream is backpressured, or the
@@ -1379,37 +1434,82 @@ where
         // If we sent a status update, we check if we can perform schema cleanup for old
         // table schema snapshots.
         if let StatusUpdateResult::Sent { flush_lsn } = status_update_result {
-            self.maybe_spawn_schema_cleanup(flush_lsn).await;
+            self.maybe_spawn_schema_cleanup(flush_lsn).await?;
         }
 
         Ok(())
     }
 
-    /// Spawns a best-effort cleanup task for obsolete schema versions.
-    async fn maybe_spawn_schema_cleanup(&mut self, flush_lsn: PgLsn) {
-        if !self.state.should_cleanup_schemas() {
-            return;
+    /// Spawns a best-effort task that prunes obsolete schema versions.
+    ///
+    /// Cleanup is interval-gated on the status-update path, but the task reads
+    /// the slot's actual `confirmed_flush_lsn` before deleting anything. This
+    /// avoids using the optimistic status update boundary, which is acceptable
+    /// for replaying data but can break decoding if schema versions are pruned
+    /// before PostgreSQL stores the acknowledgement.
+    async fn maybe_spawn_schema_cleanup(&mut self, reported_flush_lsn: PgLsn) -> EtlResult<()> {
+        self.collect_finished_schema_cleanup_task().await;
+
+        if self.state.has_schema_cleanup_task() {
+            return Ok(());
         }
 
-        // Gate cleanup by flushed progress because restart can replay WAL after
-        // the last durable flush lsn. A schema snapshot newer than that point
-        // may still be needed to decode replayed row changes, even if the live
-        // relation cache has already advanced to it.
-        let flush_lsn: SnapshotId = flush_lsn.into();
-        let mut current_snapshot_ids = self.shared_table_cache.snapshot_ids().await;
-        current_snapshot_ids.retain(|_, snapshot_id| *snapshot_id <= flush_lsn);
-
-        if current_snapshot_ids.is_empty() {
-            return;
-        }
-
-        self.state.mark_schema_cleanup_scheduled();
+        let Some(schema_cleanup_run) = self.state.try_start_schema_cleanup().await else {
+            return Ok(());
+        };
 
         let schema_store = self.schema_store.clone();
+        let pg_connection = self.config.pg_connection.clone();
+        let slot_name = self.state.slot_name().to_owned();
+        let shared_table_cache = self.shared_table_cache.clone();
         let worker_type = self.worker_context.worker_type();
+        let worker_context = self.worker_context.clone();
 
-        self.state.schema_cleanup_tasks.spawn(async move {
-            match schema_store.prune_table_schemas(current_snapshot_ids).await {
+        let cleanup_fut = async move {
+            let confirmed_flush_lsn = match Self::get_actual_confirmed_flush_lsn(
+                pg_connection,
+                &slot_name,
+                reported_flush_lsn,
+            )
+            .await
+            {
+                Ok(confirmed_flush_lsn) => confirmed_flush_lsn,
+                Err(err) => {
+                    warn!(
+                        %worker_type,
+                        %reported_flush_lsn,
+                        error = %err,
+                        "skipping schema cleanup because slot progress could not be confirmed"
+                    );
+
+                    return;
+                }
+            };
+
+            let table_ids = match Self::get_schema_cleanup_table_ids(
+                &worker_context,
+                &shared_table_cache,
+                confirmed_flush_lsn,
+            )
+            .await
+            {
+                Ok(table_ids) => table_ids,
+                Err(err) => {
+                    error!(
+                        %worker_type,
+                        error = %err,
+                        "failed to determine schema cleanup ownership"
+                    );
+
+                    return;
+                }
+            };
+
+            if table_ids.is_empty() {
+                return;
+            }
+
+            match schema_store.prune_table_schemas(table_ids, confirmed_flush_lsn.into()).await {
                 Ok(deleted_count) => {
                     counter!(
                         ETL_SCHEMA_CLEANUPS_TOTAL,
@@ -1439,15 +1539,79 @@ where
                     );
                 }
             }
-        });
+        };
+
+        self.state.set_schema_cleanup_task(tokio::spawn(async move {
+            cleanup_fut.await;
+            schema_cleanup_run.finish().await;
+        }));
+
+        Ok(())
+    }
+
+    /// Returns the slot-confirmed flush LSN to use as the cleanup boundary.
+    ///
+    /// Streaming status updates are optimistic: after sending one, the client
+    /// can keep processing and tolerate replay if PostgreSQL never stores the
+    /// acknowledgement. Schema cleanup is different because deleting a schema
+    /// that may still be needed on replay can stop decoding, so cleanup reads
+    /// `confirmed_flush_lsn` from the replication slot.
+    async fn get_actual_confirmed_flush_lsn(
+        pg_connection: PgConnectionConfig,
+        slot_name: &str,
+        reported_flush_lsn: PgLsn,
+    ) -> EtlResult<PgLsn> {
+        #[cfg(feature = "failpoints")]
+        if etl_fail_point_active(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP) {
+            return Ok(reported_flush_lsn);
+        }
+
+        let replication_client = PgReplicationClient::connect(pg_connection).await?;
+        let slot = replication_client.get_slot(&slot_name).await?;
+
+        Ok(slot.confirmed_flush_lsn)
+    }
+
+    /// Returns table ids this worker may clean up at the confirmed LSN.
+    ///
+    /// The shared cache is used only to find active tables. The schema store
+    /// computes the retained snapshot for each table from the confirmed flush
+    /// LSN before deleting anything.
+    async fn get_schema_cleanup_table_ids(
+        worker_context: &WorkerContext<S, D>,
+        shared_table_cache: &SharedTableCache,
+        confirmed_flush_lsn: PgLsn,
+    ) -> EtlResult<HashSet<TableId>> {
+        let active_table_ids = shared_table_cache.active_table_ids().await;
+        let mut table_ids = HashSet::with_capacity(active_table_ids.len());
+
+        for table_id in active_table_ids {
+            // Only prune snapshots for tables this worker would apply at this
+            // flush position. This keeps table sync workers limited to their
+            // assigned table while preserving apply worker ownership rules.
+            let should_apply_changes = Self::should_apply_changes_for_context(
+                worker_context,
+                table_id,
+                confirmed_flush_lsn,
+            )
+            .await?;
+
+            if should_apply_changes {
+                table_ids.insert(table_id);
+            }
+        }
+
+        Ok(table_ids)
     }
 
     /// Records the result of a completed background schema cleanup task.
-    fn handle_schema_cleanup_task_result(
-        &self,
-        cleanup_result: Option<Result<(), tokio::task::JoinError>>,
+    async fn handle_schema_cleanup_task_result(
+        &mut self,
+        cleanup_result: Result<(), tokio::task::JoinError>,
     ) {
-        if let Some(Err(err)) = cleanup_result {
+        if let Err(err) = cleanup_result {
+            self.state.reset_schema_cleanup_deadline().await;
+
             let worker_type = self.worker_context.worker_type();
             counter!(
                 ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
@@ -1463,10 +1627,17 @@ where
         }
     }
 
-    /// Joins all background schema cleanup tasks before the apply loop exits.
-    async fn drain_schema_cleanup_tasks(&mut self) {
-        while let Some(cleanup_result) = self.state.schema_cleanup_tasks.join_next().await {
-            self.handle_schema_cleanup_task_result(Some(cleanup_result));
+    /// Collects the schema cleanup task if it has completed.
+    async fn collect_finished_schema_cleanup_task(&mut self) {
+        if let Some(cleanup_task) = self.state.take_finished_schema_cleanup_task() {
+            self.handle_schema_cleanup_task_result(cleanup_task.await).await;
+        }
+    }
+
+    /// Joins the background schema cleanup task before the apply loop exits.
+    async fn drain_schema_cleanup_task(&mut self) {
+        if let Some(cleanup_task) = self.state.take_schema_cleanup_task() {
+            self.handle_schema_cleanup_task_result(cleanup_task.await).await;
         }
     }
 
@@ -2253,7 +2424,17 @@ where
         table_id: TableId,
         remote_final_lsn: PgLsn,
     ) -> EtlResult<bool> {
-        match &self.worker_context {
+        Self::should_apply_changes_for_context(&self.worker_context, table_id, remote_final_lsn)
+            .await
+    }
+
+    /// Determines whether a worker context owns changes for a table.
+    async fn should_apply_changes_for_context(
+        worker_context: &WorkerContext<S, D>,
+        table_id: TableId,
+        remote_final_lsn: PgLsn,
+    ) -> EtlResult<bool> {
+        match worker_context {
             WorkerContext::Apply(ctx) => {
                 apply_worker::should_apply_changes(ctx, table_id, remote_final_lsn).await
             }
@@ -3325,42 +3506,22 @@ mod tests {
             replication_progress,
             Duration::from_secs(1),
             SnapshotId::from(start_lsn),
+            "test_slot".to_string(),
         )
     }
 
-    #[test]
-    fn schema_cleanup_waits_for_interval_before_first_trigger() {
+    #[tokio::test]
+    async fn schema_cleanup_uses_deadline_between_runs() {
         let state = apply_loop_state();
 
-        assert!(!state.should_cleanup_schemas());
-    }
+        state.expire_schema_cleanup_deadline().await;
 
-    #[test]
-    fn schema_cleanup_uses_interval_after_first_trigger() {
-        let mut state = apply_loop_state();
+        let schema_cleanup_run = state.try_start_schema_cleanup().await.unwrap();
 
-        state.mark_schema_cleanup_scheduled();
+        assert!(state.try_start_schema_cleanup().await.is_none());
 
-        assert!(!state.should_cleanup_schemas());
+        schema_cleanup_run.finish().await;
 
-        state.last_schema_cleanup_at =
-            Some(Instant::now() - SCHEMA_CLEANUP_INTERVAL - Duration::from_secs(1));
-
-        assert!(state.should_cleanup_schemas());
-    }
-
-    #[test]
-    fn schema_cleanup_does_not_depend_on_status_update_type() {
-        let mut state = apply_loop_state();
-
-        state.mark_schema_cleanup_scheduled();
-
-        for _status_update_type in [
-            StatusUpdateType::KeepAlive,
-            StatusUpdateType::PeriodicKeepAlive,
-            StatusUpdateType::ShutdownFlush,
-        ] {
-            assert!(!state.should_cleanup_schemas());
-        }
+        assert!(state.try_start_schema_cleanup().await.is_none());
     }
 }

--- a/etl/src/replication/client.rs
+++ b/etl/src/replication/client.rs
@@ -720,7 +720,7 @@ impl PgReplicationClient {
 
     /// Deletes a replication slot with the specified name if it exists.
     ///
-    /// This method returns [`Ok(())`] when the slot is missing and propagates
+    /// This method returns `Ok(())` when the slot is missing and propagates
     /// any other error from [`PgReplicationClient::delete_slot`].
     pub async fn delete_slot_if_exists(&self, slot_name: &str) -> EtlResult<()> {
         self.delete_slot_internal(slot_name, false).await

--- a/etl/src/replication/mod.rs
+++ b/etl/src/replication/mod.rs
@@ -12,6 +12,6 @@ mod table_sync;
 pub(crate) use apply::{
     ApplyLoop, ApplyLoopResult, ApplyWorkerContext, TableSyncWorkerContext, WorkerContext,
 };
-pub(crate) use stream::{EventsStream, StatusUpdateType, TableCopyStream};
+pub(crate) use stream::{EventsStream, StatusUpdateResult, StatusUpdateType, TableCopyStream};
 pub(crate) use table_cache::SharedTableCache;
 pub(crate) use table_sync::{TableSyncResult, start_table_sync};

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -119,7 +119,10 @@ pub(crate) enum StatusUpdateType {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum StatusUpdateResult {
     /// A status update was accepted by the local replication stream wrapper.
-    Sent,
+    Sent {
+        /// The monotonic flush LSN accepted by the stream wrapper.
+        flush_lsn: PgLsn,
+    },
     /// No status update was sent because throttling suppressed it.
     Skipped,
 }
@@ -247,7 +250,7 @@ impl EventsStream {
             *this.last_write_lsn = Some(write_lsn);
             *this.last_flush_lsn = Some(flush_lsn);
 
-            return Ok(StatusUpdateResult::Sent);
+            return Ok(StatusUpdateResult::Sent { flush_lsn });
         }
 
         // The client's system clock at the time of transmission, as microseconds since
@@ -290,7 +293,7 @@ impl EventsStream {
         *this.last_write_lsn = Some(write_lsn);
         *this.last_flush_lsn = Some(flush_lsn);
 
-        Ok(StatusUpdateResult::Sent)
+        Ok(StatusUpdateResult::Sent { flush_lsn })
     }
 }
 

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -103,7 +103,7 @@ where
 
 /// The status update type when sending a status update message back to
 /// Postgres.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum StatusUpdateType {
     /// Represents an update in response to a keep alive from Postgres.
     KeepAlive,
@@ -113,6 +113,15 @@ pub(crate) enum StatusUpdateType {
     /// Represents an update before shutdown that requires acknowledgement from
     /// Postgres.
     ShutdownFlush,
+}
+
+/// Outcome of a status update attempt.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StatusUpdateResult {
+    /// A status update was accepted by the local replication stream wrapper.
+    Sent,
+    /// No status update was sent because throttling suppressed it.
+    Skipped,
 }
 
 impl StatusUpdateType {
@@ -167,17 +176,7 @@ impl EventsStream {
         mut flush_lsn: PgLsn,
         force: bool,
         status_update_type: StatusUpdateType,
-    ) -> EtlResult<()> {
-        // If the failpoint is active, we do not send any status update. This is useful
-        // for testing the system when we want to check what happens when no
-        // status updates are sent.
-        #[cfg(feature = "failpoints")]
-        if etl_fail_point_active(SEND_STATUS_UPDATE_FP) {
-            warn!("not sending status update due to active failpoint");
-
-            return Ok(());
-        }
-
+    ) -> EtlResult<StatusUpdateResult> {
         let this = self.project();
         // If the new write lsn is less than the last one, we can safely ignore it,
         // since we only want to report monotonically increasing values.
@@ -231,8 +230,24 @@ impl EventsStream {
                     "skipping status update"
                 );
 
-                return Ok(());
+                return Ok(StatusUpdateResult::Skipped);
             }
+        }
+
+        // If the failpoint is active, we do not send any status update. This is useful
+        // for testing the system when we want to check what happens when no
+        // status updates are sent. The local stream state is still advanced so
+        // callers exercise the same post-send paths as a status update that was
+        // lost before reaching PostgreSQL.
+        #[cfg(feature = "failpoints")]
+        if etl_fail_point_active(SEND_STATUS_UPDATE_FP) {
+            warn!("not sending status update due to active failpoint");
+
+            *this.last_update = Some(Instant::now());
+            *this.last_write_lsn = Some(write_lsn);
+            *this.last_flush_lsn = Some(flush_lsn);
+
+            return Ok(StatusUpdateResult::Sent);
         }
 
         // The client's system clock at the time of transmission, as microseconds since
@@ -275,7 +290,7 @@ impl EventsStream {
         *this.last_write_lsn = Some(write_lsn);
         *this.last_flush_lsn = Some(flush_lsn);
 
-        Ok(())
+        Ok(StatusUpdateResult::Sent)
     }
 }
 

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -177,6 +177,9 @@ impl EventsStream {
         force: bool,
         status_update_type: StatusUpdateType,
     ) -> EtlResult<StatusUpdateResult> {
+        // If the failpoint is active, we do not send any status update. This is useful
+        // for testing the system when we want to check what happens when no
+        // status updates are sent.
         #[cfg(feature = "failpoints")]
         if etl_fail_point_active(SEND_STATUS_UPDATE_FP) {
             warn!("not sending status update due to active failpoint");

--- a/etl/src/replication/stream.rs
+++ b/etl/src/replication/stream.rs
@@ -119,10 +119,7 @@ pub(crate) enum StatusUpdateType {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum StatusUpdateResult {
     /// A status update was accepted by the local replication stream wrapper.
-    Sent {
-        /// The monotonic flush LSN accepted by the stream wrapper.
-        flush_lsn: PgLsn,
-    },
+    Sent,
     /// No status update was sent because throttling suppressed it.
     Skipped,
 }
@@ -180,6 +177,13 @@ impl EventsStream {
         force: bool,
         status_update_type: StatusUpdateType,
     ) -> EtlResult<StatusUpdateResult> {
+        #[cfg(feature = "failpoints")]
+        if etl_fail_point_active(SEND_STATUS_UPDATE_FP) {
+            warn!("not sending status update due to active failpoint");
+
+            return Ok(StatusUpdateResult::Skipped);
+        }
+
         let this = self.project();
         // If the new write lsn is less than the last one, we can safely ignore it,
         // since we only want to report monotonically increasing values.
@@ -237,22 +241,6 @@ impl EventsStream {
             }
         }
 
-        // If the failpoint is active, we do not send any status update. This is useful
-        // for testing the system when we want to check what happens when no
-        // status updates are sent. The local stream state is still advanced so
-        // callers exercise the same post-send paths as a status update that was
-        // lost before reaching PostgreSQL.
-        #[cfg(feature = "failpoints")]
-        if etl_fail_point_active(SEND_STATUS_UPDATE_FP) {
-            warn!("not sending status update due to active failpoint");
-
-            *this.last_update = Some(Instant::now());
-            *this.last_write_lsn = Some(write_lsn);
-            *this.last_flush_lsn = Some(flush_lsn);
-
-            return Ok(StatusUpdateResult::Sent { flush_lsn });
-        }
-
         // The client's system clock at the time of transmission, as microseconds since
         // midnight on 2000-01-01.
         let ts = POSTGRES_EPOCH
@@ -293,7 +281,7 @@ impl EventsStream {
         *this.last_write_lsn = Some(write_lsn);
         *this.last_flush_lsn = Some(flush_lsn);
 
-        Ok(StatusUpdateResult::Sent { flush_lsn })
+        Ok(StatusUpdateResult::Sent)
     }
 }
 

--- a/etl/src/replication/table_cache.rs
+++ b/etl/src/replication/table_cache.rs
@@ -84,6 +84,12 @@ impl SharedTableCache {
         guard.get(table_id).cloned()
     }
 
+    /// Returns the current target snapshot for every table in the cache.
+    pub(crate) async fn snapshot_ids(&self) -> HashMap<TableId, SnapshotId> {
+        let guard = self.inner.read().await;
+        guard.iter().map(|(table_id, state)| (*table_id, state.snapshot_id())).collect()
+    }
+
     /// Records that a table is waiting for a new relation-state refresh for
     /// the supplied snapshot.
     pub(crate) async fn note_waiting_for_relation(
@@ -243,5 +249,23 @@ mod tests {
         let state = cache.get(&table_id).await.expect("table state should exist");
         assert_eq!(state.snapshot_id(), snapshot_id);
         assert!(state.replicated_table_schema().is_none());
+    }
+
+    #[tokio::test]
+    async fn snapshot_ids_returns_current_snapshot_by_table() {
+        let cache = SharedTableCache::new();
+        let ready_table_id = TableId::new(123);
+        let waiting_table_id = TableId::new(456);
+        let ready_snapshot_id = SnapshotId::new(10.into());
+        let waiting_snapshot_id = SnapshotId::new(20.into());
+
+        cache.note_ready(ready_table_id, create_test_schema()).await;
+        cache.note_waiting_for_relation(waiting_table_id, waiting_snapshot_id).await;
+
+        let snapshot_ids = cache.snapshot_ids().await;
+
+        assert_eq!(snapshot_ids.len(), 2);
+        assert_eq!(snapshot_ids.get(&ready_table_id), Some(&ready_snapshot_id));
+        assert_eq!(snapshot_ids.get(&waiting_table_id), Some(&waiting_snapshot_id));
     }
 }

--- a/etl/src/replication/table_cache.rs
+++ b/etl/src/replication/table_cache.rs
@@ -30,7 +30,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use etl_postgres::types::{ReplicatedTableSchema, SnapshotId, TableId};
 use tokio::sync::RwLock;
-use tracing::warn;
 
 /// Shared per-table protocol state used to decode logical replication messages.
 #[derive(Debug, Clone)]
@@ -110,26 +109,18 @@ impl SharedTableCache {
         self.upsert(table_id, SharedTableState::Ready { replicated_table_schema }).await;
     }
 
-    /// Inserts or updates shared table state when the incoming snapshot is not
-    /// stale.
+    /// Inserts or updates shared table state.
+    ///
+    /// This cache is deliberately oblivious to ordering and ownership. It
+    /// assumes workers call it only after the apply loop has established table
+    /// ownership, and it follows the order of those calls even when a reconnect
+    /// replays older WAL.
     async fn upsert(&self, table_id: TableId, new_state: SharedTableState) {
         let mut guard = self.inner.write().await;
-        let snapshot_id = new_state.snapshot_id();
-        match guard.get_mut(&table_id) {
-            Some(state) if state.snapshot_id() > snapshot_id => {
-                warn!(
-                    table_id = %table_id,
-                    current_snapshot_id = %state.snapshot_id(),
-                    requested_snapshot_id = %snapshot_id,
-                    "ignoring stale shared table cache snapshot update"
-                );
-            }
-            Some(state) => {
-                *state = new_state;
-            }
-            None => {
-                guard.insert(table_id, new_state);
-            }
+        if let Some(state) = guard.get_mut(&table_id) {
+            *state = new_state;
+        } else {
+            guard.insert(table_id, new_state);
         }
     }
 }
@@ -199,7 +190,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn older_snapshot_is_ignored() {
+    async fn older_snapshot_rewinds_to_waiting_relation() {
         let cache = SharedTableCache::new();
         let table_id = TableId::new(123);
         let replicated_table_schema = create_test_schema();
@@ -208,8 +199,8 @@ mod tests {
         cache.note_waiting_for_relation(table_id, SnapshotId::new(9.into())).await;
 
         let state = cache.get(&table_id).await.expect("table state should exist");
-        assert_eq!(state.snapshot_id(), SnapshotId::new(10.into()));
-        assert!(matches!(state, SharedTableState::Ready { .. }));
+        assert_eq!(state.snapshot_id(), SnapshotId::new(9.into()));
+        assert!(matches!(state, SharedTableState::WaitingForRelation { .. }));
     }
 
     #[tokio::test]

--- a/etl/src/replication/table_cache.rs
+++ b/etl/src/replication/table_cache.rs
@@ -84,10 +84,11 @@ impl SharedTableCache {
         guard.get(table_id).cloned()
     }
 
-    /// Returns the current target snapshot for every table in the cache.
-    pub(crate) async fn snapshot_ids(&self) -> HashMap<TableId, SnapshotId> {
+    /// Returns the current active table ids in the cache, which represent the
+    /// active tables being replicated.
+    pub(crate) async fn active_table_ids(&self) -> Vec<TableId> {
         let guard = self.inner.read().await;
-        guard.iter().map(|(table_id, state)| (*table_id, state.snapshot_id())).collect()
+        guard.keys().copied().collect()
     }
 
     /// Records that a table is waiting for a new relation-state refresh for
@@ -120,15 +121,7 @@ impl SharedTableCache {
                     table_id = %table_id,
                     current_snapshot_id = %state.snapshot_id(),
                     requested_snapshot_id = %snapshot_id,
-                    "shared table cache received a stale snapshot update; this may indicate out-of-order protocol state"
-                );
-
-                debug_assert!(
-                    state.snapshot_id() <= snapshot_id,
-                    "shared table cache received stale snapshot update for table {table_id}: \
-                     current={}, requested={}",
-                    state.snapshot_id(),
-                    snapshot_id
+                    "ignoring stale shared table cache snapshot update"
                 );
             }
             Some(state) => {
@@ -205,15 +198,18 @@ mod tests {
         assert!(matches!(state, SharedTableState::WaitingForRelation { .. }));
     }
 
-    #[should_panic(expected = "shared table cache received stale snapshot update")]
     #[tokio::test]
-    async fn older_snapshot_panics() {
+    async fn older_snapshot_is_ignored() {
         let cache = SharedTableCache::new();
         let table_id = TableId::new(123);
         let replicated_table_schema = create_test_schema();
 
         cache.note_ready(table_id, replicated_table_schema).await;
         cache.note_waiting_for_relation(table_id, SnapshotId::new(9.into())).await;
+
+        let state = cache.get(&table_id).await.expect("table state should exist");
+        assert_eq!(state.snapshot_id(), SnapshotId::new(10.into()));
+        assert!(matches!(state, SharedTableState::Ready { .. }));
     }
 
     #[tokio::test]
@@ -252,20 +248,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn snapshot_ids_returns_current_snapshot_by_table() {
+    async fn active_table_ids_returns_current_tables() {
         let cache = SharedTableCache::new();
         let ready_table_id = TableId::new(123);
         let waiting_table_id = TableId::new(456);
-        let ready_snapshot_id = SnapshotId::new(10.into());
         let waiting_snapshot_id = SnapshotId::new(20.into());
 
         cache.note_ready(ready_table_id, create_test_schema()).await;
         cache.note_waiting_for_relation(waiting_table_id, waiting_snapshot_id).await;
 
-        let snapshot_ids = cache.snapshot_ids().await;
+        let table_ids = cache.active_table_ids().await;
 
-        assert_eq!(snapshot_ids.len(), 2);
-        assert_eq!(snapshot_ids.get(&ready_table_id), Some(&ready_snapshot_id));
-        assert_eq!(snapshot_ids.get(&waiting_table_id), Some(&waiting_snapshot_id));
+        assert_eq!(table_ids.len(), 2);
+        assert!(table_ids.contains(&ready_table_id));
+        assert!(table_ids.contains(&waiting_table_id));
     }
 }

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     store::{
         cleanup::CleanupStore,
-        schema::{SchemaStore, TableSchemaRetention},
+        schema::{SchemaStore, TableSchemaRetention, TableSchemaSnapshots},
         state::{DestinationTablesMetadata, StateStore, TableReplicationStates},
     },
     types::{SnapshotId, TableId, TableSchema},
@@ -32,9 +32,8 @@ struct Inner {
     /// provides visibility into table state evolution. Entries are
     /// chronologically ordered.
     table_state_history: HashMap<TableId, Vec<TableReplicationPhase>>,
-    /// Cached table schemas keyed by (TableId, SnapshotId) for versioning
-    /// support.
-    table_schemas: HashMap<(TableId, SnapshotId), Arc<TableSchema>>,
+    /// Cached table schema snapshots.
+    table_schemas: Arc<TableSchemaSnapshots>,
     /// Cached destination table metadata indexed by table ID.
     destination_tables_metadata: DestinationTablesMetadata,
 }
@@ -64,8 +63,8 @@ impl MemoryStore {
         let inner = Inner {
             table_replication_states: Arc::new(BTreeMap::new()),
             table_state_history: HashMap::new(),
-            table_schemas: HashMap::new(),
-            destination_tables_metadata: Arc::new(HashMap::new()),
+            table_schemas: Arc::new(TableSchemaSnapshots::default()),
+            destination_tables_metadata: Arc::new(BTreeMap::new()),
         };
 
         Self { inner: Arc::new(Mutex::new(inner)) }
@@ -202,21 +201,13 @@ impl SchemaStore for MemoryStore {
     ) -> EtlResult<Option<Arc<TableSchema>>> {
         let inner = self.inner.lock().await;
 
-        // Find the best matching schema (largest snapshot_id <= requested).
-        let best_match = inner
-            .table_schemas
-            .iter()
-            .filter(|((tid, sid), _)| *tid == *table_id && *sid <= snapshot_id)
-            .max_by_key(|((_, sid), _)| *sid)
-            .map(|(_, schema)| Arc::clone(schema));
-
-        Ok(best_match)
+        Ok(inner.table_schemas.get_at_or_before(*table_id, snapshot_id))
     }
 
     async fn get_table_schemas(&self) -> EtlResult<Vec<Arc<TableSchema>>> {
         let inner = self.inner.lock().await;
 
-        Ok(inner.table_schemas.values().map(Arc::clone).collect())
+        Ok(inner.table_schemas.all())
     }
 
     async fn load_table_schemas(&self) -> EtlResult<usize> {
@@ -228,10 +219,7 @@ impl SchemaStore for MemoryStore {
     async fn store_table_schema(&self, table_schema: TableSchema) -> EtlResult<Arc<TableSchema>> {
         let mut inner = self.inner.lock().await;
 
-        let key = (table_schema.id, table_schema.snapshot_id);
-        let table_schema = Arc::new(table_schema);
-        inner.table_schemas.insert(key, Arc::clone(&table_schema));
-        Ok(table_schema)
+        Ok(Arc::make_mut(&mut inner.table_schemas).insert(table_schema))
     }
 
     async fn prune_table_schemas(
@@ -240,33 +228,7 @@ impl SchemaStore for MemoryStore {
     ) -> EtlResult<u64> {
         let mut inner = self.inner.lock().await;
 
-        let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
-        for (table_id, snapshot_id) in inner.table_schemas.keys() {
-            let Some(retention) = table_schema_retentions.get(table_id) else {
-                continue;
-            };
-
-            let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
-            if *snapshot_id > retention_snapshot_id {
-                continue;
-            }
-
-            retained_snapshot_ids
-                .entry(*table_id)
-                .and_modify(|retained_snapshot_id| {
-                    *retained_snapshot_id = (*retained_snapshot_id).max(*snapshot_id);
-                })
-                .or_insert(*snapshot_id);
-        }
-
-        let before_count = inner.table_schemas.len();
-        inner.table_schemas.retain(|(table_id, snapshot_id), _| {
-            retained_snapshot_ids
-                .get(table_id)
-                .is_none_or(|retained_snapshot_id| snapshot_id >= retained_snapshot_id)
-        });
-
-        Ok(before_count.saturating_sub(inner.table_schemas.len()) as u64)
+        Ok(Arc::make_mut(&mut inner.table_schemas).prune(&table_schema_retentions))
     }
 }
 
@@ -276,8 +238,8 @@ impl CleanupStore for MemoryStore {
 
         Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
         inner.table_state_history.remove(&table_id);
-        // Remove all schema versions for this table
-        inner.table_schemas.retain(|(tid, _), _| *tid != table_id);
+        // Remove all schema versions for this table.
+        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
         Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
 
         Ok(())

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use tokio::sync::Mutex;
+use tokio_postgres::types::PgLsn;
 
 use crate::{
     error::{ErrorKind, EtlResult},
@@ -237,13 +238,14 @@ impl SchemaStore for MemoryStore {
     async fn prune_table_schemas(
         &self,
         table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: SnapshotId,
+        confirmed_flush_lsn: PgLsn,
     ) -> EtlResult<u64> {
         let mut inner = self.inner.lock().await;
+        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
 
         let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
         for (table_id, snapshot_id) in inner.table_schemas.keys() {
-            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_lsn {
+            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_snapshot_id {
                 continue;
             }
 

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -236,15 +236,30 @@ impl SchemaStore for MemoryStore {
 
     async fn prune_table_schemas(
         &self,
-        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+        table_ids: HashSet<TableId>,
+        confirmed_flush_lsn: SnapshotId,
     ) -> EtlResult<u64> {
         let mut inner = self.inner.lock().await;
 
+        let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
+        for (table_id, snapshot_id) in inner.table_schemas.keys() {
+            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_lsn {
+                continue;
+            }
+
+            retained_snapshot_ids
+                .entry(*table_id)
+                .and_modify(|retained_snapshot_id| {
+                    *retained_snapshot_id = (*retained_snapshot_id).max(*snapshot_id);
+                })
+                .or_insert(*snapshot_id);
+        }
+
         let before_count = inner.table_schemas.len();
         inner.table_schemas.retain(|(table_id, snapshot_id), _| {
-            current_snapshot_ids
+            retained_snapshot_ids
                 .get(table_id)
-                .is_none_or(|current_snapshot_id| snapshot_id >= current_snapshot_id)
+                .is_none_or(|retained_snapshot_id| snapshot_id >= retained_snapshot_id)
         });
 
         Ok(before_count.saturating_sub(inner.table_schemas.len()) as u64)

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -1,10 +1,9 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     sync::Arc,
 };
 
 use tokio::sync::Mutex;
-use tokio_postgres::types::PgLsn;
 
 use crate::{
     error::{ErrorKind, EtlResult},
@@ -15,7 +14,7 @@ use crate::{
     },
     store::{
         cleanup::CleanupStore,
-        schema::SchemaStore,
+        schema::{SchemaStore, TableSchemaRetention},
         state::{DestinationTablesMetadata, StateStore, TableReplicationStates},
     },
     types::{SnapshotId, TableId, TableSchema},
@@ -237,15 +236,18 @@ impl SchemaStore for MemoryStore {
 
     async fn prune_table_schemas(
         &self,
-        table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: PgLsn,
+        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> EtlResult<u64> {
         let mut inner = self.inner.lock().await;
-        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
 
         let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
         for (table_id, snapshot_id) in inner.table_schemas.keys() {
-            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_snapshot_id {
+            let Some(retention) = table_schema_retentions.get(table_id) else {
+                continue;
+            };
+
+            let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
+            if *snapshot_id > retention_snapshot_id {
                 continue;
             }
 

--- a/etl/src/store/both/memory.rs
+++ b/etl/src/store/both/memory.rs
@@ -233,6 +233,22 @@ impl SchemaStore for MemoryStore {
         inner.table_schemas.insert(key, Arc::clone(&table_schema));
         Ok(table_schema)
     }
+
+    async fn prune_table_schemas(
+        &self,
+        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+    ) -> EtlResult<u64> {
+        let mut inner = self.inner.lock().await;
+
+        let before_count = inner.table_schemas.len();
+        inner.table_schemas.retain(|(table_id, snapshot_id), _| {
+            current_snapshot_ids
+                .get(table_id)
+                .is_none_or(|current_snapshot_id| snapshot_id >= current_snapshot_id)
+        });
+
+        Ok(before_count.saturating_sub(inner.table_schemas.len()) as u64)
+    }
 }
 
 impl CleanupStore for MemoryStore {

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::DerefMut,
     sync::Arc,
     time::Duration,
@@ -205,17 +205,32 @@ impl Inner {
         }
     }
 
-    /// Prunes cached schema versions older than the current snapshot for each
+    /// Prunes cached schema versions older than the retained snapshot for each
     /// table.
     fn prune_table_schemas(
         &mut self,
-        current_snapshot_ids: &HashMap<TableId, SnapshotId>,
+        table_ids: &HashSet<TableId>,
+        confirmed_flush_lsn: SnapshotId,
     ) -> usize {
+        let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
+        for (table_id, snapshot_id) in self.table_schemas.keys() {
+            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_lsn {
+                continue;
+            }
+
+            retained_snapshot_ids
+                .entry(*table_id)
+                .and_modify(|retained_snapshot_id| {
+                    *retained_snapshot_id = (*retained_snapshot_id).max(*snapshot_id);
+                })
+                .or_insert(*snapshot_id);
+        }
+
         let before_count = self.table_schemas.len();
         self.table_schemas.retain(|(table_id, snapshot_id), _| {
-            current_snapshot_ids
+            retained_snapshot_ids
                 .get(table_id)
-                .is_none_or(|current_snapshot_id| snapshot_id >= current_snapshot_id)
+                .is_none_or(|retained_snapshot_id| snapshot_id >= retained_snapshot_id)
         });
 
         before_count.saturating_sub(self.table_schemas.len())
@@ -671,12 +686,14 @@ impl SchemaStore for PostgresStore {
 
     async fn prune_table_schemas(
         &self,
-        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+        table_ids: HashSet<TableId>,
+        confirmed_flush_lsn: SnapshotId,
     ) -> EtlResult<u64> {
         let deleted_count = schema::delete_obsolete_table_schema_versions(
             &self.pool,
             self.pipeline_id as i64,
-            &current_snapshot_ids,
+            &table_ids,
+            confirmed_flush_lsn,
         )
         .await
         .map_err(|err| {
@@ -688,13 +705,13 @@ impl SchemaStore for PostgresStore {
         })?;
 
         let mut inner = self.inner.lock().await;
-        let cached_count = inner.prune_table_schemas(&current_snapshot_ids);
+        let cached_count = inner.prune_table_schemas(&table_ids, confirmed_flush_lsn);
 
         if deleted_count > 0 || cached_count > 0 {
             info!(
                 deleted_count,
                 cached_count,
-                table_count = current_snapshot_ids.len(),
+                table_count = table_ids.len(),
                 "pruned obsolete table schema versions"
             );
         }

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -12,6 +12,7 @@ use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
 };
 use tokio::sync::Mutex;
+use tokio_postgres::types::PgLsn;
 use tracing::{debug, info};
 
 use crate::{
@@ -210,11 +211,12 @@ impl Inner {
     fn prune_table_schemas(
         &mut self,
         table_ids: &HashSet<TableId>,
-        confirmed_flush_lsn: SnapshotId,
+        confirmed_flush_lsn: PgLsn,
     ) -> usize {
+        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
         let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
         for (table_id, snapshot_id) in self.table_schemas.keys() {
-            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_lsn {
+            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_snapshot_id {
                 continue;
             }
 
@@ -687,7 +689,7 @@ impl SchemaStore for PostgresStore {
     async fn prune_table_schemas(
         &self,
         table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: SnapshotId,
+        confirmed_flush_lsn: PgLsn,
     ) -> EtlResult<u64> {
         let deleted_count = schema::delete_obsolete_table_schema_versions(
             &self.pool,

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -204,6 +204,22 @@ impl Inner {
             }
         }
     }
+
+    /// Prunes cached schema versions older than the current snapshot for each
+    /// table.
+    fn prune_table_schemas(
+        &mut self,
+        current_snapshot_ids: &HashMap<TableId, SnapshotId>,
+    ) -> usize {
+        let before_count = self.table_schemas.len();
+        self.table_schemas.retain(|(table_id, snapshot_id), _| {
+            current_snapshot_ids
+                .get(table_id)
+                .is_none_or(|current_snapshot_id| snapshot_id >= current_snapshot_id)
+        });
+
+        before_count.saturating_sub(self.table_schemas.len())
+    }
 }
 
 /// Postgres-backed storage for ETL pipeline state and schema information.
@@ -247,7 +263,7 @@ impl PostgresStore {
     ///
     /// Runs the required ETL migrations and then creates a lazily-connected
     /// pool with automatic idle timeout. Connections are established on
-    /// first use and automatically closed after [`IDLE_TIMEOUT`] of
+    /// first use and automatically closed after `IDLE_TIMEOUT` of
     /// inactivity.
     pub async fn new(
         pipeline_id: PipelineId,
@@ -405,8 +421,8 @@ impl StateStore for PostgresStore {
 
     /// Retrieves destination table metadata for a specific table from cache.
     ///
-    /// This method provides fast access to destination metadata by reading
-    /// from the in-memory cache.
+    /// This method provides fast access to destination table metadata by
+    /// reading from the in-memory cache.
     async fn get_destination_table_metadata(
         &self,
         table_id: TableId,
@@ -651,6 +667,39 @@ impl SchemaStore for PostgresStore {
         inner.insert_schema_with_eviction(Arc::clone(&table_schema));
 
         Ok(table_schema)
+    }
+
+    async fn prune_table_schemas(
+        &self,
+        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+    ) -> EtlResult<u64> {
+        let deleted_count = schema::delete_obsolete_table_schema_versions(
+            &self.pool,
+            self.pipeline_id as i64,
+            &current_snapshot_ids,
+        )
+        .await
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Obsolete table schema deletion failed",
+                format!("Failed to delete obsolete table schemas from PostgreSQL: {}", err)
+            )
+        })?;
+
+        let mut inner = self.inner.lock().await;
+        let cached_count = inner.prune_table_schemas(&current_snapshot_ids);
+
+        if deleted_count > 0 || cached_count > 0 {
+            info!(
+                deleted_count,
+                cached_count,
+                table_count = current_snapshot_ids.len(),
+                "pruned obsolete table schema versions"
+            );
+        }
+
+        Ok(deleted_count)
     }
 }
 

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     ops::DerefMut,
     sync::Arc,
     time::Duration,
@@ -12,7 +12,6 @@ use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
 };
 use tokio::sync::Mutex;
-use tokio_postgres::types::PgLsn;
 use tracing::{debug, info};
 
 use crate::{
@@ -30,7 +29,7 @@ use crate::{
     },
     store::{
         cleanup::CleanupStore,
-        schema::SchemaStore,
+        schema::{SchemaStore, TableSchemaRetention},
         state::{DestinationTablesMetadata, StateStore, TableReplicationStates},
     },
     types::{PipelineId, ReplicationMask, SnapshotId, TableId, TableSchema},
@@ -210,13 +209,16 @@ impl Inner {
     /// table.
     fn prune_table_schemas(
         &mut self,
-        table_ids: &HashSet<TableId>,
-        confirmed_flush_lsn: PgLsn,
+        table_schema_retentions: &HashMap<TableId, TableSchemaRetention>,
     ) -> usize {
-        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
         let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
         for (table_id, snapshot_id) in self.table_schemas.keys() {
-            if !table_ids.contains(table_id) || *snapshot_id > confirmed_flush_snapshot_id {
+            let Some(retention) = table_schema_retentions.get(table_id) else {
+                continue;
+            };
+
+            let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
+            if *snapshot_id > retention_snapshot_id {
                 continue;
             }
 
@@ -688,14 +690,16 @@ impl SchemaStore for PostgresStore {
 
     async fn prune_table_schemas(
         &self,
-        table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: PgLsn,
+        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> EtlResult<u64> {
+        let retention_lsns = table_schema_retentions
+            .iter()
+            .map(|(table_id, retention)| (*table_id, retention.to_lsn()))
+            .collect::<HashMap<_, _>>();
         let deleted_count = schema::delete_obsolete_table_schema_versions(
             &self.pool,
             self.pipeline_id as i64,
-            &table_ids,
-            confirmed_flush_lsn,
+            &retention_lsns,
         )
         .await
         .map_err(|err| {
@@ -707,13 +711,13 @@ impl SchemaStore for PostgresStore {
         })?;
 
         let mut inner = self.inner.lock().await;
-        let cached_count = inner.prune_table_schemas(&table_ids, confirmed_flush_lsn);
+        let cached_count = inner.prune_table_schemas(&table_schema_retentions);
 
         if deleted_count > 0 || cached_count > 0 {
             info!(
                 deleted_count,
                 cached_count,
-                table_count = table_ids.len(),
+                table_count = table_schema_retentions.len(),
                 "pruned obsolete table schema versions"
             );
         }

--- a/etl/src/store/both/postgres.rs
+++ b/etl/src/store/both/postgres.rs
@@ -29,16 +29,13 @@ use crate::{
     },
     store::{
         cleanup::CleanupStore,
-        schema::{SchemaStore, TableSchemaRetention},
+        schema::{SchemaStore, TableSchemaRetention, TableSchemaSnapshots},
         state::{DestinationTablesMetadata, StateStore, TableReplicationStates},
     },
     types::{PipelineId, ReplicationMask, SnapshotId, TableId, TableSchema},
 };
 
 /// Maximum number of connections in the pool.
-///
-/// Set to 2 to allow some concurrency since database operations are performed
-/// before acquiring the cache lock.
 const MAX_POOL_CONNECTIONS: u32 = 2;
 
 /// Duration after which idle connections are closed.
@@ -113,21 +110,24 @@ fn emit_table_metrics(counts_by_phase: &HashMap<&'static str, u64>) {
 }
 
 /// Inner state of [`PostgresStore`].
+///
+/// TODO: rework the locking implementation. The store currently serializes
+/// operations with one coarse lock for consistency, but a finer-grained
+/// per-table locking algorithm would improve throughput.
 #[derive(Debug)]
 struct Inner {
     /// Count of number of tables in each phase. Used for metrics.
     phase_counts: HashMap<&'static str, u64>,
     /// Cached table replication states indexed by table ID.
     table_states: TableReplicationStates,
-    /// Cached table schemas indexed by (table_id, snapshot_id) for versioning
-    /// support.
+    /// Cached table schema snapshots.
     ///
     /// This cache is optimized for keeping the most actively used schemas in
     /// memory, not all historical snapshots. Schemas are loaded on-demand
     /// from the database when not found in cache. During normal operation,
     /// this typically contains only the latest schema version for each
     /// table, since that's what the replication pipeline actively uses.
-    table_schemas: HashMap<(TableId, SnapshotId), Arc<TableSchema>>,
+    table_schemas: Arc<TableSchemaSnapshots>,
     /// Cached destination table metadata indexed by table ID.
     destination_tables_metadata: DestinationTablesMetadata,
 }
@@ -172,73 +172,6 @@ impl Inner {
             }
         }
     }
-
-    /// Inserts a schema into the cache and evicts older snapshots if necessary.
-    ///
-    /// Maintains at most [`MAX_CACHED_SCHEMAS_PER_TABLE`] snapshots per table,
-    /// evicting the oldest snapshots when the limit is exceeded.
-    fn insert_schema_with_eviction(&mut self, table_schema: Arc<TableSchema>) {
-        let table_id = table_schema.id;
-        let snapshot_id = table_schema.snapshot_id;
-
-        // Insert the new schema.
-        self.table_schemas.insert((table_id, snapshot_id), table_schema);
-
-        // Collect all snapshot_ids for this table.
-        let mut snapshots_for_table: Vec<SnapshotId> = self
-            .table_schemas
-            .keys()
-            .filter(|(tid, _)| *tid == table_id)
-            .map(|(_, sid)| *sid)
-            .collect();
-
-        // If we exceed the limit, evict oldest snapshots.
-        if snapshots_for_table.len() > MAX_CACHED_SCHEMAS_PER_TABLE {
-            // Sort ascending so oldest are first.
-            snapshots_for_table.sort();
-
-            // Remove oldest entries until we're at the limit.
-            let to_remove = snapshots_for_table.len() - MAX_CACHED_SCHEMAS_PER_TABLE;
-            for &old_snapshot_id in snapshots_for_table.iter().take(to_remove) {
-                self.table_schemas.remove(&(table_id, old_snapshot_id));
-            }
-        }
-    }
-
-    /// Prunes cached schema versions older than the retained snapshot for each
-    /// table.
-    fn prune_table_schemas(
-        &mut self,
-        table_schema_retentions: &HashMap<TableId, TableSchemaRetention>,
-    ) -> usize {
-        let mut retained_snapshot_ids: HashMap<TableId, SnapshotId> = HashMap::new();
-        for (table_id, snapshot_id) in self.table_schemas.keys() {
-            let Some(retention) = table_schema_retentions.get(table_id) else {
-                continue;
-            };
-
-            let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
-            if *snapshot_id > retention_snapshot_id {
-                continue;
-            }
-
-            retained_snapshot_ids
-                .entry(*table_id)
-                .and_modify(|retained_snapshot_id| {
-                    *retained_snapshot_id = (*retained_snapshot_id).max(*snapshot_id);
-                })
-                .or_insert(*snapshot_id);
-        }
-
-        let before_count = self.table_schemas.len();
-        self.table_schemas.retain(|(table_id, snapshot_id), _| {
-            retained_snapshot_ids
-                .get(table_id)
-                .is_none_or(|retained_snapshot_id| snapshot_id >= retained_snapshot_id)
-        });
-
-        before_count.saturating_sub(self.table_schemas.len())
-    }
 }
 
 /// Postgres-backed storage for ETL pipeline state and schema information.
@@ -254,22 +187,10 @@ impl Inner {
 ///
 /// # Concurrency Model
 ///
-/// Write operations follow a DB-first pattern: the database is updated first,
-/// then the in-memory cache. This ensures that if a crash occurs after the DB
-/// write but before the cache update, the correct state is reloaded from DB on
-/// restart (the database is the source of truth).
-///
-/// The application-level lock is only held for brief cache updates, minimizing
-/// the critical section to increase performance. This design assumes no
-/// concurrent updates to the same table: the `apply_worker` and
-/// `table_sync_worker` coordinate through state transitions and never race on
-/// the same table.
-///
-/// If this invariant is violated, there could be some execution orders that
-/// could result in an inconsistent state. For example, there could be two state
-/// updates u1 and u2 being run in sequence. However, then u2 lands before u1
-/// due to network latency, which causes the in-memory code to be updated to the
-/// result of u2 and then later to u1, causing an inconsistent state.
+/// Store operations hold the application-level lock across the database work
+/// and the cache update. This keeps the persistent state and in-memory cache
+/// ordered consistently, at the cost of serializing operations that could
+/// eventually be independent with finer-grained per-table locking.
 #[derive(Debug, Clone)]
 pub struct PostgresStore {
     pipeline_id: PipelineId,
@@ -296,8 +217,8 @@ impl PostgresStore {
         let inner = Inner {
             phase_counts: HashMap::new(),
             table_states: Arc::new(BTreeMap::new()),
-            table_schemas: HashMap::new(),
-            destination_tables_metadata: Arc::new(HashMap::new()),
+            table_schemas: Arc::new(TableSchemaSnapshots::default()),
+            destination_tables_metadata: Arc::new(BTreeMap::new()),
         };
 
         Ok(Self { pipeline_id, pool, inner: Arc::new(Mutex::new(inner)) })
@@ -339,6 +260,7 @@ impl StateStore for PostgresStore {
     async fn load_table_replication_states(&self) -> EtlResult<usize> {
         debug!("loading table replication states from postgres state store");
 
+        let mut inner = self.inner.lock().await;
         let replication_state_rows =
             state::get_table_replication_state_rows(&self.pool, self.pipeline_id as i64).await?;
 
@@ -351,10 +273,6 @@ impl StateStore for PostgresStore {
 
         let table_states_len = table_states.len();
 
-        // For performance reasons, since we load the replication states only once
-        // during startup and from a single thread, we can afford to have a
-        // short critical section.
-        let mut inner = self.inner.lock().await;
         inner.init_phase_counts(&table_states);
         inner.table_states = Arc::new(table_states);
         emit_table_metrics(&inner.phase_counts);
@@ -384,7 +302,9 @@ impl StateStore for PostgresStore {
                 })
                 .collect::<EtlResult<Vec<_>>>()?;
 
-        // Perform all database updates in a single transaction
+        let mut inner = self.inner.lock().await;
+
+        // Perform all database updates in a single transaction.
         let mut tx = self.pool.begin().await?;
         for (table_id, state_type, metadata) in db_updates {
             state::update_replication_state_raw(
@@ -398,8 +318,7 @@ impl StateStore for PostgresStore {
         }
         tx.commit().await?;
 
-        // Update the cache
-        let mut inner = self.inner.lock().await;
+        // Update the cache.
         for (table_id, state) in updates {
             inner.set_table_state(table_id, state);
         }
@@ -415,6 +334,7 @@ impl StateStore for PostgresStore {
         &self,
         table_id: TableId,
     ) -> EtlResult<TableReplicationPhase> {
+        let mut inner = self.inner.lock().await;
         let mut tx = self.pool.begin().await?;
 
         let restored_row =
@@ -431,7 +351,6 @@ impl StateStore for PostgresStore {
         let restored_phase = TableReplicationPhase::from_state_row(restored_row)?;
         tx.commit().await?;
 
-        let mut inner = self.inner.lock().await;
         inner.set_table_state(table_id, restored_phase.clone());
         emit_table_metrics(&inner.phase_counts);
 
@@ -472,6 +391,7 @@ impl StateStore for PostgresStore {
     async fn load_destination_tables_metadata(&self) -> EtlResult<usize> {
         debug!("loading destination tables metadata from postgres state store");
 
+        let mut inner = self.inner.lock().await;
         let rows = destination_metadata::load_destination_tables_metadata(
             &self.pool,
             self.pipeline_id as i64,
@@ -485,7 +405,7 @@ impl StateStore for PostgresStore {
             )
         })?;
 
-        let mut metadata: HashMap<TableId, DestinationTableMetadata> = HashMap::new();
+        let mut metadata: BTreeMap<TableId, DestinationTableMetadata> = BTreeMap::new();
         for (table_id, row) in rows {
             metadata.insert(
                 table_id,
@@ -500,7 +420,6 @@ impl StateStore for PostgresStore {
         }
 
         let metadata_len = metadata.len();
-        let mut inner = self.inner.lock().await;
         inner.destination_tables_metadata = Arc::new(metadata);
 
         info!(count = metadata_len, "loaded destination tables metadata from postgres state store");
@@ -520,6 +439,7 @@ impl StateStore for PostgresStore {
             "storing destination table metadata"
         );
 
+        let mut inner = self.inner.lock().await;
         destination_metadata::store_destination_table_metadata(
             &self.pool,
             self.pipeline_id as i64,
@@ -539,7 +459,6 @@ impl StateStore for PostgresStore {
             )
         })?;
 
-        let mut inner = self.inner.lock().await;
         Arc::make_mut(&mut inner.destination_tables_metadata).insert(table_id, metadata);
 
         Ok(())
@@ -559,26 +478,11 @@ impl SchemaStore for PostgresStore {
         table_id: &TableId,
         snapshot_id: SnapshotId,
     ) -> EtlResult<Option<Arc<TableSchema>>> {
-        // First, check if we have a cached schema that matches the criteria.
-        //
-        // We can afford to hold the lock only for this short critical section since we
-        // assume that there is not really concurrency at the table level since
-        // each table is processed by exactly one worker.
-        {
-            let inner = self.inner.lock().await;
+        let mut inner = self.inner.lock().await;
 
-            // Find the best matching schema in the cache (largest snapshot_id <=
-            // requested).
-            let newest_table_schema = inner
-                .table_schemas
-                .iter()
-                .filter(|((tid, sid), _)| *tid == *table_id && *sid <= snapshot_id)
-                .max_by_key(|((_, sid), _)| *sid)
-                .map(|(_, schema)| Arc::clone(schema));
-
-            if newest_table_schema.is_some() {
-                return Ok(newest_table_schema);
-            }
+        let newest_table_schema = inner.table_schemas.get_at_or_before(*table_id, snapshot_id);
+        if newest_table_schema.is_some() {
+            return Ok(newest_table_schema);
         }
 
         debug!(
@@ -609,16 +513,10 @@ impl SchemaStore for PostgresStore {
             return Ok(None);
         };
 
-        let result = {
-            let mut inner = self.inner.lock().await;
-
-            let table_schema = Arc::new(table_schema);
-            inner.insert_schema_with_eviction(Arc::clone(&table_schema));
-
-            Some(table_schema)
-        };
-
-        Ok(result)
+        Ok(Some(
+            Arc::make_mut(&mut inner.table_schemas)
+                .insert_with_eviction(table_schema, MAX_CACHED_SCHEMAS_PER_TABLE),
+        ))
     }
 
     /// Retrieves all cached table schemas as a vector.
@@ -628,7 +526,7 @@ impl SchemaStore for PostgresStore {
     async fn get_table_schemas(&self) -> EtlResult<Vec<Arc<TableSchema>>> {
         let inner = self.inner.lock().await;
 
-        Ok(inner.table_schemas.values().map(Arc::clone).collect())
+        Ok(inner.table_schemas.all())
     }
 
     /// Loads table schemas from Postgres into memory cache.
@@ -640,6 +538,7 @@ impl SchemaStore for PostgresStore {
     async fn load_table_schemas(&self) -> EtlResult<usize> {
         debug!("loading table schemas from postgres state store");
 
+        let mut inner = self.inner.lock().await;
         let table_schemas = schema::load_table_schemas(&self.pool, self.pipeline_id as i64)
             .await
             .map_err(|err| {
@@ -651,12 +550,7 @@ impl SchemaStore for PostgresStore {
         })?;
         let table_schemas_len = table_schemas.len();
 
-        let mut inner = self.inner.lock().await;
-        inner.table_schemas.clear();
-        for table_schema in table_schemas {
-            let key = (table_schema.id, table_schema.snapshot_id);
-            inner.table_schemas.insert(key, Arc::new(table_schema));
-        }
+        Arc::make_mut(&mut inner.table_schemas).replace_all(table_schemas);
 
         info!(count = table_schemas_len, "loaded table schemas from postgres state store");
 
@@ -671,6 +565,7 @@ impl SchemaStore for PostgresStore {
     async fn store_table_schema(&self, table_schema: TableSchema) -> EtlResult<Arc<TableSchema>> {
         debug!(table_name = %table_schema.name, snapshot_id = %table_schema.snapshot_id, "storing table schema");
 
+        let mut inner = self.inner.lock().await;
         schema::store_table_schema(&self.pool, self.pipeline_id as i64, &table_schema)
             .await
             .map_err(|err| {
@@ -681,17 +576,15 @@ impl SchemaStore for PostgresStore {
                 )
             })?;
 
-        let mut inner = self.inner.lock().await;
-        let table_schema = Arc::new(table_schema);
-        inner.insert_schema_with_eviction(Arc::clone(&table_schema));
-
-        Ok(table_schema)
+        Ok(Arc::make_mut(&mut inner.table_schemas)
+            .insert_with_eviction(table_schema, MAX_CACHED_SCHEMAS_PER_TABLE))
     }
 
     async fn prune_table_schemas(
         &self,
         table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> EtlResult<u64> {
+        let mut inner = self.inner.lock().await;
         let retention_lsns = table_schema_retentions
             .iter()
             .map(|(table_id, retention)| (*table_id, retention.to_lsn()))
@@ -710,8 +603,7 @@ impl SchemaStore for PostgresStore {
             )
         })?;
 
-        let mut inner = self.inner.lock().await;
-        let cached_count = inner.prune_table_schemas(&table_schema_retentions);
+        let cached_count = Arc::make_mut(&mut inner.table_schemas).prune(&table_schema_retentions);
 
         if deleted_count > 0 || cached_count > 0 {
             info!(
@@ -729,6 +621,7 @@ impl SchemaStore for PostgresStore {
 impl CleanupStore for PostgresStore {
     /// Removes all state for a table from both database and cache.
     async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
         let mut tx = self.pool.begin().await?;
 
         destination_metadata::delete_destination_table_metadata(
@@ -760,10 +653,8 @@ impl CleanupStore for PostgresStore {
 
         tx.commit().await?;
 
-        let mut inner = self.inner.lock().await;
-
         inner.remove_table_state(table_id);
-        inner.table_schemas.retain(|(tid, _), _| *tid != table_id);
+        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
         Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
         emit_table_metrics(&inner.phase_counts);
 

--- a/etl/src/store/mod.rs
+++ b/etl/src/store/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! This module provides storage traits and implementations for maintaining ETL
 //! pipeline state across restarts. It includes state tracking for replication
-//! progress, table schemas, and synchronization status.
+//! progress, versioned table schemas, destination table metadata, and
+//! synchronization status.
 //!
 //! Storage is divided into three main categories:
 //! - [`state`] - Replication progress and table synchronization states
-//! - [`schema`] - Database schema information and versioned schema storage
+//! - [`schema`] - Database schema information, versioned schema storage, and
+//!   obsolete schema pruning
 //! - [`cleanup`] - Cleanup methods that span both stores
 //!
 //! The [`both`] module provides combined implementations that handle both

--- a/etl/src/store/schema/base.rs
+++ b/etl/src/store/schema/base.rs
@@ -1,34 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
-use tokio_postgres::types::PgLsn;
-
+use super::table::TableSchemaRetention;
 use crate::{
     error::EtlResult,
     types::{SnapshotId, TableId, TableSchema},
 };
-
-/// Per-table schema cleanup retention boundary.
-///
-/// Retention can be bounded by a stored schema snapshot that the destination
-/// still needs, or by the replication slot's confirmed flush LSN. Both are LSN
-/// values, but the variant records why that boundary was chosen.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TableSchemaRetention {
-    /// Retain schemas according to a destination-useful schema snapshot.
-    SnapshotId(SnapshotId),
-    /// Retain schemas according to the replication slot's confirmed flush LSN.
-    ConfirmedFlushLsn(PgLsn),
-}
-
-impl TableSchemaRetention {
-    /// Returns the underlying LSN used as the retention boundary.
-    pub fn to_lsn(self) -> PgLsn {
-        match self {
-            Self::SnapshotId(snapshot_id) => snapshot_id.into(),
-            Self::ConfirmedFlushLsn(lsn) => lsn,
-        }
-    }
-}
 
 /// Trait for storing and retrieving database table schema information.
 ///
@@ -89,7 +65,5 @@ pub trait SchemaStore {
     fn prune_table_schemas(
         &self,
         _table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
-    ) -> impl Future<Output = EtlResult<u64>> + Send {
-        async { Ok(0) }
-    }
+    ) -> impl Future<Output = EtlResult<u64>> + Send;
 }

--- a/etl/src/store/schema/base.rs
+++ b/etl/src/store/schema/base.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 
 use crate::{
     error::EtlResult,
@@ -52,19 +52,21 @@ pub trait SchemaStore {
         table_schema: TableSchema,
     ) -> impl Future<Output = EtlResult<Arc<TableSchema>>> + Send;
 
-    /// Prunes obsolete table schema versions using the current schema snapshots
-    /// in use by active replication workers.
+    /// Prunes obsolete table schema versions for tables at a confirmed LSN.
     ///
-    /// For each `table_id -> snapshot_id` entry, implementations should remove
-    /// schema versions for that table whose snapshot is lower than
-    /// `snapshot_id`. Versions at or after the current snapshot must be
-    /// preserved. If an implementation uses both a cache and persistent
-    /// storage, both must be pruned consistently.
+    /// For each table id, implementations should find the newest schema
+    /// version at or before `confirmed_flush_lsn`, preserve it, and remove
+    /// older versions. The LSN must come from the replication slot's actual
+    /// `confirmed_flush_lsn`, not an optimistic status update, because cleanup
+    /// must not delete schemas PostgreSQL may still replay. Versions newer than
+    /// `confirmed_flush_lsn` must also be preserved because PostgreSQL may
+    /// replay the DDL that created them.
     ///
     /// Returns the number of schema versions removed.
     fn prune_table_schemas(
         &self,
-        _current_snapshot_ids: HashMap<TableId, SnapshotId>,
+        _table_ids: HashSet<TableId>,
+        _confirmed_flush_lsn: SnapshotId,
     ) -> impl Future<Output = EtlResult<u64>> + Send {
         async { Ok(0) }
     }

--- a/etl/src/store/schema/base.rs
+++ b/etl/src/store/schema/base.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use tokio_postgres::types::PgLsn;
 
@@ -6,6 +6,29 @@ use crate::{
     error::EtlResult,
     types::{SnapshotId, TableId, TableSchema},
 };
+
+/// Per-table schema cleanup retention boundary.
+///
+/// Retention can be bounded by a stored schema snapshot that the destination
+/// still needs, or by the replication slot's confirmed flush LSN. Both are LSN
+/// values, but the variant records why that boundary was chosen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableSchemaRetention {
+    /// Retain schemas according to a destination-useful schema snapshot.
+    SnapshotId(SnapshotId),
+    /// Retain schemas according to the replication slot's confirmed flush LSN.
+    ConfirmedFlushLsn(PgLsn),
+}
+
+impl TableSchemaRetention {
+    /// Returns the underlying LSN used as the retention boundary.
+    pub fn to_lsn(self) -> PgLsn {
+        match self {
+            Self::SnapshotId(snapshot_id) => snapshot_id.into(),
+            Self::ConfirmedFlushLsn(lsn) => lsn,
+        }
+    }
+}
 
 /// Trait for storing and retrieving database table schema information.
 ///
@@ -54,21 +77,18 @@ pub trait SchemaStore {
         table_schema: TableSchema,
     ) -> impl Future<Output = EtlResult<Arc<TableSchema>>> + Send;
 
-    /// Prunes obsolete table schema versions for tables at a confirmed LSN.
+    /// Prunes obsolete table schema versions for tables at safe cleanup points.
     ///
-    /// For each table id, implementations should find the newest schema
-    /// version at or before `confirmed_flush_lsn`, preserve it, and remove
-    /// older versions. The LSN must come from the replication slot's actual
-    /// `confirmed_flush_lsn`, not an optimistic status update, because cleanup
-    /// must not delete schemas PostgreSQL may still replay. Versions newer than
-    /// `confirmed_flush_lsn` must also be preserved because PostgreSQL may
-    /// replay the DDL that created them.
+    /// For each table id, implementations should find the newest schema version
+    /// at or before that table's retention LSN, preserve it, and remove older
+    /// versions. Versions newer than the retention LSN must also be preserved
+    /// because PostgreSQL may replay them, or the destination may need them for
+    /// schema application.
     ///
     /// Returns the number of schema versions removed.
     fn prune_table_schemas(
         &self,
-        _table_ids: HashSet<TableId>,
-        _confirmed_flush_lsn: PgLsn,
+        _table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> impl Future<Output = EtlResult<u64>> + Send {
         async { Ok(0) }
     }

--- a/etl/src/store/schema/base.rs
+++ b/etl/src/store/schema/base.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     error::EtlResult,
@@ -10,7 +10,8 @@ use crate::{
 /// [`SchemaStore`] implementations are responsible for defining how the schema
 /// information is stored and retrieved. The store supports schema versioning
 /// where each schema version is identified by a snapshot_id (the start_lsn of
-/// the DDL message that created it).
+/// the DDL message that created it). Stores may prune obsolete versions after
+/// replication progress has been acknowledged.
 ///
 /// Implementations should ensure thread-safety and handle concurrent access to
 /// the data.
@@ -50,4 +51,21 @@ pub trait SchemaStore {
         &self,
         table_schema: TableSchema,
     ) -> impl Future<Output = EtlResult<Arc<TableSchema>>> + Send;
+
+    /// Prunes obsolete table schema versions using the current schema snapshots
+    /// in use by active replication workers.
+    ///
+    /// For each `table_id -> snapshot_id` entry, implementations should remove
+    /// schema versions for that table whose snapshot is lower than
+    /// `snapshot_id`. Versions at or after the current snapshot must be
+    /// preserved. If an implementation uses both a cache and persistent
+    /// storage, both must be pruned consistently.
+    ///
+    /// Returns the number of schema versions removed.
+    fn prune_table_schemas(
+        &self,
+        _current_snapshot_ids: HashMap<TableId, SnapshotId>,
+    ) -> impl Future<Output = EtlResult<u64>> + Send {
+        async { Ok(0) }
+    }
 }

--- a/etl/src/store/schema/base.rs
+++ b/etl/src/store/schema/base.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashSet, sync::Arc};
 
+use tokio_postgres::types::PgLsn;
+
 use crate::{
     error::EtlResult,
     types::{SnapshotId, TableId, TableSchema},
@@ -66,7 +68,7 @@ pub trait SchemaStore {
     fn prune_table_schemas(
         &self,
         _table_ids: HashSet<TableId>,
-        _confirmed_flush_lsn: SnapshotId,
+        _confirmed_flush_lsn: PgLsn,
     ) -> impl Future<Output = EtlResult<u64>> + Send {
         async { Ok(0) }
     }

--- a/etl/src/store/schema/mod.rs
+++ b/etl/src/store/schema/mod.rs
@@ -1,3 +1,3 @@
 mod base;
 
-pub use base::SchemaStore;
+pub use base::{SchemaStore, TableSchemaRetention};

--- a/etl/src/store/schema/mod.rs
+++ b/etl/src/store/schema/mod.rs
@@ -1,3 +1,6 @@
 mod base;
+mod table;
 
-pub use base::{SchemaStore, TableSchemaRetention};
+pub use base::SchemaStore;
+pub use table::TableSchemaRetention;
+pub(crate) use table::TableSchemaSnapshots;

--- a/etl/src/store/schema/table.rs
+++ b/etl/src/store/schema/table.rs
@@ -1,0 +1,282 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+
+use crate::types::{PgLsn, SnapshotId, TableId, TableSchema};
+
+/// Per-table schema cleanup retention boundary.
+///
+/// Retention can be bounded by a stored schema snapshot that the destination
+/// still needs, or by the replication slot's confirmed flush LSN. Both are LSN
+/// values, but the variant records why that boundary was chosen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableSchemaRetention {
+    /// Retain schemas according to a destination-useful schema snapshot.
+    SnapshotId(SnapshotId),
+    /// Retain schemas according to the replication slot's confirmed flush LSN.
+    ConfirmedFlushLsn(PgLsn),
+}
+
+impl TableSchemaRetention {
+    /// Returns the underlying LSN used as the retention boundary.
+    pub fn to_lsn(self) -> PgLsn {
+        match self {
+            Self::SnapshotId(snapshot_id) => snapshot_id.into(),
+            Self::ConfirmedFlushLsn(lsn) => lsn,
+        }
+    }
+}
+
+/// In-memory index of table schema snapshots grouped by table.
+///
+/// This type owns the rules for snapshot lookup and cleanup so store
+/// implementations do not each reimplement retention behavior.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TableSchemaSnapshots {
+    /// Schema versions keyed first by table and then by snapshot.
+    table_schemas: BTreeMap<TableId, BTreeMap<SnapshotId, Arc<TableSchema>>>,
+}
+
+impl TableSchemaSnapshots {
+    /// Returns the total number of stored schema snapshots.
+    pub(crate) fn len(&self) -> usize {
+        self.table_schemas.values().map(BTreeMap::len).sum()
+    }
+
+    /// Returns the number of stored snapshots for a table.
+    pub(crate) fn table_len(&self, table_id: TableId) -> usize {
+        self.table_schemas.get(&table_id).map_or(0, BTreeMap::len)
+    }
+
+    /// Returns all stored schema snapshots.
+    pub(crate) fn all(&self) -> Vec<Arc<TableSchema>> {
+        self.table_schemas.values().flat_map(|schemas| schemas.values().map(Arc::clone)).collect()
+    }
+
+    /// Returns the newest schema snapshot at or before `snapshot_id`.
+    pub(crate) fn get_at_or_before(
+        &self,
+        table_id: TableId,
+        snapshot_id: SnapshotId,
+    ) -> Option<Arc<TableSchema>> {
+        self.table_schemas
+            .get(&table_id)?
+            .range(..=snapshot_id)
+            .next_back()
+            .map(|(_, schema)| Arc::clone(schema))
+    }
+
+    /// Inserts or replaces a schema snapshot.
+    pub(crate) fn insert(&mut self, table_schema: TableSchema) -> Arc<TableSchema> {
+        let table_id = table_schema.id;
+        let snapshot_id = table_schema.snapshot_id;
+        let table_schema = Arc::new(table_schema);
+
+        self.table_schemas
+            .entry(table_id)
+            .or_default()
+            .insert(snapshot_id, Arc::clone(&table_schema));
+
+        table_schema
+    }
+
+    /// Inserts a schema snapshot and keeps at most `max_snapshots` for its
+    /// table.
+    pub(crate) fn insert_with_eviction(
+        &mut self,
+        table_schema: TableSchema,
+        max_snapshots: usize,
+    ) -> Arc<TableSchema> {
+        let table_id = table_schema.id;
+        let table_schema = self.insert(table_schema);
+
+        if max_snapshots == 0 {
+            self.table_schemas.remove(&table_id);
+            return table_schema;
+        }
+
+        if let Some(schemas) = self.table_schemas.get_mut(&table_id) {
+            while schemas.len() > max_snapshots {
+                let Some(oldest_snapshot_id) = schemas.keys().next().copied() else {
+                    break;
+                };
+
+                schemas.remove(&oldest_snapshot_id);
+            }
+        }
+
+        table_schema
+    }
+
+    /// Replaces all stored schema snapshots with the supplied values.
+    pub(crate) fn replace_all(&mut self, table_schemas: impl IntoIterator<Item = TableSchema>) {
+        self.table_schemas.clear();
+        for table_schema in table_schemas {
+            self.insert(table_schema);
+        }
+    }
+
+    /// Removes all schema snapshots for a table.
+    pub(crate) fn remove_table(&mut self, table_id: TableId) {
+        self.table_schemas.remove(&table_id);
+    }
+
+    /// Prunes obsolete schema snapshots according to per-table retention
+    /// limits.
+    ///
+    /// For each table, this preserves the newest schema at or before the
+    /// retention LSN and every newer schema. Older schemas are removed.
+    pub(crate) fn prune(
+        &mut self,
+        table_schema_retentions: &HashMap<TableId, TableSchemaRetention>,
+    ) -> u64 {
+        let mut removed_count = 0u64;
+
+        for (table_id, schemas) in &mut self.table_schemas {
+            let Some(retention) = table_schema_retentions.get(table_id) else {
+                continue;
+            };
+
+            // We find the biggest snapshot id <= than the retention one. We can rely on the
+            // sorted properties of the BTreeMap to perform this traversal from
+            // the right without finding a maximum by scanning the whole list.
+            let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
+            let retained_snapshot_id =
+                schemas.keys().rfind(|snapshot_id| **snapshot_id <= retention_snapshot_id).copied();
+
+            let Some(retained_snapshot_id) = retained_snapshot_id else {
+                continue;
+            };
+
+            // We keep all snapshots that are >= than the retained one.
+            let before_count = schemas.len();
+            schemas.retain(|snapshot_id, _| *snapshot_id >= retained_snapshot_id);
+            removed_count =
+                removed_count.saturating_add(before_count.saturating_sub(schemas.len()) as u64);
+        }
+
+        removed_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio_postgres::types::Type;
+
+    use super::*;
+    use crate::types::{ColumnSchema, TableName};
+
+    /// Builds a schema with a snapshot-specific non-key column.
+    fn test_schema(table_id: TableId, snapshot_id: u64) -> TableSchema {
+        TableSchema::with_snapshot_id(
+            table_id,
+            TableName::new("public".to_string(), format!("table_{table_id}")),
+            vec![
+                ColumnSchema::new("id".to_string(), Type::INT8, -1, 1, Some(1), false),
+                ColumnSchema::new(format!("col_at_{snapshot_id}"), Type::TEXT, -1, 2, None, true),
+            ],
+            SnapshotId::from(snapshot_id),
+        )
+    }
+
+    #[test]
+    fn get_at_or_before_returns_newest_eligible_snapshot() {
+        let table_id = TableId::new(10);
+        let mut snapshots = TableSchemaSnapshots::default();
+
+        snapshots.insert(test_schema(table_id, 100));
+        snapshots.insert(test_schema(table_id, 300));
+
+        let schema = snapshots
+            .get_at_or_before(table_id, SnapshotId::from(250))
+            .expect("schema should exist");
+        assert_eq!(schema.snapshot_id, SnapshotId::from(100));
+
+        let schema = snapshots
+            .get_at_or_before(table_id, SnapshotId::from(300))
+            .expect("schema should exist");
+        assert_eq!(schema.snapshot_id, SnapshotId::from(300));
+
+        assert!(snapshots.get_at_or_before(table_id, SnapshotId::from(50)).is_none());
+    }
+
+    #[test]
+    fn insert_with_eviction_keeps_newest_snapshots_for_table() {
+        let table_id = TableId::new(10);
+        let other_table_id = TableId::new(20);
+        let mut snapshots = TableSchemaSnapshots::default();
+
+        snapshots.insert_with_eviction(test_schema(table_id, 100), 2);
+        snapshots.insert_with_eviction(test_schema(table_id, 200), 2);
+        snapshots.insert_with_eviction(test_schema(table_id, 300), 2);
+        snapshots.insert_with_eviction(test_schema(other_table_id, 50), 2);
+
+        assert!(snapshots.get_at_or_before(table_id, SnapshotId::from(100)).is_none());
+        assert_eq!(
+            snapshots
+                .get_at_or_before(table_id, SnapshotId::from(250))
+                .expect("schema should exist")
+                .snapshot_id,
+            SnapshotId::from(200)
+        );
+        assert_eq!(snapshots.table_len(table_id), 2);
+        assert_eq!(snapshots.table_len(other_table_id), 1);
+    }
+
+    #[test]
+    fn prune_preserves_retained_snapshot_and_newer_versions() {
+        let table_id = TableId::new(10);
+        let other_table_id = TableId::new(20);
+        let untouched_table_id = TableId::new(30);
+        let mut snapshots = TableSchemaSnapshots::default();
+
+        for snapshot_id in [0, 100, 200, 300] {
+            snapshots.insert(test_schema(table_id, snapshot_id));
+        }
+        for snapshot_id in [0, 150] {
+            snapshots.insert(test_schema(other_table_id, snapshot_id));
+        }
+        snapshots.insert(test_schema(untouched_table_id, 0));
+
+        let removed = snapshots.prune(&HashMap::from([
+            (table_id, TableSchemaRetention::SnapshotId(SnapshotId::from(250))),
+            (other_table_id, TableSchemaRetention::ConfirmedFlushLsn(SnapshotId::from(150).into())),
+        ]));
+
+        assert_eq!(removed, 3);
+        assert!(snapshots.get_at_or_before(table_id, SnapshotId::from(100)).is_none());
+        assert_eq!(
+            snapshots
+                .get_at_or_before(table_id, SnapshotId::from(250))
+                .expect("schema should exist")
+                .snapshot_id,
+            SnapshotId::from(200)
+        );
+        assert_eq!(
+            snapshots
+                .get_at_or_before(table_id, SnapshotId::from(400))
+                .expect("schema should exist")
+                .snapshot_id,
+            SnapshotId::from(300)
+        );
+        assert_eq!(snapshots.table_len(other_table_id), 1);
+        assert_eq!(snapshots.table_len(untouched_table_id), 1);
+    }
+
+    #[test]
+    fn prune_skips_table_when_no_snapshot_is_before_retention() {
+        let table_id = TableId::new(10);
+        let mut snapshots = TableSchemaSnapshots::default();
+
+        snapshots.insert(test_schema(table_id, 200));
+
+        let removed = snapshots.prune(&HashMap::from([(
+            table_id,
+            TableSchemaRetention::SnapshotId(SnapshotId::from(100)),
+        )]));
+
+        assert_eq!(removed, 0);
+        assert_eq!(snapshots.table_len(table_id), 1);
+    }
+}

--- a/etl/src/store/state/base.rs
+++ b/etl/src/store/state/base.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    future::Future,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, future::Future, sync::Arc};
 
 use crate::{
     error::EtlResult,
@@ -17,7 +13,7 @@ use crate::{
 pub type TableReplicationStates = Arc<BTreeMap<TableId, TableReplicationPhase>>;
 
 /// Arc-wrapped dictionary of destination table metadata.
-pub(crate) type DestinationTablesMetadata = Arc<HashMap<TableId, DestinationTableMetadata>>;
+pub(crate) type DestinationTablesMetadata = Arc<BTreeMap<TableId, DestinationTableMetadata>>;
 
 /// Trait for storing and retrieving table replication state and destination
 /// metadata.

--- a/etl/src/test_utils/memory_destination.rs
+++ b/etl/src/test_utils/memory_destination.rs
@@ -9,7 +9,7 @@ use crate::{
         async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
     },
     error::EtlResult,
-    state::destination_metadata::DestinationTableMetadata,
+    state::destination_metadata::{DestinationTableMetadata, DestinationTableSchemaStatus},
     store::state::StateStore,
     types::{Event, ReplicatedTableSchema, TableId, TableRow},
 };
@@ -83,18 +83,31 @@ where
         inner.table_rows.clear();
     }
 
-    /// Stores destination table metadata for a table if it has not been seen
-    /// before.
-    async fn ensure_destination_table_metadata(
+    /// Stores or advances destination table metadata for a table.
+    async fn sync_destination_table_metadata(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         let table_id = replicated_table_schema.id();
         let existing_metadata = self.store.get_destination_table_metadata(table_id).await?;
-        if existing_metadata.is_none() {
-            let metadata = Self::build_destination_table_metadata(replicated_table_schema);
-            self.store.store_destination_table_metadata(table_id, metadata).await?;
-        }
+        let metadata = match existing_metadata {
+            Some(metadata)
+                if metadata.snapshot_id == replicated_table_schema.inner().snapshot_id
+                    && metadata.replication_mask == *replicated_table_schema.replication_mask() =>
+            {
+                return Ok(());
+            }
+            Some(metadata) => metadata
+                .with_schema_change(
+                    replicated_table_schema.inner().snapshot_id,
+                    replicated_table_schema.replication_mask().clone(),
+                    DestinationTableSchemaStatus::Applied,
+                )
+                .to_applied(),
+            None => Self::build_destination_table_metadata(replicated_table_schema),
+        };
+
+        self.store.store_destination_table_metadata(table_id, metadata).await?;
 
         Ok(())
     }
@@ -164,7 +177,7 @@ where
 
         // Store destination table metadata on first write, like real destinations
         // (BigQuery, Iceberg) do.
-        self.ensure_destination_table_metadata(replicated_table_schema).await?;
+        self.sync_destination_table_metadata(replicated_table_schema).await?;
 
         let mut inner = self.inner.lock().await;
         info!(%table_id, row_count = table_rows.len(), "writing table rows");
@@ -218,7 +231,7 @@ where
         }
 
         for replicated_table_schema in table_schemas.into_values() {
-            self.ensure_destination_table_metadata(&replicated_table_schema).await?;
+            self.sync_destination_table_metadata(&replicated_table_schema).await?;
         }
 
         let mut inner = self.inner.lock().await;

--- a/etl/src/test_utils/memory_destination.rs
+++ b/etl/src/test_utils/memory_destination.rs
@@ -83,7 +83,8 @@ where
         inner.table_rows.clear();
     }
 
-    /// Stores destination metadata for a table if it has not been seen before.
+    /// Stores destination table metadata for a table if it has not been seen
+    /// before.
     async fn ensure_destination_table_metadata(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
@@ -98,7 +99,7 @@ where
         Ok(())
     }
 
-    /// Builds applied destination metadata for a memory-backed table.
+    /// Builds applied destination table metadata for a memory-backed table.
     fn build_destination_table_metadata(
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> DestinationTableMetadata {
@@ -161,8 +162,8 @@ where
     ) -> EtlResult<()> {
         let table_id = replicated_table_schema.id();
 
-        // Store destination metadata on first write, like real destinations (BigQuery,
-        // Iceberg) do.
+        // Store destination table metadata on first write, like real destinations
+        // (BigQuery, Iceberg) do.
         self.ensure_destination_table_metadata(replicated_table_schema).await?;
 
         let mut inner = self.inner.lock().await;

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -35,6 +35,7 @@ type TableStateTypeCondition = (TableId, TableReplicationPhaseType, Arc<Notify>)
 type TableStateCondition =
     (TableId, Arc<Notify>, Box<dyn Fn(&TableReplicationPhase) -> bool + Send + Sync>);
 type TableSchemaCountCondition = (TableId, usize, Arc<Notify>);
+type TableSchemaPruneCondition = Arc<Notify>;
 
 struct Inner {
     table_replication_states: TableReplicationStates,
@@ -44,6 +45,7 @@ struct Inner {
     table_state_type_conditions: Vec<TableStateTypeCondition>,
     table_state_conditions: Vec<TableStateCondition>,
     table_schema_count_conditions: Vec<TableSchemaCountCondition>,
+    table_schema_prune_conditions: Vec<TableSchemaPruneCondition>,
     method_call_notifiers: HashMap<StateStoreMethod, Vec<Arc<Notify>>>,
 }
 
@@ -114,6 +116,7 @@ impl NotifyingStore {
             table_state_type_conditions: Vec::new(),
             table_state_conditions: Vec::new(),
             table_schema_count_conditions: Vec::new(),
+            table_schema_prune_conditions: Vec::new(),
             method_call_notifiers: HashMap::new(),
         };
 
@@ -207,6 +210,15 @@ impl NotifyingStore {
         let notify = Arc::new(Notify::new());
         let mut inner = self.inner.write().await;
         inner.table_schema_count_conditions.push((table_id, expected_count, Arc::clone(&notify)));
+
+        TimedNotify::new(notify)
+    }
+
+    /// Registers a notification that fires after a future schema prune call.
+    pub async fn notify_on_table_schema_prune(&self) -> TimedNotify {
+        let notify = Arc::new(Notify::new());
+        let mut inner = self.inner.write().await;
+        inner.table_schema_prune_conditions.push(Arc::clone(&notify));
 
         TimedNotify::new(notify)
     }
@@ -406,6 +418,29 @@ impl SchemaStore for NotifyingStore {
         inner.check_conditions();
 
         Ok(table_schema)
+    }
+
+    async fn prune_table_schemas(
+        &self,
+        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+    ) -> EtlResult<u64> {
+        let mut inner = self.inner.write().await;
+        let mut removed_count = 0u64;
+
+        for (table_id, schemas) in inner.table_schemas.iter_mut() {
+            if let Some(current_snapshot_id) = current_snapshot_ids.get(table_id) {
+                let before_count = schemas.len();
+                schemas.retain(|schema| schema.snapshot_id >= *current_snapshot_id);
+                removed_count =
+                    removed_count.saturating_add(before_count.saturating_sub(schemas.len()) as u64);
+            }
+        }
+
+        for notify in std::mem::take(&mut inner.table_schema_prune_conditions) {
+            notify.notify_one();
+        }
+
+        Ok(removed_count)
     }
 }
 

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -427,7 +427,7 @@ impl SchemaStore for NotifyingStore {
         let mut inner = self.inner.write().await;
         let mut removed_count = 0u64;
 
-        for (table_id, schemas) in inner.table_schemas.iter_mut() {
+        for (table_id, schemas) in &mut inner.table_schemas {
             if let Some(current_snapshot_id) = current_snapshot_ids.get(table_id) {
                 let before_count = schemas.len();
                 schemas.retain(|schema| schema.snapshot_id >= *current_snapshot_id);

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -6,6 +6,7 @@ use std::{
 
 use etl_postgres::types::{SnapshotId, TableId, TableSchema};
 use tokio::sync::{Notify, RwLock};
+use tokio_postgres::types::PgLsn;
 
 use crate::{
     error::{ErrorKind, EtlResult},
@@ -423,9 +424,10 @@ impl SchemaStore for NotifyingStore {
     async fn prune_table_schemas(
         &self,
         table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: SnapshotId,
+        confirmed_flush_lsn: PgLsn,
     ) -> EtlResult<u64> {
         let mut inner = self.inner.write().await;
+        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
         let mut removed_count = 0u64;
 
         for (table_id, schemas) in &mut inner.table_schemas {
@@ -433,7 +435,7 @@ impl SchemaStore for NotifyingStore {
                 let retained_snapshot_id = schemas
                     .iter()
                     .map(|schema| schema.snapshot_id)
-                    .filter(|snapshot_id| *snapshot_id <= confirmed_flush_lsn)
+                    .filter(|snapshot_id| *snapshot_id <= confirmed_flush_snapshot_id)
                     .max();
 
                 let Some(retained_snapshot_id) = retained_snapshot_id else {
@@ -447,8 +449,10 @@ impl SchemaStore for NotifyingStore {
             }
         }
 
-        for notify in std::mem::take(&mut inner.table_schema_prune_conditions) {
-            notify.notify_one();
+        if removed_count > 0 {
+            for notify in std::mem::take(&mut inner.table_schema_prune_conditions) {
+                notify.notify_one();
+            }
         }
 
         Ok(removed_count)

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt,
     sync::Arc,
 };
@@ -422,15 +422,26 @@ impl SchemaStore for NotifyingStore {
 
     async fn prune_table_schemas(
         &self,
-        current_snapshot_ids: HashMap<TableId, SnapshotId>,
+        table_ids: HashSet<TableId>,
+        confirmed_flush_lsn: SnapshotId,
     ) -> EtlResult<u64> {
         let mut inner = self.inner.write().await;
         let mut removed_count = 0u64;
 
         for (table_id, schemas) in &mut inner.table_schemas {
-            if let Some(current_snapshot_id) = current_snapshot_ids.get(table_id) {
+            if table_ids.contains(table_id) {
+                let retained_snapshot_id = schemas
+                    .iter()
+                    .map(|schema| schema.snapshot_id)
+                    .filter(|snapshot_id| *snapshot_id <= confirmed_flush_lsn)
+                    .max();
+
+                let Some(retained_snapshot_id) = retained_snapshot_id else {
+                    continue;
+                };
+
                 let before_count = schemas.len();
-                schemas.retain(|schema| schema.snapshot_id >= *current_snapshot_id);
+                schemas.retain(|schema| schema.snapshot_id >= retained_snapshot_id);
                 removed_count =
                     removed_count.saturating_add(before_count.saturating_sub(schemas.len()) as u64);
             }

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -1,12 +1,11 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     fmt,
     sync::Arc,
 };
 
 use etl_postgres::types::{SnapshotId, TableId, TableSchema};
 use tokio::sync::{Notify, RwLock};
-use tokio_postgres::types::PgLsn;
 
 use crate::{
     error::{ErrorKind, EtlResult},
@@ -17,7 +16,7 @@ use crate::{
     },
     store::{
         cleanup::CleanupStore,
-        schema::SchemaStore,
+        schema::{SchemaStore, TableSchemaRetention},
         state::{DestinationTablesMetadata, StateStore, TableReplicationStates},
     },
     test_utils::notify::TimedNotify,
@@ -423,19 +422,18 @@ impl SchemaStore for NotifyingStore {
 
     async fn prune_table_schemas(
         &self,
-        table_ids: HashSet<TableId>,
-        confirmed_flush_lsn: PgLsn,
+        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> EtlResult<u64> {
         let mut inner = self.inner.write().await;
-        let confirmed_flush_snapshot_id = SnapshotId::from(confirmed_flush_lsn);
         let mut removed_count = 0u64;
 
         for (table_id, schemas) in &mut inner.table_schemas {
-            if table_ids.contains(table_id) {
+            if let Some(retention) = table_schema_retentions.get(table_id) {
+                let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
                 let retained_snapshot_id = schemas
                     .iter()
                     .map(|schema| schema.snapshot_id)
-                    .filter(|snapshot_id| *snapshot_id <= confirmed_flush_snapshot_id)
+                    .filter(|snapshot_id| *snapshot_id <= retention_snapshot_id)
                     .max();
 
                 let Some(retained_snapshot_id) = retained_snapshot_id else {

--- a/etl/src/test_utils/notifying_store.rs
+++ b/etl/src/test_utils/notifying_store.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     store::{
         cleanup::CleanupStore,
-        schema::{SchemaStore, TableSchemaRetention},
+        schema::{SchemaStore, TableSchemaRetention, TableSchemaSnapshots},
         state::{DestinationTablesMetadata, StateStore, TableReplicationStates},
     },
     test_utils::notify::TimedNotify,
@@ -40,7 +40,7 @@ type TableSchemaPruneCondition = Arc<Notify>;
 struct Inner {
     table_replication_states: TableReplicationStates,
     table_state_history: HashMap<TableId, Vec<TableReplicationPhase>>,
-    table_schemas: HashMap<TableId, Vec<Arc<TableSchema>>>,
+    table_schemas: Arc<TableSchemaSnapshots>,
     destination_tables_metadata: DestinationTablesMetadata,
     table_state_type_conditions: Vec<TableStateTypeCondition>,
     table_state_conditions: Vec<TableStateCondition>,
@@ -77,7 +77,7 @@ impl Inner {
         });
 
         self.table_schema_count_conditions.retain(|(tid, expected_count, notify)| {
-            let schemas_count = self.table_schemas.get(tid).map_or(0, Vec::len);
+            let schemas_count = self.table_schemas.table_len(*tid);
             let should_retain = schemas_count < *expected_count;
             if !should_retain {
                 notify.notify_one();
@@ -111,8 +111,8 @@ impl NotifyingStore {
         let inner = Inner {
             table_replication_states: Arc::new(BTreeMap::new()),
             table_state_history: HashMap::new(),
-            table_schemas: HashMap::new(),
-            destination_tables_metadata: Arc::new(HashMap::new()),
+            table_schemas: Arc::new(TableSchemaSnapshots::default()),
+            destination_tables_metadata: Arc::new(BTreeMap::new()),
             table_state_type_conditions: Vec::new(),
             table_state_conditions: Vec::new(),
             table_schema_count_conditions: Vec::new(),
@@ -133,32 +133,34 @@ impl NotifyingStore {
     pub async fn get_latest_table_schemas(&self) -> HashMap<TableId, TableSchema> {
         let inner = self.inner.read().await;
 
-        // Return the latest schema version for each table (last in the Vec).
-        inner
-            .table_schemas
-            .iter()
-            .filter_map(|(table_id, schemas)| {
-                schemas.last().map(|schema| (*table_id, Arc::as_ref(schema).clone()))
-            })
-            .collect()
+        let mut table_schemas = HashMap::new();
+        for schema in inner.table_schemas.all() {
+            table_schemas
+                .entry(schema.id)
+                .and_modify(|current: &mut TableSchema| {
+                    if current.snapshot_id < schema.snapshot_id {
+                        *current = Arc::as_ref(&schema).clone();
+                    }
+                })
+                .or_insert_with(|| Arc::as_ref(&schema).clone());
+        }
+
+        table_schemas
     }
 
     /// Returns all stored schema snapshots grouped by table.
     pub async fn get_table_schemas(&self) -> HashMap<TableId, Vec<(SnapshotId, TableSchema)>> {
         let inner = self.inner.read().await;
 
-        // Return schemas in insertion order per table.
-        inner
-            .table_schemas
-            .iter()
-            .map(|(table_id, schemas)| {
-                let schemas_with_ids: Vec<_> = schemas
-                    .iter()
-                    .map(|schema| (schema.snapshot_id, Arc::as_ref(schema).clone()))
-                    .collect();
-                (*table_id, schemas_with_ids)
-            })
-            .collect()
+        let mut table_schemas: HashMap<TableId, Vec<_>> = HashMap::new();
+        for schema in inner.table_schemas.all() {
+            table_schemas
+                .entry(schema.id)
+                .or_default()
+                .push((schema.snapshot_id, Arc::as_ref(&schema).clone()));
+        }
+
+        table_schemas
     }
 
     /// Registers a notification that fires when a future state update reaches
@@ -371,49 +373,25 @@ impl SchemaStore for NotifyingStore {
     ) -> EtlResult<Option<Arc<TableSchema>>> {
         let inner = self.inner.read().await;
 
-        // Find the best matching schema (largest snapshot_id <= requested).
-        let best_match = inner.table_schemas.get(table_id).and_then(|schemas| {
-            schemas
-                .iter()
-                .filter(|schema| schema.snapshot_id <= snapshot_id)
-                .max_by_key(|schema| schema.snapshot_id)
-                .map(Arc::clone)
-        });
-
-        Ok(best_match)
+        Ok(inner.table_schemas.get_at_or_before(*table_id, snapshot_id))
     }
 
     async fn get_table_schemas(&self) -> EtlResult<Vec<Arc<TableSchema>>> {
         let inner = self.inner.read().await;
 
-        Ok(inner
-            .table_schemas
-            .values()
-            .flat_map(|schemas| schemas.iter().map(Arc::clone))
-            .collect())
+        Ok(inner.table_schemas.all())
     }
 
     async fn load_table_schemas(&self) -> EtlResult<usize> {
         let inner = self.inner.read().await;
 
-        Ok(inner.table_schemas.values().map(Vec::len).sum())
+        Ok(inner.table_schemas.len())
     }
 
     async fn store_table_schema(&self, table_schema: TableSchema) -> EtlResult<Arc<TableSchema>> {
         let mut inner = self.inner.write().await;
 
-        let table_id = table_schema.id;
-        let snapshot_id = table_schema.snapshot_id;
-        let table_schema = Arc::new(table_schema);
-
-        let schemas = inner.table_schemas.entry(table_id).or_default();
-        if let Some(existing_schema) =
-            schemas.iter_mut().find(|schema| schema.snapshot_id == snapshot_id)
-        {
-            *existing_schema = Arc::clone(&table_schema);
-        } else {
-            schemas.push(Arc::clone(&table_schema));
-        }
+        let table_schema = Arc::make_mut(&mut inner.table_schemas).insert(table_schema);
 
         inner.check_conditions();
 
@@ -425,27 +403,7 @@ impl SchemaStore for NotifyingStore {
         table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
     ) -> EtlResult<u64> {
         let mut inner = self.inner.write().await;
-        let mut removed_count = 0u64;
-
-        for (table_id, schemas) in &mut inner.table_schemas {
-            if let Some(retention) = table_schema_retentions.get(table_id) {
-                let retention_snapshot_id = SnapshotId::from(retention.to_lsn());
-                let retained_snapshot_id = schemas
-                    .iter()
-                    .map(|schema| schema.snapshot_id)
-                    .filter(|snapshot_id| *snapshot_id <= retention_snapshot_id)
-                    .max();
-
-                let Some(retained_snapshot_id) = retained_snapshot_id else {
-                    continue;
-                };
-
-                let before_count = schemas.len();
-                schemas.retain(|schema| schema.snapshot_id >= retained_snapshot_id);
-                removed_count =
-                    removed_count.saturating_add(before_count.saturating_sub(schemas.len()) as u64);
-            }
-        }
+        let removed_count = Arc::make_mut(&mut inner.table_schemas).prune(&table_schema_retentions);
 
         if removed_count > 0 {
             for notify in std::mem::take(&mut inner.table_schema_prune_conditions) {
@@ -463,7 +421,7 @@ impl CleanupStore for NotifyingStore {
 
         Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
         inner.table_state_history.remove(&table_id);
-        inner.table_schemas.remove(&table_id);
+        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
         Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
 
         Ok(())

--- a/etl/tests/pipeline_with_failpoints.rs
+++ b/etl/tests/pipeline_with_failpoints.rs
@@ -2,11 +2,11 @@
 
 use etl::{
     failpoints::{
-        SEND_STATUS_UPDATE_FP, START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP,
-        START_TABLE_SYNC_DURING_DATA_SYNC_FP,
+        FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP,
+        START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP, START_TABLE_SYNC_DURING_DATA_SYNC_FP,
     },
     state::table::{RetryPolicy, TableReplicationPhase, TableReplicationPhaseType},
-    store::state::StateStore,
+    store::{schema::SchemaStore, state::StateStore},
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::group_events_by_type_and_table_id,
@@ -1029,6 +1029,140 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
 
     assert_eq!(grouped.get(&(EventType::Relation, table_id)).unwrap().len(), 2);
     assert_eq!(grouped.get(&(EventType::Insert, table_id)).unwrap().len(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cleaned_schema_snapshots_are_recreated_when_status_update_is_lost() {
+    let _scenario = FailScenario::setup();
+    fail::cfg(SEND_STATUS_UPDATE_FP, "return").unwrap();
+
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let table_name = test_table_name("schema_cleanup_replay");
+    let table_id = database
+        .create_table(
+            table_name.clone(),
+            true,
+            &[("name", "text not null"), ("age", "integer not null")],
+        )
+        .await
+        .unwrap();
+
+    let publication_name = format!("pub_{}", random::<u32>());
+    database
+        .run_sql(&format!(
+            "create publication {publication_name} for table {}",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name.clone(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let ready_notify =
+        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    ready_notify.notified().await;
+
+    let events_notify = destination
+        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .await;
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[TableModification::AddColumn {
+                name: "email",
+                data_type: "text not null default 'unknown@example.com'",
+            }],
+        )
+        .await
+        .unwrap();
+
+    database
+        .insert_values(
+            table_name.clone(),
+            &["name", "age", "email"],
+            &[&"Bob", &28, &"bob@example.com"],
+        )
+        .await
+        .unwrap();
+
+    database
+        .alter_table(table_name.clone(), &[TableModification::DropColumn { name: "age" }])
+        .await
+        .unwrap();
+
+    database
+        .insert_values(table_name.clone(), &["name", "email"], &[&"Matt", &"matt@example.com"])
+        .await
+        .unwrap();
+
+    events_notify.notified().await;
+
+    let initial_events = collect_table_events(&destination.get_events().await, table_id);
+    let relation_snapshots = initial_events
+        .iter()
+        .filter_map(|event| match event {
+            Event::Relation(relation) => Some(relation.replicated_table_schema.inner().snapshot_id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let first_snapshot = relation_snapshots[0];
+    let latest_snapshot = relation_snapshots[1];
+    assert_eq!(relation_snapshots.len(), 2);
+
+    assert!(store.get_table_schema(&table_id, first_snapshot).await.unwrap().is_some());
+    assert!(store.get_table_schema(&table_id, latest_snapshot).await.unwrap().is_some());
+
+    // We need to force the schema cleanup.
+    let prune_notify = store.notify_on_table_schema_prune().await;
+    fail::cfg(FORCE_SCHEMA_CLEANUP_FP, "return").unwrap();
+    prune_notify.notified().await;
+    fail::remove(FORCE_SCHEMA_CLEANUP_FP);
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    assert!(store.get_table_schema(&table_id, first_snapshot).await.unwrap().is_none());
+    assert!(store.get_table_schema(&table_id, latest_snapshot).await.unwrap().is_some());
+
+    destination.clear_events().await;
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name,
+        store.clone(),
+        destination.clone(),
+    );
+
+    let replayed_events_notify = destination
+        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .await;
+
+    pipeline.start().await.unwrap();
+
+    replayed_events_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let replayed_events = collect_table_events(&destination.get_events().await, table_id);
+    assert_events_equal(&initial_events, &replayed_events);
+
+    assert!(store.get_table_schema(&table_id, first_snapshot).await.unwrap().is_some());
+    assert!(store.get_table_schema(&table_id, latest_snapshot).await.unwrap().is_some());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/etl/tests/pipeline_with_failpoints.rs
+++ b/etl/tests/pipeline_with_failpoints.rs
@@ -2,12 +2,11 @@
 
 use etl::{
     failpoints::{
-        FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP, FORCE_SCHEMA_CLEANUP_FP,
-        SEND_STATUS_UPDATE_FP, START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP,
-        START_TABLE_SYNC_DURING_DATA_SYNC_FP,
+        FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP,
+        START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP, START_TABLE_SYNC_DURING_DATA_SYNC_FP,
     },
     state::table::{RetryPolicy, TableReplicationPhase, TableReplicationPhaseType},
-    store::{schema::SchemaStore, state::StateStore},
+    store::state::StateStore,
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::group_events_by_type_and_table_id,
@@ -1033,49 +1032,17 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn cleaned_schema_snapshots_are_recreated_when_status_update_is_lost() {
+async fn schema_snapshots_are_pruned_after_confirmed_progress() {
     let _scenario = FailScenario::setup();
-    fail::cfg(SEND_STATUS_UPDATE_FP, "return").unwrap();
 
     init_test_tracing();
 
-    let database = spawn_source_database().await;
-    let table_name = test_table_name("schema_cleanup_replay");
-    let table_id = database
-        .create_table(
-            table_name.clone(),
-            true,
+    let (database, table_name, table_id, store, destination, pipeline, _pipeline_id, _publication) =
+        create_database_and_ready_pipeline_with_table(
+            "schema_cleanup",
             &[("name", "text not null"), ("age", "integer not null")],
         )
-        .await
-        .unwrap();
-
-    let publication_name = format!("pub_{}", random::<u32>());
-    database
-        .run_sql(&format!(
-            "create publication {publication_name} for table {}",
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let store = NotifyingStore::new();
-    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
-    let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name.clone(),
-        store.clone(),
-        destination.clone(),
-    );
-
-    let ready_notify =
-        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
-
-    pipeline.start().await.unwrap();
-
-    ready_notify.notified().await;
+        .await;
 
     let events_notify = destination
         .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
@@ -1096,7 +1063,7 @@ async fn cleaned_schema_snapshots_are_recreated_when_status_update_is_lost() {
         .insert_values(
             table_name.clone(),
             &["name", "age", "email"],
-            &[&"Bob", &28, &"bob@example.com"],
+            &[&"Alice", &25, &"alice@example.com"],
         )
         .await
         .unwrap();
@@ -1107,70 +1074,37 @@ async fn cleaned_schema_snapshots_are_recreated_when_status_update_is_lost() {
         .unwrap();
 
     database
-        .insert_values(table_name.clone(), &["name", "email"], &[&"Matt", &"matt@example.com"])
+        .insert_values(table_name.clone(), &["name", "email"], &[&"Bob", &"bob@example.com"])
         .await
         .unwrap();
 
     events_notify.notified().await;
 
-    let initial_events = collect_table_events(&destination.get_events().await, table_id);
-    let relation_snapshots = initial_events
-        .iter()
-        .filter_map(|event| match event {
-            Event::Relation(relation) => Some(relation.replicated_table_schema.inner().snapshot_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-    let first_snapshot = relation_snapshots[0];
-    let latest_snapshot = relation_snapshots[1];
-    assert_eq!(relation_snapshots.len(), 2);
-
-    assert!(store.get_table_schema(&table_id, first_snapshot).await.unwrap().is_some());
-    assert!(store.get_table_schema(&table_id, latest_snapshot).await.unwrap().is_some());
+    let table_schemas = store.get_table_schemas().await;
+    let before_snapshots = table_schemas.get(&table_id).unwrap();
+    assert_table_schema_snapshots(
+        before_snapshots,
+        &[
+            &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
+            &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
+            &[("id", Type::INT8), ("name", Type::TEXT), ("email", Type::TEXT)],
+        ],
+    );
 
     let prune_notify = store.notify_on_table_schema_prune().await;
 
-    // Force cleanup during the shutdown status update. The status update itself
-    // is still lost, while the confirmed-LSN failpoint lets this test exercise
-    // replay after cleanup without relying on PostgreSQL acknowledging it.
-    fail::cfg(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP, "return").unwrap();
     fail::cfg(FORCE_SCHEMA_CLEANUP_FP, "return").unwrap();
 
     prune_notify.notified().await;
 
     fail::remove(FORCE_SCHEMA_CLEANUP_FP);
-    fail::remove(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP);
 
     pipeline.shutdown_and_wait().await.unwrap();
 
-    assert!(store.get_table_schema(&table_id, first_snapshot).await.unwrap().is_none());
-    assert!(store.get_table_schema(&table_id, latest_snapshot).await.unwrap().is_some());
-
-    destination.clear_events().await;
-
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name,
-        store.clone(),
-        destination.clone(),
-    );
-
-    let replayed_events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
-        .await;
-
-    pipeline.start().await.unwrap();
-
-    replayed_events_notify.notified().await;
-
-    pipeline.shutdown_and_wait().await.unwrap();
-
-    let replayed_events = collect_table_events(&destination.get_events().await, table_id);
-    assert_events_equal(&initial_events, &replayed_events);
-
-    assert!(store.get_table_schema(&table_id, first_snapshot).await.unwrap().is_some());
-    assert!(store.get_table_schema(&table_id, latest_snapshot).await.unwrap().is_some());
+    let table_schemas = store.get_table_schemas().await;
+    let after_snapshots = table_schemas.get(&table_id).unwrap();
+    assert_eq!(after_snapshots.len(), 1);
+    assert_eq!(after_snapshots[0], before_snapshots[2]);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/etl/tests/pipeline_with_failpoints.rs
+++ b/etl/tests/pipeline_with_failpoints.rs
@@ -2,8 +2,9 @@
 
 use etl::{
     failpoints::{
-        FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP,
-        START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP, START_TABLE_SYNC_DURING_DATA_SYNC_FP,
+        FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP, FORCE_SCHEMA_CLEANUP_FP,
+        SEND_STATUS_UPDATE_FP, START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP,
+        START_TABLE_SYNC_DURING_DATA_SYNC_FP,
     },
     state::table::{RetryPolicy, TableReplicationPhase, TableReplicationPhaseType},
     store::{schema::SchemaStore, state::StateStore},
@@ -1127,10 +1128,17 @@ async fn cleaned_schema_snapshots_are_recreated_when_status_update_is_lost() {
     assert!(store.get_table_schema(&table_id, first_snapshot).await.unwrap().is_some());
     assert!(store.get_table_schema(&table_id, latest_snapshot).await.unwrap().is_some());
 
-    // We need to force the schema cleanup.
     let prune_notify = store.notify_on_table_schema_prune().await;
+
+    // Force cleanup during the shutdown status update. The status update itself
+    // is still lost, while the confirmed-LSN failpoint lets this test exercise
+    // replay after cleanup without relying on PostgreSQL acknowledging it.
     fail::cfg(FORCE_SCHEMA_CLEANUP_FP, "return").unwrap();
+    fail::cfg(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP, "return").unwrap();
+
     prune_notify.notified().await;
+
+    fail::remove(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP);
     fail::remove(FORCE_SCHEMA_CLEANUP_FP);
 
     pipeline.shutdown_and_wait().await.unwrap();

--- a/etl/tests/pipeline_with_failpoints.rs
+++ b/etl/tests/pipeline_with_failpoints.rs
@@ -1133,13 +1133,13 @@ async fn cleaned_schema_snapshots_are_recreated_when_status_update_is_lost() {
     // Force cleanup during the shutdown status update. The status update itself
     // is still lost, while the confirmed-LSN failpoint lets this test exercise
     // replay after cleanup without relying on PostgreSQL acknowledging it.
-    fail::cfg(FORCE_SCHEMA_CLEANUP_FP, "return").unwrap();
     fail::cfg(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP, "return").unwrap();
+    fail::cfg(FORCE_SCHEMA_CLEANUP_FP, "return").unwrap();
 
     prune_notify.notified().await;
 
-    fail::remove(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP);
     fail::remove(FORCE_SCHEMA_CLEANUP_FP);
+    fail::remove(FORCE_SCHEMA_CLEANUP_CONFIRMED_FLUSH_LSN_FP);
 
     pipeline.shutdown_and_wait().await.unwrap();
 

--- a/etl/tests/postgres_store.rs
+++ b/etl/tests/postgres_store.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "test-utils")]
 
+use std::collections::HashMap;
+
 use etl::{
     error::ErrorKind,
     etl_error,
@@ -466,6 +468,151 @@ async fn schema_cache_eviction() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let pipeline_id = 1;
+
+    let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    let table_id = TableId::new(12345);
+    let table_name = TableName::new("public".to_string(), "test_table".to_string());
+
+    for snapshot_id in [0u64, 100, 200] {
+        let columns = vec![
+            test_column("id", PgType::INT4, -1, 1, false, true),
+            test_column(&format!("col_at_{snapshot_id}"), PgType::TEXT, -1, 2, true, false),
+        ];
+        let mut table_schema = TableSchema::new(table_id, table_name.clone(), columns);
+        table_schema.snapshot_id = SnapshotId::from(snapshot_id);
+        store.store_table_schema(table_schema).await.unwrap();
+    }
+
+    let other_table_id = TableId::new(67890);
+    let other_table_name = TableName::new("public".to_string(), "other_table".to_string());
+    for snapshot_id in [0u64, 150] {
+        let columns = vec![
+            test_column("id", PgType::INT4, -1, 1, false, true),
+            test_column(&format!("other_col_at_{snapshot_id}"), PgType::TEXT, -1, 2, true, false),
+        ];
+        let mut table_schema = TableSchema::new(other_table_id, other_table_name.clone(), columns);
+        table_schema.snapshot_id = SnapshotId::from(snapshot_id);
+        store.store_table_schema(table_schema).await.unwrap();
+    }
+
+    let untouched_table_id = TableId::new(24680);
+    let untouched_table_name = TableName::new("public".to_string(), "untouched_table".to_string());
+    for snapshot_id in [0u64, 50] {
+        let columns = vec![
+            test_column("id", PgType::INT4, -1, 1, false, true),
+            test_column(
+                &format!("untouched_col_at_{snapshot_id}"),
+                PgType::TEXT,
+                -1,
+                2,
+                true,
+                false,
+            ),
+        ];
+        let mut table_schema =
+            TableSchema::new(untouched_table_id, untouched_table_name.clone(), columns);
+        table_schema.snapshot_id = SnapshotId::from(snapshot_id);
+        store.store_table_schema(table_schema).await.unwrap();
+    }
+
+    let pool = connect_to_source_database(&database.config, 1, 1, None).await.unwrap();
+    let obsolete_schema_ids: Vec<i64> = sqlx::query_scalar(
+        r#"
+        select id
+        from etl.table_schemas
+        where pipeline_id = $1
+          and (
+              (table_id = $2 and snapshot_id < $3::pg_lsn)
+              or (table_id = $4 and snapshot_id < $5::pg_lsn)
+          )
+        "#,
+    )
+    .bind(pipeline_id as i64)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(SnapshotId::from(200u64).to_pg_lsn_string())
+    .bind(SqlxTableId(other_table_id.into_inner()))
+    .bind(SnapshotId::from(150u64).to_pg_lsn_string())
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(obsolete_schema_ids.len(), 3);
+
+    let obsolete_column_count_before: i64 = sqlx::query_scalar(
+        "select count(*) from etl.table_columns where table_schema_id = any($1)",
+    )
+    .bind(&obsolete_schema_ids)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(obsolete_column_count_before > 0);
+
+    let deleted = store
+        .prune_table_schemas(HashMap::from([
+            (table_id, SnapshotId::from(200u64)),
+            (other_table_id, SnapshotId::from(150u64)),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(deleted, 3);
+
+    let cached_schemas = store.get_table_schemas().await.unwrap();
+    let table_snapshots: Vec<_> =
+        cached_schemas.iter().filter(|schema| schema.id == table_id).collect();
+    assert_eq!(table_snapshots.len(), 1);
+    assert_eq!(table_snapshots[0].snapshot_id, SnapshotId::from(200u64));
+
+    let other_table_snapshots: Vec<_> =
+        cached_schemas.iter().filter(|schema| schema.id == other_table_id).collect();
+    assert_eq!(other_table_snapshots.len(), 1);
+    assert_eq!(other_table_snapshots[0].snapshot_id, SnapshotId::from(150u64));
+
+    let untouched_table_snapshots: Vec<_> =
+        cached_schemas.iter().filter(|schema| schema.id == untouched_table_id).collect();
+    assert_eq!(untouched_table_snapshots.len(), 2);
+
+    let schema_count: i64 = sqlx::query_scalar(
+        "select count(*) from etl.table_schemas where pipeline_id = $1 and table_id = $2",
+    )
+    .bind(pipeline_id as i64)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(schema_count, 1);
+
+    let untouched_schema_count: i64 = sqlx::query_scalar(
+        "select count(*) from etl.table_schemas where pipeline_id = $1 and table_id = $2",
+    )
+    .bind(pipeline_id as i64)
+    .bind(SqlxTableId(untouched_table_id.into_inner()))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(untouched_schema_count, 2);
+
+    let obsolete_column_count_after: i64 = sqlx::query_scalar(
+        "select count(*) from etl.table_columns where table_schema_id = any($1)",
+    )
+    .bind(&obsolete_schema_ids)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(obsolete_column_count_after, 0);
+
+    let old_schema = store.get_table_schema(&table_id, SnapshotId::from(100u64)).await.unwrap();
+    assert!(old_schema.is_none());
+
+    let latest_schema =
+        store.get_table_schema(&table_id, SnapshotId::max()).await.unwrap().unwrap();
+    assert_eq!(latest_schema.snapshot_id, SnapshotId::from(200u64));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn multiple_pipelines_isolation() {
     init_test_tracing();
 
@@ -502,7 +649,7 @@ async fn multiple_pipelines_isolation() {
     assert_eq!(schemas2.len(), 1);
     assert_eq!(schemas2[0].id, table_schema2.id);
 
-    // Test destination metadata isolation
+    // Test destination table metadata isolation.
     let metadata1 = DestinationTableMetadata::new_applied(
         "pipeline1_table".to_string(),
         SnapshotId::initial(),

--- a/etl/tests/postgres_store.rs
+++ b/etl/tests/postgres_store.rs
@@ -552,7 +552,10 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
     assert!(obsolete_column_count_before > 0);
 
     let deleted = store
-        .prune_table_schemas(HashSet::from([table_id, other_table_id]), SnapshotId::from(200u64))
+        .prune_table_schemas(
+            HashSet::from([table_id, other_table_id]),
+            SnapshotId::from(200u64).into(),
+        )
         .await
         .unwrap();
     assert_eq!(deleted, 3);

--- a/etl/tests/postgres_store.rs
+++ b/etl/tests/postgres_store.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "test-utils")]
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use etl::{
     error::ErrorKind,
@@ -10,7 +10,9 @@ use etl::{
         table::{RetryPolicy, TableReplicationPhase},
     },
     store::{
-        both::postgres::PostgresStore, cleanup::CleanupStore, schema::SchemaStore,
+        both::postgres::PostgresStore,
+        cleanup::CleanupStore,
+        schema::{SchemaStore, TableSchemaRetention},
         state::StateStore,
     },
     test_utils::database::spawn_source_database,
@@ -552,10 +554,10 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
     assert!(obsolete_column_count_before > 0);
 
     let deleted = store
-        .prune_table_schemas(
-            HashSet::from([table_id, other_table_id]),
-            SnapshotId::from(200u64).into(),
-        )
+        .prune_table_schemas(HashMap::from([
+            (table_id, TableSchemaRetention::SnapshotId(SnapshotId::from(200u64))),
+            (other_table_id, TableSchemaRetention::SnapshotId(SnapshotId::from(200u64))),
+        ]))
         .await
         .unwrap();
     assert_eq!(deleted, 3);

--- a/etl/tests/postgres_store.rs
+++ b/etl/tests/postgres_store.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "test-utils")]
 
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use etl::{
     error::ErrorKind,
@@ -478,7 +478,7 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
     let table_id = TableId::new(12345);
     let table_name = TableName::new("public".to_string(), "test_table".to_string());
 
-    for snapshot_id in [0u64, 100, 200] {
+    for snapshot_id in [0u64, 100, 200, 300] {
         let columns = vec![
             test_column("id", PgType::INT4, -1, 1, false, true),
             test_column(&format!("col_at_{snapshot_id}"), PgType::TEXT, -1, 2, true, false),
@@ -552,10 +552,7 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
     assert!(obsolete_column_count_before > 0);
 
     let deleted = store
-        .prune_table_schemas(HashMap::from([
-            (table_id, SnapshotId::from(200u64)),
-            (other_table_id, SnapshotId::from(150u64)),
-        ]))
+        .prune_table_schemas(HashSet::from([table_id, other_table_id]), SnapshotId::from(200u64))
         .await
         .unwrap();
     assert_eq!(deleted, 3);
@@ -563,8 +560,9 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
     let cached_schemas = store.get_table_schemas().await.unwrap();
     let table_snapshots: Vec<_> =
         cached_schemas.iter().filter(|schema| schema.id == table_id).collect();
-    assert_eq!(table_snapshots.len(), 1);
-    assert_eq!(table_snapshots[0].snapshot_id, SnapshotId::from(200u64));
+    assert_eq!(table_snapshots.len(), 2);
+    assert!(table_snapshots.iter().any(|schema| schema.snapshot_id == SnapshotId::from(200u64)));
+    assert!(table_snapshots.iter().any(|schema| schema.snapshot_id == SnapshotId::from(300u64)));
 
     let other_table_snapshots: Vec<_> =
         cached_schemas.iter().filter(|schema| schema.id == other_table_id).collect();
@@ -583,7 +581,7 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(schema_count, 1);
+    assert_eq!(schema_count, 2);
 
     let untouched_schema_count: i64 = sqlx::query_scalar(
         "select count(*) from etl.table_schemas where pipeline_id = $1 and table_id = $2",
@@ -607,9 +605,13 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
     let old_schema = store.get_table_schema(&table_id, SnapshotId::from(100u64)).await.unwrap();
     assert!(old_schema.is_none());
 
+    let retained_schema =
+        store.get_table_schema(&table_id, SnapshotId::from(250u64)).await.unwrap().unwrap();
+    assert_eq!(retained_schema.snapshot_id, SnapshotId::from(200u64));
+
     let latest_schema =
         store.get_table_schema(&table_id, SnapshotId::max()).await.unwrap().unwrap();
-    assert_eq!(latest_schema.snapshot_id, SnapshotId::from(200u64));
+    assert_eq!(latest_schema.snapshot_id, SnapshotId::from(300u64));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR adds a background system for pruning table schema snapshots that are no needed anymore. A snapshot is not needed when it is the second biggest snapshot id <= than the `confirmed_flush_lsn` from Postgres or the smallest snapshot id used by each destination table metadata entry. The goal is to allow the system to remove all the schema snapshots that won't be needed anymore for decoding new tuple data rows or handling schema changes.

The deletion is attempted every hour since we expect schema changes to not be that frequent that could overload ETL's table in the source database.

In addition, the PR fixes a small issue in the shared table cache which was preventing older snapshot ids to be stored. However, that is sound, since it could happen when the apply loop is restarted and replays older events. We want to treat the cache is a shared map of what table state each worker saw and we rely on the fact that workers synchronize between themselves to uphold correctness properties, without needing to enforce them at compile time, which would increase the complexity of the implementation.