### PR TITLE
fix(ducklake): don't crash ETL for inline flush maintenance and use compression ratio for threshold

### DIFF
--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -693,7 +693,13 @@ where
             return Ok(());
         }
 
-        self.maybe_run_requested_inline_flush().await?;
+        if let Err(error) = self.maybe_run_requested_inline_flush().await {
+            tracing::error!(
+                table = %table_name,
+                error = ?error,
+                "ducklake inline flush failed"
+            );
+        }
 
         // Copy batches for the same table must still serialize so concurrent
         // callers do not race each other inside DuckDB.
@@ -727,7 +733,12 @@ where
     /// streaming replay watermark so retries can safely detect already
     /// committed work.
     async fn write_events_inner(&self, events: Vec<Event>) -> EtlResult<()> {
-        self.maybe_run_requested_inline_flush().await?;
+        if let Err(error) = self.maybe_run_requested_inline_flush().await {
+            tracing::error!(
+                error = ?error,
+                "ducklake inline flush failed"
+            );
+        }
         let mut event_iter = events.into_iter().peekable();
 
         while event_iter.peek().is_some() {

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -45,8 +45,13 @@ const MAINTENANCE_FLUSH_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const MAINTENANCE_EXPIRE_SNAPSHOTS_INTERVAL: Duration = Duration::from_secs(5 * 60 * 60);
 /// Fixed cadence for cleaning up old DuckLake files.
 const MAINTENANCE_CLEANUP_OLD_FILES_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
-/// Pending inlined bytes threshold that triggers a background inline flush.
-const MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD: u64 = 10_000_000;
+/// Estimated ratio from raw row payload to compressed parquet bytes.
+const PARQUET_COMPRESSION_RATIO_ESTIMATE: u64 = 3;
+/// Pending inlined bytes threshold that triggers a background inline flush. We
+/// multiply using `PARQUET_COMPRESSION_RATIO_ESTIMATE` to make sure we won't
+/// get too small data files
+const MAINTENANCE_PENDING_INLINED_DATA_BYTES_THRESHOLD: u64 =
+    10_000_000 * PARQUET_COMPRESSION_RATIO_ESTIMATE;
 /// Minimum idle window before targeted table maintenance runs, to not have
 /// maintenances ran too frequently.
 const MAINTENANCE_TABLE_COMPACTION_IDLE_THRESHOLD: Duration = Duration::from_secs(90);


### PR DESCRIPTION
Instead of crashing ETL if an error happens in a maintenance we should just log the error.