### PR TITLE
ci: gate integration tests behind environment approval for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,32 @@ jobs:
         if: matrix.check == 'sort'
         run: cargo sort --workspace --grouped --check
 
+  fork-pr-notice:
+    name: Fork PR Notice
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post security notice
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: fork-pr-security-notice
+          message: |
+            ## Integration Tests -- Maintainer Approval Required
+
+            This PR is from a fork and requires maintainer approval to run integration tests.
+
+            **Before approving in the Actions tab**, verify that this PR does not:
+            - Modify CI workflow files, scripts, or build configuration
+            - Add suspicious dependencies in `Cargo.toml`
+            - Contain code that could exfiltrate environment variables or secrets
+
+            Approving will expose BigQuery service account credentials to this workflow run.
+
   test-full:
     name: Tests (Full, ${{ matrix.postgres_label }})
+    environment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true && 'integration-tests-secrets' || null }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Add `integration-tests-secrets` environment gate on the `test-full` job, activated only for fork PRs
- Add `fork-pr-notice` job that posts a sticky security warning comment on fork PRs reminding maintainers to review before approving
- Internal PRs, pushes to main, and workflow_dispatch are unaffected

Requires the `integration-tests-secrets` GitHub Environment (already created) with `@supabase/etl` as required reviewers.

## Context

Fork PRs (e.g. #749) fail because GitHub withholds repo secrets from untrusted code. After a maintainer approves via the environment gate, GitHub grants secret access for that run.

## Test plan

- [x] Verify internal PR runs `test-full` immediately with no gate
- [ ] Verify fork PR #749 shows sticky comment and `test-full` enters "Waiting for deployment review"
- [ ] Approve and confirm tests pass with BigQuery credentials