### PR TITLE
ref(api): Improve handling of deletions

### DIFF
--- a/etl-api/src/data/pipelines.rs
+++ b/etl-api/src/data/pipelines.rs
@@ -228,6 +228,16 @@ pub async fn delete_pipeline_api_and_source_state(
     tenant_id: &str,
     pipeline: &PipelineDeletion,
 ) -> Result<(), PipelinesDbError> {
+    delete_pipeline_api_state(api_connection, tenant_id, pipeline).await?;
+
+    delete_pipeline_source_state(source_connection, pipeline.id).await
+}
+
+pub async fn delete_pipeline_api_state(
+    api_connection: &mut PgConnection,
+    tenant_id: &str,
+    pipeline: &PipelineDeletion,
+) -> Result<(), PipelinesDbError> {
     // Delete the pipeline from the main database (this does NOT cascade delete the
     // replicator due to missing constraint).
     delete_pipeline(&mut *api_connection, tenant_id, pipeline.id).await?;
@@ -236,7 +246,7 @@ pub async fn delete_pipeline_api_and_source_state(
     data::replicators::delete_replicator(&mut *api_connection, tenant_id, pipeline.replicator_id)
         .await?;
 
-    delete_pipeline_source_state(source_connection, pipeline.id).await
+    Ok(())
 }
 
 pub async fn delete_pipeline_source_state(

--- a/etl-api/src/routes/destinations_pipelines.rs
+++ b/etl-api/src/routes/destinations_pipelines.rs
@@ -26,8 +26,9 @@ use crate::{
         images::ImagesDbError,
         pipelines::{
             MAX_PIPELINES_PER_TENANT, PipelinesDbError, count_pipelines_for_tenant,
-            delete_pipeline_api_and_source_state, delete_pipeline_replication_slots, read_pipeline,
-            read_pipeline_for_deletion, read_pipelines_for_destination_for_deletion,
+            delete_pipeline_api_and_source_state, delete_pipeline_api_state,
+            delete_pipeline_replication_slots, read_pipeline, read_pipeline_for_deletion,
+            read_pipelines_for_destination_for_deletion,
         },
         sources::SourcesDbError,
     },
@@ -427,18 +428,43 @@ pub async fn delete_destination_and_pipeline(
     )
     .await?
     .ok_or(DestinationPipelineError::SourceNotFound(pipeline.source_id))?;
-    let source_pool =
-        connect_to_source_database_from_api(&source.config.into_connection_config(tls_config))
-            .await?;
-    let mut api_txn = pool.begin().await?;
-    let mut source_txn = source_pool.begin().await?;
-    delete_pipeline_api_and_source_state(
-        api_txn.deref_mut(),
-        source_txn.deref_mut(),
-        tenant_id,
-        &pipeline,
+    let source_pool = match connect_to_source_database_from_api(
+        &source.config.into_connection_config(tls_config),
     )
-    .await?;
+    .await
+    {
+        Ok(source_pool) => Some(source_pool),
+        Err(error) => {
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                destination_id,
+                pipeline_id = pipeline.id,
+                source_id = pipeline.source_id,
+                error = %error,
+                "failed to connect to source database during destination pipeline deletion, skipping source cleanup",
+            );
+
+            None
+        }
+    };
+    let mut api_txn = pool.begin().await?;
+    let mut source_txn = if let Some(source_pool) = source_pool.as_ref() {
+        Some(source_pool.begin().await?)
+    } else {
+        None
+    };
+    if let Some(source_txn) = source_txn.as_mut() {
+        delete_pipeline_api_and_source_state(
+            api_txn.deref_mut(),
+            source_txn.deref_mut(),
+            tenant_id,
+            &pipeline,
+        )
+        .await?;
+    } else {
+        delete_pipeline_api_state(api_txn.deref_mut(), tenant_id, &pipeline).await?;
+    }
+
     let remaining_pipelines =
         read_pipelines_for_destination_for_deletion(api_txn.deref_mut(), tenant_id, destination_id)
             .await?;
@@ -454,8 +480,12 @@ pub async fn delete_destination_and_pipeline(
     // and the API commit failed afterwards, the API database could still
     // reference pipeline state that no longer exists in the source database.
     api_txn.commit().await?;
-    source_txn.commit().await?;
-    delete_pipeline_replication_slots(&source_pool, pipeline.id).await?;
+    if let Some(source_txn) = source_txn {
+        source_txn.commit().await?;
+    }
+    if let Some(source_pool) = source_pool.as_ref() {
+        delete_pipeline_replication_slots(source_pool, pipeline.id).await?;
+    }
 
     Ok(Json(DeleteDestinationPipelineResponse {
         destination_id,

--- a/etl-api/src/routes/pipelines.rs
+++ b/etl-api/src/routes/pipelines.rs
@@ -26,7 +26,7 @@ use crate::{
         images::ImagesDbError,
         pipelines::{
             MAX_PIPELINES_PER_TENANT, PipelinesDbError, delete_pipeline_api_and_source_state,
-            delete_pipeline_replication_slots, read_pipeline_components,
+            delete_pipeline_api_state, delete_pipeline_replication_slots, read_pipeline_components,
             read_pipeline_for_deletion,
         },
         replicators::ReplicatorsDbError,
@@ -763,21 +763,41 @@ pub async fn delete_pipeline(
     .await?
     .ok_or(PipelineError::SourceNotFound(pipeline.source_id))?;
 
-    let source_pool =
-        connect_to_source_database_from_api(&source.config.into_connection_config(tls_config))
-            .await?;
-    let mut api_txn = pool.begin().await?;
-    let mut source_txn = source_pool.begin().await?;
-    delete_pipeline_api_and_source_state(
-        api_txn.deref_mut(),
-        source_txn.deref_mut(),
-        tenant_id,
-        &pipeline,
+    let source_pool = match connect_to_source_database_from_api(
+        &source.config.into_connection_config(tls_config),
     )
-    .await?;
-    api_txn.commit().await?;
-    source_txn.commit().await?;
-    delete_pipeline_replication_slots(&source_pool, pipeline.id).await?;
+    .await
+    {
+        Ok(source_pool) => Some(source_pool),
+        Err(error) => {
+            tracing::warn!(
+                tenant_id = %tenant_id,
+                pipeline_id = pipeline.id,
+                source_id = pipeline.source_id,
+                error = %error,
+                "failed to connect to source database during pipeline deletion, skipping source cleanup",
+            );
+
+            None
+        }
+    };
+    let mut api_txn = pool.begin().await?;
+    if let Some(source_pool) = source_pool {
+        let mut source_txn = source_pool.begin().await?;
+        delete_pipeline_api_and_source_state(
+            api_txn.deref_mut(),
+            source_txn.deref_mut(),
+            tenant_id,
+            &pipeline,
+        )
+        .await?;
+        api_txn.commit().await?;
+        source_txn.commit().await?;
+        delete_pipeline_replication_slots(&source_pool, pipeline.id).await?;
+    } else {
+        delete_pipeline_api_state(api_txn.deref_mut(), tenant_id, &pipeline).await?;
+        api_txn.commit().await?;
+    }
 
     Ok(HttpResponse::Ok().finish())
 }

--- a/etl-api/tests/destinations_pipelines.rs
+++ b/etl-api/tests/destinations_pipelines.rs
@@ -588,6 +588,39 @@ async fn destination_and_pipeline_can_be_deleted() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn destination_and_pipeline_can_be_deleted_when_source_database_is_unreachable() {
+    init_test_tracing();
+
+    let app = spawn_test_app().await;
+    let fixture = create_destination_pipeline_deletion_fixture(&app).await;
+    app.k8s_state.set_pod_status(PodStatus::Stopped).await;
+    drop_pg_database(&fixture.source_db_config).await;
+
+    let response = app
+        .delete_destination_pipeline(
+            &fixture.tenant_id,
+            fixture.destination_id,
+            fixture.pipeline_id,
+        )
+        .await;
+
+    let status = response.status();
+    assert!(status.is_success());
+    let response: DeleteDestinationPipelineResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.destination_id, fixture.destination_id);
+    assert_eq!(response.pipeline_id, fixture.pipeline_id);
+    assert!(response.destination_deleted);
+
+    let destination_response =
+        app.read_destination(&fixture.tenant_id, fixture.destination_id).await;
+    assert_eq!(destination_response.status(), StatusCode::NOT_FOUND);
+
+    let pipeline_response = app.read_pipeline(&fixture.tenant_id, fixture.pipeline_id).await;
+    assert_eq!(pipeline_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn active_destination_and_pipeline_cannot_be_deleted() {
     init_test_tracing();
 

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -680,6 +680,21 @@ async fn deleting_a_pipeline_succeeds() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn deleting_a_pipeline_succeeds_when_source_database_is_unreachable() {
+    init_test_tracing();
+    let (app, tenant_id, pipeline_id, _source_db_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
+    app.k8s_state.set_pod_status(PodStatus::Stopped).await;
+    drop_pg_database(&source_db_config).await;
+
+    let response = app.delete_pipeline(&tenant_id, pipeline_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app.read_pipeline(&tenant_id, pipeline_id).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn deleting_an_active_pipeline_fails() {
     init_test_tracing();
     let (app, tenant_id, pipeline_id, _, source_db_config) = setup_pipeline_with_source_db().await;


### PR DESCRIPTION
This PR makes the deletion of the resources not fail in case the connection to the source fails. This is done since we are designing the endpoints to be optimistic around the existence and reachability of the source database.