### PR TITLE
fix(ducklake): simplify and fix ducklake inline data flush maintenance

### DIFF
--- a/etl-destinations/src/ducklake/METRICS.md
+++ b/etl-destinations/src/ducklake/METRICS.md
@@ -106,13 +106,6 @@ How to read it:
   `reason="pending_inlined_data_bytes_threshold"` means the flush was
   scheduled from sampled inlined catalog-table size in a PostgreSQL-backed
   DuckLake catalog. This includes both inlined inserts and inlined deletions.
-- `task="flush"` with `reason="pending_bytes_threshold"` means the flush was
-  scheduled because the fallback estimated pre-compression inlined bytes
-  crossed the configured threshold. The current heuristic assumes a 4:1
-  raw-to-parquet compression ratio when direct catalog-size sampling is not
-  available.
-- `task="flush"` with `reason="pending_inserted_rows_threshold"` means the
-  optional row-count threshold was enabled in code and fired before shutdown.
 - `task="scheduled_maintenance"` with `reason="merge_interval"` means the
   next `write_events` batch tried to run the tier-0 `< 1MiB -> ~5MiB`
   `merge_adjacent_files` pass first.

--- a/etl-destinations/src/ducklake/batches.rs
+++ b/etl-destinations/src/ducklake/batches.rs
@@ -23,8 +23,8 @@ use etl::{
     error::{ErrorKind, EtlResult},
     etl_error,
     types::{
-        Cell, EventSequenceKey, OldTableRow, PartialTableRow, ReplicatedTableSchema, SizeHint,
-        TableRow, UpdatedTableRow,
+        Cell, EventSequenceKey, OldTableRow, PartialTableRow, ReplicatedTableSchema, TableRow,
+        UpdatedTableRow,
     },
 };
 use metrics::{counter, histogram};
@@ -162,18 +162,6 @@ impl TrackedTableMutation {
     /// Returns the stable event sequence key for this mutation.
     fn sequence_key(&self) -> EventSequenceKey {
         EventSequenceKey::new(self.commit_lsn, self.tx_ordinal)
-    }
-
-    /// Returns the approximate payload bytes that this mutation contributes to
-    /// inline-maintenance accounting.
-    pub(super) fn write_activity_size_hint(&self) -> u64 {
-        match &self.mutation {
-            TableMutation::Insert(row) | TableMutation::Replace(row) => row.size_hint() as u64,
-            TableMutation::Delete(row) => row.size_hint() as u64,
-            TableMutation::Update { delete_row, new_row } => {
-                (delete_row.size_hint() as u64).saturating_add(new_row.size_hint() as u64)
-            }
-        }
     }
 }
 

--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -21,8 +21,8 @@ use etl::{
     state::destination_metadata::DestinationTableMetadata,
     store::{schema::SchemaStore, state::StateStore},
     types::{
-        Event, EventSequenceKey, OldTableRow, PartialTableRow, ReplicatedTableSchema, SizeHint,
-        TableId, TableName, TableRow, UpdatedTableRow,
+        Event, EventSequenceKey, OldTableRow, PartialTableRow, ReplicatedTableSchema, TableId,
+        TableName, TableRow, UpdatedTableRow,
     },
 };
 use metrics::gauge;
@@ -695,9 +695,6 @@ where
 
         self.maybe_run_requested_inline_flush().await?;
 
-        let approx_bytes = table_rows.iter().map(|row| row.size_hint() as u64).sum::<u64>();
-        let inserted_rows = table_rows.len() as u64;
-
         // Copy batches for the same table must still serialize so concurrent
         // callers do not race each other inside DuckDB.
         self.ensure_applied_batches_table_exists().await?;
@@ -713,7 +710,7 @@ where
         )
         .await?;
         self.notify_background_maintenance(TableMaintenanceNotification::WriteActivity(
-            TableWriteActivity { table_name, approx_bytes, inserted_rows },
+            TableWriteActivity { table_name },
         ))
         .await;
 
@@ -889,12 +886,9 @@ where
 
                         let maintenance_notification =
                             maintenance_worker.as_ref().as_ref().map(|_| {
-                                TableMaintenanceNotification::WriteActivity(
-                                    table_write_activity_for_mutations(
-                                        destination_table_name.clone(),
-                                        pending_mutations.as_slice(),
-                                    ),
-                                )
+                                TableMaintenanceNotification::WriteActivity(TableWriteActivity {
+                                    table_name: destination_table_name.clone(),
+                                })
                             });
                         let prepared_batches = prepare_mutation_table_batches(
                             &replicated_table_schema,
@@ -1229,27 +1223,6 @@ async fn read_table_streaming_progress_sequence_key_blocking(
     .await
 }
 
-/// Recomputes maintenance stats from the suffix of mutations that still needs
-/// applying.
-fn table_write_activity_for_mutations(
-    table_name: DuckLakeTableName,
-    tracked_mutations: &[TrackedTableMutation],
-) -> TableWriteActivity {
-    let mut write_activity = TableWriteActivity { table_name, approx_bytes: 0, inserted_rows: 0 };
-
-    for tracked_mutation in tracked_mutations {
-        // This is only a fallback estimate for catalogs where we cannot sample
-        // actual inlined-table sizes directly. The optional row-threshold path
-        // is disabled today, so we treat each mutation as one unit of fallback
-        // activity to keep mutation-only streams visible to maintenance.
-        write_activity.approx_bytes =
-            write_activity.approx_bytes.saturating_add(tracked_mutation.write_activity_size_hint());
-        write_activity.inserted_rows = write_activity.inserted_rows.saturating_add(1);
-    }
-
-    write_activity
-}
-
 #[cfg(feature = "test-utils")]
 struct PausedStreamingWriteHook {
     reached_tx: oneshot::Sender<()>,
@@ -1330,8 +1303,8 @@ mod tests {
         config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig},
         store::{both::memory::MemoryStore, schema::SchemaStore},
         types::{
-            Cell, ColumnSchema, IdentityMask, OldTableRow, PartialTableRow, PgLsn, ReplicationMask,
-            SizeHint, TableRow, TableSchema, Type as PgType, UpdatedTableRow,
+            Cell, ColumnSchema, IdentityMask, PartialTableRow, ReplicationMask, TableRow,
+            TableSchema, Type as PgType,
         },
     };
     use etl_postgres::tokio::test_utils::PgDatabase;
@@ -1387,40 +1360,6 @@ mod tests {
             ReplicationMask::all(&table_schema),
             IdentityMask::from_bytes(vec![0, 0]),
         )
-    }
-
-    #[test]
-    fn table_write_activity_for_mutations_counts_partial_updates_and_deletes() {
-        let delete_row = OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]));
-        let update_delete_row = OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]));
-        let partial_row = UpdatedTableRow::Partial(PartialTableRow::new(
-            2,
-            TableRow::new(vec![Cell::I32(1), Cell::String("grown".to_string())]),
-            vec![],
-        ));
-        let expected_bytes = delete_row.size_hint() as u64
-            + update_delete_row.size_hint() as u64
-            + partial_row.size_hint() as u64;
-        let write_activity = table_write_activity_for_mutations(
-            "public_users".to_string(),
-            &[
-                TrackedTableMutation::new(
-                    PgLsn::from(100),
-                    PgLsn::from(100),
-                    0,
-                    TableMutation::Delete(delete_row),
-                ),
-                TrackedTableMutation::new(
-                    PgLsn::from(100),
-                    PgLsn::from(100),
-                    1,
-                    TableMutation::Update { delete_row: update_delete_row, new_row: partial_row },
-                ),
-            ],
-        );
-
-        assert_eq!(write_activity.approx_bytes, expected_bytes);
-        assert_eq!(write_activity.inserted_rows, 2);
     }
 
     #[test]

--- a/etl-destinations/src/ducklake/inline_size.rs
+++ b/etl-destinations/src/ducklake/inline_size.rs
@@ -91,7 +91,7 @@ fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
                      )
                  ),
                  0
-             ) AS total_bytes
+             )::BIGINT AS total_bytes
              FROM target_inline_tables
          ),
          inline_delete_bytes AS (
@@ -106,7 +106,7 @@ fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
                      )
                  ),
                  0
-             ) AS total_bytes
+             )::BIGINT AS total_bytes
          )
          SELECT
              (SELECT total_bytes FROM inline_data_bytes)
@@ -144,6 +144,7 @@ mod tests {
         assert!(sql.contains("duck'lake"));
         assert!(sql.contains(r#"format('%I.%I', 'duck''lake'"#));
         assert!(sql.contains("SUM("));
+        assert!(sql.contains(")::BIGINT AS total_bytes"));
     }
 
     #[tokio::test]

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -34,7 +34,6 @@ use crate::ducklake::{
         ETL_DUCKLAKE_MAINTENANCE_IN_PROGRESS, ETL_DUCKLAKE_MAINTENANCE_SKIPPED_TOTAL,
         ETL_DUCKLAKE_MAINTENANCE_STARTED_TOTAL, MAINTENANCE_OPERATION_LABEL,
         MAINTENANCE_OUTCOME_LABEL, MAINTENANCE_REASON_LABEL, MAINTENANCE_TASK_LABEL, RESULT_LABEL,
-        SMALL_FILE_SIZE_BYTES,
     },
 };
 
@@ -48,15 +47,6 @@ const MAINTENANCE_EXPIRE_SNAPSHOTS_INTERVAL: Duration = Duration::from_secs(5 * 
 const MAINTENANCE_CLEANUP_OLD_FILES_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 /// Pending inlined bytes threshold that triggers a background inline flush.
 const MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD: u64 = 10_000_000;
-/// Estimated ratio from raw row payload to compressed parquet bytes.
-const PARQUET_COMPRESSION_RATIO_ESTIMATE: u64 = 4;
-/// Fallback estimated pending bytes threshold when inline-size sampling is
-/// unavailable.
-const MAINTENANCE_PENDING_BYTES_THRESHOLD: u64 =
-    SMALL_FILE_SIZE_BYTES as u64 * PARQUET_COMPRESSION_RATIO_ESTIMATE;
-/// Optional pending inserted-rows threshold that triggers a background inline
-/// flush.
-const MAINTENANCE_PENDING_ROWS_THRESHOLD: Option<u64> = None;
 /// Minimum idle window before targeted table maintenance runs, to not have
 /// maintenances ran too frequently.
 const MAINTENANCE_TABLE_COMPACTION_IDLE_THRESHOLD: Duration = Duration::from_secs(90);
@@ -108,8 +98,6 @@ impl MaintenanceOperation {
 #[allow(clippy::enum_variant_names)]
 enum MaintenanceReason {
     PendingInlinedDataBytesThreshold,
-    PendingBytesThreshold,
-    PendingInsertedRowsThreshold,
     SnapshotRetentionThreshold,
     CleanupIntervalElapsed,
     IdleRewriteMetricsThreshold,
@@ -121,8 +109,6 @@ impl MaintenanceReason {
     fn as_str(self) -> &'static str {
         match self {
             Self::PendingInlinedDataBytesThreshold => "pending_inlined_data_bytes_threshold",
-            Self::PendingBytesThreshold => "pending_bytes_threshold",
-            Self::PendingInsertedRowsThreshold => "pending_inserted_rows_threshold",
             Self::SnapshotRetentionThreshold => "snapshot_retention_threshold",
             Self::CleanupIntervalElapsed => "cleanup_interval_elapsed",
             Self::IdleRewriteMetricsThreshold => "idle_rewrite_metrics_threshold",
@@ -167,8 +153,6 @@ impl From<u64> for MaintenanceOutcome {
 #[derive(Clone, Debug, Default)]
 pub(super) struct TableWriteActivity {
     pub(super) table_name: DuckLakeTableName,
-    pub(super) approx_bytes: u64,
-    pub(super) inserted_rows: u64,
 }
 
 /// Table-health metrics sent from the background sampler to maintenance.
@@ -307,8 +291,6 @@ impl CatalogMaintenanceState {
 /// Coalesced maintenance state for one DuckLake table.
 #[derive(Debug, Default)]
 struct TableMaintenanceState {
-    pending_bytes: u64,
-    pending_inserted_rows: u64,
     dirty_since_compaction: bool,
     last_write_at: Option<Instant>,
     latest_pending_inline_data_sizes: Option<DuckLakePendingInlineDataSizes>,
@@ -321,10 +303,7 @@ struct TableMaintenanceState {
 
 impl TableMaintenanceState {
     /// Aggregates one write notification into the existing table state.
-    fn record_write_activity(&mut self, notification: &TableWriteActivity, now: Instant) {
-        self.pending_bytes = self.pending_bytes.saturating_add(notification.approx_bytes);
-        self.pending_inserted_rows =
-            self.pending_inserted_rows.saturating_add(notification.inserted_rows);
+    fn record_write_activity(&mut self, now: Instant) {
         self.dirty_since_compaction = true;
         self.last_write_at = Some(now);
     }
@@ -343,11 +322,6 @@ impl TableMaintenanceState {
     fn record_metrics_sample(&mut self, sample: TableMetricsSample) {
         self.latest_storage_metrics = Some(sample.metrics);
         self.latest_storage_metrics_sampled_at = Some(sample.sampled_at);
-    }
-
-    /// Returns whether the table still has pending inline work.
-    fn has_pending_flush_work(&self) -> bool {
-        self.pending_bytes > 0 || self.pending_inserted_rows > 0
     }
 
     /// Returns whether the current dirty period still needs an inline-size
@@ -374,31 +348,10 @@ impl TableMaintenanceState {
     }
 
     /// Returns the primary reason that pending inlined work should be flushed.
-    fn flush_reason(&self, now: Instant) -> Option<MaintenanceReason> {
-        self.flush_reason_with_pending_rows_threshold(now, MAINTENANCE_PENDING_ROWS_THRESHOLD)
-    }
-
-    /// Returns the primary reason that pending inlined work should be flushed.
-    fn flush_reason_with_pending_rows_threshold(
-        &self,
-        _now: Instant,
-        pending_rows_threshold: Option<u64>,
-    ) -> Option<MaintenanceReason> {
+    fn flush_reason(&self) -> Option<MaintenanceReason> {
         if let Some(sizes) = self.current_pending_inline_data_sizes() {
-            return (sizes.inlined_bytes
-                >= (MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD
-                    * PARQUET_COMPRESSION_RATIO_ESTIMATE))
+            return (sizes.inlined_bytes >= MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD)
                 .then_some(MaintenanceReason::PendingInlinedDataBytesThreshold);
-        }
-
-        if self.pending_bytes >= MAINTENANCE_PENDING_BYTES_THRESHOLD {
-            return Some(MaintenanceReason::PendingBytesThreshold);
-        }
-
-        if let Some(pending_rows_threshold) = pending_rows_threshold
-            && self.pending_inserted_rows >= pending_rows_threshold
-        {
-            return Some(MaintenanceReason::PendingInsertedRowsThreshold);
         }
 
         None
@@ -406,8 +359,6 @@ impl TableMaintenanceState {
 
     /// Clears pending flush counters after a successful flush/materialization.
     fn clear_pending_flush(&mut self, now: Instant) {
-        self.pending_bytes = 0;
-        self.pending_inserted_rows = 0;
         self.latest_pending_inline_data_sizes = Some(DuckLakePendingInlineDataSizes::default());
         self.latest_pending_inline_data_sampled_at = Some(now);
     }
@@ -838,8 +789,6 @@ async fn run_ducklake_maintenance_worker(
                 apply_maintenance_notification(&mut table_states, notification);
             }
             _ = flush_interval.tick() => {
-                let mut now = Instant::now();
-
                 for (table_name, table_state) in &mut table_states {
                     if let Some(pending_inline_size_sampler) = &pending_inline_size_sampler
                         && table_state.needs_pending_inline_data_sizes_sample()
@@ -849,7 +798,7 @@ async fn run_ducklake_maintenance_worker(
                                 table_state.record_pending_inline_data_sizes(Instant::now(), sizes);
                             }
                             Err(error) => {
-                                warn!(
+                                tracing::error!(
                                     table = %table_name,
                                     error = ?error,
                                     "ducklake inline-size sampler query failed"
@@ -859,11 +808,11 @@ async fn run_ducklake_maintenance_worker(
                     }
 
                     // If it needs to be flushed
-                    if let Some(reason) = table_state.flush_reason(now) {
+                    if let Some(reason) = table_state.flush_reason() {
                         pending_inline_flush_requests.request(table_name.clone(), reason);
                         inline_flush_requested.store(true, AtomicOrdering::Release);
                     }
-                    now = Instant::now();
+                    let now = Instant::now();
 
                     if !ENABLE_TARGETED_TABLE_MAINTENANCE {
                         continue;
@@ -948,9 +897,7 @@ async fn run_ducklake_maintenance_worker(
                 }
 
                 table_states.retain(|_, state| {
-                    state.has_pending_flush_work()
-                        || state.dirty_since_compaction
-                        || state.latest_storage_metrics.is_some()
+                    state.dirty_since_compaction || state.latest_storage_metrics.is_some()
                 });
 
                 maybe_run_catalog_maintenance(
@@ -975,11 +922,11 @@ fn apply_maintenance_notification(
     match notification {
         TableMaintenanceNotification::WriteActivity(activity) => {
             table_states
-                .entry(activity.table_name.clone())
-                .and_modify(|state| state.record_write_activity(&activity, now))
+                .entry(activity.table_name)
+                .and_modify(|state| state.record_write_activity(now))
                 .or_insert_with(|| {
                     let mut state = TableMaintenanceState::default();
-                    state.record_write_activity(&activity, now);
+                    state.record_write_activity(now);
                     state
                 });
         }
@@ -1629,10 +1576,6 @@ mod tests {
             .unwrap_or(0.0)
     }
 
-    fn write_activity(approx_bytes: u64, inserted_rows: u64) -> TableWriteActivity {
-        TableWriteActivity { table_name: "public_users".to_string(), approx_bytes, inserted_rows }
-    }
-
     fn table_metrics_sample(
         sampled_at: Instant,
         metrics: DuckLakeTableStorageMetrics,
@@ -1670,7 +1613,7 @@ mod tests {
             &rendered_before,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
             MaintenanceOutcome::Applied,
         );
         let rewrite_before = maintenance_duration_count(
@@ -1684,7 +1627,7 @@ mod tests {
         record_ducklake_maintenance_duration(
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
             MaintenanceOutcome::Applied,
             0.25,
         );
@@ -1701,7 +1644,7 @@ mod tests {
             &rendered_after,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
             MaintenanceOutcome::Applied,
         );
         let rewrite_after = maintenance_duration_count(
@@ -1850,41 +1793,34 @@ mod tests {
     }
 
     #[test]
-    fn table_maintenance_state_prefers_pending_bytes_flush_reason() {
+    fn table_maintenance_state_without_sample_or_row_threshold_does_not_flush() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
-        state.record_write_activity(&write_activity(MAINTENANCE_PENDING_BYTES_THRESHOLD, 1), now);
+        state.record_write_activity(now);
 
-        assert_eq!(
-            state.flush_reason_with_pending_rows_threshold(now, Some(1)),
-            Some(MaintenanceReason::PendingBytesThreshold)
-        );
+        assert_eq!(state.flush_reason(), None);
     }
 
     #[test]
     fn table_maintenance_state_uses_sampled_inline_data_bytes_flush_reason() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
-        state.record_write_activity(&write_activity(1, 1), now);
+        state.record_write_activity(now);
         state.record_pending_inline_data_sizes(
             now + Duration::from_secs(1),
             DuckLakePendingInlineDataSizes {
-                inlined_bytes: MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD
-                    * PARQUET_COMPRESSION_RATIO_ESTIMATE,
+                inlined_bytes: MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD,
             },
         );
 
-        assert_eq!(
-            state.flush_reason(now + Duration::from_secs(2)),
-            Some(MaintenanceReason::PendingInlinedDataBytesThreshold)
-        );
+        assert_eq!(state.flush_reason(), Some(MaintenanceReason::PendingInlinedDataBytesThreshold));
     }
 
     #[test]
-    fn table_maintenance_state_prefers_sampled_inline_data_over_estimated_bytes() {
+    fn table_maintenance_state_ignores_below_threshold_sampled_inline_data() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
-        state.record_write_activity(&write_activity(MAINTENANCE_PENDING_BYTES_THRESHOLD, 1), now);
+        state.record_write_activity(now);
         state.record_pending_inline_data_sizes(
             now + Duration::from_secs(1),
             DuckLakePendingInlineDataSizes {
@@ -1892,29 +1828,14 @@ mod tests {
             },
         );
 
-        assert_eq!(state.flush_reason(now + Duration::from_secs(2)), None);
-    }
-
-    #[test]
-    fn table_maintenance_state_uses_pending_inserted_rows_flush_reason_when_enabled() {
-        let now = Instant::now();
-        let mut state = TableMaintenanceState::default();
-        state.record_write_activity(
-            &write_activity(MAINTENANCE_PENDING_BYTES_THRESHOLD - 1, 10_000),
-            now,
-        );
-
-        assert_eq!(
-            state.flush_reason_with_pending_rows_threshold(now, Some(10_000)),
-            Some(MaintenanceReason::PendingInsertedRowsThreshold)
-        );
+        assert_eq!(state.flush_reason(), None);
     }
 
     #[test]
     fn table_maintenance_state_selects_idle_rewrite_from_delete_pressure() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
-        state.record_write_activity(&write_activity(1024, 1), now);
+        state.record_write_activity(now);
         state.record_metrics_sample(table_metrics_sample(
             now + Duration::from_secs(1),
             storage_metrics(10, 20_000_000, 2, 1000, 32, 10_000, 150),
@@ -1935,7 +1856,7 @@ mod tests {
     fn table_maintenance_state_selects_emergency_rewrite_from_delete_pressure() {
         let now = Instant::now();
         let mut state = TableMaintenanceState::default();
-        state.record_write_activity(&write_activity(1024, 1), now);
+        state.record_write_activity(now);
         state.record_metrics_sample(table_metrics_sample(
             now + Duration::from_secs(1),
             storage_metrics(10, 20_000_000, 2, 1000, 128, 10_000, 150),
@@ -2009,14 +1930,14 @@ mod tests {
             &rendered_before,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
             MaintenanceOutcome::Failed,
         );
 
         let error = flush_table_inlined_data_in_background_blocking(
             &conn,
             "public_users",
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
         )
         .expect_err("flush should fail without ducklake functions");
 
@@ -2027,7 +1948,7 @@ mod tests {
             &rendered_after,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
             MaintenanceOutcome::Failed,
         );
 
@@ -2219,15 +2140,17 @@ mod tests {
         let mutation_guard = Arc::clone(&checkpoint_gate).read_owned().await;
         let inline_flush_requested = Arc::new(AtomicBool::new(true));
         let pending_inline_flush_requests = PendingInlineFlushRequests::default();
-        pending_inline_flush_requests
-            .request("public_users".to_string(), MaintenanceReason::PendingBytesThreshold);
+        pending_inline_flush_requests.request(
+            "public_users".to_string(),
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
+        );
 
         let rendered_before = handle.render();
         let skipped_before = maintenance_skipped_counter_value(
             &rendered_before,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
         );
 
         maybe_run_requested_inline_flush(
@@ -2246,14 +2169,14 @@ mod tests {
             &rendered_after,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
         );
 
         assert!(skipped_after > skipped_before);
         assert!(inline_flush_requested.load(AtomicOrdering::Acquire));
         assert_eq!(
             pending_inline_flush_requests.requests.lock().get("public_users"),
-            Some(&MaintenanceReason::PendingBytesThreshold)
+            Some(&MaintenanceReason::PendingInlinedDataBytesThreshold)
         );
 
         drop(mutation_guard);
@@ -2269,20 +2192,20 @@ mod tests {
             &rendered_before,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
         );
         let duration_before = maintenance_duration_count(
             &rendered_before,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
             MaintenanceOutcome::SkippedBusy,
         );
 
         record_ducklake_maintenance_skipped(
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
         );
 
         let rendered_after = handle.render();
@@ -2290,13 +2213,13 @@ mod tests {
             &rendered_after,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
         );
         let duration_after = maintenance_duration_count(
             &rendered_after,
             MAINTENANCE_TASK_FLUSH,
             MaintenanceOperation::FlushInlinedData,
-            MaintenanceReason::PendingBytesThreshold,
+            MaintenanceReason::PendingInlinedDataBytesThreshold,
             MaintenanceOutcome::SkippedBusy,
         );
 


### PR DESCRIPTION
SQL query to get inlined data size contained an error on types. This PR also removes useless conditions to run the inline flush maintenance. It's now simpler and better.