### PR TITLE
ref(etl-telemetry): capitalize TracingError messages

### DIFF
--- a/crates/etl-telemetry/src/tracing.rs
+++ b/crates/etl-telemetry/src/tracing.rs
@@ -43,16 +43,16 @@ static PIPELINE_ID: OnceLock<u64> = OnceLock::new();
 /// Errors that can occur during tracing initialization.
 #[derive(Debug, Error)]
 pub enum TracingError {
-    #[error("failed to build rolling file appender: {0}")]
+    #[error("Failed to build rolling file appender: {0}")]
     InitAppender(#[from] InitError),
 
-    #[error("failed to init log tracer: {0}")]
+    #[error("Failed to init log tracer: {0}")]
     InitLogTracer(#[from] SetLoggerError),
 
-    #[error("failed to set global default subscriber: {0}")]
+    #[error("Failed to set global default subscriber: {0}")]
     SetGlobalDefault(#[from] SetGlobalDefaultError),
 
-    #[error("an io error occurred: {0}")]
+    #[error("An io error occurred: {0}")]
     Io(#[from] Error),
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Refactor (style — no functional or behavioral change).

## What is the current behavior?

TracingError in crates/etl-telemetry/src/tracing.rs has four
  #[error("...")] messages that start with a lowercase letter:

```
  #[error("failed to build rolling file appender: {0}")]
  #[error("failed to init log tracer: {0}")]
  #[error("failed to set global default subscriber: {0}")]
  #[error("an io error occurred: {0}")]
```

This is inconsistent with:
  - [AGENTS.md](https://github.com/supabase/etl/blob/main/AGENTS.md) (Error Handling And Panics section)
> - Error messages should use normal sentence casing and start with an uppercase
  letter. This applies to static error text, including `thiserror` messages.

## What is the new behavior?

The four messages are capitalized so they conform to the project
  rule and match the dominant pattern across the workspace:

```
  #[error("Failed to build rolling file appender: {0}")]
  #[error("Failed to init log tracer: {0}")]
  #[error("Failed to set global default subscriber: {0}")]
  #[error("An io error occurred: {0}")]
````

  No other code changes are made. The error variants, #[from] impls,
  and source chains are unchanged.

Feel free to include screenshots if it includes visual changes.

## Additional context
