### PR TITLE
Add clickhouse client- and server-side timeouts

### DIFF
--- a/crates/etl-api/src/validation/validators.rs
+++ b/crates/etl-api/src/validation/validators.rs
@@ -7,7 +7,7 @@ use etl::store::both::memory::MemoryStore;
 use etl_config::{SerializableSecretString, parse_ducklake_url};
 use etl_destinations::{
     bigquery::BigQueryClient,
-    clickhouse::ClickHouseClient,
+    clickhouse::{ClickHouseClient, ClickHouseClientConfig},
     ducklake::{DuckLakeDestination, S3Config as DucklakeS3Config},
     iceberg::{IcebergClient, S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_SECRET_ACCESS_KEY},
 };
@@ -663,6 +663,7 @@ impl Validator for ClickHouseValidator {
             self.user.clone(),
             self.password.as_ref().map(|password| password.expose_secret().to_owned()),
             self.database.clone(),
+            ClickHouseClientConfig::default(),
         );
         match client.validate_connectivity().await {
             Ok(_) => Ok(Vec::new()),

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -24,7 +24,7 @@ use crate::clickhouse::{
 /// `lock_acquire_timeout`; flooring at 1 second avoids accidentally disabling a
 /// server-side bound when an operator passes `Duration::ZERO` or any sub-second
 /// value.
-fn secs_string(d: Duration) -> String {
+fn floor_secs(d: Duration) -> String {
     d.as_secs().max(1).to_string()
 }
 
@@ -48,6 +48,7 @@ where
             None => format!("{op} {what}"),
         }
     }
+
     let budget = config.client_budget(op);
     match tokio::time::timeout(budget, fut).await {
         Ok(Ok(value)) => Ok(value),
@@ -188,10 +189,10 @@ impl ClickHouseClient {
         }
 
         client = client
-            .with_option("connect_timeout", secs_string(config.connectivity_check_timeout))
-            .with_option("http_connection_timeout", secs_string(config.connectivity_check_timeout))
-            .with_option("http_send_timeout", secs_string(config.insert_timeout))
-            .with_option("http_receive_timeout", secs_string(config.insert_timeout));
+            .with_option("connect_timeout", floor_secs(config.connectivity_check_timeout))
+            .with_option("http_connection_timeout", floor_secs(config.connectivity_check_timeout))
+            .with_option("http_send_timeout", floor_secs(config.insert_timeout))
+            .with_option("http_receive_timeout", floor_secs(config.insert_timeout));
 
         Self { inner: Arc::new(client), config }
     }
@@ -218,7 +219,7 @@ impl ClickHouseClient {
     /// histogram labelled with the DDL `kind` and `table_name`.
     pub(crate) async fn execute_ddl(&self, kind: DdlKind, sql: &str) -> EtlResult<()> {
         let ddl_start = Instant::now();
-        let ddl_secs = secs_string(self.config.ddl_timeout);
+        let ddl_secs = floor_secs(self.config.ddl_timeout);
         // `max_execution_time` and `lock_acquire_timeout` are applied per-call
         // so the connectivity check and schema query do not inherit the (much
         // larger) DDL budget.
@@ -242,7 +243,7 @@ impl ClickHouseClient {
         &self,
         table_name: &str,
     ) -> EtlResult<Vec<ClickHouseTableColumn>> {
-        let schema_secs = secs_string(self.config.schema_query_timeout);
+        let schema_secs = floor_secs(self.config.schema_query_timeout);
         let query = self
             .inner
             .query(
@@ -303,7 +304,7 @@ impl ClickHouseClient {
 
     /// Executes `TRUNCATE TABLE IF EXISTS` for the supplied table.
     pub(crate) async fn truncate_table(&self, table_name: &str) -> EtlResult<()> {
-        let ddl_secs = secs_string(self.config.ddl_timeout);
+        let ddl_secs = floor_secs(self.config.ddl_timeout);
         let query = self
             .inner
             .query(&build_truncate_table_sql(table_name))
@@ -590,19 +591,19 @@ mod tests {
     }
 
     #[test]
-    fn secs_string_floors_at_one_second() {
+    fn floor_secs_floors_at_one_second() {
         // Whole seconds at or above 1 pass through unchanged.
-        assert_eq!(secs_string(Duration::from_secs(1)), "1");
-        assert_eq!(secs_string(Duration::from_secs(5)), "5");
-        assert_eq!(secs_string(Duration::from_secs(60)), "60");
+        assert_eq!(floor_secs(Duration::from_secs(1)), "1");
+        assert_eq!(floor_secs(Duration::from_secs(5)), "5");
+        assert_eq!(floor_secs(Duration::from_secs(60)), "60");
         // ZERO is floored to 1 to avoid disabling the server-side timeout.
-        assert_eq!(secs_string(Duration::ZERO), "1");
+        assert_eq!(floor_secs(Duration::ZERO), "1");
         // Sub-second values are floored to 1 (would otherwise truncate to 0).
-        assert_eq!(secs_string(Duration::from_nanos(1)), "1");
-        assert_eq!(secs_string(Duration::from_millis(500)), "1");
-        assert_eq!(secs_string(Duration::from_millis(999)), "1");
+        assert_eq!(floor_secs(Duration::from_nanos(1)), "1");
+        assert_eq!(floor_secs(Duration::from_millis(500)), "1");
+        assert_eq!(floor_secs(Duration::from_millis(999)), "1");
         // Fractional seconds beyond 1s truncate to whole seconds (Duration::as_secs).
-        assert_eq!(secs_string(Duration::from_millis(1500)), "1");
-        assert_eq!(secs_string(Duration::from_millis(2999)), "2");
+        assert_eq!(floor_secs(Duration::from_millis(1500)), "1");
+        assert_eq!(floor_secs(Duration::from_millis(2999)), "2");
     }
 }

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -8,6 +8,7 @@ use etl::{
 use url::Url;
 
 use crate::clickhouse::{
+    core::ClickHouseClientConfig,
     encoding::{ClickHouseValue, encode_to_row_binary},
     metrics::{ETL_CLICKHOUSE_DDL_DURATION_SECONDS, ETL_CLICKHOUSE_INSERT_DURATION_SECONDS},
     schema::{clickhouse_column_type, quote_identifier},
@@ -113,6 +114,7 @@ impl DdlKind {
 #[derive(Clone)]
 pub struct ClickHouseClient {
     inner: Arc<Client>,
+    config: ClickHouseClientConfig,
 }
 
 impl ClickHouseClient {
@@ -125,6 +127,7 @@ impl ClickHouseClient {
         user: impl Into<String>,
         password: Option<String>,
         database: impl Into<String>,
+        config: ClickHouseClientConfig,
     ) -> Self {
         let mut client =
             Client::default().with_url(url.to_string()).with_user(user).with_database(database);
@@ -133,7 +136,7 @@ impl ClickHouseClient {
             client = client.with_password(pw);
         }
 
-        Self { inner: Arc::new(client) }
+        Self { inner: Arc::new(client), config }
     }
 
     /// Verifies that the ClickHouse server is reachable.

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt,
     future::Future,
     sync::Arc,
     time::{Duration, Instant},
@@ -13,7 +12,7 @@ use etl::{
 use url::Url;
 
 use crate::clickhouse::{
-    core::ClickHouseClientConfig,
+    core::{ClickHouseClientConfig, ClickHouseOperationKind},
     encoding::{ClickHouseValue, encode_to_row_binary},
     metrics::{ETL_CLICKHOUSE_DDL_DURATION_SECONDS, ETL_CLICKHOUSE_INSERT_DURATION_SECONDS},
     schema::{clickhouse_column_type, quote_identifier},
@@ -27,73 +26,18 @@ fn secs_string(d: Duration) -> String {
     secs.to_string()
 }
 
-/// Classifies a ClickHouse client call so the three concerns of a wrapped
-/// call live in one place:
-///
-/// - `server_budget` picks the right field of [`ClickHouseClientConfig`],
-/// - `failed_kind` maps an inner `clickhouse::error::Error` onto the
-///   appropriate [`ErrorKind`] (`DestinationConnectionFailed` /
-///   `DestinationQueryFailed` / `DestinationAtomicBatchRetryable`),
-/// - `Display` produces the op name interpolated into error messages.
-///
-/// Client-side deadlines always surface as
-/// [`ErrorKind::DestinationTimeout`], independent of `op`.
-#[derive(Copy, Clone)]
-pub(crate) enum TimeoutOp {
-    /// Connectivity check (`SELECT 1`).
-    ConnectivityCheck,
-    /// Schema lookup against `system.columns`.
-    SchemaQuery,
-    /// DDL: CREATE / ALTER / DROP / RENAME / TRUNCATE.
-    Ddl,
-    /// INSERT statement flush.
-    Insert,
-}
-
-impl TimeoutOp {
-    /// Server-side budget for this op, selected from
-    /// [`ClickHouseClientConfig`].
-    fn server_budget(self, config: &ClickHouseClientConfig) -> Duration {
-        match self {
-            TimeoutOp::ConnectivityCheck => config.connectivity_check_timeout,
-            TimeoutOp::SchemaQuery => config.schema_query_server_timeout,
-            TimeoutOp::Ddl => config.ddl_server_timeout,
-            TimeoutOp::Insert => config.insert_server_timeout,
-        }
-    }
-
-    /// Error kind used when the inner future returns a
-    /// `clickhouse::error::Error`.
-    fn failed_kind(self) -> ErrorKind {
-        match self {
-            TimeoutOp::ConnectivityCheck => ErrorKind::DestinationConnectionFailed,
-            TimeoutOp::SchemaQuery | TimeoutOp::Ddl => ErrorKind::DestinationQueryFailed,
-            TimeoutOp::Insert => ErrorKind::DestinationAtomicBatchRetryable,
-        }
-    }
-}
-
-impl fmt::Display for TimeoutOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = match self {
-            TimeoutOp::ConnectivityCheck => "connectivity check",
-            TimeoutOp::SchemaQuery => "schema query",
-            TimeoutOp::Ddl => "DDL",
-            TimeoutOp::Insert => "insert",
-        };
-        f.write_str(name)
-    }
-}
-
-/// Runs `fut` under `tokio::time::timeout` using the client budget derived
-/// from `op` and `config`, and maps the three outcomes onto typed
-/// [`EtlResult`]s using `op` for kind selection and the human-readable
-/// description.
-async fn timeout_call<T, F>(op: TimeoutOp, config: &ClickHouseClientConfig, fut: F) -> EtlResult<T>
+/// Runs `fut` under `tokio::time::timeout` using the client budget for `op`
+/// from `config`, and maps the three outcomes onto typed [`EtlResult`]s
+/// using `op` for kind selection and the human-readable description.
+async fn timeout_call<T, F>(
+    op: ClickHouseOperationKind,
+    config: &ClickHouseClientConfig,
+    fut: F,
+) -> EtlResult<T>
 where
     F: Future<Output = Result<T, clickhouse::error::Error>>,
 {
-    let budget = config.client_budget(op.server_budget(config));
+    let budget = config.client_budget(op);
     match tokio::time::timeout(budget, fut).await {
         Ok(Ok(value)) => Ok(value),
         Ok(Err(err)) => Err(etl_error!(
@@ -255,7 +199,7 @@ impl ClickHouseClient {
     /// `etl-api` validators) can treat the two destinations uniformly.
     pub async fn validate_connectivity(&self) -> EtlResult<()> {
         timeout_call(
-            TimeoutOp::ConnectivityCheck,
+            ClickHouseOperationKind::ConnectivityCheck,
             &self.config,
             self.inner.query("SELECT 1").fetch_one::<u8>(),
         )
@@ -276,7 +220,8 @@ impl ClickHouseClient {
             .query(sql)
             .with_option("max_execution_time", &ddl_secs)
             .with_option("lock_acquire_timeout", &ddl_secs);
-        let result = timeout_call(TimeoutOp::Ddl, &self.config, query.execute()).await;
+        let result =
+            timeout_call(ClickHouseOperationKind::Ddl, &self.config, query.execute()).await;
         metrics::histogram!(
             ETL_CLICKHOUSE_DDL_DURATION_SECONDS,
             "kind" => kind.as_label(),
@@ -300,7 +245,7 @@ impl ClickHouseClient {
             .with_option("max_execution_time", &schema_secs)
             .bind(table_name);
         timeout_call(
-            TimeoutOp::SchemaQuery,
+            ClickHouseOperationKind::SchemaQuery,
             &self.config,
             query.fetch_all::<ClickHouseTableColumn>(),
         )
@@ -356,7 +301,7 @@ impl ClickHouseClient {
             .query(&build_truncate_table_sql(table_name))
             .with_option("max_execution_time", &ddl_secs)
             .with_option("lock_acquire_timeout", &ddl_secs);
-        timeout_call(TimeoutOp::Ddl, &self.config, query.execute()).await
+        timeout_call(ClickHouseOperationKind::Ddl, &self.config, query.execute()).await
     }
 
     /// Inserts `rows` into `table_name` using the RowBinary format.
@@ -401,7 +346,7 @@ impl ClickHouseClient {
                 bytes += row_buf.len() as u64;
             }
 
-            timeout_call(TimeoutOp::Insert, &self.config, insert.end()).await?;
+            timeout_call(ClickHouseOperationKind::Insert, &self.config, insert.end()).await?;
             metrics::histogram!(
                 ETL_CLICKHOUSE_INSERT_DURATION_SECONDS,
                 "source" => source,
@@ -487,19 +432,28 @@ mod tests {
     }
 
     #[test]
-    fn client_budget_adds_epsilon_to_server_timeout() {
+    fn client_budget_adds_epsilon_to_server_budget() {
         let mut config = ClickHouseClientConfig::default();
+        config.connectivity_check_timeout = Duration::from_secs(10);
         config.client_timeout_epsilon = Duration::from_secs(3);
-        assert_eq!(config.client_budget(Duration::from_secs(10)), Duration::from_secs(13));
-        assert_eq!(config.client_budget(Duration::ZERO), Duration::from_secs(3));
+        assert_eq!(
+            config.client_budget(ClickHouseOperationKind::ConnectivityCheck),
+            Duration::from_secs(13)
+        );
+
+        config.connectivity_check_timeout = Duration::ZERO;
+        assert_eq!(
+            config.client_budget(ClickHouseOperationKind::ConnectivityCheck),
+            Duration::from_secs(3)
+        );
     }
 
     #[test]
-    fn timeout_op_display_matches_error_messages() {
-        assert_eq!(TimeoutOp::ConnectivityCheck.to_string(), "connectivity check");
-        assert_eq!(TimeoutOp::SchemaQuery.to_string(), "schema query");
-        assert_eq!(TimeoutOp::Ddl.to_string(), "DDL");
-        assert_eq!(TimeoutOp::Insert.to_string(), "insert");
+    fn operation_kind_display_matches_error_messages() {
+        assert_eq!(ClickHouseOperationKind::ConnectivityCheck.to_string(), "connectivity check");
+        assert_eq!(ClickHouseOperationKind::SchemaQuery.to_string(), "schema query");
+        assert_eq!(ClickHouseOperationKind::Ddl.to_string(), "DDL");
+        assert_eq!(ClickHouseOperationKind::Insert.to_string(), "insert");
     }
 
     #[tokio::test(start_paused = true)]
@@ -509,7 +463,9 @@ mod tests {
         // in real wall-clock terms.
         let config = ClickHouseClientConfig::default();
         let never = std::future::pending::<Result<(), clickhouse::error::Error>>();
-        let err = timeout_call(TimeoutOp::ConnectivityCheck, &config, never).await.unwrap_err();
+        let err = timeout_call(ClickHouseOperationKind::ConnectivityCheck, &config, never)
+            .await
+            .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
         assert!(
             err.detail()
@@ -523,7 +479,8 @@ mod tests {
     async fn timeout_call_propagates_inner_error() {
         let config = ClickHouseClientConfig::default();
         let fut = async { Err::<(), _>(clickhouse::error::Error::NotEnoughData) };
-        let err = timeout_call(TimeoutOp::SchemaQuery, &config, fut).await.unwrap_err();
+        let err =
+            timeout_call(ClickHouseOperationKind::SchemaQuery, &config, fut).await.unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationQueryFailed);
         assert!(
             err.detail().is_some_and(|d| d.contains("schema query") && d.contains("failed")),
@@ -536,33 +493,42 @@ mod tests {
     async fn timeout_call_passes_through_success() {
         let config = ClickHouseClientConfig::default();
         let fut = async { Ok::<u32, clickhouse::error::Error>(42) };
-        let value = timeout_call(TimeoutOp::Insert, &config, fut).await.unwrap();
+        let value = timeout_call(ClickHouseOperationKind::Insert, &config, fut).await.unwrap();
         assert_eq!(value, 42);
     }
 
     #[test]
-    fn timeout_op_server_budget_per_bucket() {
+    fn server_budget_per_operation_kind() {
         let config = ClickHouseClientConfig::default();
         assert_eq!(
-            TimeoutOp::ConnectivityCheck.server_budget(&config),
+            config.server_budget(ClickHouseOperationKind::ConnectivityCheck),
             config.connectivity_check_timeout
         );
         assert_eq!(
-            TimeoutOp::SchemaQuery.server_budget(&config),
+            config.server_budget(ClickHouseOperationKind::SchemaQuery),
             config.schema_query_server_timeout
         );
-        assert_eq!(TimeoutOp::Ddl.server_budget(&config), config.ddl_server_timeout);
-        assert_eq!(TimeoutOp::Insert.server_budget(&config), config.insert_server_timeout);
+        assert_eq!(config.server_budget(ClickHouseOperationKind::Ddl), config.ddl_server_timeout);
+        assert_eq!(
+            config.server_budget(ClickHouseOperationKind::Insert),
+            config.insert_server_timeout
+        );
     }
 
     #[test]
-    fn timeout_op_failed_kind_per_bucket() {
+    fn operation_kind_failed_kind_per_bucket() {
         assert_eq!(
-            TimeoutOp::ConnectivityCheck.failed_kind(),
+            ClickHouseOperationKind::ConnectivityCheck.failed_kind(),
             ErrorKind::DestinationConnectionFailed
         );
-        assert_eq!(TimeoutOp::SchemaQuery.failed_kind(), ErrorKind::DestinationQueryFailed);
-        assert_eq!(TimeoutOp::Ddl.failed_kind(), ErrorKind::DestinationQueryFailed);
-        assert_eq!(TimeoutOp::Insert.failed_kind(), ErrorKind::DestinationAtomicBatchRetryable);
+        assert_eq!(
+            ClickHouseOperationKind::SchemaQuery.failed_kind(),
+            ErrorKind::DestinationQueryFailed
+        );
+        assert_eq!(ClickHouseOperationKind::Ddl.failed_kind(), ErrorKind::DestinationQueryFailed);
+        assert_eq!(
+            ClickHouseOperationKind::Insert.failed_kind(),
+            ErrorKind::DestinationAtomicBatchRetryable
+        );
     }
 }

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -532,6 +532,21 @@ mod tests {
         assert_eq!(value, 42);
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn timeout_call_inner_error_includes_context() {
+        let config = ClickHouseClientConfig::default();
+        let fut = async { Err::<(), _>(clickhouse::error::Error::NotEnoughData) };
+        let err = timeout_call(ClickHouseOperationKind::Insert, &config, Some("table: users"), fut)
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DestinationAtomicBatchRetryable);
+        assert!(
+            err.detail().is_some_and(|d| d.contains("insert failed") && d.contains("table: users")),
+            "unexpected detail: {:?}",
+            err.detail()
+        );
+    }
+
     #[test]
     fn server_budget_per_operation_kind() {
         let config = ClickHouseClientConfig::default();

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -466,4 +466,63 @@ mod tests {
 
         assert_eq!(sql, "INSERT INTO \"table\"\"name\" FORMAT RowBinary");
     }
+
+    #[test]
+    fn client_budget_adds_epsilon_to_server_timeout() {
+        let mut config = ClickHouseClientConfig::default();
+        config.client_timeout_epsilon = Duration::from_secs(3);
+        assert_eq!(config.client_budget(Duration::from_secs(10)), Duration::from_secs(13));
+        assert_eq!(config.client_budget(Duration::ZERO), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn timeout_op_display_matches_error_messages() {
+        assert_eq!(TimeoutOp::Probe.to_string(), "probe");
+        assert_eq!(TimeoutOp::SchemaQuery.to_string(), "schema query");
+        assert_eq!(TimeoutOp::Ddl.to_string(), "DDL");
+        assert_eq!(TimeoutOp::Insert.to_string(), "insert");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_call_returns_destination_timeout_on_deadline() {
+        // A future that never resolves; tokio's paused clock advances virtual
+        // time when all tasks are stalled, so the timeout fires immediately
+        // in real wall-clock terms.
+        let never = std::future::pending::<Result<(), clickhouse::error::Error>>();
+        let err = timeout_call(TimeoutOp::Probe, Duration::from_secs(1), never).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
+        assert!(
+            err.detail().is_some_and(|d| d.contains("probe") && d.contains("timed out")),
+            "unexpected detail: {:?}",
+            err.detail()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_call_propagates_inner_error() {
+        let fut = async { Err::<(), _>(clickhouse::error::Error::NotEnoughData) };
+        let err =
+            timeout_call(TimeoutOp::SchemaQuery, Duration::from_secs(1), fut).await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DestinationQueryFailed);
+        assert!(
+            err.detail().is_some_and(|d| d.contains("schema query") && d.contains("failed")),
+            "unexpected detail: {:?}",
+            err.detail()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_call_passes_through_success() {
+        let fut = async { Ok::<u32, clickhouse::error::Error>(42) };
+        let value = timeout_call(TimeoutOp::Insert, Duration::from_secs(1), fut).await.unwrap();
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn timeout_op_failed_kind_per_bucket() {
+        assert_eq!(TimeoutOp::Probe.failed_kind(), ErrorKind::DestinationConnectionFailed);
+        assert_eq!(TimeoutOp::SchemaQuery.failed_kind(), ErrorKind::DestinationQueryFailed);
+        assert_eq!(TimeoutOp::Ddl.failed_kind(), ErrorKind::DestinationQueryFailed);
+        assert_eq!(TimeoutOp::Insert.failed_kind(), ErrorKind::DestinationAtomicBatchRetryable);
+    }
 }

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -1,4 +1,9 @@
-use std::{sync::Arc, time::Instant};
+use std::{
+    fmt,
+    future::Future,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use clickhouse::Client;
 use etl::{
@@ -13,6 +18,81 @@ use crate::clickhouse::{
     metrics::{ETL_CLICKHOUSE_DDL_DURATION_SECONDS, ETL_CLICKHOUSE_INSERT_DURATION_SECONDS},
     schema::{clickhouse_column_type, quote_identifier},
 };
+
+/// Formats a `Duration` as a whole-seconds string, suitable for ClickHouse
+/// settings passed via `.with_option(...)`. Sub-second precision is rounded
+/// up to a 1s floor so a `Duration::from_millis(500)` does not become `"0"`.
+fn secs_string(d: Duration) -> String {
+    let secs = d.as_secs().max(u64::from(d.subsec_nanos() > 0));
+    secs.to_string()
+}
+
+/// Classifies a ClickHouse client call so error mapping is centralised: each
+/// op chooses how a server-returned failure and a client-side deadline map
+/// onto [`ErrorKind`].
+#[derive(Copy, Clone)]
+pub(crate) enum TimeoutOp {
+    /// Connectivity probe (`SELECT 1`).
+    Probe,
+    /// Schema lookup against `system.columns`.
+    SchemaQuery,
+    /// DDL: CREATE / ALTER / DROP / RENAME / TRUNCATE.
+    Ddl,
+    /// INSERT statement flush.
+    Insert,
+}
+
+impl TimeoutOp {
+    /// Error kind used when the inner future returns a
+    /// `clickhouse::error::Error`.
+    fn failed_kind(self) -> ErrorKind {
+        match self {
+            TimeoutOp::Probe => ErrorKind::DestinationConnectionFailed,
+            TimeoutOp::SchemaQuery | TimeoutOp::Ddl => ErrorKind::DestinationQueryFailed,
+            TimeoutOp::Insert => ErrorKind::DestinationAtomicBatchRetryable,
+        }
+    }
+
+    /// Error kind used when the client-side `tokio::time::timeout` fires.
+    fn timeout_kind(self) -> ErrorKind {
+        ErrorKind::DestinationTimeout
+    }
+}
+
+impl fmt::Display for TimeoutOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            TimeoutOp::Probe => "probe",
+            TimeoutOp::SchemaQuery => "schema query",
+            TimeoutOp::Ddl => "DDL",
+            TimeoutOp::Insert => "insert",
+        };
+        f.write_str(name)
+    }
+}
+
+/// Runs `fut` under `tokio::time::timeout(budget, fut)` and maps the three
+/// outcomes onto typed [`EtlResult`]s using `op` for kind selection and the
+/// human-readable description.
+async fn timeout_call<T, F>(op: TimeoutOp, budget: Duration, fut: F) -> EtlResult<T>
+where
+    F: Future<Output = Result<T, clickhouse::error::Error>>,
+{
+    match tokio::time::timeout(budget, fut).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(err)) => Err(etl_error!(
+            op.failed_kind(),
+            "ClickHouse call failed",
+            format!("ClickHouse {op} failed"),
+            source: err
+        )),
+        Err(_) => Err(etl_error!(
+            op.timeout_kind(),
+            "ClickHouse call timed out",
+            format!("ClickHouse {op} timed out after {budget:?}")
+        )),
+    }
+}
 
 /// Capacity of the internal write buffer used per INSERT statement.
 ///
@@ -136,6 +216,18 @@ impl ClickHouseClient {
             client = client.with_password(pw);
         }
 
+        // Server-side transport timeouts. These bound the time the server is
+        // willing to spend on the connection itself. `max_execution_time` and
+        // `lock_acquire_timeout` are intentionally not set here: they are
+        // DDL-specific and would otherwise leak into probe and schema_query
+        // calls, which expect much tighter budgets. DDL applies them via
+        // per-call `.with_option(...)` overrides instead.
+        client = client
+            .with_option("connect_timeout", &secs_string(config.probe_server_timeout))
+            .with_option("http_connection_timeout", &secs_string(config.probe_server_timeout))
+            .with_option("http_send_timeout", &secs_string(config.insert_server_timeout))
+            .with_option("http_receive_timeout", &secs_string(config.insert_server_timeout));
+
         Self { inner: Arc::new(client), config }
     }
 
@@ -146,9 +238,10 @@ impl ClickHouseClient {
     /// destination's `validate_connectivity` so callers (notably the
     /// `etl-api` validators) can treat the two destinations uniformly.
     pub async fn validate_connectivity(&self) -> EtlResult<()> {
-        self.inner.query("SELECT 1").fetch_one::<u8>().await.map(|_| ()).map_err(
-            |err| etl_error!(ErrorKind::Unknown, "ClickHouse connectivity check failed", source: err),
-        )
+        let budget = self.config.client_budget(self.config.probe_server_timeout);
+        timeout_call(TimeoutOp::Probe, budget, self.inner.query("SELECT 1").fetch_one::<u8>())
+            .await?;
+        Ok(())
     }
 
     /// Executes a DDL statement (e.g. `CREATE TABLE IF NOT EXISTS …`) and
@@ -156,10 +249,16 @@ impl ClickHouseClient {
     /// histogram labelled with the DDL `kind` and `table_name`.
     pub(crate) async fn execute_ddl(&self, kind: DdlKind, sql: &str) -> EtlResult<()> {
         let ddl_start = Instant::now();
-        let result =
-            self.inner.query(sql).execute().await.map_err(
-                |err| etl_error!(ErrorKind::Unknown, "ClickHouse DDL failed", source: err),
-            );
+        let ddl_secs = secs_string(self.config.ddl_server_timeout);
+        // `max_execution_time` and `lock_acquire_timeout` are applied per-call
+        // so probe and schema_query do not inherit the (much larger) DDL budget.
+        let query = self
+            .inner
+            .query(sql)
+            .with_option("max_execution_time", &ddl_secs)
+            .with_option("lock_acquire_timeout", &ddl_secs);
+        let budget = self.config.client_budget(self.config.ddl_server_timeout);
+        let result = timeout_call(TimeoutOp::Ddl, budget, query.execute()).await;
         metrics::histogram!(
             ETL_CLICKHOUSE_DDL_DURATION_SECONDS,
             "kind" => kind.as_label(),
@@ -173,22 +272,18 @@ impl ClickHouseClient {
         &self,
         table_name: &str,
     ) -> EtlResult<Vec<ClickHouseTableColumn>> {
-        self.inner
+        let schema_secs = secs_string(self.config.schema_query_server_timeout);
+        let query = self
+            .inner
             .query(
                 "SELECT name, type AS type_name FROM system.columns WHERE database = \
                  currentDatabase() AND table = ? ORDER BY position",
             )
-            .bind(table_name)
-            .fetch_all::<ClickHouseTableColumn>()
+            .with_option("max_execution_time", &schema_secs)
+            .bind(table_name);
+        let budget = self.config.client_budget(self.config.schema_query_server_timeout);
+        timeout_call(TimeoutOp::SchemaQuery, budget, query.fetch_all::<ClickHouseTableColumn>())
             .await
-            .map_err(|err| {
-                etl_error!(
-                    ErrorKind::Unknown,
-                    "ClickHouse schema query failed",
-                    format!("table: {table_name}"),
-                    source: err
-                )
-            })
     }
 
     /// Adds a column to an existing ClickHouse table.
@@ -234,14 +329,14 @@ impl ClickHouseClient {
 
     /// Executes `TRUNCATE TABLE IF EXISTS` for the supplied table.
     pub(crate) async fn truncate_table(&self, table_name: &str) -> EtlResult<()> {
-        self.inner.query(&build_truncate_table_sql(table_name)).execute().await.map_err(|err| {
-            etl_error!(
-                ErrorKind::Unknown,
-                "ClickHouse truncate failed",
-                format!("table: {table_name}"),
-                source: err
-            )
-        })
+        let ddl_secs = secs_string(self.config.ddl_server_timeout);
+        let query = self
+            .inner
+            .query(&build_truncate_table_sql(table_name))
+            .with_option("max_execution_time", &ddl_secs)
+            .with_option("lock_acquire_timeout", &ddl_secs);
+        let budget = self.config.client_budget(self.config.ddl_server_timeout);
+        timeout_call(TimeoutOp::Ddl, budget, query.execute()).await
     }
 
     /// Inserts `rows` into `table_name` using the RowBinary format.
@@ -286,14 +381,8 @@ impl ClickHouseClient {
                 bytes += row_buf.len() as u64;
             }
 
-            insert.end().await.map_err(|err| {
-                etl_error!(
-                    ErrorKind::Unknown,
-                    "ClickHouse insert flush failed",
-                    format!("table: {table_name}"),
-                    source: err
-                )
-            })?;
+            let budget = self.config.client_budget(self.config.insert_server_timeout);
+            timeout_call(TimeoutOp::Insert, budget, insert.end()).await?;
             metrics::histogram!(
                 ETL_CLICKHOUSE_INSERT_DURATION_SECONDS,
                 "source" => source,

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -220,9 +220,6 @@ impl ClickHouseClient {
     pub(crate) async fn execute_ddl(&self, kind: DdlKind, sql: &str) -> EtlResult<()> {
         let ddl_start = Instant::now();
         let ddl_secs = floor_secs(self.config.ddl_timeout);
-        // `max_execution_time` and `lock_acquire_timeout` are applied per-call
-        // so the connectivity check and schema query do not inherit the (much
-        // larger) DDL budget.
         let query = self
             .inner
             .query(sql)

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -27,8 +27,8 @@ fn secs_string(d: Duration) -> String {
 }
 
 /// Runs `fut` under `tokio::time::timeout` using the client budget for `op`
-/// from `config`, and maps the three outcomes onto typed [`EtlResult`]s
-/// using `op` for kind selection and the human-readable description.
+/// from `config`. Inner ClickHouse errors map onto `op.failed_kind()`;
+/// client-side deadlines map onto [`ErrorKind::DestinationTimeout`].
 async fn timeout_call<T, F>(
     op: ClickHouseOperationKind,
     config: &ClickHouseClientConfig,

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -449,6 +449,14 @@ mod tests {
         assert_eq!(sql, "INSERT INTO \"table\"\"name\" FORMAT RowBinary");
     }
 
+    /// # GIVEN
+    /// A config with a custom server budget and epsilon.
+    ///
+    /// # WHEN
+    /// `client_budget(op)` is queried.
+    ///
+    /// # THEN
+    /// It returns `server_budget(op) + client_timeout_epsilon`.
     #[test]
     fn client_budget_adds_epsilon_to_server_budget() {
         let config = ClickHouseClientConfig {
@@ -472,6 +480,15 @@ mod tests {
         );
     }
 
+    /// # GIVEN
+    /// Each `ClickHouseOperationKind` variant.
+    ///
+    /// # WHEN
+    /// `Display` is invoked.
+    ///
+    /// # THEN
+    /// It produces the human-readable op name interpolated into error
+    /// messages by `timeout_call`.
     #[test]
     fn operation_kind_display_matches_error_messages() {
         assert_eq!(ClickHouseOperationKind::ConnectivityCheck.to_string(), "connectivity check");
@@ -480,6 +497,15 @@ mod tests {
         assert_eq!(ClickHouseOperationKind::Insert.to_string(), "insert");
     }
 
+    /// # GIVEN
+    /// A future that never resolves and a config with a finite budget.
+    ///
+    /// # WHEN
+    /// `timeout_call` is awaited under paused time.
+    ///
+    /// # THEN
+    /// It returns an `EtlError` with kind `DestinationTimeout` and a
+    /// detail that mentions the op and "timed out".
     #[tokio::test(start_paused = true)]
     async fn timeout_call_returns_destination_timeout_on_deadline() {
         // A future that never resolves; tokio's paused clock advances virtual
@@ -499,6 +525,14 @@ mod tests {
         );
     }
 
+    /// # GIVEN
+    /// A never-resolving future and `Some(context)`.
+    ///
+    /// # WHEN
+    /// `timeout_call`'s deadline fires.
+    ///
+    /// # THEN
+    /// The error detail contains the context string.
     #[tokio::test(start_paused = true)]
     async fn timeout_call_appends_context_to_detail() {
         let config = ClickHouseClientConfig::default();
@@ -514,6 +548,16 @@ mod tests {
         );
     }
 
+    /// # GIVEN
+    /// A future that returns a `clickhouse::error::Error` before the
+    /// deadline.
+    ///
+    /// # WHEN
+    /// `timeout_call` is awaited with no context.
+    ///
+    /// # THEN
+    /// It returns an `EtlError` with the op's `failed_kind` and a detail
+    /// that mentions the op and "failed".
     #[tokio::test(start_paused = true)]
     async fn timeout_call_propagates_inner_error() {
         let config = ClickHouseClientConfig::default();
@@ -529,6 +573,14 @@ mod tests {
         );
     }
 
+    /// # GIVEN
+    /// A future that resolves to `Ok` before the deadline.
+    ///
+    /// # WHEN
+    /// `timeout_call` is awaited.
+    ///
+    /// # THEN
+    /// It returns the inner `Ok` value unchanged.
     #[tokio::test(start_paused = true)]
     async fn timeout_call_passes_through_success() {
         let config = ClickHouseClientConfig::default();
@@ -538,6 +590,16 @@ mod tests {
         assert_eq!(value, 42);
     }
 
+    /// # GIVEN
+    /// A future that returns a `clickhouse::error::Error` and
+    /// `Some(context)`.
+    ///
+    /// # WHEN
+    /// `timeout_call` is awaited.
+    ///
+    /// # THEN
+    /// The error has the op's `failed_kind`, the detail contains the
+    /// context, and the inner clickhouse error is attached as `source`.
     #[tokio::test(start_paused = true)]
     async fn timeout_call_inner_error_includes_context() {
         use std::error::Error as _;
@@ -555,6 +617,14 @@ mod tests {
         assert!(err.source().is_some(), "expected inner clickhouse error to be attached");
     }
 
+    /// # GIVEN
+    /// A default `ClickHouseClientConfig`.
+    ///
+    /// # WHEN
+    /// `server_budget(op)` is queried for each variant.
+    ///
+    /// # THEN
+    /// Each variant returns the corresponding config field.
     #[test]
     fn server_budget_per_operation_kind() {
         let config = ClickHouseClientConfig::default();
@@ -570,6 +640,15 @@ mod tests {
         assert_eq!(config.server_budget(ClickHouseOperationKind::Insert), config.insert_timeout);
     }
 
+    /// # GIVEN
+    /// Each `ClickHouseOperationKind` variant.
+    ///
+    /// # WHEN
+    /// `failed_kind` is queried.
+    ///
+    /// # THEN
+    /// Each variant maps to the `ErrorKind` that drives the appropriate
+    /// retry policy for that bucket.
     #[test]
     fn operation_kind_failed_kind_per_bucket() {
         assert_eq!(
@@ -587,6 +666,15 @@ mod tests {
         );
     }
 
+    /// # GIVEN
+    /// Various `Duration` values: whole, sub-second, zero, fractional.
+    ///
+    /// # WHEN
+    /// `floor_secs` is called.
+    ///
+    /// # THEN
+    /// It returns a whole-seconds string with a floor of `"1"` (so
+    /// `Duration::ZERO` and sub-second values do not collapse to `"0"`).
     #[test]
     fn floor_secs_floors_at_one_second() {
         // Whole seconds at or above 1 pass through unchanged.

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -27,8 +27,8 @@ fn floor_secs(d: Duration) -> String {
     d.as_secs().max(1).to_string()
 }
 
-/// Runs `fut` under `tokio::time::timeout` using the client budget for `op`
-/// from `config`. Inner ClickHouse errors map onto `op.failed_kind()`;
+/// Runs `fut` under `tokio::time::timeout` using the client-side timeout for
+/// `op` from `config`. Inner ClickHouse errors map onto `op.failed_kind()`;
 /// client-side deadlines map onto [`ErrorKind::DestinationTimeout`].
 /// `context`, when present, is appended to the error detail (e.g.
 /// `"table: foo"`) so call-site-specific diagnostic info is preserved.
@@ -48,8 +48,8 @@ where
         }
     }
 
-    let budget = config.client_budget(op);
-    match tokio::time::timeout(budget, fut).await {
+    let client_timeout = config.client_timeout_for(op);
+    match tokio::time::timeout(client_timeout, fut).await {
         Ok(Ok(value)) => Ok(value),
         Ok(Err(err)) => Err(etl_error!(
             op.failed_kind(),
@@ -60,7 +60,7 @@ where
         Err(_) => Err(etl_error!(
             ErrorKind::DestinationTimeout,
             "ClickHouse call timed out",
-            detail(op, &format!("timed out after {budget:?}"), context)
+            detail(op, &format!("timed out after {client_timeout:?}"), context)
         )),
     }
 }
@@ -453,22 +453,22 @@ mod tests {
     }
 
     /// # GIVEN
-    /// A config with a custom server budget and epsilon.
+    /// A config with a custom server timeout and epsilon.
     ///
     /// # WHEN
-    /// `client_budget(op)` is queried.
+    /// `client_timeout_for(op)` is queried.
     ///
     /// # THEN
-    /// It returns `server_budget(op) + client_timeout_epsilon`.
+    /// It returns `server_timeout_for(op) + client_timeout_epsilon`.
     #[test]
-    fn client_budget_adds_epsilon_to_server_budget() {
+    fn client_timeout_adds_epsilon_to_server_timeout() {
         let config = ClickHouseClientConfig {
             connectivity_check_timeout: Duration::from_secs(10),
             client_timeout_epsilon: Duration::from_secs(3),
             ..Default::default()
         };
         assert_eq!(
-            config.client_budget(ClickHouseOperationKind::ConnectivityCheck),
+            config.client_timeout_for(ClickHouseOperationKind::ConnectivityCheck),
             Duration::from_secs(13)
         );
 
@@ -478,7 +478,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            config.client_budget(ClickHouseOperationKind::ConnectivityCheck),
+            config.client_timeout_for(ClickHouseOperationKind::ConnectivityCheck),
             Duration::from_secs(3)
         );
     }
@@ -624,23 +624,26 @@ mod tests {
     /// A default `ClickHouseClientConfig`.
     ///
     /// # WHEN
-    /// `server_budget(op)` is queried for each variant.
+    /// `server_timeout_for(op)` is queried for each variant.
     ///
     /// # THEN
     /// Each variant returns the corresponding config field.
     #[test]
-    fn server_budget_per_operation_kind() {
+    fn server_timeout_per_operation_kind() {
         let config = ClickHouseClientConfig::default();
         assert_eq!(
-            config.server_budget(ClickHouseOperationKind::ConnectivityCheck),
+            config.server_timeout_for(ClickHouseOperationKind::ConnectivityCheck),
             config.connectivity_check_timeout
         );
         assert_eq!(
-            config.server_budget(ClickHouseOperationKind::SchemaQuery),
+            config.server_timeout_for(ClickHouseOperationKind::SchemaQuery),
             config.schema_query_timeout
         );
-        assert_eq!(config.server_budget(ClickHouseOperationKind::Ddl), config.ddl_timeout);
-        assert_eq!(config.server_budget(ClickHouseOperationKind::Insert), config.insert_timeout);
+        assert_eq!(config.server_timeout_for(ClickHouseOperationKind::Ddl), config.ddl_timeout);
+        assert_eq!(
+            config.server_timeout_for(ClickHouseOperationKind::Insert),
+            config.insert_timeout
+        );
     }
 
     /// # GIVEN

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -21,9 +21,8 @@ use crate::clickhouse::{
 /// Formats a `Duration` as a whole-seconds string for ClickHouse
 /// `.with_option(...)` settings, floored at `"1"`. ClickHouse interprets `"0"`
 /// as "no timeout" for `http_*_timeout`, `max_execution_time`, and
-/// `lock_acquire_timeout`; flooring at 1 second avoids accidentally disabling a
-/// server-side bound when an operator passes `Duration::ZERO` or any sub-second
-/// value.
+/// `lock_acquire_timeout`; the floor prevents `Duration::ZERO` or any
+/// sub-second value from accidentally disabling the bound.
 fn floor_secs(d: Duration) -> String {
     d.as_secs().max(1).to_string()
 }

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -18,12 +18,14 @@ use crate::clickhouse::{
     schema::{clickhouse_column_type, quote_identifier},
 };
 
-/// Formats a `Duration` as a whole-seconds string, suitable for ClickHouse
-/// settings passed via `.with_option(...)`. Sub-second precision is rounded
-/// up to a 1s floor so a `Duration::from_millis(500)` does not become `"0"`.
+/// Formats a `Duration` as a whole-seconds string for ClickHouse
+/// `.with_option(...)` settings, floored at `"1"`. ClickHouse interprets `"0"`
+/// as "no timeout" for `http_*_timeout`, `max_execution_time`, and
+/// `lock_acquire_timeout`; flooring at 1 second avoids accidentally disabling a
+/// server-side bound when an operator passes `Duration::ZERO` or any sub-second
+/// value.
 fn secs_string(d: Duration) -> String {
-    let secs = d.as_secs().max(u64::from(d.subsec_nanos() > 0));
-    secs.to_string()
+    d.as_secs().max(1).to_string()
 }
 
 /// Runs `fut` under `tokio::time::timeout` using the client budget for `op`
@@ -582,17 +584,15 @@ mod tests {
     }
 
     #[test]
-    fn secs_string_rounds_subseconds_up() {
-        // Whole seconds pass through unchanged.
+    fn secs_string_floors_at_one_second() {
+        // Whole seconds at or above 1 pass through unchanged.
+        assert_eq!(secs_string(Duration::from_secs(1)), "1");
         assert_eq!(secs_string(Duration::from_secs(5)), "5");
         assert_eq!(secs_string(Duration::from_secs(60)), "60");
-        // Zero is preserved: in ClickHouse settings "0" usually means "no
-        // timeout", which is the right thing to propagate for a deliberate
-        // override.
-        assert_eq!(secs_string(Duration::ZERO), "0");
-        // Sub-second values round up to a 1s floor so they don't collapse to
-        // "0" and disable the setting unintentionally.
-        assert_eq!(secs_string(Duration::from_millis(1)), "1");
+        // ZERO is floored to 1 to avoid disabling the server-side timeout.
+        assert_eq!(secs_string(Duration::ZERO), "1");
+        // Sub-second values are floored to 1 (would otherwise truncate to 0).
+        assert_eq!(secs_string(Duration::from_nanos(1)), "1");
         assert_eq!(secs_string(Duration::from_millis(500)), "1");
         assert_eq!(secs_string(Duration::from_millis(999)), "1");
         // Fractional seconds beyond 1s truncate to whole seconds (Duration::as_secs).

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -27,9 +27,17 @@ fn secs_string(d: Duration) -> String {
     secs.to_string()
 }
 
-/// Classifies a ClickHouse client call so error mapping is centralised: each
-/// op chooses how a server-returned failure maps onto [`ErrorKind`].
-/// Client-side deadlines always map to [`ErrorKind::DestinationTimeout`].
+/// Classifies a ClickHouse client call so the three concerns of a wrapped
+/// call live in one place:
+///
+/// - `server_budget` picks the right field of [`ClickHouseClientConfig`],
+/// - `failed_kind` maps an inner `clickhouse::error::Error` onto the
+///   appropriate [`ErrorKind`] (`DestinationConnectionFailed` /
+///   `DestinationQueryFailed` / `DestinationAtomicBatchRetryable`),
+/// - `Display` produces the op name interpolated into error messages.
+///
+/// Client-side deadlines always surface as
+/// [`ErrorKind::DestinationTimeout`], independent of `op`.
 #[derive(Copy, Clone)]
 pub(crate) enum TimeoutOp {
     /// Connectivity check (`SELECT 1`).
@@ -43,6 +51,17 @@ pub(crate) enum TimeoutOp {
 }
 
 impl TimeoutOp {
+    /// Server-side budget for this op, selected from
+    /// [`ClickHouseClientConfig`].
+    fn server_budget(self, config: &ClickHouseClientConfig) -> Duration {
+        match self {
+            TimeoutOp::ConnectivityCheck => config.connectivity_check_timeout,
+            TimeoutOp::SchemaQuery => config.schema_query_server_timeout,
+            TimeoutOp::Ddl => config.ddl_server_timeout,
+            TimeoutOp::Insert => config.insert_server_timeout,
+        }
+    }
+
     /// Error kind used when the inner future returns a
     /// `clickhouse::error::Error`.
     fn failed_kind(self) -> ErrorKind {
@@ -66,13 +85,15 @@ impl fmt::Display for TimeoutOp {
     }
 }
 
-/// Runs `fut` under `tokio::time::timeout(budget, fut)` and maps the three
-/// outcomes onto typed [`EtlResult`]s using `op` for kind selection and the
-/// human-readable description.
-async fn timeout_call<T, F>(op: TimeoutOp, budget: Duration, fut: F) -> EtlResult<T>
+/// Runs `fut` under `tokio::time::timeout` using the client budget derived
+/// from `op` and `config`, and maps the three outcomes onto typed
+/// [`EtlResult`]s using `op` for kind selection and the human-readable
+/// description.
+async fn timeout_call<T, F>(op: TimeoutOp, config: &ClickHouseClientConfig, fut: F) -> EtlResult<T>
 where
     F: Future<Output = Result<T, clickhouse::error::Error>>,
 {
+    let budget = config.client_budget(op.server_budget(config));
     match tokio::time::timeout(budget, fut).await {
         Ok(Ok(value)) => Ok(value),
         Ok(Err(err)) => Err(etl_error!(
@@ -233,10 +254,9 @@ impl ClickHouseClient {
     /// destination's `validate_connectivity` so callers (notably the
     /// `etl-api` validators) can treat the two destinations uniformly.
     pub async fn validate_connectivity(&self) -> EtlResult<()> {
-        let budget = self.config.client_budget(self.config.connectivity_check_timeout);
         timeout_call(
             TimeoutOp::ConnectivityCheck,
-            budget,
+            &self.config,
             self.inner.query("SELECT 1").fetch_one::<u8>(),
         )
         .await?;
@@ -256,8 +276,7 @@ impl ClickHouseClient {
             .query(sql)
             .with_option("max_execution_time", &ddl_secs)
             .with_option("lock_acquire_timeout", &ddl_secs);
-        let budget = self.config.client_budget(self.config.ddl_server_timeout);
-        let result = timeout_call(TimeoutOp::Ddl, budget, query.execute()).await;
+        let result = timeout_call(TimeoutOp::Ddl, &self.config, query.execute()).await;
         metrics::histogram!(
             ETL_CLICKHOUSE_DDL_DURATION_SECONDS,
             "kind" => kind.as_label(),
@@ -280,9 +299,12 @@ impl ClickHouseClient {
             )
             .with_option("max_execution_time", &schema_secs)
             .bind(table_name);
-        let budget = self.config.client_budget(self.config.schema_query_server_timeout);
-        timeout_call(TimeoutOp::SchemaQuery, budget, query.fetch_all::<ClickHouseTableColumn>())
-            .await
+        timeout_call(
+            TimeoutOp::SchemaQuery,
+            &self.config,
+            query.fetch_all::<ClickHouseTableColumn>(),
+        )
+        .await
     }
 
     /// Adds a column to an existing ClickHouse table.
@@ -334,8 +356,7 @@ impl ClickHouseClient {
             .query(&build_truncate_table_sql(table_name))
             .with_option("max_execution_time", &ddl_secs)
             .with_option("lock_acquire_timeout", &ddl_secs);
-        let budget = self.config.client_budget(self.config.ddl_server_timeout);
-        timeout_call(TimeoutOp::Ddl, budget, query.execute()).await
+        timeout_call(TimeoutOp::Ddl, &self.config, query.execute()).await
     }
 
     /// Inserts `rows` into `table_name` using the RowBinary format.
@@ -380,8 +401,7 @@ impl ClickHouseClient {
                 bytes += row_buf.len() as u64;
             }
 
-            let budget = self.config.client_budget(self.config.insert_server_timeout);
-            timeout_call(TimeoutOp::Insert, budget, insert.end()).await?;
+            timeout_call(TimeoutOp::Insert, &self.config, insert.end()).await?;
             metrics::histogram!(
                 ETL_CLICKHOUSE_INSERT_DURATION_SECONDS,
                 "source" => source,
@@ -487,10 +507,9 @@ mod tests {
         // A future that never resolves; tokio's paused clock advances virtual
         // time when all tasks are stalled, so the timeout fires immediately
         // in real wall-clock terms.
+        let config = ClickHouseClientConfig::default();
         let never = std::future::pending::<Result<(), clickhouse::error::Error>>();
-        let err = timeout_call(TimeoutOp::ConnectivityCheck, Duration::from_secs(1), never)
-            .await
-            .unwrap_err();
+        let err = timeout_call(TimeoutOp::ConnectivityCheck, &config, never).await.unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
         assert!(
             err.detail()
@@ -502,9 +521,9 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn timeout_call_propagates_inner_error() {
+        let config = ClickHouseClientConfig::default();
         let fut = async { Err::<(), _>(clickhouse::error::Error::NotEnoughData) };
-        let err =
-            timeout_call(TimeoutOp::SchemaQuery, Duration::from_secs(1), fut).await.unwrap_err();
+        let err = timeout_call(TimeoutOp::SchemaQuery, &config, fut).await.unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationQueryFailed);
         assert!(
             err.detail().is_some_and(|d| d.contains("schema query") && d.contains("failed")),
@@ -515,9 +534,25 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn timeout_call_passes_through_success() {
+        let config = ClickHouseClientConfig::default();
         let fut = async { Ok::<u32, clickhouse::error::Error>(42) };
-        let value = timeout_call(TimeoutOp::Insert, Duration::from_secs(1), fut).await.unwrap();
+        let value = timeout_call(TimeoutOp::Insert, &config, fut).await.unwrap();
         assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn timeout_op_server_budget_per_bucket() {
+        let config = ClickHouseClientConfig::default();
+        assert_eq!(
+            TimeoutOp::ConnectivityCheck.server_budget(&config),
+            config.connectivity_check_timeout
+        );
+        assert_eq!(
+            TimeoutOp::SchemaQuery.server_budget(&config),
+            config.schema_query_server_timeout
+        );
+        assert_eq!(TimeoutOp::Ddl.server_budget(&config), config.ddl_server_timeout);
+        assert_eq!(TimeoutOp::Insert.server_budget(&config), config.insert_server_timeout);
     }
 
     #[test]

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -42,8 +42,8 @@ where
 {
     fn detail(op: ClickHouseOperationKind, what: &str, context: Option<&str>) -> String {
         match context {
-            Some(c) => format!("ClickHouse {op} {what}; {c}"),
-            None => format!("ClickHouse {op} {what}"),
+            Some(c) => format!("{op} {what}; {c}"),
+            None => format!("{op} {what}"),
         }
     }
     let budget = config.client_budget(op);
@@ -188,8 +188,8 @@ impl ClickHouseClient {
         client = client
             .with_option("connect_timeout", &secs_string(config.connectivity_check_timeout))
             .with_option("http_connection_timeout", &secs_string(config.connectivity_check_timeout))
-            .with_option("http_send_timeout", &secs_string(config.insert_server_timeout))
-            .with_option("http_receive_timeout", &secs_string(config.insert_server_timeout));
+            .with_option("http_send_timeout", &secs_string(config.insert_timeout))
+            .with_option("http_receive_timeout", &secs_string(config.insert_timeout));
 
         Self { inner: Arc::new(client), config }
     }
@@ -216,7 +216,7 @@ impl ClickHouseClient {
     /// histogram labelled with the DDL `kind` and `table_name`.
     pub(crate) async fn execute_ddl(&self, kind: DdlKind, sql: &str) -> EtlResult<()> {
         let ddl_start = Instant::now();
-        let ddl_secs = secs_string(self.config.ddl_server_timeout);
+        let ddl_secs = secs_string(self.config.ddl_timeout);
         // `max_execution_time` and `lock_acquire_timeout` are applied per-call
         // so the connectivity check and schema query do not inherit the (much
         // larger) DDL budget.
@@ -240,7 +240,7 @@ impl ClickHouseClient {
         &self,
         table_name: &str,
     ) -> EtlResult<Vec<ClickHouseTableColumn>> {
-        let schema_secs = secs_string(self.config.schema_query_server_timeout);
+        let schema_secs = secs_string(self.config.schema_query_timeout);
         let query = self
             .inner
             .query(
@@ -301,7 +301,7 @@ impl ClickHouseClient {
 
     /// Executes `TRUNCATE TABLE IF EXISTS` for the supplied table.
     pub(crate) async fn truncate_table(&self, table_name: &str) -> EtlResult<()> {
-        let ddl_secs = secs_string(self.config.ddl_server_timeout);
+        let ddl_secs = secs_string(self.config.ddl_timeout);
         let query = self
             .inner
             .query(&build_truncate_table_sql(table_name))
@@ -541,13 +541,10 @@ mod tests {
         );
         assert_eq!(
             config.server_budget(ClickHouseOperationKind::SchemaQuery),
-            config.schema_query_server_timeout
+            config.schema_query_timeout
         );
-        assert_eq!(config.server_budget(ClickHouseOperationKind::Ddl), config.ddl_server_timeout);
-        assert_eq!(
-            config.server_budget(ClickHouseOperationKind::Insert),
-            config.insert_server_timeout
-        );
+        assert_eq!(config.server_budget(ClickHouseOperationKind::Ddl), config.ddl_timeout);
+        assert_eq!(config.server_budget(ClickHouseOperationKind::Insert), config.insert_timeout);
     }
 
     #[test]

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -28,12 +28,12 @@ fn secs_string(d: Duration) -> String {
 }
 
 /// Classifies a ClickHouse client call so error mapping is centralised: each
-/// op chooses how a server-returned failure and a client-side deadline map
-/// onto [`ErrorKind`].
+/// op chooses how a server-returned failure maps onto [`ErrorKind`].
+/// Client-side deadlines always map to [`ErrorKind::DestinationTimeout`].
 #[derive(Copy, Clone)]
 pub(crate) enum TimeoutOp {
-    /// Connectivity probe (`SELECT 1`).
-    Probe,
+    /// Connectivity check (`SELECT 1`).
+    ConnectivityCheck,
     /// Schema lookup against `system.columns`.
     SchemaQuery,
     /// DDL: CREATE / ALTER / DROP / RENAME / TRUNCATE.
@@ -47,22 +47,17 @@ impl TimeoutOp {
     /// `clickhouse::error::Error`.
     fn failed_kind(self) -> ErrorKind {
         match self {
-            TimeoutOp::Probe => ErrorKind::DestinationConnectionFailed,
+            TimeoutOp::ConnectivityCheck => ErrorKind::DestinationConnectionFailed,
             TimeoutOp::SchemaQuery | TimeoutOp::Ddl => ErrorKind::DestinationQueryFailed,
             TimeoutOp::Insert => ErrorKind::DestinationAtomicBatchRetryable,
         }
-    }
-
-    /// Error kind used when the client-side `tokio::time::timeout` fires.
-    fn timeout_kind(self) -> ErrorKind {
-        ErrorKind::DestinationTimeout
     }
 }
 
 impl fmt::Display for TimeoutOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
-            TimeoutOp::Probe => "probe",
+            TimeoutOp::ConnectivityCheck => "connectivity check",
             TimeoutOp::SchemaQuery => "schema query",
             TimeoutOp::Ddl => "DDL",
             TimeoutOp::Insert => "insert",
@@ -87,7 +82,7 @@ where
             source: err
         )),
         Err(_) => Err(etl_error!(
-            op.timeout_kind(),
+            ErrorKind::DestinationTimeout,
             "ClickHouse call timed out",
             format!("ClickHouse {op} timed out after {budget:?}")
         )),
@@ -239,8 +234,12 @@ impl ClickHouseClient {
     /// `etl-api` validators) can treat the two destinations uniformly.
     pub async fn validate_connectivity(&self) -> EtlResult<()> {
         let budget = self.config.client_budget(self.config.connectivity_check_timeout);
-        timeout_call(TimeoutOp::Probe, budget, self.inner.query("SELECT 1").fetch_one::<u8>())
-            .await?;
+        timeout_call(
+            TimeoutOp::ConnectivityCheck,
+            budget,
+            self.inner.query("SELECT 1").fetch_one::<u8>(),
+        )
+        .await?;
         Ok(())
     }
 
@@ -477,7 +476,7 @@ mod tests {
 
     #[test]
     fn timeout_op_display_matches_error_messages() {
-        assert_eq!(TimeoutOp::Probe.to_string(), "probe");
+        assert_eq!(TimeoutOp::ConnectivityCheck.to_string(), "connectivity check");
         assert_eq!(TimeoutOp::SchemaQuery.to_string(), "schema query");
         assert_eq!(TimeoutOp::Ddl.to_string(), "DDL");
         assert_eq!(TimeoutOp::Insert.to_string(), "insert");
@@ -489,10 +488,13 @@ mod tests {
         // time when all tasks are stalled, so the timeout fires immediately
         // in real wall-clock terms.
         let never = std::future::pending::<Result<(), clickhouse::error::Error>>();
-        let err = timeout_call(TimeoutOp::Probe, Duration::from_secs(1), never).await.unwrap_err();
+        let err = timeout_call(TimeoutOp::ConnectivityCheck, Duration::from_secs(1), never)
+            .await
+            .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
         assert!(
-            err.detail().is_some_and(|d| d.contains("probe") && d.contains("timed out")),
+            err.detail()
+                .is_some_and(|d| d.contains("connectivity check") && d.contains("timed out")),
             "unexpected detail: {:?}",
             err.detail()
         );
@@ -520,7 +522,10 @@ mod tests {
 
     #[test]
     fn timeout_op_failed_kind_per_bucket() {
-        assert_eq!(TimeoutOp::Probe.failed_kind(), ErrorKind::DestinationConnectionFailed);
+        assert_eq!(
+            TimeoutOp::ConnectivityCheck.failed_kind(),
+            ErrorKind::DestinationConnectionFailed
+        );
         assert_eq!(TimeoutOp::SchemaQuery.failed_kind(), ErrorKind::DestinationQueryFailed);
         assert_eq!(TimeoutOp::Ddl.failed_kind(), ErrorKind::DestinationQueryFailed);
         assert_eq!(TimeoutOp::Insert.failed_kind(), ErrorKind::DestinationAtomicBatchRetryable);

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -185,12 +185,6 @@ impl ClickHouseClient {
             client = client.with_password(pw);
         }
 
-        // Server-side transport timeouts. These bound the time the server is
-        // willing to spend on the connection itself. `max_execution_time` and
-        // `lock_acquire_timeout` are intentionally not set here: they are
-        // DDL-specific and would otherwise leak into the connectivity check
-        // and schema query, which expect much tighter budgets. DDL and
-        // TRUNCATE apply them via per-call `.with_option(...)` overrides.
         client = client
             .with_option("connect_timeout", &secs_string(config.connectivity_check_timeout))
             .with_option("http_connection_timeout", &secs_string(config.connectivity_check_timeout))

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -203,11 +203,15 @@ impl ClickHouseClient {
     /// destination's `validate_connectivity` so callers (notably the
     /// `etl-api` validators) can treat the two destinations uniformly.
     pub async fn validate_connectivity(&self) -> EtlResult<()> {
+        let query = self
+            .inner
+            .query("SELECT 1")
+            .with_option("max_execution_time", floor_secs(self.config.connectivity_check_timeout));
         timeout_call(
             ClickHouseOperationKind::ConnectivityCheck,
             &self.config,
             None,
-            self.inner.query("SELECT 1").fetch_one::<u8>(),
+            query.fetch_one::<u8>(),
         )
         .await?;
         Ok(())

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -29,27 +29,36 @@ fn secs_string(d: Duration) -> String {
 /// Runs `fut` under `tokio::time::timeout` using the client budget for `op`
 /// from `config`. Inner ClickHouse errors map onto `op.failed_kind()`;
 /// client-side deadlines map onto [`ErrorKind::DestinationTimeout`].
+/// `context`, when present, is appended to the error detail (e.g.
+/// `"table: foo"`) so call-site-specific diagnostic info is preserved.
 async fn timeout_call<T, F>(
     op: ClickHouseOperationKind,
     config: &ClickHouseClientConfig,
+    context: Option<&str>,
     fut: F,
 ) -> EtlResult<T>
 where
     F: Future<Output = Result<T, clickhouse::error::Error>>,
 {
+    fn detail(op: ClickHouseOperationKind, what: &str, context: Option<&str>) -> String {
+        match context {
+            Some(c) => format!("ClickHouse {op} {what}; {c}"),
+            None => format!("ClickHouse {op} {what}"),
+        }
+    }
     let budget = config.client_budget(op);
     match tokio::time::timeout(budget, fut).await {
         Ok(Ok(value)) => Ok(value),
         Ok(Err(err)) => Err(etl_error!(
             op.failed_kind(),
             "ClickHouse call failed",
-            format!("ClickHouse {op} failed"),
+            detail(op, "failed", context),
             source: err
         )),
         Err(_) => Err(etl_error!(
             ErrorKind::DestinationTimeout,
             "ClickHouse call timed out",
-            format!("ClickHouse {op} timed out after {budget:?}")
+            detail(op, &format!("timed out after {budget:?}"), context)
         )),
     }
 }
@@ -179,9 +188,9 @@ impl ClickHouseClient {
         // Server-side transport timeouts. These bound the time the server is
         // willing to spend on the connection itself. `max_execution_time` and
         // `lock_acquire_timeout` are intentionally not set here: they are
-        // DDL-specific and would otherwise leak into probe and schema_query
-        // calls, which expect much tighter budgets. DDL applies them via
-        // per-call `.with_option(...)` overrides instead.
+        // DDL-specific and would otherwise leak into the connectivity check
+        // and schema query, which expect much tighter budgets. DDL and
+        // TRUNCATE apply them via per-call `.with_option(...)` overrides.
         client = client
             .with_option("connect_timeout", &secs_string(config.connectivity_check_timeout))
             .with_option("http_connection_timeout", &secs_string(config.connectivity_check_timeout))
@@ -201,6 +210,7 @@ impl ClickHouseClient {
         timeout_call(
             ClickHouseOperationKind::ConnectivityCheck,
             &self.config,
+            None,
             self.inner.query("SELECT 1").fetch_one::<u8>(),
         )
         .await?;
@@ -214,14 +224,15 @@ impl ClickHouseClient {
         let ddl_start = Instant::now();
         let ddl_secs = secs_string(self.config.ddl_server_timeout);
         // `max_execution_time` and `lock_acquire_timeout` are applied per-call
-        // so probe and schema_query do not inherit the (much larger) DDL budget.
+        // so the connectivity check and schema query do not inherit the (much
+        // larger) DDL budget.
         let query = self
             .inner
             .query(sql)
             .with_option("max_execution_time", &ddl_secs)
             .with_option("lock_acquire_timeout", &ddl_secs);
         let result =
-            timeout_call(ClickHouseOperationKind::Ddl, &self.config, query.execute()).await;
+            timeout_call(ClickHouseOperationKind::Ddl, &self.config, None, query.execute()).await;
         metrics::histogram!(
             ETL_CLICKHOUSE_DDL_DURATION_SECONDS,
             "kind" => kind.as_label(),
@@ -247,6 +258,7 @@ impl ClickHouseClient {
         timeout_call(
             ClickHouseOperationKind::SchemaQuery,
             &self.config,
+            Some(&format!("table: {table_name}")),
             query.fetch_all::<ClickHouseTableColumn>(),
         )
         .await
@@ -301,7 +313,13 @@ impl ClickHouseClient {
             .query(&build_truncate_table_sql(table_name))
             .with_option("max_execution_time", &ddl_secs)
             .with_option("lock_acquire_timeout", &ddl_secs);
-        timeout_call(ClickHouseOperationKind::Ddl, &self.config, query.execute()).await
+        timeout_call(
+            ClickHouseOperationKind::Ddl,
+            &self.config,
+            Some(&format!("table: {table_name}")),
+            query.execute(),
+        )
+        .await
     }
 
     /// Inserts `rows` into `table_name` using the RowBinary format.
@@ -346,7 +364,13 @@ impl ClickHouseClient {
                 bytes += row_buf.len() as u64;
             }
 
-            timeout_call(ClickHouseOperationKind::Insert, &self.config, insert.end()).await?;
+            timeout_call(
+                ClickHouseOperationKind::Insert,
+                &self.config,
+                Some(&format!("table: {table_name}")),
+                insert.end(),
+            )
+            .await?;
             metrics::histogram!(
                 ETL_CLICKHOUSE_INSERT_DURATION_SECONDS,
                 "source" => source,
@@ -463,7 +487,7 @@ mod tests {
         // in real wall-clock terms.
         let config = ClickHouseClientConfig::default();
         let never = std::future::pending::<Result<(), clickhouse::error::Error>>();
-        let err = timeout_call(ClickHouseOperationKind::ConnectivityCheck, &config, never)
+        let err = timeout_call(ClickHouseOperationKind::ConnectivityCheck, &config, None, never)
             .await
             .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
@@ -476,11 +500,27 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn timeout_call_appends_context_to_detail() {
+        let config = ClickHouseClientConfig::default();
+        let never = std::future::pending::<Result<(), clickhouse::error::Error>>();
+        let err =
+            timeout_call(ClickHouseOperationKind::Insert, &config, Some("table: users"), never)
+                .await
+                .unwrap_err();
+        assert!(
+            err.detail().is_some_and(|d| d.contains("table: users")),
+            "unexpected detail: {:?}",
+            err.detail()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn timeout_call_propagates_inner_error() {
         let config = ClickHouseClientConfig::default();
         let fut = async { Err::<(), _>(clickhouse::error::Error::NotEnoughData) };
-        let err =
-            timeout_call(ClickHouseOperationKind::SchemaQuery, &config, fut).await.unwrap_err();
+        let err = timeout_call(ClickHouseOperationKind::SchemaQuery, &config, None, fut)
+            .await
+            .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationQueryFailed);
         assert!(
             err.detail().is_some_and(|d| d.contains("schema query") && d.contains("failed")),
@@ -493,7 +533,8 @@ mod tests {
     async fn timeout_call_passes_through_success() {
         let config = ClickHouseClientConfig::default();
         let fut = async { Ok::<u32, clickhouse::error::Error>(42) };
-        let value = timeout_call(ClickHouseOperationKind::Insert, &config, fut).await.unwrap();
+        let value =
+            timeout_call(ClickHouseOperationKind::Insert, &config, None, fut).await.unwrap();
         assert_eq!(value, 42);
     }
 
@@ -530,5 +571,24 @@ mod tests {
             ClickHouseOperationKind::Insert.failed_kind(),
             ErrorKind::DestinationAtomicBatchRetryable
         );
+    }
+
+    #[test]
+    fn secs_string_rounds_subseconds_up() {
+        // Whole seconds pass through unchanged.
+        assert_eq!(secs_string(Duration::from_secs(5)), "5");
+        assert_eq!(secs_string(Duration::from_secs(60)), "60");
+        // Zero is preserved: in ClickHouse settings "0" usually means "no
+        // timeout", which is the right thing to propagate for a deliberate
+        // override.
+        assert_eq!(secs_string(Duration::ZERO), "0");
+        // Sub-second values round up to a 1s floor so they don't collapse to
+        // "0" and disable the setting unintentionally.
+        assert_eq!(secs_string(Duration::from_millis(1)), "1");
+        assert_eq!(secs_string(Duration::from_millis(500)), "1");
+        assert_eq!(secs_string(Duration::from_millis(999)), "1");
+        // Fractional seconds beyond 1s truncate to whole seconds (Duration::as_secs).
+        assert_eq!(secs_string(Duration::from_millis(1500)), "1");
+        assert_eq!(secs_string(Duration::from_millis(2999)), "2");
     }
 }

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -534,6 +534,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn timeout_call_inner_error_includes_context() {
+        use std::error::Error as _;
         let config = ClickHouseClientConfig::default();
         let fut = async { Err::<(), _>(clickhouse::error::Error::NotEnoughData) };
         let err = timeout_call(ClickHouseOperationKind::Insert, &config, Some("table: users"), fut)
@@ -545,6 +546,7 @@ mod tests {
             "unexpected detail: {:?}",
             err.detail()
         );
+        assert!(err.source().is_some(), "expected inner clickhouse error to be attached");
     }
 
     #[test]

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -188,10 +188,10 @@ impl ClickHouseClient {
         }
 
         client = client
-            .with_option("connect_timeout", &secs_string(config.connectivity_check_timeout))
-            .with_option("http_connection_timeout", &secs_string(config.connectivity_check_timeout))
-            .with_option("http_send_timeout", &secs_string(config.insert_timeout))
-            .with_option("http_receive_timeout", &secs_string(config.insert_timeout));
+            .with_option("connect_timeout", secs_string(config.connectivity_check_timeout))
+            .with_option("http_connection_timeout", secs_string(config.connectivity_check_timeout))
+            .with_option("http_send_timeout", secs_string(config.insert_timeout))
+            .with_option("http_receive_timeout", secs_string(config.insert_timeout));
 
         Self { inner: Arc::new(client), config }
     }
@@ -453,15 +453,21 @@ mod tests {
 
     #[test]
     fn client_budget_adds_epsilon_to_server_budget() {
-        let mut config = ClickHouseClientConfig::default();
-        config.connectivity_check_timeout = Duration::from_secs(10);
-        config.client_timeout_epsilon = Duration::from_secs(3);
+        let config = ClickHouseClientConfig {
+            connectivity_check_timeout: Duration::from_secs(10),
+            client_timeout_epsilon: Duration::from_secs(3),
+            ..Default::default()
+        };
         assert_eq!(
             config.client_budget(ClickHouseOperationKind::ConnectivityCheck),
             Duration::from_secs(13)
         );
 
-        config.connectivity_check_timeout = Duration::ZERO;
+        let config = ClickHouseClientConfig {
+            connectivity_check_timeout: Duration::ZERO,
+            client_timeout_epsilon: Duration::from_secs(3),
+            ..Default::default()
+        };
         assert_eq!(
             config.client_budget(ClickHouseOperationKind::ConnectivityCheck),
             Duration::from_secs(3)

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -223,8 +223,8 @@ impl ClickHouseClient {
         // calls, which expect much tighter budgets. DDL applies them via
         // per-call `.with_option(...)` overrides instead.
         client = client
-            .with_option("connect_timeout", &secs_string(config.probe_server_timeout))
-            .with_option("http_connection_timeout", &secs_string(config.probe_server_timeout))
+            .with_option("connect_timeout", &secs_string(config.connectivity_check_timeout))
+            .with_option("http_connection_timeout", &secs_string(config.connectivity_check_timeout))
             .with_option("http_send_timeout", &secs_string(config.insert_server_timeout))
             .with_option("http_receive_timeout", &secs_string(config.insert_server_timeout));
 
@@ -238,7 +238,7 @@ impl ClickHouseClient {
     /// destination's `validate_connectivity` so callers (notably the
     /// `etl-api` validators) can treat the two destinations uniformly.
     pub async fn validate_connectivity(&self) -> EtlResult<()> {
-        let budget = self.config.client_budget(self.config.probe_server_timeout);
+        let budget = self.config.client_budget(self.config.connectivity_check_timeout);
         timeout_call(TimeoutOp::Probe, budget, self.inner.query("SELECT 1").fetch_one::<u8>())
             .await?;
         Ok(())

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -234,9 +234,9 @@ impl Default for ClickHouseClientConfig {
 
 /// Categories of ClickHouse client calls.
 ///
-/// Enables the following:
-/// - selecting the corresponding server-side budget,
-/// - mapping a generic clickhouse error onto the appropriate [`ErrorKind`].
+/// Used to:
+/// - select the corresponding server-side budget,
+/// - map a generic clickhouse error onto the appropriate [`ErrorKind`].
 #[derive(Copy, Clone)]
 pub(crate) enum ClickHouseOperationKind {
     /// Connectivity check (`SELECT 1`).

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -179,13 +179,13 @@ pub struct ClickHouseClientConfig {
     /// Server-side budget for the connectivity check (`SELECT 1`).
     pub connectivity_check_timeout: Duration,
     /// Server-side budget for schema lookups (`system.columns`).
-    pub schema_query_server_timeout: Duration,
+    pub schema_query_timeout: Duration,
     /// Server-side budget for DDL (CREATE / ALTER / DROP / RENAME / TRUNCATE).
-    pub ddl_server_timeout: Duration,
+    pub ddl_timeout: Duration,
     /// Server-side budget per INSERT statement. Wraps `insert.end().await`,
     /// which is the only awaited network step inside `insert_rows`; each
     /// flushed chunk therefore gets its own deadline.
-    pub insert_server_timeout: Duration,
+    pub insert_timeout: Duration,
     /// Slack added to the server-side budget to derive the client-side
     /// `tokio::time::timeout`.
     pub client_timeout_epsilon: Duration,
@@ -195,11 +195,11 @@ impl ClickHouseClientConfig {
     /// Default server-side budget for the connectivity check.
     pub const DEFAULT_CONNECTIVITY_CHECK_TIMEOUT: Duration = Duration::from_secs(8);
     /// Default server-side budget for schema lookups.
-    pub const DEFAULT_SCHEMA_QUERY_SERVER_TIMEOUT: Duration = Duration::from_secs(16);
+    pub const DEFAULT_SCHEMA_QUERY_TIMEOUT: Duration = Duration::from_secs(16);
     /// Default server-side budget for DDL.
-    pub const DEFAULT_DDL_SERVER_TIMEOUT: Duration = Duration::from_secs(128);
+    pub const DEFAULT_DDL_TIMEOUT: Duration = Duration::from_secs(128);
     /// Default server-side budget per INSERT statement.
-    pub const DEFAULT_INSERT_SERVER_TIMEOUT: Duration = Duration::from_secs(256);
+    pub const DEFAULT_INSERT_TIMEOUT: Duration = Duration::from_secs(256);
     /// Default slack between server-side and client-side budgets.
     pub const DEFAULT_CLIENT_TIMEOUT_EPSILON: Duration = Duration::from_secs(4);
 
@@ -207,9 +207,9 @@ impl ClickHouseClientConfig {
     pub(crate) fn server_budget(&self, op: ClickHouseOperationKind) -> Duration {
         match op {
             ClickHouseOperationKind::ConnectivityCheck => self.connectivity_check_timeout,
-            ClickHouseOperationKind::SchemaQuery => self.schema_query_server_timeout,
-            ClickHouseOperationKind::Ddl => self.ddl_server_timeout,
-            ClickHouseOperationKind::Insert => self.insert_server_timeout,
+            ClickHouseOperationKind::SchemaQuery => self.schema_query_timeout,
+            ClickHouseOperationKind::Ddl => self.ddl_timeout,
+            ClickHouseOperationKind::Insert => self.insert_timeout,
         }
     }
 
@@ -224,9 +224,9 @@ impl Default for ClickHouseClientConfig {
     fn default() -> Self {
         Self {
             connectivity_check_timeout: Self::DEFAULT_CONNECTIVITY_CHECK_TIMEOUT,
-            schema_query_server_timeout: Self::DEFAULT_SCHEMA_QUERY_SERVER_TIMEOUT,
-            ddl_server_timeout: Self::DEFAULT_DDL_SERVER_TIMEOUT,
-            insert_server_timeout: Self::DEFAULT_INSERT_SERVER_TIMEOUT,
+            schema_query_timeout: Self::DEFAULT_SCHEMA_QUERY_TIMEOUT,
+            ddl_timeout: Self::DEFAULT_DDL_TIMEOUT,
+            insert_timeout: Self::DEFAULT_INSERT_TIMEOUT,
             client_timeout_epsilon: Self::DEFAULT_CLIENT_TIMEOUT_EPSILON,
         }
     }

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -170,39 +170,30 @@ impl Default for ClickHouseInserterConfig {
     }
 }
 
-/// Per-operation timeouts applied to the [`ClickHouseClient`].
+/// Configuration for the [`ClickHouseClient`].
 ///
-/// The strategy is layered: server-side ClickHouse settings
-/// (`max_execution_time`, `http_receive_timeout`, etc.) bound the work done by
-/// the server, and a `tokio::time::timeout` on the client side bounds the
-/// wall-clock wait with a slightly larger budget (`server +
-/// client_timeout_epsilon`). The server-side limit usually wins so callers see
-/// a typed ClickHouse error; the client-side limit is the hard ceiling for
-/// unreachable or unresponsive servers and surfaces as
-/// [`etl::error::ErrorKind::DestinationTimeout`].
+/// Holds the server-side and client-side timeouts applied to each operation
+/// bucket. Additional client-level knobs can be added here over time.
 #[derive(Copy, Clone)]
 pub struct ClickHouseClientConfig {
-    /// Server-side budget for the connectivity probe (`SELECT 1`).
-    pub probe_server_timeout: Duration,
+    /// Server-side budget for the connectivity check (`SELECT 1`).
+    pub connectivity_check_timeout: Duration,
     /// Server-side budget for schema lookups (`system.columns`).
     pub schema_query_server_timeout: Duration,
     /// Server-side budget for DDL (CREATE / ALTER / DROP / RENAME / TRUNCATE).
-    /// Applied per-call so probe and schema_query do not inherit a
-    /// multi-minute `max_execution_time`.
     pub ddl_server_timeout: Duration,
     /// Server-side budget per INSERT statement. Wraps `insert.end().await`,
     /// which is the only awaited network step inside `insert_rows`; each
     /// flushed chunk therefore gets its own deadline.
     pub insert_server_timeout: Duration,
-    /// Slack added on top of the server-side timeout for the client-side
-    /// `tokio::time::timeout` budget, so the server's typed error wins the
-    /// race against our hard ceiling.
+    /// Slack added to the server-side budget to derive the client-side
+    /// `tokio::time::timeout`.
     pub client_timeout_epsilon: Duration,
 }
 
 impl ClickHouseClientConfig {
-    /// Default server-side budget for the connectivity probe.
-    pub const DEFAULT_PROBE_SERVER_TIMEOUT: Duration = Duration::from_secs(8);
+    /// Default server-side budget for the connectivity check.
+    pub const DEFAULT_CONNECTIVITY_CHECK_TIMEOUT: Duration = Duration::from_secs(8);
     /// Default server-side budget for schema lookups.
     pub const DEFAULT_SCHEMA_QUERY_SERVER_TIMEOUT: Duration = Duration::from_secs(16);
     /// Default server-side budget for DDL.
@@ -210,7 +201,7 @@ impl ClickHouseClientConfig {
     /// Default server-side budget per INSERT statement.
     pub const DEFAULT_INSERT_SERVER_TIMEOUT: Duration = Duration::from_secs(256);
     /// Default slack between server-side and client-side budgets.
-    pub const DEFAULT_CLIENT_TIMEOUT_EPSILON: Duration = Duration::from_secs(5);
+    pub const DEFAULT_CLIENT_TIMEOUT_EPSILON: Duration = Duration::from_secs(4);
 
     /// Returns the client-side `tokio::time::timeout` budget that
     /// corresponds to a given server-side timeout: `server + epsilon`.
@@ -222,7 +213,7 @@ impl ClickHouseClientConfig {
 impl Default for ClickHouseClientConfig {
     fn default() -> Self {
         Self {
-            probe_server_timeout: Self::DEFAULT_PROBE_SERVER_TIMEOUT,
+            connectivity_check_timeout: Self::DEFAULT_CONNECTIVITY_CHECK_TIMEOUT,
             schema_query_server_timeout: Self::DEFAULT_SCHEMA_QUERY_SERVER_TIMEOUT,
             ddl_server_timeout: Self::DEFAULT_DDL_SERVER_TIMEOUT,
             insert_server_timeout: Self::DEFAULT_INSERT_SERVER_TIMEOUT,

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -203,10 +203,20 @@ impl ClickHouseClientConfig {
     /// Default slack between server-side and client-side budgets.
     pub const DEFAULT_CLIENT_TIMEOUT_EPSILON: Duration = Duration::from_secs(4);
 
-    /// Returns the client-side `tokio::time::timeout` budget that
-    /// corresponds to a given server-side timeout: `server + epsilon`.
-    pub(crate) fn client_budget(&self, server: Duration) -> Duration {
-        server + self.client_timeout_epsilon
+    /// Server-side budget for `op`: the corresponding field of this config.
+    pub(crate) fn server_budget(&self, op: ClickHouseOperationKind) -> Duration {
+        match op {
+            ClickHouseOperationKind::ConnectivityCheck => self.connectivity_check_timeout,
+            ClickHouseOperationKind::SchemaQuery => self.schema_query_server_timeout,
+            ClickHouseOperationKind::Ddl => self.ddl_server_timeout,
+            ClickHouseOperationKind::Insert => self.insert_server_timeout,
+        }
+    }
+
+    /// Client-side `tokio::time::timeout` budget for `op`: server budget
+    /// plus `client_timeout_epsilon`.
+    pub(crate) fn client_budget(&self, op: ClickHouseOperationKind) -> Duration {
+        self.server_budget(op) + self.client_timeout_epsilon
     }
 }
 
@@ -219,6 +229,55 @@ impl Default for ClickHouseClientConfig {
             insert_server_timeout: Self::DEFAULT_INSERT_SERVER_TIMEOUT,
             client_timeout_epsilon: Self::DEFAULT_CLIENT_TIMEOUT_EPSILON,
         }
+    }
+}
+
+/// Categories of ClickHouse client calls.
+///
+/// Enables the following:
+/// - selecting the server-side budget from [`ClickHouseClientConfig`],
+/// - mapping an inner `clickhouse::error::Error` onto the appropriate
+///   [`ErrorKind`] (`DestinationConnectionFailed` / `DestinationQueryFailed` /
+///   `DestinationAtomicBatchRetryable`),
+/// - producing the op name interpolated into error messages via `Display`.
+///
+/// Client-side deadlines always surface as
+/// [`ErrorKind::DestinationTimeout`], independent of the op.
+#[derive(Copy, Clone)]
+pub(crate) enum ClickHouseOperationKind {
+    /// Connectivity check (`SELECT 1`).
+    ConnectivityCheck,
+    /// Schema lookup against `system.columns`.
+    SchemaQuery,
+    /// DDL: CREATE / ALTER / DROP / RENAME / TRUNCATE.
+    Ddl,
+    /// INSERT statement flush.
+    Insert,
+}
+
+impl ClickHouseOperationKind {
+    /// Error kind used when the inner future returns a
+    /// `clickhouse::error::Error`.
+    pub(crate) fn failed_kind(self) -> ErrorKind {
+        match self {
+            ClickHouseOperationKind::ConnectivityCheck => ErrorKind::DestinationConnectionFailed,
+            ClickHouseOperationKind::SchemaQuery | ClickHouseOperationKind::Ddl => {
+                ErrorKind::DestinationQueryFailed
+            }
+            ClickHouseOperationKind::Insert => ErrorKind::DestinationAtomicBatchRetryable,
+        }
+    }
+}
+
+impl std::fmt::Display for ClickHouseOperationKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            ClickHouseOperationKind::ConnectivityCheck => "connectivity check",
+            ClickHouseOperationKind::SchemaQuery => "schema query",
+            ClickHouseOperationKind::Ddl => "DDL",
+            ClickHouseOperationKind::Insert => "insert",
+        };
+        f.write_str(name)
     }
 }
 

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -203,8 +203,8 @@ impl ClickHouseClientConfig {
     /// Default slack between server-side and client-side budgets.
     pub const DEFAULT_CLIENT_TIMEOUT_EPSILON: Duration = Duration::from_secs(4);
 
-    /// Server-side budget for `op`.
-    pub(crate) fn server_budget(&self, op: ClickHouseOperationKind) -> Duration {
+    /// Server-side timeout for `op`.
+    pub(crate) fn server_timeout_for(&self, op: ClickHouseOperationKind) -> Duration {
         match op {
             ClickHouseOperationKind::ConnectivityCheck => self.connectivity_check_timeout,
             ClickHouseOperationKind::SchemaQuery => self.schema_query_timeout,
@@ -213,10 +213,10 @@ impl ClickHouseClientConfig {
         }
     }
 
-    /// Client-side `tokio::time::timeout` budget for `op`: server budget
-    /// plus `client_timeout_epsilon`.
-    pub(crate) fn client_budget(&self, op: ClickHouseOperationKind) -> Duration {
-        self.server_budget(op) + self.client_timeout_epsilon
+    /// Client-side `tokio::time::timeout` for `op`:
+    /// `server_timeout_for(op) + client_timeout_epsilon`.
+    pub(crate) fn client_timeout_for(&self, op: ClickHouseOperationKind) -> Duration {
+        self.server_timeout_for(op) + self.client_timeout_epsilon
     }
 }
 

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -203,7 +203,7 @@ impl ClickHouseClientConfig {
     /// Default slack between server-side and client-side budgets.
     pub const DEFAULT_CLIENT_TIMEOUT_EPSILON: Duration = Duration::from_secs(4);
 
-    /// Server-side budget for `op`: the corresponding field of this config.
+    /// Server-side budget for `op`.
     pub(crate) fn server_budget(&self, op: ClickHouseOperationKind) -> Duration {
         match op {
             ClickHouseOperationKind::ConnectivityCheck => self.connectivity_check_timeout,
@@ -235,14 +235,8 @@ impl Default for ClickHouseClientConfig {
 /// Categories of ClickHouse client calls.
 ///
 /// Enables the following:
-/// - selecting the server-side budget from [`ClickHouseClientConfig`],
-/// - mapping an inner `clickhouse::error::Error` onto the appropriate
-///   [`ErrorKind`] (`DestinationConnectionFailed` / `DestinationQueryFailed` /
-///   `DestinationAtomicBatchRetryable`),
-/// - producing the op name interpolated into error messages via `Display`.
-///
-/// Client-side deadlines always surface as
-/// [`ErrorKind::DestinationTimeout`], independent of the op.
+/// - selecting the corresponding server-side budget,
+/// - mapping a generic clickhouse error onto the appropriate [`ErrorKind`].
 #[derive(Copy, Clone)]
 pub(crate) enum ClickHouseOperationKind {
     /// Connectivity check (`SELECT 1`).

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use etl::{
     destination::{
@@ -170,6 +170,67 @@ impl Default for ClickHouseInserterConfig {
     }
 }
 
+/// Per-operation timeouts applied to the [`ClickHouseClient`].
+///
+/// The strategy is layered: server-side ClickHouse settings
+/// (`max_execution_time`, `http_receive_timeout`, etc.) bound the work done by
+/// the server, and a `tokio::time::timeout` on the client side bounds the
+/// wall-clock wait with a slightly larger budget (`server +
+/// client_timeout_epsilon`). The server-side limit usually wins so callers see
+/// a typed ClickHouse error; the client-side limit is the hard ceiling for
+/// unreachable or unresponsive servers and surfaces as
+/// [`etl::error::ErrorKind::DestinationTimeout`].
+#[derive(Copy, Clone)]
+pub struct ClickHouseClientConfig {
+    /// Server-side budget for the connectivity probe (`SELECT 1`).
+    pub probe_server_timeout: Duration,
+    /// Server-side budget for schema lookups (`system.columns`).
+    pub schema_query_server_timeout: Duration,
+    /// Server-side budget for DDL (CREATE / ALTER / DROP / RENAME / TRUNCATE).
+    /// Applied per-call so probe and schema_query do not inherit a
+    /// multi-minute `max_execution_time`.
+    pub ddl_server_timeout: Duration,
+    /// Server-side budget per INSERT statement. Wraps `insert.end().await`,
+    /// which is the only awaited network step inside `insert_rows`; each
+    /// flushed chunk therefore gets its own deadline.
+    pub insert_server_timeout: Duration,
+    /// Slack added on top of the server-side timeout for the client-side
+    /// `tokio::time::timeout` budget, so the server's typed error wins the
+    /// race against our hard ceiling.
+    pub client_timeout_epsilon: Duration,
+}
+
+impl ClickHouseClientConfig {
+    /// Default server-side budget for the connectivity probe.
+    pub const DEFAULT_PROBE_SERVER_TIMEOUT: Duration = Duration::from_secs(8);
+    /// Default server-side budget for schema lookups.
+    pub const DEFAULT_SCHEMA_QUERY_SERVER_TIMEOUT: Duration = Duration::from_secs(16);
+    /// Default server-side budget for DDL.
+    pub const DEFAULT_DDL_SERVER_TIMEOUT: Duration = Duration::from_secs(128);
+    /// Default server-side budget per INSERT statement.
+    pub const DEFAULT_INSERT_SERVER_TIMEOUT: Duration = Duration::from_secs(256);
+    /// Default slack between server-side and client-side budgets.
+    pub const DEFAULT_CLIENT_TIMEOUT_EPSILON: Duration = Duration::from_secs(5);
+
+    /// Returns the client-side `tokio::time::timeout` budget that
+    /// corresponds to a given server-side timeout: `server + epsilon`.
+    pub(crate) fn client_budget(&self, server: Duration) -> Duration {
+        server + self.client_timeout_epsilon
+    }
+}
+
+impl Default for ClickHouseClientConfig {
+    fn default() -> Self {
+        Self {
+            probe_server_timeout: Self::DEFAULT_PROBE_SERVER_TIMEOUT,
+            schema_query_server_timeout: Self::DEFAULT_SCHEMA_QUERY_SERVER_TIMEOUT,
+            ddl_server_timeout: Self::DEFAULT_DDL_SERVER_TIMEOUT,
+            insert_server_timeout: Self::DEFAULT_INSERT_SERVER_TIMEOUT,
+            client_timeout_epsilon: Self::DEFAULT_CLIENT_TIMEOUT_EPSILON,
+        }
+    }
+}
+
 /// CDC-capable ClickHouse destination that replicates Postgres tables.
 ///
 /// Uses append-only MergeTree tables with two CDC columns (`cdc_operation`,
@@ -209,11 +270,12 @@ where
         password: Option<String>,
         database: impl Into<String>,
         inserter_config: ClickHouseInserterConfig,
+        client_config: ClickHouseClientConfig,
         store: S,
     ) -> EtlResult<Self> {
         register_metrics();
         Ok(Self {
-            client: ClickHouseClient::new(url, user, password, database),
+            client: ClickHouseClient::new(url, user, password, database, client_config),
             inserter_config,
             store: Arc::new(store),
             table_cache: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/etl-destinations/src/clickhouse/mod.rs
+++ b/crates/etl-destinations/src/clickhouse/mod.rs
@@ -6,6 +6,6 @@ mod schema;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
-pub use core::{ClickHouseDestination, ClickHouseInserterConfig};
+pub use core::{ClickHouseClientConfig, ClickHouseDestination, ClickHouseInserterConfig};
 
 pub use client::ClickHouseClient;

--- a/crates/etl-destinations/src/clickhouse/test_utils.rs
+++ b/crates/etl-destinations/src/clickhouse/test_utils.rs
@@ -6,7 +6,7 @@ use tokio::runtime::Handle;
 use url::Url;
 use uuid::Uuid;
 
-use crate::clickhouse::{ClickHouseDestination, ClickHouseInserterConfig};
+use crate::clickhouse::{ClickHouseClientConfig, ClickHouseDestination, ClickHouseInserterConfig};
 
 /// ClickHouse HTTP URL (e.g. `http://localhost:8123`).
 pub const CLICKHOUSE_URL_ENV: &str = "TESTS_CLICKHOUSE_URL";
@@ -140,6 +140,7 @@ impl ClickHouseTestDatabase {
             self.password.clone(),
             &self.database,
             config,
+            ClickHouseClientConfig::default(),
             store,
         )
         .expect("Failed to create ClickHouseDestination for test")

--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -11,7 +11,7 @@ use etl::{
     types::PipelineId,
 };
 use etl_destinations::clickhouse::{
-    ClickHouseInserterConfig,
+    ClickHouseClientConfig, ClickHouseInserterConfig,
     client::ClickHouseClient,
     test_utils::{
         ClickHouseTestDatabase, get_clickhouse_password, get_clickhouse_url, get_clickhouse_user,
@@ -1906,6 +1906,7 @@ async fn validate_connectivity_succeeds_against_running_clickhouse() {
         get_clickhouse_user(),
         get_clickhouse_password(),
         "default",
+        ClickHouseClientConfig::default(),
     );
     assert!(client.validate_connectivity().await.is_ok());
 }
@@ -1925,6 +1926,7 @@ async fn validate_connectivity_fails_against_unreachable_clickhouse() {
         "nobody",
         None::<String>,
         "default",
+        ClickHouseClientConfig::default(),
     );
     assert!(client.validate_connectivity().await.is_err());
 }

--- a/crates/etl-examples/src/bin/clickhouse.rs
+++ b/crates/etl-examples/src/bin/clickhouse.rs
@@ -47,7 +47,9 @@ use etl::{
     pipeline::Pipeline,
     store::PostgresStore,
 };
-use etl_destinations::clickhouse::{ClickHouseDestination, ClickHouseInserterConfig};
+use etl_destinations::clickhouse::{
+    ClickHouseClientConfig, ClickHouseDestination, ClickHouseInserterConfig,
+};
 use tokio::signal;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -207,6 +209,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         args.clickhouse_args.clickhouse_password,
         args.clickhouse_args.clickhouse_database,
         ClickHouseInserterConfig::default(),
+        ClickHouseClientConfig::default(),
         store.clone(),
     )?;
 

--- a/crates/etl-replicator/src/core.rs
+++ b/crates/etl-replicator/src/core.rs
@@ -16,7 +16,7 @@ use etl_config::{
 };
 use etl_destinations::{
     bigquery::BigQueryDestination,
-    clickhouse::{ClickHouseDestination, ClickHouseInserterConfig},
+    clickhouse::{ClickHouseClientConfig, ClickHouseDestination, ClickHouseInserterConfig},
     ducklake::{DuckLakeDestination, S3Config as DucklakeS3Config},
     iceberg::{
         DestinationNamespace, IcebergClient, IcebergDestination, S3_ACCESS_KEY_ID, S3_ENDPOINT,
@@ -197,6 +197,7 @@ pub(crate) async fn start_replicator_with_config(
                 password.as_ref().map(|p| p.expose_secret().to_owned()),
                 database,
                 ClickHouseInserterConfig::default(),
+                ClickHouseClientConfig::default(),
                 state_store.clone(),
             )?;
 

--- a/crates/etl/src/error.rs
+++ b/crates/etl/src/error.rs
@@ -88,6 +88,7 @@ pub enum ErrorKind {
     DestinationQueryFailed,
     DestinationAtomicBatchRetryable,
     SourceLockTimeout,
+    DestinationTimeout,
     SourceOperationCanceled,
 
     // Schema Errors

--- a/crates/etl/src/state/table.rs
+++ b/crates/etl/src/state/table.rs
@@ -91,6 +91,7 @@ impl TableReplicationError {
             // Errors that can be retried automatically
             ErrorKind::SourceConnectionFailed
             | ErrorKind::DestinationConnectionFailed
+            | ErrorKind::DestinationTimeout
             | ErrorKind::SourceOperationCanceled
             | ErrorKind::SourceDatabaseShutdown
             | ErrorKind::SourceLockTimeout

--- a/crates/etl/src/workers/policy.rs
+++ b/crates/etl/src/workers/policy.rs
@@ -51,6 +51,7 @@ pub(crate) fn build_error_handling_policy(error: &EtlError) -> ErrorHandlingPoli
         ErrorKind::SourceConnectionFailed
         | ErrorKind::DestinationConnectionFailed
         | ErrorKind::DestinationAtomicBatchRetryable
+        | ErrorKind::DestinationTimeout
         | ErrorKind::SourceDatabaseShutdown
         | ErrorKind::SourceDatabaseInRecovery => {
             ErrorHandlingPolicy::new(RetryDirective::Timed, None)


### PR DESCRIPTION
Wraps every `ClickHouseClient` call (connectivity check, schema query,
DDL/TRUNCATE, INSERT) with a server-side ClickHouse timeout setting and a
client-side `tokio::time::timeout`. Without this, an unresponsive server
may hang the pipeline indefinitely.

Per-op-kind budgets live in the new `ClickHouseClientConfig`
(`connectivity_check_timeout` / `schema_query_timeout` / `ddl_timeout` /
`insert_timeout`, plus a `client_timeout_epsilon` for the
`server + epsilon` client-side ceiling). Defaults: 8s / 16s / 128s / 256s +
4s. Potential follow-up: make these ClickHouseOperationKind's more core to
ETL overall, and generalize across all destinations.

Client-side deadlines surface as the new `ErrorKind::DestinationTimeout`,
added to the auto-retry policy alongside `DestinationConnectionFailed` and
`DestinationAtomicBatchRetryable`. Server-side errors keep their existing
  per-op classification.

All callers (replicator, examples, api validators, test utils) pass
`ClickHouseClientConfig::default()`; exposing the budgets through
replicator/API config is left as a follow-up.