### PR TITLE
feat(ducklake): add pause metrics for external maintenances

### DIFF
--- a/crates/etl-destinations/src/ducklake/METRICS.md
+++ b/crates/etl-destinations/src/ducklake/METRICS.md
@@ -10,16 +10,14 @@ The metrics fall into four groups:
 - external maintenance metrics: operation-trigger counts and duration samples
   for time foreground ingestion was quiesced by the Kubernetes maintenance
   plane.
-- table-health samples: histograms recorded by a background sampler every
-  30 seconds from the PostgreSQL DuckLake metadata catalog. They describe the
-  current shape of tables known to the current destination instance.
+- table-health samples: gauges recorded by a background sampler every 30 seconds
+  from the PostgreSQL DuckLake metadata catalog. They describe the current shape
+  of tables known to the current destination instance.
 - catalog-backlog gauges: current global snapshot and deletion backlog in the
   attached DuckLake catalog.
 
-These metrics intentionally avoid a `table_name` label. That keeps Prometheus
-cardinality low. The tradeoff is that table-health metrics are sampled as
-histograms over recently written tables rather than exported as one time series
-per table.
+Table-health metrics carry a `table` label because they are used to diagnose and
+trigger table-specific maintenance behavior.
 
 ## Metric groups
 
@@ -78,6 +76,7 @@ How to read them:
 ### External maintenance metrics
 
 - `etl_ducklake_external_maintenance_pause_duration_seconds`
+- `etl_ducklake_external_maintenance_pause_active`
 - `etl_ducklake_external_maintenance_triggered_total`
 
 `etl_ducklake_external_maintenance_pause_duration_seconds` is emitted by the
@@ -87,7 +86,13 @@ only the time after the destination has drained foreground mutations and reporte
 
 It carries one label:
 
-- `outcome`: `cleared`, `expired`, `replaced`, or `resource_deleted`
+- `outcome`: `cleared`, `expired`, `replaced`, or `state_missing`
+
+`etl_ducklake_external_maintenance_pause_active` is a 0/1 gauge emitted by the
+replicator while foreground ingestion is blocked or draining for an external
+maintenance pause. A value of `1` means ingestion is paused for external
+maintenance; `0` means the replicator is not currently paused by external
+maintenance.
 
 `etl_ducklake_external_maintenance_triggered_total` counts external maintenance
 operation requests emitted by the replicator after it samples DuckLake catalog

--- a/crates/etl-destinations/src/ducklake/external_maintenance.rs
+++ b/crates/etl-destinations/src/ducklake/external_maintenance.rs
@@ -593,11 +593,10 @@ fn record_external_maintenance_triggers(
 mod tests {
     use etl_telemetry::metrics::init_metrics_handle;
 
+    use super::record_external_maintenance_pause_active;
     use crate::ducklake::metrics::{
         ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE, register_metrics,
     };
-
-    use super::record_external_maintenance_pause_active;
 
     fn pause_active_gauge_value(rendered: &str) -> Option<f64> {
         rendered.lines().find_map(|line| {

--- a/crates/etl-destinations/src/ducklake/external_maintenance.rs
+++ b/crates/etl-destinations/src/ducklake/external_maintenance.rs
@@ -13,7 +13,7 @@ pub use etl_maintenance::{
     ExternalMaintenanceState, ExternalMaintenanceStore, ExternalMaintenanceWatcherConfig,
     KubernetesExternalMaintenanceStore, PostgresExternalMaintenanceStore,
 };
-use metrics::{counter, histogram};
+use metrics::{counter, gauge, histogram};
 use sqlx::PgPool;
 use tokio::time;
 use tracing::{debug, info, warn};
@@ -21,6 +21,7 @@ use tracing::{debug, info, warn};
 use crate::ducklake::{
     DuckLakeDestination, DuckLakeExternalMaintenancePause,
     metrics::{
+        ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE,
         ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_DURATION_SECONDS,
         ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_TRIGGERED_TOTAL, MAINTENANCE_OPERATION_LABEL,
         MAINTENANCE_OUTCOME_LABEL, MAINTENANCE_REASON_LABEL,
@@ -89,6 +90,7 @@ where
     M: ExternalMaintenanceStore,
 {
     let mut held_pause: Option<HeldPause> = None;
+    record_external_maintenance_pause_active(false);
 
     info!(
         poll_interval_ms = config.poll_interval.as_millis() as u64,
@@ -217,6 +219,7 @@ async fn reconcile_pause<S, M>(
         pause.expires_at.to_rfc3339()
     );
     report_pausing(store, &pause.run_id, config.store_timeout).await;
+    record_external_maintenance_pause_active(true);
 
     let external_pause = destination.acquire_external_maintenance_pause().await;
     if pause.expires_at <= Utc::now() {
@@ -305,6 +308,7 @@ fn release_held_pause(held: HeldPause, outcome: &'static str) {
     let held_ms =
         Utc::now().signed_duration_since(held.quiesced_at).num_milliseconds().max(0) as u64;
     record_external_maintenance_pause_duration(&held, outcome);
+    record_external_maintenance_pause_active(false);
     info!(
         run_id = %held.run_id,
         outcome,
@@ -314,6 +318,10 @@ fn release_held_pause(held: HeldPause, outcome: &'static str) {
         outcome,
         held_ms
     );
+}
+
+fn record_external_maintenance_pause_active(active: bool) {
+    gauge!(ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE).set(if active { 1.0 } else { 0.0 });
 }
 
 fn record_external_maintenance_pause_duration(held: &HeldPause, outcome: &'static str) {
@@ -578,5 +586,40 @@ fn record_external_maintenance_triggers(
             MAINTENANCE_REASON_LABEL => REASON_SNAPSHOT_RETENTION_THRESHOLD,
         )
         .increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use etl_telemetry::metrics::init_metrics_handle;
+
+    use crate::ducklake::metrics::{
+        ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE, register_metrics,
+    };
+
+    use super::record_external_maintenance_pause_active;
+
+    fn pause_active_gauge_value(rendered: &str) -> Option<f64> {
+        rendered.lines().find_map(|line| {
+            if line.starts_with(ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE) {
+                line.split_whitespace().last()?.parse::<f64>().ok()
+            } else {
+                None
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn recording_external_maintenance_pause_active_exports_gauge_value() {
+        let handle = init_metrics_handle().expect("failed to initialize prometheus handle");
+        register_metrics();
+
+        record_external_maintenance_pause_active(true);
+        let rendered = handle.render();
+        assert_eq!(pause_active_gauge_value(&rendered), Some(1.0));
+
+        record_external_maintenance_pause_active(false);
+        let rendered = handle.render();
+        assert_eq!(pause_active_gauge_value(&rendered), Some(0.0));
     }
 }

--- a/crates/etl-destinations/src/ducklake/metrics.rs
+++ b/crates/etl-destinations/src/ducklake/metrics.rs
@@ -53,6 +53,8 @@ pub(crate) const ETL_DUCKLAKE_FAILED_BATCHES_TOTAL: &str = "etl_ducklake_failed_
 pub(crate) const ETL_DUCKLAKE_REPLAYED_BATCHES_TOTAL: &str = "etl_ducklake_replayed_batches_total";
 pub(crate) const ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_DURATION_SECONDS: &str =
     "etl_ducklake_external_maintenance_pause_duration_seconds";
+pub(crate) const ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE: &str =
+    "etl_ducklake_external_maintenance_pause_active";
 pub(crate) const ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_TRIGGERED_TOTAL: &str =
     "etl_ducklake_external_maintenance_triggered_total";
 pub(crate) const ETL_DUCKLAKE_TABLE_ACTIVE_DATA_FILES: &str =
@@ -230,6 +232,11 @@ pub(crate) fn register_metrics() {
             Unit::Seconds,
             "Duration that DuckLake foreground ingestion was paused for an external maintenance \
              run, labeled by outcome."
+        );
+        describe_gauge!(
+            ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE,
+            Unit::Count,
+            "External DuckLake maintenance foreground-ingestion pause current state (0 or 1)."
         );
         describe_counter!(
             ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_TRIGGERED_TOTAL,


### PR DESCRIPTION
This is useful to debug or know the current status of the replicator without having to check logs.