### PR TITLE
fix(ducklake): improve ducklake maintenances

### DIFF
--- a/etl-destinations/src/ducklake/core.rs
+++ b/etl-destinations/src/ducklake/core.rs
@@ -158,7 +158,7 @@ where
     }
 
     async fn shutdown(&self) -> EtlResult<()> {
-        self.tasks.drain().await?;
+        self.tasks.shutdown().await?;
         self.shutdown_maintenance_worker().await?;
         self.shutdown_metrics_sampler().await?;
 
@@ -1173,12 +1173,15 @@ where
             let _ = maintenance_worker.shutdown_tx.send(());
             let handle = maintenance_worker.handle.lock().take();
             if let Some(handle) = handle {
-                handle.await.map_err(|_| {
-                    etl_error!(
+                handle.abort();
+                if let Err(err) = handle.await
+                    && !err.is_cancelled()
+                {
+                    return Err(etl_error!(
                         ErrorKind::ApplyWorkerPanic,
                         "DuckLake maintenance worker task panicked"
-                    )
-                })?;
+                    ));
+                }
             }
         }
 
@@ -1191,12 +1194,15 @@ where
             let _ = metrics_sampler.shutdown_tx.send(());
             let handle = metrics_sampler.handle.lock().take();
             if let Some(handle) = handle {
-                handle.await.map_err(|_| {
-                    etl_error!(
+                handle.abort();
+                if let Err(err) = handle.await
+                    && !err.is_cancelled()
+                {
+                    return Err(etl_error!(
                         ErrorKind::ApplyWorkerPanic,
-                        "DuckLake metrics sampler task panicked"
-                    )
-                })?;
+                        "DuckLake maintenance worker task panicked"
+                    ));
+                }
             }
         }
 

--- a/etl-destinations/src/ducklake/maintenance.rs
+++ b/etl-destinations/src/ducklake/maintenance.rs
@@ -256,13 +256,24 @@ impl CatalogMaintenanceConfig {
 }
 
 /// Periodic catalog-maintenance state tracked by the background worker.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct CatalogMaintenanceState {
     last_expire_snapshots_completed_at: Option<Instant>,
     last_cleanup_old_files_completed_at: Option<Instant>,
 }
 
 impl CatalogMaintenanceState {
+    /// Builds catalog-maintenance state seeded to "just ran now".
+    ///
+    /// Fresh destinations should not immediately run snapshot expiration or
+    /// old-file cleanup on startup before the configured cadence elapses.
+    fn new(now: Instant) -> Self {
+        Self {
+            last_expire_snapshots_completed_at: Some(now),
+            last_cleanup_old_files_completed_at: Some(now),
+        }
+    }
+
     /// Returns whether snapshot expiration is due now.
     fn expire_snapshots_due(&self, now: Instant, interval: Duration) -> bool {
         match self.last_expire_snapshots_completed_at {
@@ -769,11 +780,15 @@ async fn run_ducklake_maintenance_worker(
     mut shutdown_rx: watch::Receiver<()>,
 ) {
     let blocking_slots = pool.blocking_slots();
-    let mut flush_interval = tokio::time::interval(MAINTENANCE_FLUSH_POLL_INTERVAL);
+    let started_at = Instant::now();
+    let mut flush_interval = tokio::time::interval_at(
+        started_at + MAINTENANCE_FLUSH_POLL_INTERVAL,
+        MAINTENANCE_FLUSH_POLL_INTERVAL,
+    );
     flush_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     let mut table_states: HashMap<DuckLakeTableName, TableMaintenanceState> = HashMap::new();
-    let mut catalog_maintenance_state = CatalogMaintenanceState::default();
+    let mut catalog_maintenance_state = CatalogMaintenanceState::new(started_at);
 
     loop {
         tokio::select! {
@@ -1884,13 +1899,10 @@ mod tests {
     #[test]
     fn catalog_maintenance_state_tracks_independent_due_intervals() {
         let now = Instant::now();
-        let mut state = CatalogMaintenanceState::default();
+        let state = CatalogMaintenanceState::new(now);
 
-        assert!(state.expire_snapshots_due(now, MAINTENANCE_EXPIRE_SNAPSHOTS_INTERVAL));
-        assert!(state.cleanup_old_files_due(now, MAINTENANCE_CLEANUP_OLD_FILES_INTERVAL));
-
-        state.complete_expire_snapshots(now);
-        state.complete_cleanup_old_files(now);
+        assert!(!state.expire_snapshots_due(now, MAINTENANCE_EXPIRE_SNAPSHOTS_INTERVAL));
+        assert!(!state.cleanup_old_files_due(now, MAINTENANCE_CLEANUP_OLD_FILES_INTERVAL));
 
         assert!(!state.expire_snapshots_due(
             now + MAINTENANCE_EXPIRE_SNAPSHOTS_INTERVAL - Duration::from_secs(1),

--- a/etl-destinations/tests/ducklake_pipeline.rs
+++ b/etl-destinations/tests/ducklake_pipeline.rs
@@ -237,6 +237,99 @@ async fn table_copy_and_streaming_with_restart() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn table_copy_and_streaming_without_restart() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::Both).await;
+    let lake = create_test_lake("table_copy_and_streaming_without_restart").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
+
+    let users_table_name = table_name_to_ducklake_table_name(&database_schema.users_schema().name)
+        .expect("failed to build DuckLake users table name");
+    let orders_table_name =
+        table_name_to_ducklake_table_name(&database_schema.orders_schema().name)
+            .expect("failed to build DuckLake orders table name");
+
+    insert_mock_data(
+        &mut database,
+        &database_schema.users_schema().name,
+        &database_schema.orders_schema().name,
+        1..=2,
+        false,
+    )
+    .await;
+
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+
+    let destination = build_destination(&catalog_url, &data_url, store.clone()).await;
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready = store
+        .notify_on_table_state_type(
+            database_schema.users_schema().id,
+            TableReplicationPhaseType::Ready,
+        )
+        .await;
+    let orders_ready = store
+        .notify_on_table_state_type(
+            database_schema.orders_schema().id,
+            TableReplicationPhaseType::Ready,
+        )
+        .await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+    orders_ready.notified().await;
+
+    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+
+    insert_mock_data(
+        &mut database,
+        &database_schema.users_schema().name,
+        &database_schema.orders_schema().name,
+        3..=4,
+        false,
+    )
+    .await;
+
+    event_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+    drop(destination);
+    checkpoint_lake(&catalog_url, &data_url);
+
+    let conn = open_lake_conn(&catalog_url, &data_url);
+    assert_eq!(
+        query_user_rows(&conn, &users_table_name),
+        vec![
+            (1, "user_1".to_owned(), 1),
+            (2, "user_2".to_owned(), 2),
+            (3, "user_3".to_owned(), 3),
+            (4, "user_4".to_owned(), 4),
+        ]
+    );
+    assert_eq!(
+        query_order_rows(&conn, &orders_table_name),
+        vec![
+            (1, "description_1".to_owned()),
+            (2, "description_2".to_owned()),
+            (3, "description_3".to_owned()),
+            (4, "description_4".to_owned()),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn table_insert_update_delete() {
     init_test_tracing();
 


### PR DESCRIPTION
Add a test to avoid regression and improve the way maintenances are handled when starting ETL. Improve shutdown handling too.