### PR TITLE
fix(api): do not create k8s labels bigger than 63 characters

### DIFF
--- a/crates/etl-api/migrations/20260520000000_constrain_tenant_id.sql
+++ b/crates/etl-api/migrations/20260520000000_constrain_tenant_id.sql
@@ -1,0 +1,7 @@
+alter table app.tenants
+    add constraint tenants_id_kubernetes_safe_check
+    check (
+        char_length(id) between 1 and 25
+        and id ~ '^[a-z0-9]([a-z0-9-]{0,23}[a-z0-9])?$'
+    )
+    not valid;

--- a/crates/etl-api/migrations/20260520000000_constrain_tenant_id.sql
+++ b/crates/etl-api/migrations/20260520000000_constrain_tenant_id.sql
@@ -1,7 +1,0 @@
-alter table app.tenants
-    add constraint tenants_id_kubernetes_safe_check
-    check (
-        char_length(id) between 1 and 25
-        and id ~ '^[a-z0-9]([a-z0-9-]{0,23}[a-z0-9])?$'
-    )
-    not valid;

--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -275,6 +275,9 @@ pub trait K8sClient: Send + Sync {
     /// Does nothing if the stateful set does not exist.
     async fn delete_replicator_stateful_set(&self, prefix: &str) -> Result<(), K8sError>;
 
+    /// Returns whether the replicator [`StatefulSet`] exists.
+    async fn replicator_stateful_set_exists(&self, prefix: &str) -> Result<bool, K8sError>;
+
     /// Creates or updates the DuckLake maintenance CR.
     async fn create_or_update_ducklake_maintenance(
         &self,

--- a/crates/etl-api/src/k8s/cache.rs
+++ b/crates/etl-api/src/k8s/cache.rs
@@ -236,6 +236,10 @@ mod tests {
             Ok(())
         }
 
+        async fn replicator_stateful_set_exists(&self, _prefix: &str) -> Result<bool, K8sError> {
+            Ok(false)
+        }
+
         async fn create_or_update_ducklake_maintenance(
             &self,
             _prefix: &str,

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -213,6 +213,25 @@ pub async fn is_replicator_pod_stopped(
     Ok(matches!(pod_status, PodStatus::Stopped))
 }
 
+/// Returns `true` if existing Kubernetes resources should be reconciled.
+///
+/// A stopped pod normally means the pipeline is intentionally inactive. A
+/// StatefulSet without a pod means Kubernetes still has desired runtime state,
+/// so reconciliation should repair or migrate it.
+pub async fn should_reconcile_replicator_resources(
+    k8s_client: &dyn K8sClient,
+    tenant_id: &str,
+    replicator_id: i64,
+) -> Result<bool, K8sCoreError> {
+    let prefix = create_k8s_object_prefix(tenant_id, replicator_id);
+    let pod_status = k8s_client.get_replicator_pod_status(&prefix).await?;
+    if !matches!(pod_status, PodStatus::Stopped) {
+        return Ok(true);
+    }
+
+    Ok(k8s_client.replicator_stateful_set_exists(&prefix).await?)
+}
+
 /// Returns `true` when the replicator is active in Kubernetes.
 pub async fn is_replicator_active(
     k8s_client: &dyn K8sClient,
@@ -535,6 +554,7 @@ mod tests {
     struct RecordingK8sClient {
         calls: Arc<Mutex<Vec<String>>>,
         pod_status: PodStatus,
+        stateful_set_exists: bool,
     }
 
     impl RecordingK8sClient {
@@ -545,7 +565,11 @@ mod tests {
 
     impl Default for RecordingK8sClient {
         fn default() -> Self {
-            Self { calls: Arc::default(), pod_status: PodStatus::Stopped }
+            Self {
+                calls: Arc::default(),
+                pod_status: PodStatus::Stopped,
+                stateful_set_exists: false,
+            }
         }
     }
 
@@ -673,6 +697,10 @@ mod tests {
             Ok(())
         }
 
+        async fn replicator_stateful_set_exists(&self, _prefix: &str) -> Result<bool, K8sError> {
+            Ok(self.stateful_set_exists)
+        }
+
         async fn create_or_update_ducklake_maintenance(
             &self,
             prefix: &str,
@@ -748,6 +776,34 @@ mod tests {
             .expect("failed to inspect pipeline status");
 
         assert!(is_active);
+    }
+
+    #[tokio::test]
+    async fn stopped_pod_with_stateful_set_is_reconciled() {
+        let client = RecordingK8sClient {
+            pod_status: PodStatus::Stopped,
+            stateful_set_exists: true,
+            ..Default::default()
+        };
+
+        let should_reconcile =
+            should_reconcile_replicator_resources(&client, "tenant-42", 4).await.unwrap();
+
+        assert!(should_reconcile);
+    }
+
+    #[tokio::test]
+    async fn stopped_pod_without_stateful_set_is_not_reconciled() {
+        let client = RecordingK8sClient {
+            pod_status: PodStatus::Stopped,
+            stateful_set_exists: false,
+            ..Default::default()
+        };
+
+        let should_reconcile =
+            should_reconcile_replicator_resources(&client, "tenant-42", 4).await.unwrap();
+
+        assert!(!should_reconcile);
     }
 
     #[tokio::test]

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -62,7 +62,9 @@ const POSTGRES_SECRET_NAME_SUFFIX: &str = "postgres-password";
 /// ConfigMap name suffix for the replicator configuration files.
 const REPLICATOR_CONFIG_MAP_NAME_SUFFIX: &str = "replicator-config";
 /// StatefulSet name suffix for the replicator workload.
-const REPLICATOR_STATEFUL_SET_SUFFIX: &str = "replicator-stateful-set";
+const REPLICATOR_STATEFUL_SET_SUFFIX: &str = "repl";
+/// Previous StatefulSet suffix kept for existing pipeline cleanup/status.
+const LEGACY_REPLICATOR_STATEFUL_SET_SUFFIX: &str = "replicator-stateful-set";
 /// Application label suffix used to group resources.
 const REPLICATOR_APP_SUFFIX: &str = "replicator-app";
 /// Container name suffix for the replicator container.
@@ -589,6 +591,13 @@ impl K8sClient for HttpK8sClient {
         )?;
 
         let stateful_set_name = create_stateful_set_name(prefix);
+        let legacy_stateful_set_name = create_legacy_stateful_set_name(prefix);
+        if legacy_stateful_set_name != stateful_set_name {
+            let dp = DeleteParams::default();
+            Self::handle_delete_with_404_ignore(
+                self.stateful_sets_api.delete(&legacy_stateful_set_name, &dp).await,
+            )?;
+        }
 
         let container_environment = create_container_environment_json(
             prefix,
@@ -630,13 +639,28 @@ impl K8sClient for HttpK8sClient {
     async fn delete_replicator_stateful_set(&self, prefix: &str) -> Result<(), K8sError> {
         debug!("deleting stateful set");
 
-        let stateful_set_name = create_stateful_set_name(prefix);
         let dp = DeleteParams::default();
-        Self::handle_delete_with_404_ignore(
-            self.stateful_sets_api.delete(&stateful_set_name, &dp).await,
-        )?;
+        for stateful_set_name in stateful_set_names_for_lookup(prefix) {
+            Self::handle_delete_with_404_ignore(
+                self.stateful_sets_api.delete(&stateful_set_name, &dp).await,
+            )?;
+        }
 
         Ok(())
+    }
+
+    async fn replicator_stateful_set_exists(&self, prefix: &str) -> Result<bool, K8sError> {
+        debug!("checking stateful set existence");
+
+        for stateful_set_name in stateful_set_names_for_lookup(prefix) {
+            match self.stateful_sets_api.get(&stateful_set_name).await {
+                Ok(_) => return Ok(true),
+                Err(kube::Error::Api(er)) if er.code == 404 => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        Ok(false)
     }
 
     async fn create_or_update_ducklake_maintenance(
@@ -671,11 +695,19 @@ impl K8sClient for HttpK8sClient {
     async fn get_replicator_pod_status(&self, prefix: &str) -> Result<PodStatus, K8sError> {
         debug!("getting pod status");
 
-        let pod_name = create_pod_name(prefix);
-        let pod = match self.pods_api.get(&pod_name).await {
-            Ok(pod) => pod,
-            Err(kube::Error::Api(er)) if er.code == 404 => return Ok(PodStatus::Stopped),
-            Err(e) => return Err(e.into()),
+        let mut pod = None;
+        for pod_name in pod_names_for_status(prefix) {
+            match self.pods_api.get(&pod_name).await {
+                Ok(found_pod) => {
+                    pod = Some(found_pod);
+                    break;
+                }
+                Err(kube::Error::Api(er)) if er.code == 404 => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        let Some(pod) = pod else {
+            return Ok(PodStatus::Stopped);
         };
 
         let replicator_container_name = create_replicator_container_name(prefix);
@@ -738,8 +770,31 @@ fn create_stateful_set_name(prefix: &str) -> String {
     format!("{prefix}-{REPLICATOR_STATEFUL_SET_SUFFIX}")
 }
 
+fn create_legacy_stateful_set_name(prefix: &str) -> String {
+    format!("{prefix}-{LEGACY_REPLICATOR_STATEFUL_SET_SUFFIX}")
+}
+
 fn create_pod_name(prefix: &str) -> String {
     format!("{prefix}-{REPLICATOR_STATEFUL_SET_SUFFIX}-0")
+}
+
+fn create_legacy_pod_name(prefix: &str) -> String {
+    format!("{prefix}-{LEGACY_REPLICATOR_STATEFUL_SET_SUFFIX}-0")
+}
+
+fn unique_current_and_legacy_names(current: String, legacy: String) -> Vec<String> {
+    if current == legacy { vec![current] } else { vec![current, legacy] }
+}
+
+fn stateful_set_names_for_lookup(prefix: &str) -> Vec<String> {
+    unique_current_and_legacy_names(
+        create_stateful_set_name(prefix),
+        create_legacy_stateful_set_name(prefix),
+    )
+}
+
+fn pod_names_for_status(prefix: &str) -> Vec<String> {
+    unique_current_and_legacy_names(create_pod_name(prefix), create_legacy_pod_name(prefix))
 }
 
 fn create_replicator_app_name(prefix: &str) -> String {
@@ -1467,6 +1522,9 @@ mod tests {
     use crate::configs::pipeline::ReplicatorResourcesConfig;
 
     const TENANT_ID: &str = "abcdefghijklmnopqrst";
+    const MAX_TENANT_ID: &str = "abcdefghijklmnopqrstuvwxy";
+    const MAX_K8S_LABEL_VALUE_LEN: usize = 63;
+    const CONTROLLER_REVISION_HASH_LEN: usize = 10;
 
     fn create_k8s_object_prefix(tenant_id: &str, replicator_id: i64) -> String {
         format!("{tenant_id}-{replicator_id}")
@@ -1498,6 +1556,48 @@ mod tests {
             .any(|entry| entry.get("name").and_then(serde_json::Value::as_str) == Some(name))
     }
 
+    fn collect_kubernetes_label_values(
+        value: &serde_json::Value,
+        labels: &mut Vec<(String, String)>,
+    ) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for label_field in ["labels", "matchLabels"] {
+                    if let Some(serde_json::Value::Object(label_map)) = map.get(label_field) {
+                        labels.extend(label_map.iter().filter_map(|(key, value)| {
+                            value.as_str().map(|value| (key.clone(), value.to_owned()))
+                        }));
+                    }
+                }
+
+                for child in map.values() {
+                    collect_kubernetes_label_values(child, labels);
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for child in values {
+                    collect_kubernetes_label_values(child, labels);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn assert_kubernetes_label_values_are_safe(resource_name: &str, resource: &serde_json::Value) {
+        let mut labels = Vec::new();
+        collect_kubernetes_label_values(resource, &mut labels);
+        assert!(!labels.is_empty(), "{resource_name} should contain Kubernetes labels");
+
+        for (key, value) in labels {
+            assert!(
+                value.len() <= MAX_K8S_LABEL_VALUE_LEN,
+                "{resource_name} generated label {key}={value} with length {}, exceeding \
+                 {MAX_K8S_LABEL_VALUE_LEN}",
+                value.len()
+            );
+        }
+    }
+
     #[test]
     fn test_replicator_resource_config_uses_environment_defaults() {
         let prod = ReplicatorResourceConfig::load(&Environment::Prod).unwrap();
@@ -1527,6 +1627,150 @@ mod tests {
         assert_eq!(config.replicator_memory_request, "1536Mi");
         assert_eq!(config.replicator_cpu_limit, "1500m");
         assert_eq!(config.replicator_memory_limit, "1843Mi");
+    }
+
+    #[test]
+    fn generated_kubernetes_labels_fit_with_max_tenant_and_replicator_ids() {
+        let prefix = create_k8s_object_prefix(MAX_TENANT_ID, i64::MAX);
+        let replicator_app_name = create_replicator_app_name(&prefix);
+        let postgres_secret_name = create_postgres_secret_name(&prefix);
+        let clickhouse_secret_name = create_clickhouse_secret_name(&prefix);
+        let bq_secret_name = create_bq_secret_name(&prefix);
+        let iceberg_secret_name = create_iceberg_secret_name(&prefix);
+        let ducklake_secret_name = create_ducklake_secret_name(&prefix);
+        let config_map_name = create_replicator_config_map_name(&prefix);
+        let ducklake_maintenance_name = create_ducklake_maintenance_name(&prefix);
+        let stateful_set_name = create_stateful_set_name(&prefix);
+        let controller_revision_label =
+            format!("{stateful_set_name}-{hash}", hash = "0".repeat(CONTROLLER_REVISION_HASH_LEN));
+
+        assert!(
+            controller_revision_label.len() <= MAX_K8S_LABEL_VALUE_LEN,
+            "stateful set controller revision label {controller_revision_label} has length {}, \
+             exceeding {MAX_K8S_LABEL_VALUE_LEN}",
+            controller_revision_label.len()
+        );
+
+        let environment = Environment::Prod;
+        let config = ReplicatorResourceConfig::load(&environment).unwrap();
+        let replicator_image = "supabase/replicator:1.2.3";
+        let container_environment = create_container_environment_json(
+            &prefix,
+            &environment,
+            replicator_image,
+            DestinationType::Ducklake,
+            None,
+            LogLevel::Info,
+        );
+        let node_selector = create_node_selector_json(&environment);
+        let init_containers = create_init_containers_json(&prefix, &environment, &config);
+        let volumes = create_volumes_json(&prefix, &environment);
+        let volume_mounts = create_volume_mounts_json(&environment);
+
+        let resources = vec![
+            (
+                "postgres secret",
+                create_postgres_secret_json(&postgres_secret_name, &replicator_app_name, "secret"),
+            ),
+            (
+                "clickhouse secret",
+                serde_json::to_value(create_clickhouse_password_secret(
+                    &clickhouse_secret_name,
+                    &replicator_app_name,
+                    "secret",
+                ))
+                .unwrap(),
+            ),
+            (
+                "bigquery secret",
+                create_bq_service_account_key_secret_json(
+                    &bq_secret_name,
+                    &replicator_app_name,
+                    "secret",
+                ),
+            ),
+            (
+                "iceberg secret",
+                create_iceberg_secret_json(
+                    &iceberg_secret_name,
+                    &replicator_app_name,
+                    "secret",
+                    "secret",
+                    "secret",
+                ),
+            ),
+            (
+                "ducklake secret",
+                create_ducklake_secret_json(
+                    &ducklake_secret_name,
+                    &replicator_app_name,
+                    "secret",
+                    "secret",
+                ),
+            ),
+            (
+                "replicator config map",
+                create_replicator_config_map_json(
+                    &config_map_name,
+                    &replicator_app_name,
+                    vec![ReplicatorConfigMapFile {
+                        filename: "prod.json".to_owned(),
+                        content: "{}".to_owned(),
+                    }],
+                ),
+            ),
+            (
+                "ducklake maintenance",
+                create_ducklake_maintenance_json(
+                    &prefix,
+                    &ducklake_maintenance_name,
+                    DuckLakeMaintenanceResourceConfig {
+                        tenant_id: MAX_TENANT_ID.to_owned(),
+                        pipeline_id: i64::MAX,
+                        replicator_id: i64::MAX,
+                        image: replicator_image.to_owned(),
+                        policy: DuckLakeMaintenancePolicy::default(),
+                    },
+                ),
+            ),
+            (
+                "replicator stateful set",
+                create_replicator_stateful_set_json(
+                    &prefix,
+                    &stateful_set_name,
+                    replicator_image,
+                    container_environment,
+                    node_selector,
+                    init_containers,
+                    volumes,
+                    volume_mounts,
+                    &config,
+                ),
+            ),
+        ];
+
+        for (resource_name, resource) in resources {
+            assert_kubernetes_label_values_are_safe(resource_name, &resource);
+        }
+    }
+
+    #[test]
+    fn replicator_workload_names_use_short_suffix_and_keep_legacy_lookup_names() {
+        let prefix = create_k8s_object_prefix("tenant-1", 42);
+
+        assert_eq!(create_stateful_set_name(&prefix), "tenant-1-42-repl");
+        assert_eq!(create_legacy_stateful_set_name(&prefix), "tenant-1-42-replicator-stateful-set");
+        assert_eq!(
+            stateful_set_names_for_lookup(&prefix),
+            vec!["tenant-1-42-repl".to_owned(), "tenant-1-42-replicator-stateful-set".to_owned(),]
+        );
+        assert_eq!(
+            pod_names_for_status(&prefix),
+            vec![
+                "tenant-1-42-repl-0".to_owned(),
+                "tenant-1-42-replicator-stateful-set-0".to_owned(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -62,7 +62,7 @@ const POSTGRES_SECRET_NAME_SUFFIX: &str = "postgres-password";
 /// ConfigMap name suffix for the replicator configuration files.
 const REPLICATOR_CONFIG_MAP_NAME_SUFFIX: &str = "replicator-config";
 /// StatefulSet name suffix for the replicator workload.
-const REPLICATOR_STATEFUL_SET_SUFFIX: &str = "repl";
+const REPLICATOR_STATEFUL_SET_SUFFIX: &str = "replicator";
 /// Previous StatefulSet suffix kept for existing pipeline cleanup/status.
 const LEGACY_REPLICATOR_STATEFUL_SET_SUFFIX: &str = "replicator-stateful-set";
 /// Application label suffix used to group resources.
@@ -1522,7 +1522,8 @@ mod tests {
     use crate::configs::pipeline::ReplicatorResourcesConfig;
 
     const TENANT_ID: &str = "abcdefghijklmnopqrst";
-    const MAX_TENANT_ID: &str = "abcdefghijklmnopqrstuvwxy";
+    const MAX_TENANT_ID: &str = "abcdefghijklmnopqrst";
+    const MAX_BIGINT_ID: i64 = 9_223_372_036_854_775_807;
     const MAX_K8S_LABEL_VALUE_LEN: usize = 63;
     const CONTROLLER_REVISION_HASH_LEN: usize = 10;
 
@@ -1631,7 +1632,7 @@ mod tests {
 
     #[test]
     fn generated_kubernetes_labels_fit_with_max_tenant_and_replicator_ids() {
-        let prefix = create_k8s_object_prefix(MAX_TENANT_ID, i64::MAX);
+        let prefix = create_k8s_object_prefix(MAX_TENANT_ID, MAX_BIGINT_ID);
         let replicator_app_name = create_replicator_app_name(&prefix);
         let postgres_secret_name = create_postgres_secret_name(&prefix);
         let clickhouse_secret_name = create_clickhouse_secret_name(&prefix);
@@ -1726,8 +1727,8 @@ mod tests {
                     &ducklake_maintenance_name,
                     DuckLakeMaintenanceResourceConfig {
                         tenant_id: MAX_TENANT_ID.to_owned(),
-                        pipeline_id: i64::MAX,
-                        replicator_id: i64::MAX,
+                        pipeline_id: MAX_BIGINT_ID,
+                        replicator_id: MAX_BIGINT_ID,
                         image: replicator_image.to_owned(),
                         policy: DuckLakeMaintenancePolicy::default(),
                     },
@@ -1758,16 +1759,19 @@ mod tests {
     fn replicator_workload_names_use_short_suffix_and_keep_legacy_lookup_names() {
         let prefix = create_k8s_object_prefix("tenant-1", 42);
 
-        assert_eq!(create_stateful_set_name(&prefix), "tenant-1-42-repl");
+        assert_eq!(create_stateful_set_name(&prefix), "tenant-1-42-replicator");
         assert_eq!(create_legacy_stateful_set_name(&prefix), "tenant-1-42-replicator-stateful-set");
         assert_eq!(
             stateful_set_names_for_lookup(&prefix),
-            vec!["tenant-1-42-repl".to_owned(), "tenant-1-42-replicator-stateful-set".to_owned(),]
+            vec![
+                "tenant-1-42-replicator".to_owned(),
+                "tenant-1-42-replicator-stateful-set".to_owned(),
+            ]
         );
         assert_eq!(
             pod_names_for_status(&prefix),
             vec![
-                "tenant-1-42-repl-0".to_owned(),
+                "tenant-1-42-replicator-0".to_owned(),
                 "tenant-1-42-replicator-stateful-set-0".to_owned(),
             ]
         );

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-assertion_line: 1786
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -11,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
@@ -10,7 +10,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-repl",
+    "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/k8s/http.rs
-expression: stateful_set_json
+expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
 ---
 {
   "apiVersion": "apps/v1",
@@ -10,7 +10,7 @@ expression: stateful_set_json
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
       "etl.supabase.com/app-type": "etl-replicator-app"
     },
-    "name": "abcdefghijklmnopqrst-42-replicator-stateful-set",
+    "name": "abcdefghijklmnopqrst-42-repl",
     "namespace": "etl-data-plane"
   },
   "spec": {

--- a/crates/etl-api/src/routes/mod.rs
+++ b/crates/etl-api/src/routes/mod.rs
@@ -30,7 +30,7 @@ pub enum TenantIdError {
     TenantIdIllFormed,
 }
 
-pub(crate) const MAX_TENANT_ID_LEN: usize = 25;
+pub(crate) const MAX_TENANT_ID_LEN: usize = 20;
 
 pub(crate) fn validate_tenant_id(tenant_id: &str) -> Result<(), TenantIdError> {
     let is_valid_char =
@@ -72,15 +72,14 @@ mod tests {
     fn tenant_id_validation_accepts_kubernetes_safe_ids() {
         validate_tenant_id("a").unwrap();
         validate_tenant_id("abc123").unwrap();
-        validate_tenant_id("etl-simulator-ducklake-0").unwrap();
-        validate_tenant_id("abcdefghijklmnopqrstuvwxy").unwrap();
+        validate_tenant_id("abcdefghijklmnopqrst").unwrap();
     }
 
     #[test]
     fn tenant_id_validation_rejects_kubernetes_unsafe_ids() {
         for tenant_id in [
             "",
-            "abcdefghijklmnopqrstuvwxyz",
+            "abcdefghijklmnopqrstu",
             "-tenant",
             "tenant-",
             "tenant_id",

--- a/crates/etl-api/src/routes/mod.rs
+++ b/crates/etl-api/src/routes/mod.rs
@@ -30,6 +30,27 @@ pub enum TenantIdError {
     TenantIdIllFormed,
 }
 
+pub(crate) const MAX_TENANT_ID_LEN: usize = 25;
+
+pub(crate) fn validate_tenant_id(tenant_id: &str) -> Result<(), TenantIdError> {
+    let is_valid_char =
+        |byte: u8| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-';
+
+    let Some(first) = tenant_id.bytes().next() else {
+        return Err(TenantIdError::TenantIdIllFormed);
+    };
+
+    if tenant_id.len() > MAX_TENANT_ID_LEN
+        || !(first.is_ascii_lowercase() || first.is_ascii_digit())
+        || tenant_id.ends_with('-')
+        || !tenant_id.bytes().all(is_valid_char)
+    {
+        return Err(TenantIdError::TenantIdIllFormed);
+    }
+
+    Ok(())
+}
+
 fn extract_tenant_id(req: &HttpRequest) -> Result<&str, TenantIdError> {
     let headers = req.headers();
     let tenant_id = headers
@@ -38,5 +59,39 @@ fn extract_tenant_id(req: &HttpRequest) -> Result<&str, TenantIdError> {
         .to_str()
         .map_err(|_| TenantIdError::TenantIdIllFormed)?;
 
+    validate_tenant_id(tenant_id)?;
+
     Ok(tenant_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tenant_id_validation_accepts_kubernetes_safe_ids() {
+        validate_tenant_id("a").unwrap();
+        validate_tenant_id("abc123").unwrap();
+        validate_tenant_id("etl-simulator-ducklake-0").unwrap();
+        validate_tenant_id("abcdefghijklmnopqrstuvwxy").unwrap();
+    }
+
+    #[test]
+    fn tenant_id_validation_rejects_kubernetes_unsafe_ids() {
+        for tenant_id in [
+            "",
+            "abcdefghijklmnopqrstuvwxyz",
+            "-tenant",
+            "tenant-",
+            "tenant_id",
+            "Tenant",
+            "tenant.id",
+            "tenant/id",
+        ] {
+            assert_eq!(
+                validate_tenant_id(tenant_id).unwrap_err().to_string(),
+                TenantIdError::TenantIdIllFormed.to_string()
+            );
+        }
+    }
 }

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -38,7 +38,8 @@ use crate::{
         TrustedRootCertsError,
         core::{
             create_k8s_object_prefix, create_or_update_pipeline_resources_in_k8s,
-            delete_pipeline_resources_in_k8s, is_replicator_active, is_replicator_pod_stopped,
+            delete_pipeline_resources_in_k8s, is_replicator_active,
+            should_reconcile_replicator_resources,
         },
     },
     routes::{ErrorMessage, TenantIdError, extract_tenant_id, utils as route_utils},
@@ -706,7 +707,8 @@ pub(crate) async fn update_pipeline(
     let (pipeline, replicator, image, source, destination) =
         read_pipeline_components(&mut txn, tenant_id, pipeline_id, &encryption_key).await?;
 
-    if is_replicator_pod_stopped(k8s_client.as_ref(), tenant_id, replicator.id).await? {
+    if !should_reconcile_replicator_resources(k8s_client.as_ref(), tenant_id, replicator.id).await?
+    {
         txn.commit().await?;
 
         return Ok(HttpResponse::Ok().finish());
@@ -1383,9 +1385,11 @@ pub(crate) async fn update_pipeline_version(
         return Ok(HttpResponse::Ok().finish());
     }
 
-    // If a replicator is not running, we don't want to create/update k8s resources.
-    // It's fine to just update the image version in the db.
-    if is_replicator_pod_stopped(k8s_client.as_ref(), tenant_id, replicator.id).await? {
+    // If a replicator has no runtime resources, we don't want to create new K8s
+    // resources. If a StatefulSet still exists, reconcile it even when no pod is
+    // currently running so a broken or stale StatefulSet can be repaired.
+    if !should_reconcile_replicator_resources(k8s_client.as_ref(), tenant_id, replicator.id).await?
+    {
         txn.commit().await?;
 
         return Ok(HttpResponse::Ok().finish());

--- a/crates/etl-api/src/routes/tenants.rs
+++ b/crates/etl-api/src/routes/tenants.rs
@@ -29,7 +29,7 @@ use crate::{
         K8sClient, TrustedRootCertsCache, TrustedRootCertsError,
         core::{K8sCoreError, first_active_pipeline_id},
     },
-    routes::ErrorMessage,
+    routes::{ErrorMessage, TenantIdError, validate_tenant_id},
 };
 
 #[derive(Debug, Error)]
@@ -57,6 +57,9 @@ pub enum TenantError {
 
     #[error("The pipeline with id {0} is active; stop it before deleting it")]
     ActivePipeline(i64),
+
+    #[error(transparent)]
+    TenantId(#[from] TenantIdError),
 }
 
 impl TenantError {
@@ -80,6 +83,7 @@ impl ResponseError for TenantError {
         match self {
             TenantError::TenantsDb(TenantsDbError::Conflict(_))
             | TenantError::ActivePipeline(_) => StatusCode::CONFLICT,
+            TenantError::TenantId(_) => StatusCode::BAD_REQUEST,
             TenantError::TenantsDb(_)
             | TenantError::SourcesDb(_)
             | TenantError::PipelinesDb(_)
@@ -165,6 +169,7 @@ pub(crate) async fn create_tenant(
     root_span: RootSpan,
 ) -> Result<impl Responder, TenantError> {
     let tenant = tenant.into_inner();
+    validate_tenant_id(&tenant.id)?;
 
     root_span.record("project", &tenant.id);
 
@@ -198,6 +203,7 @@ pub(crate) async fn create_or_update_tenant(
 ) -> Result<impl Responder, TenantError> {
     let tenant_id = tenant_id.into_inner();
     let tenant = tenant.into_inner();
+    validate_tenant_id(&tenant_id)?;
 
     root_span.record("project", &tenant_id);
 
@@ -227,6 +233,7 @@ pub(crate) async fn read_tenant(
     root_span: RootSpan,
 ) -> Result<impl Responder, TenantError> {
     let tenant_id = tenant_id.into_inner();
+    validate_tenant_id(&tenant_id)?;
 
     root_span.record("project", &tenant_id);
 
@@ -261,6 +268,7 @@ pub(crate) async fn update_tenant(
 ) -> Result<impl Responder, TenantError> {
     let tenant = tenant.into_inner();
     let tenant_id = tenant_id.into_inner();
+    validate_tenant_id(&tenant_id)?;
 
     root_span.record("project", &tenant_id);
 
@@ -296,6 +304,7 @@ pub(crate) async fn delete_tenant(
     root_span: RootSpan,
 ) -> Result<impl Responder, TenantError> {
     let tenant_id = tenant_id.into_inner();
+    validate_tenant_id(&tenant_id)?;
 
     root_span.record("project", &tenant_id);
 

--- a/crates/etl-api/src/routes/tenants_sources.rs
+++ b/crates/etl-api/src/routes/tenants_sources.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     data::{self, tenants::TenantsDbError, tenants_sources::TenantSourceDbError},
     k8s::TrustedRootCertsCache,
-    routes::{ErrorMessage, common, utils},
+    routes::{ErrorMessage, TenantIdError, common, utils, validate_tenant_id},
     validation::ValidationError,
 };
 
@@ -35,6 +35,9 @@ enum TenantSourceError {
 
     #[error("Validation failed: {0}")]
     ValidationFailed(String),
+
+    #[error(transparent)]
+    TenantId(#[from] TenantIdError),
 }
 
 impl TenantSourceError {
@@ -66,6 +69,7 @@ impl ResponseError for TenantSourceError {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             TenantSourceError::Validation(error) => utils::validation_error_status_code(error),
+            TenantSourceError::TenantId(_) => StatusCode::BAD_REQUEST,
             TenantSourceError::ValidationFailed(_) => StatusCode::UNPROCESSABLE_ENTITY,
         }
     }
@@ -140,6 +144,7 @@ pub(crate) async fn create_tenant_and_source(
     root_span: RootSpan,
 ) -> Result<impl Responder, TenantSourceError> {
     let tenant_and_source = tenant_and_source.into_inner();
+    validate_tenant_id(&tenant_and_source.tenant_id)?;
 
     root_span.record("project", &tenant_and_source.tenant_id);
 

--- a/crates/etl-api/tests/destinations_pipelines.rs
+++ b/crates/etl-api/tests/destinations_pipelines.rs
@@ -206,13 +206,13 @@ async fn destination_and_pipeline_with_another_tenants_source_cannot_be_created(
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
     let source2_id = create_source(&app, tenant2_id).await;
@@ -342,13 +342,13 @@ async fn destination_and_pipeline_with_another_tenants_source_cannot_be_updated(
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
 
@@ -389,13 +389,13 @@ async fn destination_and_pipeline_with_another_tenants_destination_cannot_be_upd
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
 
@@ -441,13 +441,13 @@ async fn destination_and_pipeline_with_another_tenants_pipeline_cannot_be_update
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
 

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -293,13 +293,13 @@ async fn pipeline_with_another_tenants_source_cannot_be_created() {
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
     let source2_id = create_source(&app, tenant2_id).await;
@@ -326,13 +326,13 @@ async fn pipeline_with_another_tenants_destination_cannot_be_created() {
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
     let source1_id = create_source(&app, tenant1_id).await;
@@ -548,13 +548,13 @@ async fn pipeline_with_another_tenants_source_cannot_be_updated() {
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
     let source1_id = create_source(&app, tenant1_id).await;
@@ -592,13 +592,13 @@ async fn pipeline_with_another_tenants_destination_cannot_be_updated() {
     let tenant1_id = &create_tenant_with_id_and_name(
         &app,
         "abcdefghijklmnopqrst".to_owned(),
-        "tenant_1".to_owned(),
+        "tenant-1".to_owned(),
     )
     .await;
     let tenant2_id = &create_tenant_with_id_and_name(
         &app,
         "tsrqponmlkjihgfedcba".to_owned(),
-        "tenant_2".to_owned(),
+        "tenant-2".to_owned(),
     )
     .await;
     let source1_id = create_source(&app, tenant1_id).await;

--- a/crates/etl-api/tests/support/k8s_client.rs
+++ b/crates/etl-api/tests/support/k8s_client.rs
@@ -190,6 +190,10 @@ impl K8sClient for MockK8sClient {
         Ok(())
     }
 
+    async fn replicator_stateful_set_exists(&self, _prefix: &str) -> Result<bool, K8sError> {
+        Ok(false)
+    }
+
     async fn create_or_update_ducklake_maintenance(
         &self,
         _prefix: &str,


### PR DESCRIPTION
Fix Kubernetes resource naming for ETL replicators by shortening the StatefulSet suffix from replicator-stateful-set to repl, and add tenant ID validation so generated Kubernetes labels stay within the 63-character limit.

This PR also fixes a reconciliation issue, when we want to update the default pipeline image for a pipeline which has a stafulset but pod is in error or doesn't exist, it now updates the container image properly. This can be really helpful in case we deployed or we have an image failing when starting.