### PR TITLE
experimental(sqlx): Attempt to use new sqlx version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,13 +1819,13 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
 dependencies = [
  "cfg-if",
  "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2522,6 +2522,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -5832,9 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "decccfa5f2f3eac95eb68085cfe69a0172fa9711666c3a634cfc806d4fb74a47"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5845,12 +5847,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "86854e8c6aba0dafcf1c04b4836b0b7fa3a20c560e3554567afefe1258fa4e60"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "crc",
  "crossbeam-queue",
  "either",
@@ -5859,12 +5862,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -5881,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "d7aab9442ed1568e3aed6c368737226ee4e0e8d1deb0e0887fa6bf15282ace44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5894,15 +5896,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "34eb4976b8f02ac57ee98d4ce40cd1aad7ab31d9792977bc3171f787ba6ba2fb"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -5913,15 +5915,16 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "6fef16f3d52a3710a672b48175b713e86476e2df85576a753c8b37ad11a483c0"
 dependencies = [
  "atoi",
  "base64",
@@ -5944,7 +5947,6 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
@@ -5961,9 +5963,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "f053cf36ecb2793a9d9bb02d01bbad1ef66481d5db6ff5ab2dfb7b070cc0d13c"
 dependencies = [
  "atoi",
  "base64",
@@ -5983,7 +5985,6 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "once_cell",
  "rand 0.8.6",
  "serde",
  "serde_json",
@@ -5998,9 +5999,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "fe2cd6cee87120b1e1dd31356b5589911995c777707e49f2750eec7c7fe43eef"
 dependencies = [
  "atoi",
  "flume",
@@ -7313,15 +7314,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7354,21 +7346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7415,12 +7392,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7433,12 +7404,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7448,12 +7413,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7481,12 +7440,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7496,12 +7449,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7517,12 +7464,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7532,12 +7473,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ secrecy = { version = "0.10.3", default-features = false }
 sentry = { version = "0.42.0" }
 serde = { version = "1.0.219", default-features = false }
 serde_json = { version = "1.0.141", default-features = false }
-sqlx = { version = "0.8.6", default-features = false }
+sqlx = { version = "0.9.0-alpha.1", default-features = false }
 sysinfo = { version = "0.38.2", default-features = false }
 tempfile = { version = "3.23.0", default-features = false }
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ secrecy = { version = "0.10.3", default-features = false }
 sentry = { version = "0.42.0" }
 serde = { version = "1.0.219", default-features = false }
 serde_json = { version = "1.0.141", default-features = false }
+# Use the 0.9 alpha for the rustls VerifyCa fix in https://github.com/launchbadge/sqlx/pull/3861.
 sqlx = { version = "0.9.0-alpha.1", default-features = false }
 sysinfo = { version = "0.38.2", default-features = false }
 tempfile = { version = "3.23.0", default-features = false }

--- a/etl-api/Cargo.toml
+++ b/etl-api/Cargo.toml
@@ -44,7 +44,7 @@ secrecy = { workspace = true }
 sentry = { workspace = true, features = ["actix"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "macros", "postgres", "json", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "macros", "postgres", "json", "migrate"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true, default-features = false }

--- a/etl-api/src/data/publications.rs
+++ b/etl-api/src/data/publications.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use pg_escape::{quote_identifier, quote_literal};
+use pg_escape::quote_identifier;
 use serde::Serialize;
-use sqlx::{Executor, PgPool, Row};
+use sqlx::{AssertSqlSafe, PgPool, Row};
 use thiserror::Error;
 use utoipa::ToSchema;
 
@@ -48,7 +48,7 @@ pub async fn create_publication(
     // replication
     query.push_str(" with (publish_via_partition_root = true)");
 
-    pool.execute(query.as_str()).await?;
+    sqlx::query(AssertSqlSafe(query)).execute(pool).await?;
     Ok(())
 }
 
@@ -74,7 +74,7 @@ pub async fn update_publication(
         }
     }
 
-    pool.execute(query.as_str()).await?;
+    sqlx::query(AssertSqlSafe(query)).execute(pool).await?;
     Ok(())
 }
 
@@ -87,7 +87,7 @@ pub async fn drop_publication(
     let quoted_publication_name = quote_identifier(publication_name);
     query.push_str(&quoted_publication_name);
 
-    pool.execute(query.as_str()).await?;
+    sqlx::query(AssertSqlSafe(query)).execute(pool).await?;
     Ok(())
 }
 
@@ -95,25 +95,19 @@ pub async fn read_publication(
     publication_name: &str,
     pool: &PgPool,
 ) -> Result<Option<Publication>, PublicationsDbError> {
-    let mut query = String::new();
-    query.push_str(
-        r#"
+    let query = r#"
         select p.pubname,
             pt.schemaname as "schemaname?",
             pt.tablename as "tablename?"
         from pg_publication p
         left join pg_publication_tables pt on p.pubname = pt.pubname
-        where p.pubname =
-	   "#,
-    );
-
-    let quoted_publication_name = quote_literal(publication_name);
-    query.push_str(&quoted_publication_name);
+        where p.pubname = $1;
+	   "#;
 
     let mut tables = vec![];
     let mut name: Option<String> = None;
 
-    for row in pool.fetch_all(query.as_str()).await? {
+    for row in sqlx::query(query).bind(publication_name).fetch_all(pool).await? {
         let pub_name: String = row.get("pubname");
         if let Some(ref name) = name {
             assert_eq!(name.as_str(), pub_name);
@@ -142,7 +136,7 @@ pub async fn read_all_publications(pool: &PgPool) -> Result<Vec<Publication>, Pu
 
     let mut pub_name_to_tables: HashMap<String, Vec<Table>> = HashMap::new();
 
-    for row in pool.fetch_all(query).await? {
+    for row in sqlx::query(query).fetch_all(pool).await? {
         let pub_name: String = row.get("pubname");
         let schema: Option<String> = row.get("schemaname?");
         let table_name: Option<String> = row.get("tablename?");

--- a/etl-api/tests/pipelines.rs
+++ b/etl-api/tests/pipelines.rs
@@ -16,7 +16,7 @@ use etl_postgres::sqlx::test_utils::drop_pg_database;
 use etl_telemetry::tracing::init_test_tracing;
 use pg_escape::quote_identifier;
 use reqwest::StatusCode;
-use sqlx::{PgPool, postgres::types::Oid};
+use sqlx::{AssertSqlSafe, PgPool, postgres::types::Oid};
 
 use crate::support::{
     database::{create_test_source_database, run_etl_migrations_on_source_database},
@@ -167,10 +167,10 @@ async fn test_rollback(
 async fn create_test_table(source_db_pool: &PgPool, table_name: &str) -> Oid {
     sqlx::query("create schema if not exists test").execute(source_db_pool).await.unwrap();
 
-    sqlx::query(&format!(
+    sqlx::query(AssertSqlSafe(format!(
         "create table if not exists test.{} (id serial primary key, name text)",
         quote_identifier(table_name)
-    ))
+    )))
     .execute(source_db_pool)
     .await
     .expect("Failed to create test table");

--- a/etl-api/tests/support/database.rs
+++ b/etl-api/tests/support/database.rs
@@ -14,7 +14,7 @@ use etl_config::{
 use etl_postgres::sqlx::test_utils::create_pg_database;
 use pg_escape::{quote_identifier, quote_literal};
 use secrecy::ExposeSecret;
-use sqlx::{Connection, Executor, PgConnection, PgPool};
+use sqlx::{AssertSqlSafe, Connection, PgConnection, PgPool};
 use uuid::Uuid;
 
 use crate::support::test_app::TestApp;
@@ -116,22 +116,24 @@ pub(crate) async fn create_trusted_source_database() -> TrustedSourceDatabase {
         .await
         .expect("Failed to connect to Postgres");
 
-    connection
-        .execute(&*format!(
-            "create role {} with login password {} superuser inherit nocreaterole nocreatedb \
-             replication bypassrls connection limit -1",
-            quote_identifier(&trusted_username),
-            quote_literal(&trusted_password),
-        ))
+    let create_role_query = format!(
+        "create role {} with login password {} superuser inherit nocreaterole nocreatedb \
+         replication bypassrls connection limit -1",
+        quote_identifier(&trusted_username),
+        quote_literal(&trusted_password),
+    );
+    sqlx::query(AssertSqlSafe(create_role_query))
+        .execute(&mut connection)
         .await
         .expect("Failed to create trusted ETL role");
 
-    connection
-        .execute(&*format!(
-            "grant create on database {} to {}",
-            quote_identifier(&admin_config.name),
-            quote_identifier(&trusted_username),
-        ))
+    let grant_create_query = format!(
+        "grant create on database {} to {}",
+        quote_identifier(&admin_config.name),
+        quote_identifier(&trusted_username),
+    );
+    sqlx::query(AssertSqlSafe(grant_create_query))
+        .execute(&mut connection)
         .await
         .expect("Failed to grant CREATE on database to trusted ETL role");
 
@@ -154,8 +156,9 @@ pub(crate) async fn drop_trusted_source_database(database: TrustedSourceDatabase
         .await
         .expect("Failed to connect to Postgres");
 
-    connection
-        .execute(&*format!("drop role if exists {}", quote_identifier(&trusted_username),))
+    let drop_role_query = format!("drop role if exists {}", quote_identifier(&trusted_username));
+    sqlx::query(AssertSqlSafe(drop_role_query))
+        .execute(&mut connection)
         .await
         .expect("Failed to drop trusted ETL role");
 
@@ -191,11 +194,14 @@ pub(crate) async fn run_etl_migrations_on_source_database(source_db_config: &PgC
     let mut store_migrator = sqlx::migrate!("../etl/migrations/postgres_store");
     store_migrator.set_ignore_missing(true);
     store_migrator
-        .run_direct(&mut connection)
+        .run_direct(None, &mut connection)
         .await
         .expect("failed to run ETL Postgres store migrations");
 
     let mut source_migrator = sqlx::migrate!("../etl/migrations/source");
     source_migrator.set_ignore_missing(true);
-    source_migrator.run_direct(&mut connection).await.expect("failed to run ETL source migrations");
+    source_migrator
+        .run_direct(None, &mut connection)
+        .await
+        .expect("failed to run ETL source migrations");
 }

--- a/etl-benchmarks/Cargo.toml
+++ b/etl-benchmarks/Cargo.toml
@@ -27,7 +27,7 @@ etl-telemetry = { workspace = true }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal"] }
 tracing = { workspace = true, default-features = true }
 

--- a/etl-benchmarks/src/common.rs
+++ b/etl-benchmarks/src/common.rs
@@ -647,7 +647,7 @@ pub async fn run_etl_migrations(args: &PgConnectionArgs) -> Result<()> {
 
     let mut migrator = sqlx::migrate!("../etl/migrations/source");
     migrator.set_ignore_missing(true);
-    migrator.run_direct(&mut connection).await.context("failed to run ETL migrations")?;
+    migrator.run_direct(None, &mut connection).await.context("failed to run ETL migrations")?;
 
     Ok(())
 }

--- a/etl-destinations/Cargo.toml
+++ b/etl-destinations/Cargo.toml
@@ -88,7 +88,7 @@ regex = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true, features = ["json"] }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
-sqlx = { workspace = true, optional = true, features = ["runtime-tokio-rustls", "postgres"] }
+sqlx = { workspace = true, optional = true, features = ["runtime-tokio", "tls-rustls", "postgres"] }
 tokio = { workspace = true, optional = true, features = ["rt", "sync", "time"] }
 tokio-postgres = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }

--- a/etl-destinations/src/ducklake/inline_size.rs
+++ b/etl-destinations/src/ducklake/inline_size.rs
@@ -4,7 +4,7 @@ use etl::{
 };
 use metrics::gauge;
 use pg_escape::{quote_identifier, quote_literal};
-use sqlx::PgPool;
+use sqlx::{AssertSqlSafe, PgPool};
 
 use crate::ducklake::metrics::{ETL_DUCKLAKE_TABLE_ACTIVE_INLINED_DATA_BYTES, TABLE_LABEL};
 
@@ -33,16 +33,17 @@ impl DuckLakePendingInlineSizeSampler {
         table_name: &str,
     ) -> EtlResult<DuckLakePendingInlineDataSizes> {
         let sql = pending_inline_data_bytes_query(&self.metadata_schema);
-        let inlined_bytes: i64 =
-            sqlx::query_scalar(&sql).bind(table_name).fetch_one(&self.pool).await.map_err(
-                |source| {
-                    etl_error!(
-                        ErrorKind::DestinationQueryFailed,
-                        "DuckLake inline-size sampler query failed",
-                        source: source
-                    )
-                },
-            )?;
+        let inlined_bytes: i64 = sqlx::query_scalar(AssertSqlSafe(sql))
+            .bind(table_name)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|source| {
+                etl_error!(
+                    ErrorKind::DestinationQueryFailed,
+                    "DuckLake inline-size sampler query failed",
+                    source: source
+                )
+            })?;
         Ok(record_pending_inline_data_sizes(inlined_bytes, table_name))
     }
 }

--- a/etl-destinations/src/ducklake/metrics.rs
+++ b/etl-destinations/src/ducklake/metrics.rs
@@ -11,7 +11,7 @@ use etl::{
 use metrics::{Unit, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use parking_lot::Mutex;
 use pg_escape::{quote_identifier, quote_literal};
-use sqlx::PgPool;
+use sqlx::{AssertSqlSafe, PgPool};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
@@ -502,17 +502,18 @@ pub(super) async fn query_table_storage_metrics(
         active_delete_files,
         active_delete_bytes,
         deleted_rows,
-    ): (i64, i64, i64, i64, i64, i64, i64) =
-        sqlx::query_as(&sql).bind(table_name).fetch_one(metadata_pg_pool).await.map_err(
-            |source| {
-                etl_error!(
-                    ErrorKind::DestinationQueryFailed,
-                    "DuckLake table storage metrics query failed",
-                    format!("table={table_name}, metadata_schema={metadata_schema}"),
-                    source: source
-                )
-            },
-        )?;
+    ): (i64, i64, i64, i64, i64, i64, i64) = sqlx::query_as(AssertSqlSafe(sql))
+        .bind(table_name)
+        .fetch_one(metadata_pg_pool)
+        .await
+        .map_err(|source| {
+            etl_error!(
+                ErrorKind::DestinationQueryFailed,
+                "DuckLake table storage metrics query failed",
+                format!("table={table_name}, metadata_schema={metadata_schema}"),
+                source: source
+            )
+        })?;
 
     Ok(DuckLakeTableStorageMetrics {
         active_data_files,
@@ -541,7 +542,7 @@ pub(super) async fn query_catalog_maintenance_metrics(
         files_scheduled_for_deletion_bytes,
         oldest_scheduled_deletion_epoch_ms,
     ): (i64, i64, Option<i64>, i64, i64, Option<i64>) =
-        sqlx::query_as(&sql).fetch_one(metadata_pg_pool).await.map_err(|source| {
+        sqlx::query_as(AssertSqlSafe(sql)).fetch_one(metadata_pg_pool).await.map_err(|source| {
             etl_error!(
                 ErrorKind::DestinationQueryFailed,
                 "DuckLake catalog maintenance metrics query failed",

--- a/etl-postgres/Cargo.toml
+++ b/etl-postgres/Cargo.toml
@@ -24,7 +24,7 @@ bytes = { workspace = true }
 etl-config = { workspace = true }
 pg_escape = { workspace = true }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "macros", "postgres", "json", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "macros", "postgres", "json", "migrate"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { workspace = true, features = ["runtime", "with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }

--- a/etl-postgres/src/replication/slots.rs
+++ b/etl-postgres/src/replication/slots.rs
@@ -189,16 +189,14 @@ pub async fn delete_pipeline_replication_slots(
         // associated with this pipeline id. We use both the exact apply slot
         // name and the table-sync prefix so cleanup can still succeed even if
         // ETL metadata was already removed.
-        let terminate_query = String::from(
-            r#"
+        let terminate_query = r#"
             select pg_terminate_backend(r.active_pid)
             from pg_replication_slots r
             where (r.slot_name = $1 or r.slot_name like $2 escape '\')
               and r.active = true
               and r.active_pid is not null;
-            "#,
-        );
-        let result = sqlx::query(&terminate_query)
+            "#;
+        let result = sqlx::query(terminate_query)
             .bind(&apply_slot_name)
             .bind(&table_sync_pattern)
             .execute(pool)
@@ -215,14 +213,12 @@ pub async fn delete_pipeline_replication_slots(
         // Phase 2: drop all matching replication slots, whether still active or already
         // inactive. Note: pg_drop_replication_slot will signal walsenders to
         // terminate if still active
-        let drop_query = String::from(
-            r#"
+        let drop_query = r#"
             select pg_drop_replication_slot(r.slot_name)
             from pg_replication_slots r
             where r.slot_name = $1 or r.slot_name like $2 escape '\';
-            "#,
-        );
-        let result = sqlx::query(&drop_query)
+            "#;
+        let result = sqlx::query(drop_query)
             .bind(&apply_slot_name)
             .bind(&table_sync_pattern)
             .execute(pool)

--- a/etl-postgres/src/sqlx/test_utils.rs
+++ b/etl-postgres/src/sqlx/test_utils.rs
@@ -1,5 +1,6 @@
 use etl_config::shared::{IntoConnectOptions, PgConnectionConfig};
-use sqlx::{Connection, Executor, PgConnection, PgPool};
+use pg_escape::{quote_identifier, quote_literal};
+use sqlx::{AssertSqlSafe, Connection, PgConnection, PgPool};
 
 /// Creates a new Postgres database and returns a connection pool.
 ///
@@ -13,8 +14,9 @@ pub async fn create_pg_database(config: &PgConnectionConfig) -> PgPool {
     let mut connection = PgConnection::connect_with(&config.without_db(None))
         .await
         .expect("Failed to connect to Postgres");
-    connection
-        .execute(&*format!(r#"create database "{}";"#, config.name))
+    let create_database_query = format!("create database {};", quote_identifier(&config.name));
+    sqlx::query(AssertSqlSafe(create_database_query))
+        .execute(&mut connection)
         .await
         .expect("Failed to create database");
 
@@ -41,24 +43,24 @@ pub async fn drop_pg_database(config: &PgConnectionConfig) {
     };
 
     // Forcefully terminate any remaining connections to the database.
-    if let Err(e) = connection
-        .execute(&*format!(
-            r#"
+    let terminate_connections_query = format!(
+        r#"
             select pg_terminate_backend(pg_stat_activity.pid)
             from pg_stat_activity
-            where pg_stat_activity.datname = '{}'
+            where pg_stat_activity.datname = {}
             and pid <> pg_backend_pid();"#,
-            config.name
-        ))
-        .await
+        quote_literal(&config.name)
+    );
+    if let Err(e) =
+        sqlx::query(AssertSqlSafe(terminate_connections_query)).execute(&mut connection).await
     {
         eprintln!("warning: failed to terminate connections for database {}: {}", config.name, e);
     }
 
     // Drop the database.
-    if let Err(e) =
-        connection.execute(&*format!(r#"drop database if exists "{}";"#, config.name)).await
-    {
+    let drop_database_query =
+        format!("drop database if exists {};", quote_identifier(&config.name));
+    if let Err(e) = sqlx::query(AssertSqlSafe(drop_database_query)).execute(&mut connection).await {
         eprintln!("warning: failed to drop database {}: {}", config.name, e);
     }
 }

--- a/etl-replicator/Cargo.toml
+++ b/etl-replicator/Cargo.toml
@@ -25,7 +25,7 @@ secrecy = { workspace = true }
 sentry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
 
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tracing = { workspace = true, default-features = true }

--- a/etl/Cargo.toml
+++ b/etl/Cargo.toml
@@ -34,7 +34,7 @@ rand = { workspace = true, features = ["thread_rng"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 serde_json = { workspace = true, features = ["std"] }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
 sysinfo = { workspace = true, features = ["system"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 tokio-postgres = { workspace = true, features = ["runtime", "with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }

--- a/etl/src/migrations.rs
+++ b/etl/src/migrations.rs
@@ -59,7 +59,7 @@ async fn run_migration_set(
     let mut conn = create_migration_connection(connection_config).await?;
 
     debug!(migration_set = label, "applying ETL migrations");
-    migrator.run_direct(&mut conn).await?;
+    migrator.run_direct(None, &mut conn).await?;
     debug!(migration_set = label, "ETL migrations successfully applied");
 
     Ok(())

--- a/etl/tests/migrations.rs
+++ b/etl/tests/migrations.rs
@@ -270,7 +270,7 @@ async fn postgres_store_schema_storage_migration_round_trips_old_state() {
     let database = spawn_unmigrated_database().await;
 
     let mut conn = migration_connection(&database.config).await;
-    postgres_store_migrator().run_direct(&mut conn).await.unwrap();
+    postgres_store_migrator().run_direct(None, &mut conn).await.unwrap();
     postgres_store_migrator().undo(&mut conn, POSTGRES_STORE_BASE_VERSION).await.unwrap();
     drop(conn);
 
@@ -353,7 +353,7 @@ async fn postgres_store_schema_storage_migration_round_trips_old_state() {
         .unwrap();
 
     let mut conn = migration_connection(&database.config).await;
-    postgres_store_migrator().run_direct(&mut conn).await.unwrap();
+    postgres_store_migrator().run_direct(None, &mut conn).await.unwrap();
     drop(conn);
 
     let migrated_columns: String = client


### PR DESCRIPTION
This PR uses a new SQLx version that has fixed an issue with the handling of certificates validation. Now it properly handles the `verify-ca` by not failing in case a host name is unmatched.