### PR TITLE
fix(core): Improve reset semantics for the table

### DIFF
--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -15,7 +15,7 @@ use clap::{Args, ValueEnum};
 use etl::{
     destination::{
         Destination,
-        async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+        async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     },
     error::EtlResult,
     test_utils::notifying_store::NotifyingStore,
@@ -347,12 +347,12 @@ where
         self.inner.shutdown().await
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        self.inner.truncate_table(replicated_table_schema, async_result).await
+        self.inner.drop_table_for_copy(replicated_table_schema, async_result).await
     }
 
     async fn write_table_rows(
@@ -401,10 +401,10 @@ impl Destination for NullDestination {
         "null"
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         _replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
         async_result.send(Ok(()));
         Ok(())
@@ -544,18 +544,18 @@ impl Destination for BenchDestination {
         }
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
         match self {
             Self::Null(destination) => {
-                destination.truncate_table(replicated_table_schema, async_result).await
+                destination.drop_table_for_copy(replicated_table_schema, async_result).await
             }
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => {
-                destination.truncate_table(replicated_table_schema, async_result).await
+                destination.drop_table_for_copy(replicated_table_schema, async_result).await
             }
         }
     }

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -769,6 +769,25 @@ impl BigQueryClient {
         Ok(())
     }
 
+    /// Drops a view from BigQuery.
+    ///
+    /// Executes a DROP VIEW statement to remove the logical view if it exists.
+    pub async fn drop_view(
+        &self,
+        dataset_id: &BigQueryDatasetId,
+        view_name: &BigQueryTableId,
+    ) -> EtlResult<()> {
+        let full_view_name = self.full_table_name(dataset_id, view_name)?;
+
+        info!(%full_view_name, "dropping view from bigquery");
+
+        let query = format!("drop view if exists {full_view_name}");
+
+        let _ = self.query(QueryRequest::new(query)).await?;
+
+        Ok(())
+    }
+
     /// Drops a table from BigQuery.
     ///
     /// Executes a DROP TABLE statement to remove the table and all its data.

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -13,7 +13,11 @@ use gcp_bigquery_client::{
         cloud::bigquery::storage::v1::{RowError, StorageError, storage_error::StorageErrorCode},
         rpc::Status as GoogleRpcStatus,
     },
-    model::{query_request::QueryRequest, query_response::ResultSet},
+    model::{
+        query_parameter::QueryParameter, query_parameter_type::QueryParameterType,
+        query_parameter_value::QueryParameterValue, query_request::QueryRequest,
+        query_response::ResultSet,
+    },
     storage::{
         BatchAppendRequest, BatchAppendResult, ColumnMode, ColumnType, FieldDescriptor,
         StorageApiConfig, StreamName, TableBatch, TableDescriptor,
@@ -45,15 +49,16 @@ const MAX_INFLIGHT_REQUESTS_PER_CONNECTION: usize = 100;
 /// This upper bound ensures reasonable memory usage and prevents overflow when
 /// computing max inflight requests from connection pool size.
 const MAX_SAFE_INFLIGHT_REQUESTS: usize = 100_000;
-/// Maximum time to retry appends while BigQuery propagates a schema change.
+/// Maximum time to retry writes while the BigQuery Storage Write API is still
+/// using stale table metadata.
 ///
 /// Google documents schema update detection as happening on the order of
 /// minutes.
-const SCHEMA_PROPAGATION_RETRY_TIMEOUT: Duration = Duration::from_secs(180);
-/// Initial backoff when retrying appends during schema propagation.
-const SCHEMA_PROPAGATION_RETRY_DELAY: Duration = Duration::from_secs(1);
-/// Maximum backoff when retrying appends during schema propagation.
-const SCHEMA_PROPAGATION_MAX_RETRY_DELAY: Duration = Duration::from_secs(15);
+const STORAGE_WRITE_METADATA_LAG_RETRY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Initial backoff when retrying writes during storage write metadata lag.
+const STORAGE_WRITE_METADATA_LAG_RETRY_DELAY: Duration = Duration::from_secs(1);
+/// Maximum backoff when retrying writes during storage write metadata lag.
+const STORAGE_WRITE_METADATA_LAG_MAX_RETRY_DELAY: Duration = Duration::from_secs(15);
 /// Protobuf type name for BigQuery storage errors embedded in gRPC status
 /// details.
 const BIGQUERY_STORAGE_ERROR_TYPE_NAME: &str = "google.cloud.bigquery.storage.v1.StorageError";
@@ -99,8 +104,8 @@ impl fmt::Display for BigQueryOperationType {
 enum BatchProcessResult {
     /// Batch succeeded with byte metrics.
     Success { bytes_sent: usize, bytes_received: usize },
-    /// Batch hit schema propagation after DDL and should be retried.
-    RetryableSchemaPropagation { detail: String },
+    /// Batch hit storage write metadata lag after DDL and should be retried.
+    RetryableStorageWriteMetadataLag { detail: String },
     /// Batch had row-level errors.
     RowErrors { errors: Vec<RowError> },
     /// Batch had a request-level error.
@@ -122,18 +127,21 @@ enum AppendProcessingResult {
     Error(EtlError),
 }
 
-/// A batch append request that should be retried after schema propagation
-/// finishes.
+/// A batch append request that should be retried after Storage Write metadata
+/// lag clears.
 #[derive(Debug)]
 struct RetryableAppendRequest {
     request: BatchAppendRequest<BigQueryTableRow>,
     detail: String,
 }
 
-/// Builds a concise description for a set of schema-propagation retries.
-fn format_retryable_append_requests(requests: &[RetryableAppendRequest]) -> String {
+/// Builds a concise description for a set of Storage Write metadata lag
+/// retries.
+fn format_retryable_storage_write_metadata_lag_requests(
+    requests: &[RetryableAppendRequest],
+) -> String {
     match requests.split_first() {
-        None => "schema propagation error".to_owned(),
+        None => "storage write metadata lag error".to_owned(),
         Some((first, [])) => first.detail.clone(),
         Some((first, rest)) => {
             let distinct_other_details =
@@ -237,9 +245,7 @@ fn append_processing_result_from_request_error(
     error: BQError,
     append_requests: Vec<BatchAppendRequest<BigQueryTableRow>>,
 ) -> AppendProcessingResult {
-    if is_retryable_schema_propagation_error(&error) {
-        let detail =
-            bq_error_to_etl_error(error).detail().unwrap_or("schema propagation error").to_owned();
+    if let Some(detail) = retryable_storage_write_metadata_lag_detail(&error) {
         AppendProcessingResult::Retry {
             pending_requests: append_requests
                 .into_iter()
@@ -253,19 +259,19 @@ fn append_processing_result_from_request_error(
     }
 }
 
-/// Builds the error returned when local schema-propagation retries are
+/// Builds the error returned when local Storage Write metadata lag retries are
 /// exhausted.
 ///
-/// The destination absorbs the common short propagation delay locally. If
-/// BigQuery still has not accepted the schema once that bounded window expires,
-/// the worker-level timed retry policy should take over.
-fn schema_propagation_timeout_error(detail: &str) -> EtlError {
+/// The destination absorbs the common short lag window locally. If
+/// BigQuery still has not accepted the storage write metadata once that bounded
+/// window expires, the worker-level timed retry policy should take over.
+fn storage_write_metadata_lag_timeout_error(detail: &str) -> EtlError {
     etl_error!(
         ErrorKind::DestinationAtomicBatchRetryable,
-        "BigQuery schema propagation timed out",
+        "BigQuery storage write metadata lag timed out",
         format!(
-            "BigQuery did not accept the updated schema within {} seconds after DDL: {}",
-            SCHEMA_PROPAGATION_RETRY_TIMEOUT.as_secs(),
+            "BigQuery did not accept the storage write metadata within {} seconds after DDL: {}",
+            STORAGE_WRITE_METADATA_LAG_RETRY_TIMEOUT.as_secs(),
             detail
         )
     )
@@ -278,8 +284,8 @@ fn row_error_to_etl_error(err: RowError) -> EtlError {
 
 /// Converts a request-level append error into a [`BatchProcessResult`].
 fn batch_process_result_from_request_error(error: BQError) -> BatchProcessResult {
-    if is_retryable_schema_propagation_error(&error) {
-        BatchProcessResult::RetryableSchemaPropagation { detail: error.to_string() }
+    if retryable_storage_write_metadata_lag_detail(&error).is_some() {
+        BatchProcessResult::RetryableStorageWriteMetadataLag { detail: error.to_string() }
     } else {
         BatchProcessResult::RequestError { error }
     }
@@ -485,7 +491,7 @@ fn decode_storage_error_codes(status: &tonic::Status) -> Vec<&'static str> {
 }
 
 /// Returns true when the request-level BigQuery error matches the documented
-/// schema propagation case.
+/// storage write metadata lag case.
 ///
 /// BigQuery documents `StorageErrorCode::SCHEMA_MISMATCH_EXTRA_FIELDS` as the
 /// structured signal for schema mismatch during appends. We fall back to the
@@ -513,6 +519,31 @@ fn is_retryable_schema_propagation_error(error: &BQError) -> bool {
         || message.contains("extra proto fields")
         || message.contains("schema_mismatch_extra_field")
         || message.contains("schema_mismatch_extra_fields")
+}
+
+/// Returns true for BigQuery's transient default-stream error after a table is
+/// dropped and recreated with the same name.
+fn is_retryable_table_recreation_error(error: &BQError) -> bool {
+    let BQError::TonicStatusError(status) = error else {
+        return false;
+    };
+
+    status.code() == Code::NotFound
+        && status.message().to_ascii_lowercase().contains("is re-created")
+}
+
+/// Returns retry detail when a Storage Write append failed due to BigQuery
+/// metadata propagation after DDL.
+fn retryable_storage_write_metadata_lag_detail(error: &BQError) -> Option<String> {
+    if is_retryable_schema_propagation_error(error) {
+        return Some(error.to_string());
+    }
+
+    if is_retryable_table_recreation_error(error) {
+        return Some(error.to_string());
+    }
+
+    None
 }
 
 /// Client for interacting with Google BigQuery.
@@ -819,9 +850,28 @@ impl BigQueryClient {
     ) -> EtlResult<Vec<BigQueryTableId>> {
         info!(%dataset_id, %base_table_id, "listing sequenced tables from bigquery");
 
-        let query =
-            Self::list_sequenced_table_ids_query(&self.project_id, dataset_id, base_table_id)?;
-        let mut result_set = self.query(QueryRequest::new(query)).await?;
+        let project_id = Self::sanitize_identifier(&self.project_id, "BigQuery project id")?;
+        let dataset_id = Self::sanitize_identifier(dataset_id, "BigQuery dataset id")?;
+        let query = format!(
+            "select table_name from `{project_id}.{dataset_id}.INFORMATION_SCHEMA.TABLES` where \
+             table_type = 'BASE TABLE' and starts_with(table_name, @table_name_prefix) order by \
+             table_name"
+        );
+        let mut request = QueryRequest::new(query);
+        request.parameter_mode = Some("NAMED".to_owned());
+        request.query_parameters = Some(vec![QueryParameter {
+            name: Some("table_name_prefix".to_owned()),
+            parameter_type: Some(QueryParameterType {
+                r#type: "STRING".to_owned(),
+                ..Default::default()
+            }),
+            parameter_value: Some(QueryParameterValue {
+                value: Some(format!("{base_table_id}_")),
+                ..Default::default()
+            }),
+        }]);
+
+        let mut result_set = self.query(request).await?;
         let mut table_ids = Vec::new();
 
         while result_set.next_row() {
@@ -951,7 +1001,7 @@ impl BigQueryClient {
     ///
     /// Retries for transient request and transport failures are handled inside
     /// the underlying Storage Write API library. This method also retries
-    /// the narrow class of schema propagation failures that can happen
+    /// the narrow class of storage write metadata lag failures that can happen
     /// after DDL, then converts final failures into ETL errors.
     pub(super) async fn append_table_batches(
         &self,
@@ -967,7 +1017,7 @@ impl BigQueryClient {
 
         let started_at = Instant::now();
         let mut attempt = 1;
-        let mut retry_delay = SCHEMA_PROPAGATION_RETRY_DELAY;
+        let mut retry_delay = STORAGE_WRITE_METADATA_LAG_RETRY_DELAY;
 
         loop {
             match self.append_table_batches_once(pending_requests).await? {
@@ -985,7 +1035,9 @@ impl BigQueryClient {
                     total_bytes_sent += bytes_sent;
                     total_bytes_received += bytes_received;
 
-                    let retry_summary = format_retryable_append_requests(&next_pending_requests);
+                    let retry_summary = format_retryable_storage_write_metadata_lag_requests(
+                        &next_pending_requests,
+                    );
                     pending_requests =
                         next_pending_requests.into_iter().map(|request| request.request).collect();
 
@@ -996,16 +1048,16 @@ impl BigQueryClient {
 
                     let elapsed = started_at.elapsed();
                     let remaining_timeout =
-                        SCHEMA_PROPAGATION_RETRY_TIMEOUT.saturating_sub(elapsed);
+                        STORAGE_WRITE_METADATA_LAG_RETRY_TIMEOUT.saturating_sub(elapsed);
 
                     if remaining_timeout.is_zero() {
-                        return Err(schema_propagation_timeout_error(&retry_summary));
+                        return Err(storage_write_metadata_lag_timeout_error(&retry_summary));
                     }
 
                     let sleep_delay = retry_delay.min(remaining_timeout);
 
                     if sleep_delay.is_zero() {
-                        return Err(schema_propagation_timeout_error(&retry_summary));
+                        return Err(storage_write_metadata_lag_timeout_error(&retry_summary));
                     }
 
                     warn!(
@@ -1013,12 +1065,12 @@ impl BigQueryClient {
                         pending_batch_count,
                         retry_delay_ms = sleep_delay.as_millis() as u64,
                         error_detail = %retry_summary,
-                        "bigquery schema change still propagating, retrying append"
+                        "bigquery storage write metadata still lagging, retrying append"
                     );
 
                     sleep(sleep_delay).await;
 
-                    retry_delay = (retry_delay * 2).min(SCHEMA_PROPAGATION_MAX_RETRY_DELAY);
+                    retry_delay = (retry_delay * 2).min(STORAGE_WRITE_METADATA_LAG_MAX_RETRY_DELAY);
                     attempt += 1;
                 }
                 AppendProcessingResult::Error(error) => return Err(error),
@@ -1072,7 +1124,7 @@ impl BigQueryClient {
                     total_bytes_sent += bytes_sent;
                     total_bytes_received += bytes_received;
                 }
-                BatchProcessResult::RetryableSchemaPropagation { detail } => {
+                BatchProcessResult::RetryableStorageWriteMetadataLag { detail } => {
                     retryable_batch_details[batch_index] = Some(detail);
                 }
                 BatchProcessResult::RowErrors { errors: row_errors } => {
@@ -1174,24 +1226,6 @@ impl BigQueryClient {
             .map_err(bq_error_to_etl_error)?;
 
         Ok(ResultSet::new_from_query_response(query_response))
-    }
-
-    /// Builds the metadata query for sequenced physical table discovery.
-    fn list_sequenced_table_ids_query(
-        project_id: &BigQueryProjectId,
-        dataset_id: &BigQueryDatasetId,
-        base_table_id: &BigQueryTableId,
-    ) -> EtlResult<String> {
-        let project_id = Self::sanitize_identifier(project_id, "BigQuery project id")?;
-        let dataset_id = Self::sanitize_identifier(dataset_id, "BigQuery dataset id")?;
-        let _ = Self::sanitize_identifier(base_table_id, "BigQuery table id")?;
-        let regex = format!("^{base_table_id}_[0-9]+$");
-
-        Ok(format!(
-            "select table_name from `{project_id}.{dataset_id}.INFORMATION_SCHEMA.TABLES` where \
-             table_type = 'BASE TABLE' and regexp_contains(table_name, '{regex}') order by \
-             table_name"
-        ))
     }
 
     /// Sanitizes a BigQuery identifier for safe backtick quoting.
@@ -1615,26 +1649,6 @@ mod tests {
     }
 
     #[test]
-    fn list_sequenced_table_ids_query_filters_matching_base_tables() {
-        let project_id = "test-project".to_owned();
-        let dataset_id = "test_dataset".to_owned();
-        let base_table_id = "public_users".to_owned();
-        let query = BigQueryClient::list_sequenced_table_ids_query(
-            &project_id,
-            &dataset_id,
-            &base_table_id,
-        )
-        .unwrap();
-
-        assert_eq!(
-            query,
-            "select table_name from `test-project.test_dataset.INFORMATION_SCHEMA.TABLES` where \
-             table_type = 'BASE TABLE' and regexp_contains(table_name, '^public_users_[0-9]+$') \
-             order by table_name"
-        );
-    }
-
-    #[test]
     fn add_primary_key_clause() {
         let columns_with_pk = vec![
             test_column("id", Type::INT4, 1, false, Some(1)),
@@ -1787,7 +1801,7 @@ mod tests {
             bytes_sent: 128,
         });
 
-        assert!(matches!(result, BatchProcessResult::RetryableSchemaPropagation { .. }));
+        assert!(matches!(result, BatchProcessResult::RetryableStorageWriteMetadataLag { .. }));
     }
 
     #[test]
@@ -1801,7 +1815,7 @@ mod tests {
             bytes_sent: 128,
         });
 
-        assert!(matches!(result, BatchProcessResult::RetryableSchemaPropagation { .. }));
+        assert!(matches!(result, BatchProcessResult::RetryableStorageWriteMetadataLag { .. }));
     }
 
     #[test]
@@ -1815,14 +1829,41 @@ mod tests {
             bytes_sent: 128,
         });
 
-        assert!(matches!(result, BatchProcessResult::RetryableSchemaPropagation { .. }));
+        assert!(matches!(result, BatchProcessResult::RetryableStorageWriteMetadataLag { .. }));
     }
 
     #[test]
-    fn schema_propagation_timeout_error_is_worker_retryable() {
-        let error = schema_propagation_timeout_error("schema lag");
+    fn process_single_batch_append_result_retries_table_recreation_propagation() {
+        let result = process_single_batch_append_result(BatchAppendResult {
+            batch_index: 0,
+            responses: vec![Err(tonic::Status::not_found(
+                "Table 123:dataset.test_users_0 is re-created. Entity: \
+                 projects/project/datasets/dataset/tables/test_users_0/streams/_default",
+            ))],
+            bytes_sent: 128,
+        });
+
+        assert!(matches!(result, BatchProcessResult::RetryableStorageWriteMetadataLag { .. }));
+    }
+
+    #[test]
+    fn process_single_batch_append_result_does_not_retry_generic_not_found() {
+        let result = process_single_batch_append_result(BatchAppendResult {
+            batch_index: 0,
+            responses: vec![Err(tonic::Status::not_found(
+                "Table 123:dataset.test_users_0 was not found.",
+            ))],
+            bytes_sent: 128,
+        });
+
+        assert!(matches!(result, BatchProcessResult::RequestError { .. }));
+    }
+
+    #[test]
+    fn storage_write_metadata_lag_timeout_error_is_worker_retryable() {
+        let error = storage_write_metadata_lag_timeout_error("storage write metadata lag");
 
         assert_eq!(error.kind(), ErrorKind::DestinationAtomicBatchRetryable);
-        assert_eq!(error.description(), Some("BigQuery schema propagation timed out"));
+        assert_eq!(error.description(), Some("BigQuery storage write metadata lag timed out"));
     }
 }

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -772,7 +772,7 @@ impl BigQueryClient {
     /// Drops a view from BigQuery.
     ///
     /// Executes a DROP VIEW statement to remove the logical view if it exists.
-    pub async fn drop_view(
+    pub async fn drop_view_if_exists(
         &self,
         dataset_id: &BigQueryDatasetId,
         view_name: &BigQueryTableId,
@@ -791,7 +791,7 @@ impl BigQueryClient {
     /// Drops a table from BigQuery.
     ///
     /// Executes a DROP TABLE statement to remove the table and all its data.
-    pub async fn drop_table(
+    pub async fn drop_table_if_exists(
         &self,
         dataset_id: &BigQueryDatasetId,
         table_id: &BigQueryTableId,
@@ -805,6 +805,34 @@ impl BigQueryClient {
         let _ = self.query(QueryRequest::new(query)).await?;
 
         Ok(())
+    }
+
+    /// Lists physical sequenced table ids for a base table.
+    ///
+    /// Queries `INFORMATION_SCHEMA.TABLES` instead of using the destination's
+    /// local cache so reset cleanup can remove versions left behind by earlier
+    /// processes.
+    pub async fn list_sequenced_table_ids(
+        &self,
+        dataset_id: &BigQueryDatasetId,
+        base_table_id: &BigQueryTableId,
+    ) -> EtlResult<Vec<BigQueryTableId>> {
+        info!(%dataset_id, %base_table_id, "listing sequenced tables from bigquery");
+
+        let query =
+            Self::list_sequenced_table_ids_query(&self.project_id, dataset_id, base_table_id)?;
+        let mut result_set = self.query(QueryRequest::new(query)).await?;
+        let mut table_ids = Vec::new();
+
+        while result_set.next_row() {
+            if let Some(table_id) =
+                result_set.get_string_by_name("table_name").map_err(bq_error_to_etl_error)?
+            {
+                table_ids.push(table_id);
+            }
+        }
+
+        Ok(table_ids)
     }
 
     /// Adds a column to an existing BigQuery table.
@@ -1146,6 +1174,24 @@ impl BigQueryClient {
             .map_err(bq_error_to_etl_error)?;
 
         Ok(ResultSet::new_from_query_response(query_response))
+    }
+
+    /// Builds the metadata query for sequenced physical table discovery.
+    fn list_sequenced_table_ids_query(
+        project_id: &BigQueryProjectId,
+        dataset_id: &BigQueryDatasetId,
+        base_table_id: &BigQueryTableId,
+    ) -> EtlResult<String> {
+        let project_id = Self::sanitize_identifier(project_id, "BigQuery project id")?;
+        let dataset_id = Self::sanitize_identifier(dataset_id, "BigQuery dataset id")?;
+        let _ = Self::sanitize_identifier(base_table_id, "BigQuery table id")?;
+        let regex = format!("^{base_table_id}_[0-9]+$");
+
+        Ok(format!(
+            "select table_name from `{project_id}.{dataset_id}.INFORMATION_SCHEMA.TABLES` where \
+             table_type = 'BASE TABLE' and regexp_contains(table_name, '{regex}') order by \
+             table_name"
+        ))
     }
 
     /// Sanitizes a BigQuery identifier for safe backtick quoting.
@@ -1566,6 +1612,26 @@ mod tests {
             result,
             Err(err) if err.kind() == ErrorKind::DestinationTableNameInvalid
         ));
+    }
+
+    #[test]
+    fn list_sequenced_table_ids_query_filters_matching_base_tables() {
+        let project_id = "test-project".to_owned();
+        let dataset_id = "test_dataset".to_owned();
+        let base_table_id = "public_users".to_owned();
+        let query = BigQueryClient::list_sequenced_table_ids_query(
+            &project_id,
+            &dataset_id,
+            &base_table_id,
+        )
+        .unwrap();
+
+        assert_eq!(
+            query,
+            "select table_name from `test-project.test_dataset.INFORMATION_SCHEMA.TABLES` where \
+             table_type = 'BASE TABLE' and regexp_contains(table_name, '^public_users_[0-9]+$') \
+             order by table_name"
+        );
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
-    iter,
     str::FromStr,
     sync::Arc,
 };
@@ -11,7 +10,7 @@ use etl::{
     concurrency::TaskSet,
     destination::{
         Destination,
-        async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+        async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     },
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
@@ -65,6 +64,11 @@ impl SequencedBigQueryTableId {
     /// Creates a new sequenced table ID starting at version 0.
     fn new(table_id: BigQueryTableId) -> Self {
         Self(table_id, 0)
+    }
+
+    /// Returns the logical base table id for this sequenced table id.
+    fn base_table_id(&self) -> &BigQueryTableId {
+        &self.0
     }
 
     /// Returns the next version of this sequenced table ID.
@@ -169,6 +173,18 @@ impl Inner {
     /// Creates empty synchronized destination state.
     fn new() -> Self {
         Self { created_tables: HashSet::new(), created_views: HashMap::new() }
+    }
+
+    /// Returns cached sequenced table ids for the supplied logical table.
+    fn created_table_ids_for_base(
+        &self,
+        base_table_id: &BigQueryTableId,
+    ) -> Vec<SequencedBigQueryTableId> {
+        self.created_tables
+            .iter()
+            .filter(|table_id| table_id.base_table_id() == base_table_id)
+            .cloned()
+            .collect()
     }
 }
 
@@ -1096,6 +1112,53 @@ where
 
         Ok(())
     }
+
+    /// Drops destination table objects before a fresh table copy.
+    ///
+    /// Destination metadata is intentionally left untouched here. The table
+    /// sync worker clears it only after this drop succeeds so this method
+    /// can use the last stored destination table id to find the object that
+    /// must be removed.
+    async fn drop_table_for_copy_inner(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()> {
+        let table_id = replicated_table_schema.id();
+        let base_bigquery_table_id =
+            table_name_to_bigquery_table_id(replicated_table_schema.name())?;
+        let base_sequenced_bigquery_table_id =
+            SequencedBigQueryTableId::new(base_bigquery_table_id.clone());
+        let mut table_ids = HashSet::new();
+
+        if let Some(metadata) = self.state_store.get_destination_table_metadata(table_id).await? {
+            table_ids.insert(metadata.destination_table_id.parse::<SequencedBigQueryTableId>()?);
+        }
+
+        {
+            let inner = self.inner.lock().await;
+            table_ids.extend(inner.created_table_ids_for_base(&base_bigquery_table_id));
+        }
+
+        table_ids.insert(base_sequenced_bigquery_table_id);
+
+        self.client.drop_view(&self.dataset_id, &base_bigquery_table_id).await?;
+
+        for sequenced_bigquery_table_id in &table_ids {
+            self.client
+                .drop_table(&self.dataset_id, &sequenced_bigquery_table_id.to_string())
+                .await?;
+        }
+
+        let mut inner = self.inner.lock().await;
+        for sequenced_bigquery_table_id in table_ids {
+            inner.created_tables.remove(&sequenced_bigquery_table_id);
+        }
+        inner.created_views.remove(&base_bigquery_table_id);
+
+        info!(table_id = table_id.0, "dropped bigquery table before copy");
+
+        Ok(())
+    }
 }
 
 /// Validates that a replicated table schema can be applied in BigQuery.
@@ -1170,15 +1233,14 @@ where
         self.tasks.shutdown().await
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;
 
-        let result =
-            self.process_truncate_for_schemas(iter::once(replicated_table_schema.clone())).await;
+        let result = self.drop_table_for_copy_inner(replicated_table_schema).await;
         async_result.send(result);
 
         Ok(())
@@ -1766,6 +1828,25 @@ mod tests {
     fn sequenced_bigquery_table_id_to_bigquery_table_id_zero_sequence() {
         let table_id = SequencedBigQueryTableId("simple_table".to_owned(), 0);
         assert_eq!(table_id.to_bigquery_table_id(), "simple_table");
+    }
+
+    #[test]
+    fn inner_created_table_ids_for_base_filters_cached_tables() {
+        let mut inner = Inner::new();
+        let base_table_id = "users_table".to_owned();
+        let current_table_id = SequencedBigQueryTableId(base_table_id.clone(), 2);
+        let older_table_id = SequencedBigQueryTableId(base_table_id.clone(), 1);
+        let other_table_id = SequencedBigQueryTableId("orders_table".to_owned(), 1);
+
+        inner.created_tables.insert(current_table_id.clone());
+        inner.created_tables.insert(older_table_id.clone());
+        inner.created_tables.insert(other_table_id);
+
+        let table_ids = inner.created_table_ids_for_base(&base_table_id);
+
+        assert_eq!(table_ids.len(), 2);
+        assert!(table_ids.contains(&current_table_id));
+        assert!(table_ids.contains(&older_table_id));
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -66,11 +66,6 @@ impl SequencedBigQueryTableId {
         Self(table_id, 0)
     }
 
-    /// Returns the logical base table id for this sequenced table id.
-    fn base_table_id(&self) -> &BigQueryTableId {
-        &self.0
-    }
-
     /// Returns the next version of this sequenced table ID.
     fn next(&self) -> Self {
         Self(self.0.clone(), self.1 + 1)
@@ -79,6 +74,16 @@ impl SequencedBigQueryTableId {
     /// Extracts the base BigQuery table ID without the sequence number.
     fn to_bigquery_table_id(&self) -> BigQueryTableId {
         self.0.clone()
+    }
+
+    /// Returns whether this sequenced table belongs to `base_table_id`.
+    fn belongs_to_base(&self, base_table_id: &BigQueryTableId) -> bool {
+        &self.0 == base_table_id
+    }
+
+    /// Parses a sequenced table id only when it belongs to `base_table_id`.
+    fn parse_for_base(table_id: &str, base_table_id: &BigQueryTableId) -> Option<Self> {
+        table_id.parse::<Self>().ok().filter(|table_id| table_id.belongs_to_base(base_table_id))
     }
 }
 
@@ -173,18 +178,6 @@ impl Inner {
     /// Creates empty synchronized destination state.
     fn new() -> Self {
         Self { created_tables: HashSet::new(), created_views: HashMap::new() }
-    }
-
-    /// Returns cached sequenced table ids for the supplied logical table.
-    fn created_table_ids_for_base(
-        &self,
-        base_table_id: &BigQueryTableId,
-    ) -> Vec<SequencedBigQueryTableId> {
-        self.created_tables
-            .iter()
-            .filter(|table_id| table_id.base_table_id() == base_table_id)
-            .cloned()
-            .collect()
     }
 }
 
@@ -1092,7 +1085,7 @@ where
             self.tasks
                 .spawn(async move {
                     if let Err(err) = client
-                        .drop_table(&dataset_id, &sequenced_bigquery_table_id.to_string())
+                        .drop_table_if_exists(&dataset_id, &sequenced_bigquery_table_id.to_string())
                         .await
                     {
                         warn!(
@@ -1113,48 +1106,45 @@ where
         Ok(())
     }
 
-    /// Drops destination table objects before a fresh table copy.
-    ///
-    /// Destination metadata is intentionally left untouched here. The table
-    /// sync worker clears it only after this drop succeeds so this method
-    /// can use the last stored destination table id to find the object that
-    /// must be removed.
+    /// Drops destination table objects before restarting a table copy.
     async fn drop_table_for_copy_inner(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
-        let table_id = replicated_table_schema.id();
         let base_bigquery_table_id =
             table_name_to_bigquery_table_id(replicated_table_schema.name())?;
-        let base_sequenced_bigquery_table_id =
-            SequencedBigQueryTableId::new(base_bigquery_table_id.clone());
         let mut table_ids = HashSet::new();
 
-        if let Some(metadata) = self.state_store.get_destination_table_metadata(table_id).await? {
-            table_ids.insert(metadata.destination_table_id.parse::<SequencedBigQueryTableId>()?);
-        }
+        // Discover physical table versions from BigQuery instead of the local cache.
+        // Older processes may have created versions this process never cached.
+        let listed_table_ids =
+            self.client.list_sequenced_table_ids(&self.dataset_id, &base_bigquery_table_id).await?;
+        let listed_sequenced_table_ids =
+            listed_table_ids.into_iter().filter_map(|listed_table_id| {
+                SequencedBigQueryTableId::parse_for_base(&listed_table_id, &base_bigquery_table_id)
+            });
+        table_ids.extend(listed_sequenced_table_ids);
 
-        {
-            let inner = self.inner.lock().await;
-            table_ids.extend(inner.created_table_ids_for_base(&base_bigquery_table_id));
-        }
+        // We first drop the view, so that the table is not queriable anymore.
+        self.client.drop_view_if_exists(&self.dataset_id, &base_bigquery_table_id).await?;
 
-        table_ids.insert(base_sequenced_bigquery_table_id);
-
-        self.client.drop_view(&self.dataset_id, &base_bigquery_table_id).await?;
-
+        // We then drop each table individually. If any of these operations fail, on the
+        // next restart the tables will be cleaned up.
         for sequenced_bigquery_table_id in &table_ids {
             self.client
-                .drop_table(&self.dataset_id, &sequenced_bigquery_table_id.to_string())
+                .drop_table_if_exists(&self.dataset_id, &sequenced_bigquery_table_id.to_string())
                 .await?;
         }
 
+        // Once destination cleanup is done, remove any stale local cache entries.
         let mut inner = self.inner.lock().await;
+        inner.created_views.remove(&base_bigquery_table_id);
+
         for sequenced_bigquery_table_id in table_ids {
             inner.created_tables.remove(&sequenced_bigquery_table_id);
         }
-        inner.created_views.remove(&base_bigquery_table_id);
 
+        let table_id = replicated_table_schema.id();
         info!(table_id = table_id.0, "dropped bigquery table before copy");
 
         Ok(())
@@ -1831,22 +1821,32 @@ mod tests {
     }
 
     #[test]
-    fn inner_created_table_ids_for_base_filters_cached_tables() {
-        let mut inner = Inner::new();
+    fn sequenced_bigquery_table_id_belongs_to_base() {
         let base_table_id = "users_table".to_owned();
-        let current_table_id = SequencedBigQueryTableId(base_table_id.clone(), 2);
-        let older_table_id = SequencedBigQueryTableId(base_table_id.clone(), 1);
-        let other_table_id = SequencedBigQueryTableId("orders_table".to_owned(), 1);
+        let users_table_id = SequencedBigQueryTableId(base_table_id.clone(), 2);
+        let orders_table_id = SequencedBigQueryTableId("orders_table".to_owned(), 2);
 
-        inner.created_tables.insert(current_table_id.clone());
-        inner.created_tables.insert(older_table_id.clone());
-        inner.created_tables.insert(other_table_id);
+        assert!(users_table_id.belongs_to_base(&base_table_id));
+        assert!(!orders_table_id.belongs_to_base(&base_table_id));
+    }
 
-        let table_ids = inner.created_table_ids_for_base(&base_table_id);
+    #[test]
+    fn sequenced_bigquery_table_id_parse_for_base_ignores_unrelated_tables() {
+        let base_table_id = "users_table".to_owned();
 
-        assert_eq!(table_ids.len(), 2);
-        assert!(table_ids.contains(&current_table_id));
-        assert!(table_ids.contains(&older_table_id));
+        assert_eq!(
+            SequencedBigQueryTableId::parse_for_base("users_table_2", &base_table_id),
+            Some(SequencedBigQueryTableId("users_table".to_owned(), 2))
+        );
+        assert_eq!(
+            SequencedBigQueryTableId::parse_for_base("users_table_backup", &base_table_id),
+            None
+        );
+        assert_eq!(
+            SequencedBigQueryTableId::parse_for_base("orders_table_2", &base_table_id),
+            None
+        );
+        assert_eq!(SequencedBigQueryTableId::parse_for_base("users_table", &base_table_id), None);
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -179,6 +179,12 @@ impl Inner {
     fn new() -> Self {
         Self { created_tables: HashSet::new(), created_views: HashMap::new() }
     }
+
+    /// Clears cached state for a destination table.
+    fn clear_table_cache(&mut self, base_table_id: &BigQueryTableId) {
+        self.created_views.remove(base_table_id);
+        self.created_tables.retain(|table_id| !table_id.belongs_to_base(base_table_id));
+    }
 }
 
 /// A BigQuery destination that implements the ETL [`Destination`] trait.
@@ -1113,6 +1119,7 @@ where
     ) -> EtlResult<()> {
         let base_bigquery_table_id =
             table_name_to_bigquery_table_id(replicated_table_schema.name())?;
+        let table_id = replicated_table_schema.id();
         let mut table_ids = HashSet::new();
 
         // Discover physical table versions from BigQuery instead of the local cache.
@@ -1138,13 +1145,8 @@ where
 
         // Once destination cleanup is done, remove any stale local cache entries.
         let mut inner = self.inner.lock().await;
-        inner.created_views.remove(&base_bigquery_table_id);
+        inner.clear_table_cache(&base_bigquery_table_id);
 
-        for sequenced_bigquery_table_id in table_ids {
-            inner.created_tables.remove(&sequenced_bigquery_table_id);
-        }
-
-        let table_id = replicated_table_schema.id();
         info!(table_id = table_id.0, "dropped bigquery table before copy");
 
         Ok(())
@@ -1847,6 +1849,37 @@ mod tests {
             None
         );
         assert_eq!(SequencedBigQueryTableId::parse_for_base("users_table", &base_table_id), None);
+    }
+
+    #[test]
+    fn clear_table_cache_removes_all_cached_table_state_for_base() {
+        let base_table_id = "users_table".to_owned();
+        let mut inner = Inner::new();
+
+        inner.created_tables.insert(SequencedBigQueryTableId(base_table_id.clone(), 0));
+        inner.created_tables.insert(SequencedBigQueryTableId(base_table_id.clone(), 1));
+        inner.created_tables.insert(SequencedBigQueryTableId("orders_table".to_owned(), 0));
+        inner
+            .created_views
+            .insert(base_table_id.clone(), SequencedBigQueryTableId(base_table_id.clone(), 1));
+        inner.created_views.insert(
+            "orders_table".to_owned(),
+            SequencedBigQueryTableId("orders_table".to_owned(), 0),
+        );
+
+        inner.clear_table_cache(&base_table_id);
+
+        assert_eq!(
+            inner.created_tables,
+            HashSet::from([SequencedBigQueryTableId("orders_table".to_owned(), 0)])
+        );
+        assert_eq!(
+            inner.created_views,
+            HashMap::from([(
+                "orders_table".to_owned(),
+                SequencedBigQueryTableId("orders_table".to_owned(), 0),
+            )])
+        );
     }
 
     #[test]

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -130,6 +130,12 @@ fn build_truncate_table_sql(table_name: &str) -> String {
     format!("TRUNCATE TABLE IF EXISTS {table_name}")
 }
 
+/// Builds the SQL used to drop a ClickHouse table.
+fn build_drop_table_sql(table_name: &str) -> String {
+    let table_name = quote_identifier(table_name);
+    format!("DROP TABLE IF EXISTS {table_name}")
+}
+
 /// Builds the SQL used to insert RowBinary rows into a ClickHouse table.
 fn build_insert_rows_sql(table_name: &str) -> String {
     let table_name = quote_identifier(table_name);
@@ -143,6 +149,7 @@ fn build_insert_rows_sql(table_name: &str) -> String {
 pub(crate) enum DdlKind {
     CreateTable,
     CreateView,
+    DropTable,
     DropView,
     AddColumn,
     DropColumn,
@@ -154,6 +161,7 @@ impl DdlKind {
         match self {
             DdlKind::CreateTable => "create_table",
             DdlKind::CreateView => "create_view",
+            DdlKind::DropTable => "drop_table",
             DdlKind::DropView => "drop_view",
             DdlKind::AddColumn => "add_column",
             DdlKind::DropColumn => "drop_column",
@@ -370,6 +378,12 @@ impl ClickHouseClient {
         .await
     }
 
+    /// Executes `DROP TABLE IF EXISTS` for the supplied table.
+    pub(crate) async fn drop_table(&self, table_name: &str) -> EtlResult<()> {
+        let sql = build_drop_table_sql(table_name);
+        self.execute_ddl(DdlKind::DropTable, &sql).await
+    }
+
     /// Inserts `rows` into `table_name` using the RowBinary format.
     ///
     /// Each element of `rows` is a complete, already-encoded row of
@@ -494,6 +508,13 @@ mod tests {
         let sql = build_truncate_table_sql("table\"name");
 
         assert_eq!(sql, "TRUNCATE TABLE IF EXISTS \"table\"\"name\"");
+    }
+
+    #[test]
+    fn drop_table_sql_quotes_identifiers() {
+        let sql = build_drop_table_sql("table\"name");
+
+        assert_eq!(sql, "DROP TABLE IF EXISTS \"table\"\"name\"");
     }
 
     #[test]

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use etl::{
     destination::{
         Destination,
-        async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+        async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -603,6 +603,20 @@ where
     async fn truncate_table_inner(&self, schema: &ReplicatedTableSchema) -> EtlResult<()> {
         let (clickhouse_table_name, _) = self.ensure_table_exists(schema).await?;
         self.client.truncate_table(&clickhouse_table_name).await
+    }
+
+    async fn drop_table_for_copy_inner(&self, schema: &ReplicatedTableSchema) -> EtlResult<()> {
+        let clickhouse_table_name = try_stringify_table_name(schema.name())?;
+
+        if matches!(self.inserter_config.engine, ClickHouseEngine::ReplacingMergeTree) {
+            let drop_view = drop_current_view_sql(&clickhouse_table_name);
+            self.client.execute_ddl(DdlKind::DropView, &drop_view).await?;
+        }
+
+        self.client.drop_table(&clickhouse_table_name).await?;
+        self.table_cache.write().remove(&clickhouse_table_name);
+
+        Ok(())
     }
 
     async fn write_table_rows_inner(
@@ -1259,12 +1273,12 @@ where
     // sending" error if the path ever skips `send`, so the receiver is never
     // silently abandoned.
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        let result = self.truncate_table_inner(replicated_table_schema).await;
+        let result = self.drop_table_for_copy_inner(replicated_table_schema).await;
         async_result.send(result);
         Ok(())
     }

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -12,7 +12,7 @@ use etl::{
     concurrency::TaskSet,
     destination::{
         Destination,
-        async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+        async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -222,12 +222,12 @@ where
         Ok(())
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        let result = self.truncate_table(replicated_table_schema).await;
+        let result = self.drop_table_for_copy_inner(replicated_table_schema).await;
         async_result.send(result);
 
         Ok(())
@@ -759,6 +759,83 @@ where
         .await
     }
 
+    /// Drops the destination table and replay markers before a fresh copy.
+    async fn drop_table_for_copy_inner(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()> {
+        let table_name = self.resolve_destination_table_name(replicated_table_schema).await?;
+        let _table_write_permit = self.acquire_table_write_slot(&table_name).await?;
+        self.ensure_applied_batches_table_exists().await?;
+        self.ensure_streaming_progress_table_exists().await?;
+        let _checkpoint_guard = self.acquire_mutation_guard().await;
+        let table_name_for_drop = table_name.clone();
+
+        self.run_duckdb_blocking(move |conn| -> EtlResult<()> {
+            conn.execute_batch("BEGIN TRANSACTION").map_err(|e| {
+                etl_error!(
+                    ErrorKind::DestinationQueryFailed,
+                    "DuckLake BEGIN TRANSACTION failed",
+                    source: e
+                )
+            })?;
+
+            let result = (|| -> EtlResult<()> {
+                let quoted_table_name = quote_identifier(&table_name_for_drop).into_owned();
+                let drop_table_sql =
+                    format!("DROP TABLE IF EXISTS {LAKE_CATALOG}.{quoted_table_name};");
+                conn.execute_batch(&drop_table_sql).map_err(|e| {
+                    etl_error!(
+                        ErrorKind::DestinationQueryFailed,
+                        "DuckLake DROP TABLE failed",
+                        format_query_error_detail(&drop_table_sql),
+                        source: e
+                    )
+                })?;
+
+                clear_applied_batch_markers_for_kind(
+                    conn,
+                    &table_name_for_drop,
+                    DuckLakeTableBatchKind::Copy,
+                )?;
+                clear_applied_batch_markers_for_kind(
+                    conn,
+                    &table_name_for_drop,
+                    DuckLakeTableBatchKind::Mutation,
+                )?;
+                clear_applied_batch_markers_for_kind(
+                    conn,
+                    &table_name_for_drop,
+                    DuckLakeTableBatchKind::Truncate,
+                )?;
+                clear_table_streaming_progress(conn, &table_name_for_drop)?;
+                Ok(())
+            })();
+
+            match result {
+                Ok(()) => conn.execute_batch("COMMIT").map_err(|e| {
+                    etl_error!(
+                        ErrorKind::DestinationQueryFailed,
+                        "DuckLake COMMIT failed",
+                        source: e
+                    )
+                }),
+                Err(error) => {
+                    let err = conn.execute_batch("ROLLBACK");
+                    if let Err(err) = err {
+                        tracing::error!(error = %err, "error rollback");
+                    }
+                    Err(error)
+                }
+            }
+        })
+        .await?;
+
+        self.created_tables.lock().remove(&table_name);
+
+        Ok(())
+    }
+
     /// Bulk-inserts rows into the destination table inside a single
     /// transaction.
     ///
@@ -1112,7 +1189,7 @@ where
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<DuckLakeTableName> {
         let table_id = replicated_table_schema.id();
-        let table_name = self.get_or_create_destination_table_name(replicated_table_schema).await?;
+        let table_name = self.resolve_destination_table_name(replicated_table_schema).await?;
 
         // Fast path: already created.
         {
@@ -1225,9 +1302,8 @@ where
         .await
     }
 
-    /// Returns the stored destination table name for `table_id`, creating a
-    /// default name if none exists yet.
-    async fn get_or_create_destination_table_name(
+    /// Returns the stored destination table name or the deterministic default.
+    async fn resolve_destination_table_name(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<DuckLakeTableName> {

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -759,7 +759,7 @@ where
         .await
     }
 
-    /// Drops the destination table and replay markers before a fresh copy.
+    /// Drops the destination table and replay markers before restarting a copy.
     async fn drop_table_for_copy_inner(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,

--- a/crates/etl-destinations/src/iceberg/core.rs
+++ b/crates/etl-destinations/src/iceberg/core.rs
@@ -8,7 +8,7 @@ use etl::{
     concurrency::TaskSet,
     destination::{
         Destination,
-        async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+        async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -226,6 +226,40 @@ where
 
         // We recreate the table with the same schema.
         self.prepare_table_for_streaming(&mut inner, replicated_table_schema).await?;
+
+        Ok(())
+    }
+
+    /// Drops an Iceberg table before a fresh table copy.
+    async fn drop_table_for_copy_inner(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()> {
+        let table_id = replicated_table_schema.id();
+        let table_name = replicated_table_schema.name();
+        let table_namespace = schema_to_namespace(&table_name.schema);
+        let (default_table_name, namespace) = {
+            let inner = self.inner.lock().await;
+            let default_table_name =
+                table_name_to_iceberg_table_name(table_name, inner.namespace.is_single())?;
+            let namespace = inner.namespace.get_or(&table_namespace).to_owned();
+
+            (default_table_name, namespace)
+        };
+        let iceberg_table_name =
+            if let Some(metadata) = self.store.get_destination_table_metadata(table_id).await? {
+                metadata.destination_table_id
+            } else {
+                default_table_name
+            };
+
+        self.client
+            .drop_table_if_exists(&namespace, iceberg_table_name.clone())
+            .await
+            .map_err(iceberg_error_to_etl_error)?;
+
+        let mut inner = self.inner.lock().await;
+        inner.created_tables.remove(&iceberg_table_name);
 
         Ok(())
     }
@@ -593,16 +627,16 @@ where
         self.tasks.shutdown().await
     }
 
-    /// Truncates the specified table by dropping and recreating it.
+    /// Drops the specified table before a fresh copy.
     ///
-    /// Removes all data from the target Iceberg table while preserving
-    /// the table schema structure for continued CDC operations.
-    async fn truncate_table(
+    /// The table sync worker clears ETL metadata after this succeeds, and the
+    /// next copy recreates the table from the fresh `0/0` schema.
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        let result = IcebergDestination::truncate_table(self, replicated_table_schema).await;
+        let result = self.drop_table_for_copy_inner(replicated_table_schema).await;
         async_result.send(result);
 
         Ok(())

--- a/crates/etl-destinations/src/iceberg/core.rs
+++ b/crates/etl-destinations/src/iceberg/core.rs
@@ -230,7 +230,7 @@ where
         Ok(())
     }
 
-    /// Drops an Iceberg table before a fresh table copy.
+    /// Drops an Iceberg table before restarting a table copy.
     async fn drop_table_for_copy_inner(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -214,6 +214,95 @@ async fn table_copy_and_streaming_with_restart() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn table_copy_reset_drops_destination_table_before_recopy() {
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let bigquery_database = setup_bigquery_database().await;
+    let users_schema = database_schema.users_schema();
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+
+    database
+        .insert_values(users_schema.name.clone(), &["name", "age"], &[&"before_1", &1])
+        .await
+        .unwrap();
+    database
+        .insert_values(users_schema.name.clone(), &["name", "age"], &[&"before_2", &2])
+        .await
+        .unwrap();
+
+    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
+    let destination = TestDestinationWrapper::wrap(raw_destination);
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready =
+        store.notify_on_table_state_type(users_schema.id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let users_rows = bigquery_database.query_table(users_schema.name.clone()).await.unwrap();
+    assert_eq!(
+        parse_bigquery_table_rows::<BigQueryUser>(users_rows),
+        vec![BigQueryUser::new(1, "before_1", 1), BigQueryUser::new(2, "before_2", 2),]
+    );
+
+    database
+        .run_sql(&format!("delete from {} where true", users_schema.name.as_quoted_identifier()))
+        .await
+        .unwrap();
+    database
+        .insert_values(users_schema.name.clone(), &["name", "age"], &[&"after", &3])
+        .await
+        .unwrap();
+    store.reset_table_state(users_schema.id).await.unwrap();
+
+    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
+    let destination = TestDestinationWrapper::wrap(raw_destination);
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready =
+        store.notify_on_table_state_type(users_schema.id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    assert!(destination.was_table_dropped_for_copy(users_schema.id).await);
+    let users_rows = bigquery_database.query_table(users_schema.name).await.unwrap();
+    assert_eq!(
+        parse_bigquery_table_rows::<BigQueryUser>(users_rows),
+        vec![BigQueryUser::new(3, "after", 3)]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn table_insert_update_delete() {
     if skip_if_missing_bigquery_env_vars() {
         return;

--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -52,6 +52,7 @@ const ID_VALUE_PROJECTION: &str = "id, value";
 const UPDATE_FLOW_TABLE: &str = "test_update__flow";
 const DELETE_FLOW_TABLE: &str = "test_delete__flow";
 const RESTART_FLOW_TABLE: &str = "test_restart__flow";
+const RESET_COPY_TABLE: &str = "test_reset__copy";
 const TRUNCATE_FLOW_TABLE: &str = "test_truncate__flow";
 
 /// Days from 1970-01-01 to 2024-01-15 (used to verify the `date_col`
@@ -928,6 +929,119 @@ async fn pipeline_restart_resumes_streaming_inner(engine: ClickHouseEngine) {
     assert_eq!(rows[0].value, "before_restart");
     assert_eq!(rows[1].id, 2);
     assert_eq!(rows[1].value, "after_restart");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_copy_reset_drops_destination_table_before_recopy_merge_tree() {
+    table_copy_reset_drops_destination_table_before_recopy_inner(ClickHouseEngine::MergeTree).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_copy_reset_drops_destination_table_before_recopy_replacing_merge_tree() {
+    table_copy_reset_drops_destination_table_before_recopy_inner(
+        ClickHouseEngine::ReplacingMergeTree,
+    )
+    .await;
+}
+
+async fn table_copy_reset_drops_destination_table_before_recopy_inner(engine: ClickHouseEngine) {
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = spawn_source_database().await;
+    let table_name = test_table_name("reset_copy");
+
+    let table_id = database
+        .create_table(table_name.clone(), true, &[("value", "text not null")])
+        .await
+        .expect("Failed to create reset_copy test table");
+
+    let publication_name = "test_pub_clickhouse_reset_copy";
+    database
+        .create_publication(publication_name, std::slice::from_ref(&table_name))
+        .await
+        .expect("Failed to create reset_copy publication");
+
+    database
+        .run_sql(&format!(
+            "INSERT INTO {} (value) VALUES ('before_1'), ('before_2')",
+            table_name.as_quoted_identifier(),
+        ))
+        .await
+        .expect("Failed to insert initial reset_copy rows");
+
+    let clickhouse_db = setup_clickhouse_database().await;
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+    let reset_query =
+        || current_state_query(engine, RESET_COPY_TABLE, ID_VALUE_PROJECTION, &["id"], "id");
+
+    let destination = TestDestinationWrapper::wrap(
+        clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
+    );
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name.to_owned(),
+        store.clone(),
+        destination,
+    );
+
+    let table_ready =
+        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    table_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let rows: Vec<IdValueRow> = clickhouse_db.query(&reset_query()).await;
+    assert_eq!(rows.len(), 2, "first copy should produce two rows");
+    assert_eq!(rows[0].value, "before_1");
+    assert_eq!(rows[1].value, "before_2");
+
+    database
+        .run_sql(&format!("DELETE FROM {} WHERE true", table_name.as_quoted_identifier()))
+        .await
+        .expect("Failed to delete reset_copy source rows");
+    database
+        .run_sql(&format!(
+            "INSERT INTO {} (value) VALUES ('after')",
+            table_name.as_quoted_identifier(),
+        ))
+        .await
+        .expect("Failed to insert recopy reset_copy row");
+
+    store.reset_table_state(table_id).await.unwrap();
+
+    let destination = TestDestinationWrapper::wrap(
+        clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
+    );
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name.to_owned(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready =
+        store.notify_on_table_state_type(table_id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    table_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    assert!(destination.was_table_dropped_for_copy(table_id).await);
+    let rows: Vec<IdValueRow> = clickhouse_db.query(&reset_query()).await;
+    assert_eq!(rows.len(), 1, "recopy should not retain rows from the first copy");
+    assert_eq!(rows[0].id, 3);
+    assert_eq!(rows[0].value, "after");
 }
 
 /// Tests that TRUNCATE clears the ClickHouse table and that subsequent inserts

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -237,6 +237,98 @@ async fn table_copy_and_streaming_with_restart() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn table_copy_reset_drops_destination_table_before_recopy() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let lake = create_test_lake("table_copy_reset_drops_destination_table_before_recopy").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
+
+    let users_schema = database_schema.users_schema();
+    let users_table_name = table_name_to_ducklake_table_name(&users_schema.name)
+        .expect("failed to build DuckLake users table name");
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+
+    database
+        .insert_values(users_schema.name.clone(), &["name", "age"], &[&"before_1", &1])
+        .await
+        .unwrap();
+    database
+        .insert_values(users_schema.name.clone(), &["name", "age"], &[&"before_2", &2])
+        .await
+        .unwrap();
+
+    let destination = build_destination(&catalog_url, &data_url, store.clone()).await;
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready =
+        store.notify_on_table_state_type(users_schema.id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    checkpoint_lake(&catalog_url, &data_url);
+
+    let conn = open_lake_conn(&catalog_url, &data_url);
+    assert_eq!(
+        query_user_rows(&conn, &users_table_name),
+        vec![(1, "before_1".to_owned(), 1), (2, "before_2".to_owned(), 2)]
+    );
+    drop(conn);
+    drop(destination);
+    checkpoint_lake(&catalog_url, &data_url);
+
+    database
+        .run_sql(&format!("delete from {} where true", users_schema.name.as_quoted_identifier()))
+        .await
+        .unwrap();
+    database
+        .insert_values(users_schema.name.clone(), &["name", "age"], &[&"after", &3])
+        .await
+        .unwrap();
+    store.reset_table_state(users_schema.id).await.unwrap();
+
+    let destination = build_destination(&catalog_url, &data_url, store.clone()).await;
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready =
+        store.notify_on_table_state_type(users_schema.id, TableReplicationPhaseType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    assert!(destination.was_table_dropped_for_copy(users_schema.id).await);
+    drop(destination);
+    checkpoint_lake(&catalog_url, &data_url);
+
+    let conn = open_lake_conn(&catalog_url, &data_url);
+    assert_eq!(query_user_rows(&conn, &users_table_name), vec![(3, "after".to_owned(), 3)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn table_copy_and_streaming_without_restart() {
     init_test_tracing();
 

--- a/crates/etl-replicator/src/error_reporting.rs
+++ b/crates/etl-replicator/src/error_reporting.rs
@@ -201,7 +201,11 @@ impl<S> CleanupStore for ErrorReportingStateStore<S>
 where
     S: CleanupStore + Send + Sync,
 {
-    async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
-        self.inner.cleanup_table_state(table_id).await
+    async fn clear_table_copy_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.inner.clear_table_copy_state(table_id).await
+    }
+
+    async fn delete_table_pipeline_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.inner.delete_table_pipeline_state(table_id).await
     }
 }

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -25,11 +25,11 @@ use crate::{
 pub type WriteTableRowsResult<T = ()> = AsyncResult<T>;
 
 /// Async completion handle used for
-/// [`crate::destination::Destination::truncate_table`].
+/// [`crate::destination::Destination::drop_table_for_copy`].
 ///
-/// ETL waits for this result immediately. It is primarily an API consistency
-/// hook rather than a mechanism for overlapping more ETL work with truncation.
-pub type TruncateTableResult<T = ()> = AsyncResult<T>;
+/// ETL waits for this result immediately before clearing stored table-copy
+/// metadata and starting a fresh copy.
+pub type DropTableForCopyResult<T = ()> = AsyncResult<T>;
 
 /// Async completion handle used for
 /// [`crate::destination::Destination::write_events`].

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use crate::{
-    destination::async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+    destination::async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     error::EtlResult,
     types::{Event, ReplicatedTableSchema, TableRow},
 };
@@ -35,20 +35,21 @@ pub trait Destination {
         async { Ok(()) }
     }
 
-    /// Truncates all data in the specified table.
+    /// Drops the specified destination table before a fresh table copy.
     ///
-    /// This operation is called during initial table synchronization to ensure
-    /// the destination table starts from a clean state before bulk loading.
+    /// This operation is called when table synchronization intentionally
+    /// restarts from scratch. Implementations should remove the destination
+    /// object and any destination-private replay markers for the table so the
+    /// next copy can recreate it from the fresh source schema.
     ///
-    /// Implementations complete `async_result` when truncation is actually
-    /// done. ETL still waits for that result immediately before continuing.
-    /// The asynchronous result exists mainly to keep the destination
-    /// interface uniform across methods, not to let ETL overlap more work
-    /// with truncation.
-    fn truncate_table(
+    /// The supplied schema describes the previously known destination table and
+    /// exists only so the destination can locate what should be removed. ETL
+    /// clears its own destination metadata and stored schemas only after this
+    /// result completes successfully.
+    fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 
     /// Writes a batch of table rows to the destination.

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -35,7 +35,7 @@ pub trait Destination {
         async { Ok(()) }
     }
 
-    /// Drops the specified destination table before a fresh table copy.
+    /// Drops destination objects before restarting a table copy.
     ///
     /// This operation is called when table synchronization intentionally
     /// restarts from scratch. Implementations should remove the destination

--- a/crates/etl/src/destination/mod.rs
+++ b/crates/etl/src/destination/mod.rs
@@ -7,5 +7,5 @@
 pub mod async_result;
 mod base;
 
-pub use async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult};
+pub use async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult};
 pub use base::Destination;

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -63,7 +63,9 @@
 //!         BatchConfig, InvalidatedSlotBehavior, MemoryBackpressureConfig, PgConnectionConfig,
 //!         PipelineConfig, TableSyncCopyConfig, TcpKeepaliveConfig, TlsConfig,
 //!     },
-//!     destination::{Destination, TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+//!     destination::{
+//!         Destination, DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult,
+//!     },
 //!     error::EtlResult,
 //!     pipeline::Pipeline,
 //!     store::MemoryStore,
@@ -77,10 +79,10 @@
 //!     fn name() -> &'static str {
 //!         "noop"
 //!     }
-//!     async fn truncate_table(
+//!     async fn drop_table_for_copy(
 //!         &self,
 //!         _replicated_table_schema: &ReplicatedTableSchema,
-//!         async_result: TruncateTableResult<()>,
+//!         async_result: DropTableForCopyResult<()>,
 //!     ) -> EtlResult<()> {
 //!         async_result.send(Ok(()));
 //!         Ok(())

--- a/crates/etl/src/pipeline.rs
+++ b/crates/etl/src/pipeline.rs
@@ -406,9 +406,9 @@ where
                     "table removed from publication, purging stored state and slot"
                 );
 
-                // We clean up all table state before removing the slot, so that we don't incur
-                // in the case where we have a slot tied to an invalid state.
-                self.store.cleanup_table_state(table_id).await?;
+                // We delete all table state before removing the slot, so that we don't
+                // incur in the case where we have a slot tied to an invalid state.
+                self.store.delete_table_pipeline_state(table_id).await?;
 
                 // We try to delete the replication slot.
                 let slot_name: String =

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -76,6 +76,7 @@ use crate::{
     },
     state::table::{TableReplicationPhase, TableReplicationPhaseType},
     store::{
+        cleanup::CleanupStore,
         schema::{SchemaStore, TableSchemaRetention},
         state::StateStore,
     },
@@ -557,14 +558,6 @@ impl ApplyLoopState {
         Some(SchemaCleanupRun { deadline: Arc::clone(&self.schema_cleanup_deadline) })
     }
 
-    /// Moves the schema cleanup deadline into the past for tests.
-    #[cfg(test)]
-    async fn expire_schema_cleanup_deadline(&self) {
-        let mut schema_cleanup_deadline = self.schema_cleanup_deadline.lock().await;
-        *schema_cleanup_deadline =
-            Some(Instant::now() - SCHEMA_CLEANUP_INTERVAL - Duration::from_secs(1));
-    }
-
     /// Returns `true` if a schema cleanup task is still recorded.
     fn has_schema_cleanup_task(&self) -> bool {
         self.schema_cleanup_task.is_some()
@@ -720,7 +713,7 @@ pub(crate) struct ApplyLoop<S, D> {
 
 impl<S, D> ApplyLoop<S, D>
 where
-    S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+    S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
     D: Destination + Clone + Send + Sync + 'static,
 {
     /// Starts the apply loop for processing replication events.
@@ -2482,7 +2475,7 @@ mod apply_worker {
         current_lsn: PgLsn,
     ) -> EtlResult<Option<ExitIntent>>
     where
-        S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+        S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
         D: Destination + Clone + Send + Sync + 'static,
     {
         for (table_id, table_replication_phase) in get_syncing_tables(&ctx.store).await? {
@@ -2602,7 +2595,7 @@ mod apply_worker {
         current_lsn: PgLsn,
     ) -> EtlResult<Option<ExitIntent>>
     where
-        S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+        S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
         D: Destination + Clone + Send + Sync + 'static,
     {
         let worker_state = ctx.pool.get_active_worker_state(table_id).await;
@@ -2741,7 +2734,7 @@ mod apply_worker {
         current_lsn: PgLsn,
     ) -> EtlResult<()>
     where
-        S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+        S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
         D: Destination + Clone + Send + Sync + 'static,
     {
         for (table_id, table_replication_phase) in get_syncing_tables(&ctx.store).await? {
@@ -2767,7 +2760,7 @@ mod apply_worker {
         current_lsn: PgLsn,
     ) -> EtlResult<()>
     where
-        S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+        S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
         D: Destination + Clone + Send + Sync + 'static,
     {
         let worker_state = ctx.pool.get_active_worker_state(table_id).await;
@@ -2879,7 +2872,7 @@ mod apply_worker {
         current_lsn: PgLsn,
     ) -> EtlResult<Option<ExitIntent>>
     where
-        S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+        S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
         D: Destination + Clone + Send + Sync + 'static,
     {
         for (table_id, table_replication_phase) in get_syncing_tables(&ctx.store).await? {
@@ -2911,7 +2904,7 @@ mod apply_worker {
         current_lsn: PgLsn,
     ) -> EtlResult<Option<ExitIntent>>
     where
-        S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+        S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
         D: Destination + Clone + Send + Sync + 'static,
     {
         let worker_state = ctx.pool.get_active_worker_state(table_id).await;
@@ -3111,7 +3104,7 @@ mod apply_worker {
         worker: TableSyncWorker<S, D>,
     ) -> Pin<Box<dyn Future<Output = EtlResult<()>> + Send>>
     where
-        S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+        S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
         D: Destination + Clone + Send + Sync + 'static,
     {
         Box::pin(async move { worker.spawn_into_pool(&pool).await })
@@ -3350,37 +3343,4 @@ async fn get_replicated_table_schema(
     };
 
     Ok(replicated_table_schema)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn apply_loop_state() -> ApplyLoopState {
-        let start_lsn = PgLsn::from(100u64);
-        let replication_progress =
-            ReplicationProgress { last_received_lsn: start_lsn, last_flush_lsn: start_lsn };
-
-        ApplyLoopState::new(
-            replication_progress,
-            Duration::from_secs(1),
-            SnapshotId::from(start_lsn),
-            "test_slot".to_owned(),
-        )
-    }
-
-    #[tokio::test]
-    async fn schema_cleanup_uses_deadline_between_runs() {
-        let state = apply_loop_state();
-
-        state.expire_schema_cleanup_deadline().await;
-
-        let schema_cleanup_run = state.try_start_schema_cleanup().await.unwrap();
-
-        assert!(state.try_start_schema_cleanup().await.is_none());
-
-        schema_cleanup_run.finish().await;
-
-        assert!(state.try_start_schema_cleanup().await.is_none());
-    }
 }

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -2056,7 +2056,7 @@ where
         let used_bootstrap_snapshot = shared_table_state.is_none();
         let table_snapshot_id = shared_table_state
             .map_or_else(|| self.state.bootstrap_snapshot_id(), |state| state.snapshot_id());
-        let table_schema = get_table_schema(
+        let table_schema = get_table_schema_for_relation(
             &self.schema_store,
             &table_id,
             table_snapshot_id,
@@ -3247,12 +3247,11 @@ mod table_sync_worker {
 
 /// Retrieves a table schema from the schema store by table ID and snapshot.
 ///
-/// When `used_bootstrap_snapshot` is `false`, the returned schema must match
-/// the requested snapshot exactly. When it is `true`, the lookup is allowed to
-/// resolve to an older schema version because the first `RELATION` message may
-/// arrive before shared per-table protocol state has been established, but it
-/// must never resolve to a newer schema than requested.
-async fn get_table_schema<S>(
+/// The reason for this handling is that the bootstrap snapshot id is just used
+/// as a boundary id that is needed for when etl starts and no DDL takes place.
+/// As soon as a DDL takes place within this active replication session, the
+/// exact snapshot id will be used to load the right table schema.
+async fn get_table_schema_for_relation<S>(
     schema_store: &S,
     table_id: &TableId,
     snapshot_id: SnapshotId,

--- a/crates/etl/src/replication/table_cache.rs
+++ b/crates/etl/src/replication/table_cache.rs
@@ -109,6 +109,16 @@ impl SharedTableCache {
         self.upsert(table_id, SharedTableState::Ready { replicated_table_schema }).await;
     }
 
+    /// Removes cached runtime state for a table.
+    ///
+    /// This is intentionally idempotent: a first copy may not have cached state
+    /// yet, while an in-process copy restart may have stale ready state from
+    /// the previous copy.
+    pub(crate) async fn remove_table(&self, table_id: TableId) {
+        let mut guard = self.inner.write().await;
+        guard.remove(&table_id);
+    }
+
     /// Inserts or updates shared table state.
     ///
     /// This cache is deliberately oblivious to ordering and ownership. It
@@ -253,5 +263,23 @@ mod tests {
         assert_eq!(table_ids.len(), 2);
         assert!(table_ids.contains(&ready_table_id));
         assert!(table_ids.contains(&waiting_table_id));
+    }
+
+    #[tokio::test]
+    async fn remove_table_is_idempotent() {
+        let cache = SharedTableCache::new();
+        let table_id = TableId::new(123);
+
+        cache.remove_table(table_id).await;
+        assert!(cache.get(&table_id).await.is_none());
+
+        cache.note_ready(table_id, create_test_schema()).await;
+        assert!(cache.get(&table_id).await.is_some());
+
+        cache.remove_table(table_id).await;
+        cache.remove_table(table_id).await;
+
+        assert!(cache.get(&table_id).await.is_none());
+        assert!(!cache.active_table_ids().await.contains(&table_id));
     }
 }

--- a/crates/etl/src/replication/table_cache.rs
+++ b/crates/etl/src/replication/table_cache.rs
@@ -25,6 +25,23 @@
 //!   relation state for that snapshot.
 //! - [`SharedTableState::Ready`], where the full [`ReplicatedTableSchema`]
 //!   needed for row decoding is already materialized in memory.
+//!
+//! The cache relies on the following invariants:
+//! - A table has exactly one protocol owner at a time. The owner may be the
+//!   apply worker or the table sync worker for that table; non-owners must skip
+//!   DDL, `RELATION`, and row messages without changing the cache.
+//! - A table copy stores the initial schema with snapshot `0/0` and marks the
+//!   table [`SharedTableState::Ready`] before copied or catchup rows can be
+//!   decoded.
+//! - A table-copy restart removes any cached state before storing the fresh
+//!   `0/0` schema. The new copy lineage must repopulate the cache; stale ready
+//!   state from a previous copy must not be reused.
+//! - DDL handling stores the durable schema version before moving the cache to
+//!   [`SharedTableState::WaitingForRelation`] for that snapshot.
+//! - [`SharedTableState::WaitingForRelation`] is not a failure state, but it is
+//!   not decodable. Row handlers must reject row messages until a later
+//!   `RELATION` message materializes the runtime masks and moves the table back
+//!   to [`SharedTableState::Ready`].
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/etl/src/replication/table_cache.rs
+++ b/crates/etl/src/replication/table_cache.rs
@@ -31,8 +31,7 @@
 //!   apply worker or the table sync worker for that table; non-owners must skip
 //!   DDL, `RELATION`, and row messages without changing the cache.
 //! - A table copy stores the initial schema with snapshot `0/0` and marks the
-//!   table [`SharedTableState::Ready`] before copied or catchup rows can be
-//!   decoded.
+//!   table [`SharedTableState::Ready`] before catchup rows can be decoded.
 //! - A table-copy restart removes any cached state before storing the fresh
 //!   `0/0` schema. The new copy lineage must repopulate the cache; stale ready
 //!   state from a previous copy must not be reused.

--- a/crates/etl/src/replication/table_sync.rs
+++ b/crates/etl/src/replication/table_sync.rs
@@ -16,14 +16,14 @@ use crate::{
     concurrency::{BatchBudgetController, MemoryMonitor, ShutdownRx},
     destination::{
         Destination,
-        async_result::{TruncateTableResult, WriteTableRowsResult},
+        async_result::{DropTableForCopyResult, WriteTableRowsResult},
     },
     error::{ErrorKind, EtlResult},
     etl_error,
     metrics::{ETL_TABLE_COPY_DURATION_SECONDS, PARTITIONING_LABEL},
     replication::{WorkerType, client::PgReplicationClient, table_cache::SharedTableCache},
     state::table::{TableReplicationPhase, TableReplicationPhaseType},
-    store::{schema::SchemaStore, state::StateStore},
+    store::{cleanup::CleanupStore, schema::SchemaStore, state::StateStore},
     types::PipelineId,
     workers::{TableCopyResult, TableSyncWorkerState, table_copy},
 };
@@ -69,7 +69,7 @@ pub(crate) async fn start_table_sync<S, D>(
     batch_budget: BatchBudgetController,
 ) -> EtlResult<TableSyncResult>
 where
-    S: StateStore + SchemaStore + Clone + Send + 'static,
+    S: StateStore + SchemaStore + CleanupStore + Clone + Send + 'static,
     D: Destination + Clone + Send + 'static,
 {
     info!(table_id = table_id.0, "starting initial table sync");
@@ -148,88 +148,67 @@ where
             // - `Init` -> we can be in this state because we just started replicating the
             //   table or the state
             //  was reset. In this case we don't want to make assumptions about the previous
-            // state, so we  just try to delete the slot and truncate the table.
+            // state, so we just try to delete the slot and drop the table.
             // - `DataSync` -> we can be in this state because we failed during data sync,
             //   meaning that table
-            //  copy failed. In this case, we want to delete the slot and truncate the
+            //  copy failed. In this case, we want to delete the slot and drop the
             // table.
             //
             // We try to delete the slot also during `Init` because we support state
             // rollback and a slot might be there from the previous run.
             replication_client.delete_slot_if_exists(&slot_name).await?;
-            store.delete_replication_progress(WorkerType::TableSync { table_id }).await?;
 
-            // We must truncate the destination table before starting a copy to avoid data
-            // inconsistencies.
+            // We must drop the destination table and clear old ETL schema state before
+            // starting a copy to avoid data inconsistencies.
             //
             // Example scenario:
             // 1. The source table has a single row (id = 1) that is copied to the
             //    destination during the initial copy.
-            // 2. Before the table’s phase is set to `FinishedCopy`, the process crashes.
+            // 2. Before the table's phase is set to `FinishedCopy`, the process crashes.
             // 3. While down, the source deletes row id = 1 and inserts row id = 2.
-            // 4. When restarted, the process sees the table in the ` DataSync ` state,
+            // 4. When restarted, the process sees the table in the `DataSync` state,
             //    deletes the slot, and copies again.
             // 5. This time, only row id = 2 is copied, but row id = 1 still exists in the
             //    destination.
             // Result: the destination has two rows (id = 1 and id = 2) instead of only one
-            // (id = 2). Fix: Always truncate the destination table before
-            // starting a copy.
+            // (id = 2). Fix: Always drop the destination table before starting a copy.
             //
             // Try to load the previously stored destination table metadata, which contains
             // both the snapshot_id and replication_mask. If available, we can load the
-            // corresponding table schema and truncate the destination table before starting
-            // a copy. If the metadata is not present, we can safely assume that
-            // no data is there in the table; thus a truncate won't be issued.
+            // corresponding table schema and drop the destination table before starting a
+            // copy. If the metadata is not present, there is no destination object we
+            // know how to drop, but stale ETL schemas are still cleared below
+            // before the fresh `0/0` copy schema is stored.
             if let Some(current_metadata) = store.get_destination_table_metadata(table_id).await? {
-                match current_metadata.into_applied() {
-                    Err(err) => {
-                        // The schema DDL never completed. Skip the truncate and let the
-                        // destination re-create the table during the copy phase.
-                        warn!(
-                            table_id = table_id.0,
-                            error = %err,
-                            "destination table metadata is not in applied state; skipping pre-copy truncation"
-                        );
-                    }
-                    Ok(applied_metadata) => {
-                        if let Some(table_schema) =
-                            store.get_table_schema(&table_id, applied_metadata.snapshot_id).await?
-                        {
-                            let replicated_table_schema = ReplicatedTableSchema::from_mask(
-                                table_schema,
-                                applied_metadata.replication_mask,
-                            );
-                            let (truncate_result, pending_truncate_result) =
-                                TruncateTableResult::new(());
+                if let Some(table_schema) =
+                    store.get_table_schema(&table_id, current_metadata.snapshot_id).await?
+                {
+                    let replicated_table_schema = ReplicatedTableSchema::from_mask(
+                        table_schema,
+                        current_metadata.replication_mask,
+                    );
+                    let (drop_result, pending_drop_result) = DropTableForCopyResult::new(());
 
-                            if let Err(err) = destination
-                                .truncate_table(&replicated_table_schema, truncate_result)
-                                .await
-                            {
-                                warn!(
-                                    table_id = table_id.0,
-                                    error = %err,
-                                    "failed to dispatch destination table truncation before copy, continuing"
-                                );
-                            } else if let Err(err) = pending_truncate_result.await.into_result() {
-                                warn!(
-                                    table_id = table_id.0,
-                                    error = %err,
-                                    "failed to truncate destination table before copy, continuing"
-                                );
-                            } else {
-                                info!(%table_id, "truncated destination table before starting copy");
-                            }
-                        } else {
-                            bail!(
-                                ErrorKind::InvalidState,
-                                "Destination table metadata found, but not corresponding table \
-                                 schema exists"
-                            );
-                        }
-                    }
+                    destination.drop_table_for_copy(&replicated_table_schema, drop_result).await?;
+                    pending_drop_result.await.into_result()?;
+
+                    info!(%table_id, "dropped destination table before starting copy");
+                } else {
+                    bail!(
+                        ErrorKind::InvalidState,
+                        "Destination table metadata found, but no corresponding table schema \
+                         exists"
+                    );
                 }
             }
+
+            // We clear durable and in-memory table-copy state only after the destination
+            // table was dropped. The shared cache removal is idempotent: a first copy has
+            // no cached state yet, while an in-process retry can still hold the previous
+            // ready runtime schema. The fresh `0/0` copy schema below is the only state
+            // allowed to repopulate the cache.
+            store.clear_table_copy_state(table_id).await?;
+            shared_table_cache.remove_table(table_id).await;
 
             // We are ready to start copying table data, and we update the state
             // accordingly.

--- a/crates/etl/src/replication/table_sync.rs
+++ b/crates/etl/src/replication/table_sync.rs
@@ -48,6 +48,36 @@ pub(crate) enum TableSyncResult {
     },
 }
 
+/// Returns the existing [`ReplicatedTableSchema`] if one exists.
+///
+/// A [`ReplicatedTableSchema`] could be there when starting a table copy
+/// because it was either interrupted or the state was reset.
+async fn get_existing_replicated_table_schema<S>(
+    store: &S,
+    table_id: TableId,
+) -> EtlResult<Option<ReplicatedTableSchema>>
+where
+    S: StateStore + SchemaStore + Send + 'static,
+{
+    let Some(current_metadata) = store.get_destination_table_metadata(table_id).await? else {
+        return Ok(None);
+    };
+
+    let Some(table_schema) =
+        store.get_table_schema(&table_id, current_metadata.snapshot_id).await?
+    else {
+        bail!(
+            ErrorKind::InvalidState,
+            "Destination table metadata found, but no corresponding table schema exists"
+        );
+    };
+
+    let existing_replicated_table_schema =
+        ReplicatedTableSchema::from_mask(table_schema, current_metadata.replication_mask);
+
+    Ok(Some(existing_replicated_table_schema))
+}
+
 /// Starts table synchronization for a specific table.
 ///
 /// This function performs the initial data copy for a table from the source
@@ -144,22 +174,8 @@ where
     // In case the phase is any other phase, we will return an error.
     let start_lsn = match phase_type {
         TableReplicationPhaseType::Init | TableReplicationPhaseType::DataSync => {
-            // When we are in these states, it could be for the following reasons:
-            // - `Init` -> we can be in this state because we just started replicating the
-            //   table or the state
-            //  was reset. In this case we don't want to make assumptions about the previous
-            // state, so we just try to delete the slot and drop the table.
-            // - `DataSync` -> we can be in this state because we failed during data sync,
-            //   meaning that table
-            //  copy failed. In this case, we want to delete the slot and drop the
-            // table.
-            //
-            // We try to delete the slot also during `Init` because we support state
-            // rollback and a slot might be there from the previous run.
-            replication_client.delete_slot_if_exists(&slot_name).await?;
-
-            // We must drop the destination table and clear old ETL schema state before
-            // starting a copy to avoid data inconsistencies.
+            // We must drop the destination table before starting a copy to avoid data
+            // inconsistencies when there is a previous table.
             //
             // Example scenario:
             // 1. The source table has a single row (id = 1) that is copied to the
@@ -170,43 +186,36 @@ where
             //    deletes the slot, and copies again.
             // 5. This time, only row id = 2 is copied, but row id = 1 still exists in the
             //    destination.
-            // Result: the destination has two rows (id = 1 and id = 2) instead of only one
-            // (id = 2). Fix: Always drop the destination table before starting a copy.
             //
-            // Try to load the previously stored destination table metadata, which contains
-            // both the snapshot_id and replication_mask. If available, we can load the
-            // corresponding table schema and drop the destination table before starting a
-            // copy. If the metadata is not present, there is no destination object we
-            // know how to drop, but stale ETL schemas are still cleared below
-            // before the fresh `0/0` copy schema is stored.
-            if let Some(current_metadata) = store.get_destination_table_metadata(table_id).await? {
-                if let Some(table_schema) =
-                    store.get_table_schema(&table_id, current_metadata.snapshot_id).await?
-                {
-                    let replicated_table_schema = ReplicatedTableSchema::from_mask(
-                        table_schema,
-                        current_metadata.replication_mask,
-                    );
-                    let (drop_result, pending_drop_result) = DropTableForCopyResult::new(());
-
-                    destination.drop_table_for_copy(&replicated_table_schema, drop_result).await?;
-                    pending_drop_result.await.into_result()?;
-
-                    info!(%table_id, "dropped destination table before starting copy");
-                } else {
-                    bail!(
-                        ErrorKind::InvalidState,
-                        "Destination table metadata found, but no corresponding table schema \
-                         exists"
-                    );
-                }
+            // Result: the destination has two rows (id = 1 and id = 2) instead of only one
+            // (id = 2).
+            //
+            // Fix: Always drop the destination table before starting a copy.
+            if let Some(current_replication_table_schema) =
+                get_existing_replicated_table_schema(&store, table_id).await?
+            {
+                let (drop_result, pending_drop_result) = DropTableForCopyResult::new(());
+                destination
+                    .drop_table_for_copy(&current_replication_table_schema, drop_result)
+                    .await?;
+                pending_drop_result.await.into_result()?;
             }
 
-            // We clear durable and in-memory table-copy state only after the destination
-            // table was dropped. The shared cache removal is idempotent: a first copy has
-            // no cached state yet, while an in-process retry can still hold the previous
-            // ready runtime schema. The fresh `0/0` copy schema below is the only state
-            // allowed to repopulate the cache.
+            // When we are in these states, it could be for the following reasons:
+            // - `Init` -> the table is newly included or table state was rolled back. We
+            //   avoid assumptions about previous state and delete any leftover slot.
+            // - `DataSync` -> the previous copy failed before completion. We delete the
+            //   table sync slot so the next copy starts from a clean snapshot.
+            //
+            // We try to delete the slot also during `Init` because we support state
+            // rollback and a slot might be there from the previous run.
+            replication_client.delete_slot_if_exists(&slot_name).await?;
+
+            // We clear durable and in-memory table-copy state only after external cleanup
+            // succeeds. The shared cache removal is idempotent: a first copy has no cached
+            // state yet, while an in-process retry can still hold the previous ready
+            // runtime schema. The fresh `0/0` copy schema below is the only state allowed
+            // to repopulate the cache.
             store.clear_table_copy_state(table_id).await?;
             shared_table_cache.remove_table(table_id).await;
 

--- a/crates/etl/src/replication/table_sync.rs
+++ b/crates/etl/src/replication/table_sync.rs
@@ -21,7 +21,7 @@ use crate::{
     error::{ErrorKind, EtlResult},
     etl_error,
     metrics::{ETL_TABLE_COPY_DURATION_SECONDS, PARTITIONING_LABEL},
-    replication::{WorkerType, client::PgReplicationClient, table_cache::SharedTableCache},
+    replication::{client::PgReplicationClient, table_cache::SharedTableCache},
     state::table::{TableReplicationPhase, TableReplicationPhaseType},
     store::{cleanup::CleanupStore, schema::SchemaStore, state::StateStore},
     types::PipelineId,
@@ -160,20 +160,23 @@ where
     let slot_name: String =
         EtlReplicationSlot::for_table_sync_worker(pipeline_id, table_id).try_into()?;
 
-    // There are three phases in which the table can be in:
-    // - `Init` -> this means that the table sync was never done, so we just perform
-    //   it.
-    // - `DataSync` -> this means that there was a failure during data sync, and we
-    //   have to restart
-    //  copying all the table data and delete the slot.
-    // - `FinishedCopy` -> this means that the table was successfully copied, but we
-    //   didn't manage to complete the table sync function, so we just want to
-    //   continue the cdc stream from durable table-sync progress when available, or
-    //   from the slot's confirmed flush LSN otherwise.
+    // There are three phases from which table sync can start:
+    // - `Init` -> the table sync was never done or the table was reset, so we
+    //   perform it.
+    // - `DataSync` -> a previous copy did not complete, so we restart the copy from
+    //   a clean snapshot.
+    // - `FinishedCopy` -> the copy completed, but the table sync worker did not
+    //   finish the ownership handoff. This is a narrow crash window, so we
+    //   intentionally restart the copy instead of trying to resume catchup.
+    //   Resuming soundly would require persisting the exact runtime relation
+    //   decoding state, including identity masks, and making handoff safe when no
+    //   further `RELATION` message arrives.
     //
     // In case the phase is any other phase, we will return an error.
     let start_lsn = match phase_type {
-        TableReplicationPhaseType::Init | TableReplicationPhaseType::DataSync => {
+        TableReplicationPhaseType::Init
+        | TableReplicationPhaseType::DataSync
+        | TableReplicationPhaseType::FinishedCopy => {
             // We must drop the destination table before starting a copy to avoid data
             // inconsistencies when there is a previous table.
             //
@@ -201,6 +204,11 @@ where
                 pending_drop_result.await.into_result()?;
             }
 
+            // We try to delete the slot if it already exists, since we might be starting a
+            // table copy after a previous one was reset or didn't complete
+            // successfully.
+            replication_client.delete_slot_if_exists(&slot_name).await?;
+
             // We clear durable and in-memory table-copy state only after external cleanup
             // succeeds. The shared cache removal is idempotent: a first copy has no cached
             // state yet, while an in-process retry can still hold the previous ready
@@ -208,16 +216,6 @@ where
             // to repopulate the cache.
             store.clear_table_copy_state(table_id).await?;
             shared_table_cache.remove_table(table_id).await;
-
-            // When we are in these states, it could be for the following reasons:
-            // - `Init` -> the table is newly included or table state was rolled back. We
-            //   avoid assumptions about previous state and delete any leftover slot.
-            // - `DataSync` -> the previous copy failed before completion. We delete the
-            //   table sync slot so the next copy starts from a clean snapshot.
-            //
-            // We try to delete the slot also during `Init` because we support state
-            // rollback and a slot might be there from the previous run.
-            replication_client.delete_slot_if_exists(&slot_name).await?;
 
             // We are ready to start copying table data, and we update the state
             // accordingly.
@@ -296,7 +294,6 @@ where
             // without waiting for a fresh relation message after restarts.
             let replicated_table_schema =
                 ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask);
-            shared_table_cache.note_ready(table_id, replicated_table_schema.clone()).await;
 
             let mut total_table_copy_rows = 0;
             let mut total_table_copy_duration_secs = 0.0;
@@ -369,41 +366,16 @@ where
                 inner.set_and_store(TableReplicationPhase::FinishedCopy, &store).await?;
             }
 
+            // After we finished copying, we mark this table as ready in the cache, so
+            // that we can start streaming and decoding immediately.
+            //
+            // This is needed, since it could be that the apply loop for the `Catchup` phase
+            // might be idle and progress only via keepalives and in that case no `Relation`
+            // message will be received, so we want the apply worker to already be able to
+            // start decoding.
+            shared_table_cache.note_ready(table_id, replicated_table_schema.clone()).await;
+
             slot.consistent_point
-        }
-        TableReplicationPhaseType::FinishedCopy => {
-            let slot = replication_client.get_slot(&slot_name).await?;
-            let worker_type = WorkerType::TableSync { table_id };
-            let durable_flush_lsn = store.get_replication_progress(worker_type).await?;
-            if let Some(durable_flush_lsn) = durable_flush_lsn {
-                // Durable progress and slot progress can legitimately differ. During idle
-                // periods we keep sending PostgreSQL feedback with the received LSN, but
-                // we do not persist those idle-only advances to the state database to
-                // avoid extra customer-database writes. Conversely, durable progress can
-                // be ahead if ETL flushed a batch but PostgreSQL did not confirm the
-                // feedback yet. Startup uses the latest boundary available from either
-                // source as a resume floor, which guarantees no event older than the
-                // chosen start LSN is emitted.
-                let start_lsn = durable_flush_lsn.max(slot.confirmed_flush_lsn);
-
-                info!(
-                    table_id = table_id.0,
-                    %durable_flush_lsn,
-                    confirmed_flush_lsn = %slot.confirmed_flush_lsn,
-                    %start_lsn,
-                    "resuming table sync from durable replication progress and replication slot"
-                );
-
-                start_lsn
-            } else {
-                info!(
-                    table_id = table_id.0,
-                    confirmed_flush_lsn = %slot.confirmed_flush_lsn,
-                    "durable table sync progress not found, using slot fallback"
-                );
-
-                slot.confirmed_flush_lsn
-            }
         }
         _ => unreachable!("phase type already validated above"),
     };

--- a/crates/etl/src/replication/table_sync.rs
+++ b/crates/etl/src/replication/table_sync.rs
@@ -201,6 +201,14 @@ where
                 pending_drop_result.await.into_result()?;
             }
 
+            // We clear durable and in-memory table-copy state only after external cleanup
+            // succeeds. The shared cache removal is idempotent: a first copy has no cached
+            // state yet, while an in-process retry can still hold the previous ready
+            // runtime schema. The fresh `0/0` copy schema below is the only state allowed
+            // to repopulate the cache.
+            store.clear_table_copy_state(table_id).await?;
+            shared_table_cache.remove_table(table_id).await;
+
             // When we are in these states, it could be for the following reasons:
             // - `Init` -> the table is newly included or table state was rolled back. We
             //   avoid assumptions about previous state and delete any leftover slot.
@@ -210,14 +218,6 @@ where
             // We try to delete the slot also during `Init` because we support state
             // rollback and a slot might be there from the previous run.
             replication_client.delete_slot_if_exists(&slot_name).await?;
-
-            // We clear durable and in-memory table-copy state only after external cleanup
-            // succeeds. The shared cache removal is idempotent: a first copy has no cached
-            // state yet, while an in-process retry can still hold the previous ready
-            // runtime schema. The fresh `0/0` copy schema below is the only state allowed
-            // to repopulate the cache.
-            store.clear_table_copy_state(table_id).await?;
-            shared_table_cache.remove_table(table_id).await;
 
             // We are ready to start copying table data, and we update the state
             // accordingly.

--- a/crates/etl/src/store/both/memory.rs
+++ b/crates/etl/src/store/both/memory.rs
@@ -56,6 +56,15 @@ pub struct MemoryStore {
     inner: Arc<Mutex<Inner>>,
 }
 
+/// Scope of table-scoped state removal.
+#[derive(Debug, Clone, Copy)]
+enum TableStateCleanupScope {
+    /// Clear state that belongs to the previous table copy.
+    CopyRestart,
+    /// Delete all ETL state for a table removed from the publication.
+    PipelineRemoval,
+}
+
 impl MemoryStore {
     /// Creates a new empty memory store.
     ///
@@ -72,6 +81,26 @@ impl MemoryStore {
         };
 
         Self { inner: Arc::new(Mutex::new(inner)) }
+    }
+
+    /// Deletes table-scoped state according to the requested scope.
+    async fn delete_table_state_for_scope(
+        &self,
+        table_id: TableId,
+        scope: TableStateCleanupScope,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
+
+        if matches!(scope, TableStateCleanupScope::PipelineRemoval) {
+            Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
+            inner.table_state_history.remove(&table_id);
+        }
+
+        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
+        Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+        inner.replication_progress.remove(&WorkerType::TableSync { table_id });
+
+        Ok(())
     }
 }
 
@@ -269,16 +298,11 @@ impl SchemaStore for MemoryStore {
 }
 
 impl CleanupStore for MemoryStore {
-    async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
-        let mut inner = self.inner.lock().await;
+    async fn clear_table_copy_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.delete_table_state_for_scope(table_id, TableStateCleanupScope::CopyRestart).await
+    }
 
-        Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
-        inner.table_state_history.remove(&table_id);
-        // Remove all schema versions for this table.
-        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
-        Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
-        inner.replication_progress.remove(&WorkerType::TableSync { table_id });
-
-        Ok(())
+    async fn delete_table_pipeline_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.delete_table_state_for_scope(table_id, TableStateCleanupScope::PipelineRemoval).await
     }
 }

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -45,6 +45,15 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// need more than 2 schema versions for any given table.
 const MAX_CACHED_SCHEMAS_PER_TABLE: usize = 2;
 
+/// Scope of table-scoped state removal.
+#[derive(Debug, Clone, Copy)]
+enum TableStateCleanupScope {
+    /// Clear state that belongs to the previous table copy.
+    CopyRestart,
+    /// Delete all ETL state for a table removed from the publication.
+    PipelineRemoval,
+}
+
 /// Creates a lazily connected pool with automatic idle connection cleanup.
 ///
 /// This function returns immediately without establishing any connections.
@@ -182,6 +191,72 @@ impl PostgresStore {
         };
 
         Ok(Self { pipeline_id, pool, inner: Arc::new(Mutex::new(inner)) })
+    }
+
+    /// Deletes table-scoped persistent and cached state according to the
+    /// requested scope.
+    async fn delete_table_state_for_scope(
+        &self,
+        table_id: TableId,
+        scope: TableStateCleanupScope,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
+        let mut tx = self.pool.begin().await?;
+
+        destination_metadata::delete_destination_table_metadata(
+            &mut *tx,
+            self.pipeline_id as i64,
+            table_id,
+        )
+        .await
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination table metadata deletion failed",
+                source: err
+            )
+        })?;
+
+        schema::delete_table_schema_for_table(&mut *tx, self.pipeline_id as i64, table_id)
+            .await
+            .map_err(|err| {
+                etl_error!(
+                    ErrorKind::SourceQueryFailed,
+                    "Table schema deletion failed",
+                    source: err
+                )
+            })?;
+
+        if matches!(scope, TableStateCleanupScope::PipelineRemoval) {
+            state::delete_replication_state_for_table(&mut *tx, self.pipeline_id as i64, table_id)
+                .await?;
+        }
+
+        progress::delete_replication_progress_for_table(
+            &mut *tx,
+            self.pipeline_id as i64,
+            table_id,
+        )
+        .await
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Replication progress deletion failed",
+                source: err
+            )
+        })?;
+
+        tx.commit().await?;
+
+        if matches!(scope, TableStateCleanupScope::PipelineRemoval) {
+            inner.remove_table_state(table_id);
+            emit_table_metrics(&inner.phase_counts);
+        }
+
+        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
+        Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+
+        Ok(())
     }
 }
 
@@ -637,60 +712,13 @@ impl SchemaStore for PostgresStore {
 }
 
 impl CleanupStore for PostgresStore {
+    async fn clear_table_copy_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.delete_table_state_for_scope(table_id, TableStateCleanupScope::CopyRestart).await
+    }
+
     /// Removes all state for a table from both database and cache.
-    async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
-        let mut inner = self.inner.lock().await;
-        let mut tx = self.pool.begin().await?;
-
-        destination_metadata::delete_destination_table_metadata(
-            &mut *tx,
-            self.pipeline_id as i64,
-            table_id,
-        )
-        .await
-        .map_err(|err| {
-            etl_error!(
-                ErrorKind::SourceQueryFailed,
-                "Destination table metadata deletion failed",
-                format!("Failed to delete destination table metadata in PostgreSQL: {}", err)
-            )
-        })?;
-
-        schema::delete_table_schema_for_table(&mut *tx, self.pipeline_id as i64, table_id)
-            .await
-            .map_err(|err| {
-                etl_error!(
-                    ErrorKind::SourceQueryFailed,
-                    "Table schema deletion failed",
-                    format!("Failed to delete table schema in PostgreSQL: {}", err)
-                )
-            })?;
-
-        state::delete_replication_state_for_table(&mut *tx, self.pipeline_id as i64, table_id)
-            .await?;
-
-        progress::delete_replication_progress_for_table(
-            &mut *tx,
-            self.pipeline_id as i64,
-            table_id,
-        )
-        .await
-        .map_err(|err| {
-            etl_error!(
-                ErrorKind::SourceQueryFailed,
-                "Replication progress deletion failed",
-                source: err
-            )
-        })?;
-
-        tx.commit().await?;
-
-        inner.remove_table_state(table_id);
-        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
-        Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
-        emit_table_metrics(&inner.phase_counts);
-
-        Ok(())
+    async fn delete_table_pipeline_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.delete_table_state_for_scope(table_id, TableStateCleanupScope::PipelineRemoval).await
     }
 }
 

--- a/crates/etl/src/store/cleanup.rs
+++ b/crates/etl/src/store/cleanup.rs
@@ -4,10 +4,21 @@ use crate::{error::EtlResult, types::TableId};
 
 /// Combined maintenance operations across state and schema stores.
 ///
-/// Provides atomic cleanup primitives that affect both replication state
-/// and schema-related data for a specific table. Implementations should
-/// ensure consistency across in-memory caches and the persistent store.
+/// Provides atomic table-scoped primitives that affect both replication state
+/// and schema-related data. Implementations should ensure consistency across
+/// in-memory caches and the persistent store.
 pub trait CleanupStore {
+    /// Clears stored table-copy state for `table_id`.
+    ///
+    /// Removes destination table metadata, all stored table schemas, and
+    /// durable table-sync progress while preserving the table replication
+    /// phase. This is used after the destination object has been dropped and
+    /// before a fresh `0/0` table-copy schema is stored.
+    fn clear_table_copy_state(
+        &self,
+        table_id: TableId,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
+
     /// Deletes all stored state for `table_id` for the current pipeline.
     ///
     /// Removes replication state (including history), table schemas, and
@@ -15,5 +26,8 @@ pub trait CleanupStore {
     /// destination table.
     ///
     /// Intended for use when a table is removed from the publication.
-    fn cleanup_table_state(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send;
+    fn delete_table_pipeline_state(
+        &self,
+        table_id: TableId,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
 }

--- a/crates/etl/src/test_utils/memory_destination.rs
+++ b/crates/etl/src/test_utils/memory_destination.rs
@@ -6,7 +6,7 @@ use tracing::info;
 use crate::{
     destination::{
         Destination,
-        async_result::{TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+        async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     },
     error::EtlResult,
     state::destination_metadata::{DestinationTableMetadata, DestinationTableSchemaStatus},
@@ -28,8 +28,8 @@ struct Inner {
 /// terminates.
 ///
 /// Like real destinations (BigQuery, Iceberg), this destination tracks table
-/// metadata (snapshot IDs and replication masks) in a state store to support
-/// features like table truncation during state resets.
+/// metadata (snapshot IDs and replication masks) in a state store to mirror
+/// destinations that persist table-copy state.
 #[derive(Clone)]
 pub struct MemoryDestination<S> {
     inner: Arc<Mutex<Inner>>,
@@ -133,17 +133,17 @@ where
         "memory"
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        // For truncation, we simulate removing all table rows for a specific table and
+        // For table drops, we simulate removing all table rows for a specific table and
         // also the events of that table.
         let mut inner = self.inner.lock().await;
 
         let table_id = replicated_table_schema.id();
-        info!(%table_id, "truncating table");
+        info!(%table_id, "dropping table for copy");
 
         inner.table_rows.remove(&table_id);
         inner.events.retain_mut(|event| {

--- a/crates/etl/src/test_utils/notifying_store.rs
+++ b/crates/etl/src/test_utils/notifying_store.rs
@@ -108,6 +108,15 @@ pub struct NotifyingStore {
     inner: Arc<RwLock<Inner>>,
 }
 
+/// Scope of table-scoped state removal.
+#[derive(Debug, Clone, Copy)]
+enum TableStateCleanupScope {
+    /// Clear state that belongs to the previous table copy.
+    CopyRestart,
+    /// Delete all ETL state for a table removed from the publication.
+    PipelineRemoval,
+}
+
 impl NotifyingStore {
     /// Creates an empty notifying store.
     pub fn new() -> Self {
@@ -238,6 +247,27 @@ impl NotifyingStore {
         let states = Arc::make_mut(&mut inner.table_replication_states);
         states.remove(&table_id);
         states.insert(table_id, TableReplicationPhase::Init);
+
+        Ok(())
+    }
+
+    /// Deletes table-scoped state according to the requested scope.
+    async fn delete_table_state_for_scope(
+        &self,
+        table_id: TableId,
+        scope: TableStateCleanupScope,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.write().await;
+
+        if matches!(scope, TableStateCleanupScope::PipelineRemoval) {
+            Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
+            inner.table_state_history.remove(&table_id);
+        }
+
+        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
+        Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+        inner.replication_progress.remove(&WorkerType::TableSync { table_id });
+        inner.check_conditions();
 
         Ok(())
     }
@@ -452,16 +482,12 @@ impl SchemaStore for NotifyingStore {
 }
 
 impl CleanupStore for NotifyingStore {
-    async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
-        let mut inner = self.inner.write().await;
+    async fn clear_table_copy_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.delete_table_state_for_scope(table_id, TableStateCleanupScope::CopyRestart).await
+    }
 
-        Arc::make_mut(&mut inner.table_replication_states).remove(&table_id);
-        inner.table_state_history.remove(&table_id);
-        Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
-        Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
-        inner.replication_progress.remove(&WorkerType::TableSync { table_id });
-
-        Ok(())
+    async fn delete_table_pipeline_state(&self, table_id: TableId) -> EtlResult<()> {
+        self.delete_table_state_for_scope(table_id, TableStateCleanupScope::PipelineRemoval).await
     }
 }
 

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -16,8 +16,8 @@ use crate::{
     destination::{
         Destination,
         async_result::{
-            ApplyLoopAsyncResultMetadata, DispatchMetrics, TruncateTableResult, WriteEventsResult,
-            WriteTableRowsResult,
+            ApplyLoopAsyncResultMetadata, DispatchMetrics, DropTableForCopyResult,
+            WriteEventsResult, WriteTableRowsResult,
         },
     },
     error::EtlResult,
@@ -37,7 +37,7 @@ struct Inner<D> {
     wrapped_destination: D,
     events: Vec<Event>,
     table_rows: HashMap<TableId, Vec<TableRow>>,
-    truncated_tables: HashSet<TableId>,
+    tables_dropped_for_copy: HashSet<TableId>,
     event_conditions: Vec<(EventCheckFn, Arc<Notify>)>,
     table_row_conditions: Vec<(TableRowCheckFn, Arc<Notify>)>,
     combined_conditions: Vec<(CombinedCheckFn, Arc<Notify>)>,
@@ -119,7 +119,7 @@ impl<D> TestDestinationWrapper<D> {
             wrapped_destination: destination,
             events: Vec::new(),
             table_rows: HashMap::new(),
-            truncated_tables: HashSet::new(),
+            tables_dropped_for_copy: HashSet::new(),
             event_conditions: Vec::new(),
             table_row_conditions: Vec::new(),
             combined_conditions: Vec::new(),
@@ -211,9 +211,10 @@ impl<D> TestDestinationWrapper<D> {
         inner.events.clear();
     }
 
-    /// Returns whether the table was truncated through the wrapper.
-    pub async fn was_table_truncated(&self, table_id: TableId) -> bool {
-        self.inner.read().await.truncated_tables.contains(&table_id)
+    /// Returns whether the table was dropped for a fresh copy through the
+    /// wrapper.
+    pub async fn was_table_dropped_for_copy(&self, table_id: TableId) -> bool {
+        self.inner.read().await.tables_dropped_for_copy.contains(&table_id)
     }
 
     /// Returns how many times [`Destination::write_table_rows`] was called.
@@ -235,44 +236,47 @@ where
         "wrapper"
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
         let destination = {
             let inner = self.inner.read().await;
             inner.wrapped_destination.clone()
         };
 
-        let (wrapped_truncate_result, pending_result) = TruncateTableResult::new(());
-        destination.truncate_table(replicated_table_schema, wrapped_truncate_result).await?;
+        let (wrapped_drop_result, pending_drop_result) = DropTableForCopyResult::new(());
+        destination.drop_table_for_copy(replicated_table_schema, wrapped_drop_result).await?;
 
         // We send the result back before doing the internal checks for this utility, to
         // avoid checking before the apply loop received the result.
-        let result = pending_result.await.into_result();
+        let result = pending_drop_result.await.into_result();
+        let should_record_drop = result.is_ok();
         async_result.send(result);
 
         let mut inner = self.inner.write().await;
 
         let table_id = replicated_table_schema.id();
-        inner.truncated_tables.insert(table_id);
-        inner.table_rows.remove(&table_id);
-        inner.events.retain_mut(|event| {
-            let has_table_id = event.has_table_id(&table_id);
-            if let Event::Truncate(truncate_event) = event
-                && has_table_id
-            {
-                truncate_event.truncated_tables.retain(|s| s.id() != table_id);
-                if truncate_event.truncated_tables.is_empty() {
-                    return false;
+        if should_record_drop {
+            inner.tables_dropped_for_copy.insert(table_id);
+            inner.table_rows.remove(&table_id);
+            inner.events.retain_mut(|event| {
+                let has_table_id = event.has_table_id(&table_id);
+                if let Event::Truncate(truncate_event) = event
+                    && has_table_id
+                {
+                    truncate_event.truncated_tables.retain(|s| s.id() != table_id);
+                    if truncate_event.truncated_tables.is_empty() {
+                        return false;
+                    }
+
+                    return true;
                 }
 
-                return true;
-            }
-
-            !has_table_id
-        });
+                !has_table_id
+            });
+        }
 
         Ok(())
     }
@@ -289,14 +293,14 @@ where
             inner.wrapped_destination.clone()
         };
 
-        let (wrapped_flush_result, pending_result) = WriteTableRowsResult::new(());
+        let (wrapped_flush_result, pending_flush_result) = WriteTableRowsResult::new(());
         destination
             .write_table_rows(replicated_table_schema, table_rows.clone(), wrapped_flush_result)
             .await?;
 
         // We send the result back before doing the internal checks for this utility, to
         // avoid checking before the apply loop received the result.
-        let result = pending_result.await.into_result();
+        let result = pending_flush_result.await.into_result();
         let should_record_table_rows = result.is_ok();
         async_result.send(result);
 
@@ -325,7 +329,7 @@ where
             inner.wrapped_destination.clone()
         };
 
-        let (wrapped_flush_result, pending_result) =
+        let (wrapped_flush_result, pending_flush_result) =
             WriteEventsResult::new(ApplyLoopAsyncResultMetadata {
                 commit_end_lsn: None,
                 metrics: DispatchMetrics {
@@ -349,7 +353,7 @@ where
             .spawn(async move {
                 // We send the result back before doing the internal checks for this utility, to
                 // avoid checking before the apply loop received the result.
-                let result = pending_result.await.into_result();
+                let result = pending_flush_result.await.into_result();
                 let should_record_events = result.is_ok();
                 async_result.send(result);
 

--- a/crates/etl/src/workers/apply.rs
+++ b/crates/etl/src/workers/apply.rs
@@ -22,7 +22,7 @@ use crate::{
         client::{GetOrCreateSlotResult, PgReplicationClient, SlotState},
     },
     state::table::{TableReplicationPhase, TableReplicationPhaseType},
-    store::{schema::SchemaStore, state::StateStore},
+    store::{cleanup::CleanupStore, schema::SchemaStore, state::StateStore},
     types::PipelineId,
     workers::{
         TableSyncWorkerPool,
@@ -130,7 +130,7 @@ impl<S, D> ApplyWorker<S, D> {
 
 impl<S, D> ApplyWorker<S, D>
 where
-    S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+    S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
     D: Destination + Clone + Send + Sync + 'static,
 {
     /// Handles apply worker errors using policy-based retry and backoff.

--- a/crates/etl/src/workers/table_sync.rs
+++ b/crates/etl/src/workers/table_sync.rs
@@ -25,7 +25,7 @@ use crate::{
     state::table::{
         RetryPolicy, TableReplicationError, TableReplicationPhase, TableReplicationPhaseType,
     },
-    store::{schema::SchemaStore, state::StateStore},
+    store::{cleanup::CleanupStore, schema::SchemaStore, state::StateStore},
     types::PipelineId,
     workers::{
         TableSyncWorkerPool,
@@ -380,7 +380,7 @@ impl<S, D> TableSyncWorker<S, D> {
 
 impl<S, D> TableSyncWorker<S, D>
 where
-    S: StateStore + SchemaStore + Clone + Send + Sync + 'static,
+    S: StateStore + SchemaStore + CleanupStore + Clone + Send + Sync + 'static,
     D: Destination + Clone + Send + Sync + 'static,
 {
     /// Handles a table sync worker failure using the configured retry policy.

--- a/crates/etl/src/workers/table_sync.rs
+++ b/crates/etl/src/workers/table_sync.rs
@@ -508,8 +508,8 @@ where
                 // in a table sync worker, this is why it's not in the apply worker:
                 // - Errored -> Init: okay since it will restart from scratch.
                 // - Errored -> DataSync: okay since it will restart the copy from a new slot.
-                // - Errored -> FinishedCopy: okay since the table was already copied, so it
-                //   resumes streaming from durable table-sync progress or the slot fallback.
+                // - Errored -> FinishedCopy: okay since table sync startup treats it as a clean
+                //   copy restart.
                 // - Errored -> SyncDone: okay since the table sync will immediately stop.
                 // - Errored -> Ready: same as SyncDone.
                 //

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use etl::{
     error::ErrorKind,
     state::table::{TableReplicationPhase, TableReplicationPhaseType},
-    store::state::StateStore,
+    store::{schema::SchemaStore, state::StateStore},
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::{EventCondition, group_events_by_type_and_table_id},
@@ -1764,8 +1764,8 @@ async fn empty_tables_are_created_at_destination() {
 }
 
 /// Tests that resetting a table's state to Init triggers a table sync that
-/// truncates the destination before re-copying data. This ensures no duplicate
-/// data after a state reset.
+/// drops the destination table before re-copying data. This ensures no
+/// duplicate data after a state reset.
 ///
 /// Test flow:
 /// 1. Initial table sync: 5 rows (ids 1-5) written to table_rows for both users
@@ -1775,7 +1775,7 @@ async fn empty_tables_are_created_at_destination() {
 /// 4. Insert 3 new rows (ids 100-102) for users only
 /// 5. Verify: users has 10 total rows (table_rows + events), orders unchanged
 #[tokio::test(flavor = "multi_thread")]
-async fn table_sync_truncates_destination_after_state_reset() {
+async fn table_sync_drops_destination_table_after_state_reset() {
     init_test_tracing();
     let mut database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::Both).await;
@@ -1870,10 +1870,10 @@ async fn table_sync_truncates_destination_after_state_reset() {
 
     // We clear the events and rows to check that only users data is written.
     //
-    // This deletion becomes a bit confusing when used in the context of truncation
-    // that should take care of deleting data by itself, however, in this test
-    // we just want to make sure that truncation is called and that the data is
-    // rewritten from scratch.
+    // This deletion becomes a bit confusing when used in the context of a
+    // destination drop that should take care of deleting data by itself. In
+    // this test we just want to make sure that the drop is called and that the
+    // data is rewritten from scratch.
     destination.clear_events().await;
     destination.clear_table_rows().await;
 
@@ -1886,14 +1886,14 @@ async fn table_sync_truncates_destination_after_state_reset() {
         )
         .await;
 
-    // Reset users table state to Init, triggering a new table sync with truncate.
+    // Reset users table state to Init, triggering a fresh table sync.
     store.reset_table_state(database_schema.users_schema().id).await.unwrap();
 
     users_ready_notify.notified().await;
 
     // Wait for all user events (table_rows + CDC) to be processed.
-    // After reset, data can end up in either table_rows or events depending on
-    // timing.
+    // After the state reset, data can end up in either table_rows or events
+    // depending on timing.
     let total_expected_users = initial_rows + cdc_rows + new_rows_after_reset;
     let all_users_events_notify = destination
         .wait_for_all_events(vec![EventCondition::Table(
@@ -1940,9 +1940,18 @@ async fn table_sync_truncates_destination_after_state_reset() {
             .contains_key(&(EventType::Insert, database_schema.orders_schema().id))
     );
 
-    // Verify truncate was called for users (due to reset) but not for orders.
-    assert!(destination.was_table_truncated(database_schema.users_schema().id).await);
-    assert!(!destination.was_table_truncated(database_schema.orders_schema().id).await);
+    // Verify the destination table was dropped for users but not for orders.
+    assert!(destination.was_table_dropped_for_copy(database_schema.users_schema().id).await);
+    assert!(!destination.was_table_dropped_for_copy(database_schema.orders_schema().id).await);
+
+    let user_schemas = SchemaStore::get_table_schemas(&store)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|schema| schema.id == database_schema.users_schema().id)
+        .collect::<Vec<_>>();
+    assert_eq!(user_schemas.len(), 1);
+    assert_eq!(user_schemas[0].snapshot_id, etl_postgres::types::SnapshotId::initial());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -836,7 +836,7 @@ async fn state_transitions_and_history() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn cleanup_deletes_state_schema_and_metadata_for_table() {
+async fn delete_table_pipeline_state_deletes_state_schema_and_metadata_for_table() {
     init_test_tracing();
 
     let database = spawn_source_database().await;
@@ -844,17 +844,17 @@ async fn cleanup_deletes_state_schema_and_metadata_for_table() {
 
     let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
 
-    // Test idempotency: cleanup on non-existent table should succeed
+    // Test idempotency: deleting state for a non-existent table should succeed.
     let nonexistent_table_id = TableId::new(99999);
-    store.cleanup_table_state(nonexistent_table_id).await.unwrap();
+    store.delete_table_pipeline_state(nonexistent_table_id).await.unwrap();
 
-    // Prepare two tables: one we will delete, one we will keep
+    // Prepare two tables: one we will delete, one we will keep.
     let table_1_schema = create_sample_table_schema();
     let table_1_id = table_1_schema.id;
     let table_2_schema = create_another_table_schema();
     let table_2_id = table_2_schema.id;
 
-    // Populate state, schema, and metadata for both tables
+    // Populate state, schema, and metadata for both tables.
     store.update_table_replication_state(table_1_id, TableReplicationPhase::Ready).await.unwrap();
     store
         .update_table_replication_state(table_2_id, TableReplicationPhase::DataSync)
@@ -878,39 +878,123 @@ async fn cleanup_deletes_state_schema_and_metadata_for_table() {
     store.store_destination_table_metadata(table_1_id, metadata1).await.unwrap();
     store.store_destination_table_metadata(table_2_id, metadata2).await.unwrap();
 
-    // Sanity check before cleanup
+    // Sanity check before deleting state.
     assert!(store.get_table_replication_state(table_1_id).await.unwrap().is_some());
     assert!(store.get_table_schema(&table_1_id, SnapshotId::max()).await.unwrap().is_some());
     assert!(store.get_applied_destination_table_metadata(table_1_id).await.unwrap().is_some());
 
-    // Execute cleanup for table 1
-    store.cleanup_table_state(table_1_id).await.unwrap();
+    // Delete pipeline state for table 1.
+    store.delete_table_pipeline_state(table_1_id).await.unwrap();
 
-    // Verify in-memory cache for table 1 has been cleaned
+    // Verify in-memory cache for table 1 has been deleted.
     assert!(store.get_table_replication_state(table_1_id).await.unwrap().is_none());
     assert!(store.get_table_schema(&table_1_id, SnapshotId::max()).await.unwrap().is_none());
     assert!(store.get_applied_destination_table_metadata(table_1_id).await.unwrap().is_none());
 
-    // Verify other table is unaffected
+    // Verify other table is unaffected.
     assert!(store.get_table_replication_state(table_2_id).await.unwrap().is_some());
     assert!(store.get_table_schema(&table_2_id, SnapshotId::max()).await.unwrap().is_some());
     assert!(store.get_applied_destination_table_metadata(table_2_id).await.unwrap().is_some());
 
-    // Create a new store instance and load from DB to ensure persistence
+    // Create a new store instance and load from DB to ensure persistence.
     let new_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
     new_store.load_table_replication_states().await.unwrap();
     new_store.load_table_schemas().await.unwrap();
     new_store.load_destination_tables_metadata().await.unwrap();
 
-    // Table 1 should not be present after reload
+    // Table 1 should not be present after reload.
     assert!(new_store.get_table_replication_state(table_1_id).await.unwrap().is_none());
     assert!(new_store.get_table_schema(&table_1_id, SnapshotId::max()).await.unwrap().is_none());
     assert!(new_store.get_applied_destination_table_metadata(table_1_id).await.unwrap().is_none());
 
-    // Table 2 should still be present
+    // Table 2 should still be present.
     assert!(new_store.get_table_replication_state(table_2_id).await.unwrap().is_some());
     assert!(new_store.get_table_schema(&table_2_id, SnapshotId::max()).await.unwrap().is_some());
     assert!(new_store.get_applied_destination_table_metadata(table_2_id).await.unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clear_table_copy_state_keeps_replication_state_and_deletes_schema_metadata_and_progress() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let pipeline_id = 1;
+
+    let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+
+    let mut table_schema = create_sample_table_schema();
+    let table_id = table_schema.id;
+    let other_table_schema = create_another_table_schema();
+    let other_table_id = other_table_schema.id;
+
+    store.update_table_replication_state(table_id, TableReplicationPhase::DataSync).await.unwrap();
+    store
+        .update_table_replication_state(other_table_id, TableReplicationPhase::Ready)
+        .await
+        .unwrap();
+
+    table_schema.snapshot_id = SnapshotId::initial();
+    store.store_table_schema(table_schema.clone()).await.unwrap();
+    table_schema.snapshot_id = SnapshotId::from(100u64);
+    store.store_table_schema(table_schema).await.unwrap();
+    store.store_table_schema(other_table_schema).await.unwrap();
+
+    let metadata = DestinationTableMetadata::new_applied(
+        "dest_table".to_owned(),
+        SnapshotId::from(100u64),
+        ReplicationMask::from_bytes(vec![1, 1, 1]),
+    );
+    let other_metadata = DestinationTableMetadata::new_applied(
+        "other_dest_table".to_owned(),
+        SnapshotId::initial(),
+        ReplicationMask::from_bytes(vec![1, 1]),
+    );
+    store.store_destination_table_metadata(table_id, metadata).await.unwrap();
+    store.store_destination_table_metadata(other_table_id, other_metadata).await.unwrap();
+    store
+        .upsert_replication_progress(WorkerType::TableSync { table_id }, PgLsn::from(200u64))
+        .await
+        .unwrap();
+
+    store.clear_table_copy_state(table_id).await.unwrap();
+
+    assert_eq!(
+        store.get_table_replication_state(table_id).await.unwrap(),
+        Some(TableReplicationPhase::DataSync)
+    );
+    assert!(store.get_table_schema(&table_id, SnapshotId::max()).await.unwrap().is_none());
+    assert!(store.get_applied_destination_table_metadata(table_id).await.unwrap().is_none());
+    assert!(
+        store.get_replication_progress(WorkerType::TableSync { table_id }).await.unwrap().is_none()
+    );
+
+    assert!(store.get_table_schema(&other_table_id, SnapshotId::max()).await.unwrap().is_some());
+    assert!(store.get_applied_destination_table_metadata(other_table_id).await.unwrap().is_some());
+
+    let new_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    new_store.load_table_replication_states().await.unwrap();
+    new_store.load_table_schemas().await.unwrap();
+    new_store.load_destination_tables_metadata().await.unwrap();
+
+    assert_eq!(
+        new_store.get_table_replication_state(table_id).await.unwrap(),
+        Some(TableReplicationPhase::DataSync)
+    );
+    assert!(new_store.get_table_schema(&table_id, SnapshotId::max()).await.unwrap().is_none());
+    assert!(new_store.get_applied_destination_table_metadata(table_id).await.unwrap().is_none());
+    assert!(
+        new_store
+            .get_replication_progress(WorkerType::TableSync { table_id })
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        new_store.get_table_schema(&other_table_id, SnapshotId::max()).await.unwrap().is_some()
+    );
+    assert!(
+        new_store.get_applied_destination_table_metadata(other_table_id).await.unwrap().is_some()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -922,6 +922,11 @@ async fn clear_table_copy_state_keeps_replication_state_and_deletes_schema_metad
 
     let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
 
+    // Test idempotency: clearing copy state for a non-existent table should
+    // succeed.
+    let nonexistent_table_id = TableId::new(99999);
+    store.clear_table_copy_state(nonexistent_table_id).await.unwrap();
+
     let mut table_schema = create_sample_table_schema();
     let table_id = table_schema.id;
     let other_table_schema = create_another_table_schema();

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -79,7 +79,7 @@ Where replicated data goes. Implement the `Destination` trait to send data anywh
 pub trait Destination {
     fn name() -> &'static str;
     fn shutdown(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
-    fn truncate_table(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: TruncateTableResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
+    fn drop_table_for_copy(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: DropTableForCopyResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, rows: Vec<TableRow>, async_result: WriteTableRowsResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
 }
@@ -88,14 +88,14 @@ pub trait Destination {
 | Method | When called | Purpose |
 |--------|-------------|---------|
 | `name()` | On initialization | Identify the destination |
-| `truncate_table()` | Before initial copy | Clear destination table using the current replicated schema |
+| `drop_table_for_copy()` | Before a fresh initial copy or copy retry | Drop the existing destination object and destination-private replay state using the current replicated schema |
 | `write_table_rows()` | During initial copy | Receive bulk rows for the current replicated schema |
 | `write_events()` | After initial copy | Receive streaming changes |
 
 Each write-like method receives an async result handle. The intent is different per method:
 
 - `write_events()`: after dispatch succeeds, ETL may keep processing while the destination finishes the batch.
-- `truncate_table()` and `write_table_rows()`: ETL waits for the result immediately. The handle is still useful because it keeps the destination API uniform and lets implementations reuse similar internal patterns.
+- `drop_table_for_copy()` and `write_table_rows()`: ETL waits for the result immediately. After a successful drop, ETL clears its own copy-scoped schema, destination metadata, and table-sync progress before storing the fresh `0/0` copy schema.
 
 ### Store
 
@@ -103,7 +103,7 @@ Persists pipeline state so replication can resume after restarts. Three traits w
 
 - **StateStore**: Tracks replication phase per table and destination table metadata
 - **SchemaStore**: Stores versioned table schema information (columns, types, primary keys, snapshot IDs) and prunes obsolete schema versions after acknowledged progress
-- **CleanupStore**: Removes stored state when a table is dropped from the publication
+- **CleanupStore**: Clears copy-scoped state before a table copy restart and removes all stored state when a table leaves the publication
 
 `StateStore` and `SchemaStore` use a cache-first pattern: reads hit an in-memory cache, writes go to both the cache and persistent storage. Schema pruning follows the same rule for implementations with durable storage: obsolete versions are removed from both the cache and the persistent store.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -88,7 +88,7 @@ pub trait Destination {
 | Method | When called | Purpose |
 |--------|-------------|---------|
 | `name()` | On initialization | Identify the destination |
-| `drop_table_for_copy()` | Before a fresh initial copy or copy retry | Drop the existing destination object and destination-private replay state using the current replicated schema |
+| `drop_table_for_copy()` | Before restarting a table copy when previous destination state exists | Drop the existing destination object and destination-private replay state using the previously stored replicated schema |
 | `write_table_rows()` | During initial copy | Receive bulk rows for the current replicated schema |
 | `write_events()` | After initial copy | Receive streaming changes |
 

--- a/docs/explanation/traits.md
+++ b/docs/explanation/traits.md
@@ -12,7 +12,7 @@ Receives replicated data. This is the primary extension point for sending data t
 pub trait Destination {
     fn name() -> &'static str;
     fn shutdown(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
-    fn truncate_table(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: TruncateTableResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
+    fn drop_table_for_copy(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: DropTableForCopyResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, table_rows: Vec<TableRow>, async_result: WriteTableRowsResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
 }
@@ -24,19 +24,17 @@ pub trait Destination {
 |--------|---------|
 | `name()` | Returns identifier for logging and diagnostics |
 | `shutdown()` | Called when the pipeline shuts down. Default is a no-op. Override for cleanup or bookkeeping |
-| `truncate_table()` | Clears table data before initial sync. Receives the current replicated schema for the table |
+| `drop_table_for_copy()` | Drops the existing destination object and destination-private replay state before a fresh initial copy or copy retry. Receives the current replicated schema for the table |
 | `write_table_rows()` | Writes rows during initial table copy. Receives the current replicated schema and may get an empty vector for tables with no data |
 | `write_events()` | Processes streaming replication events (inserts, updates, deletes). Batches may span multiple tables |
 
 ### Implementation Notes
 
-- Operations should be idempotent when possible (ETL may retry on failure)
+- `drop_table_for_copy()` should be idempotent. ETL calls it before clearing copy-scoped store state, so implementations can still use the supplied schema and existing destination metadata to locate the old object.
+- Other operations should be idempotent when possible (ETL may retry on failure)
 - Handle concurrent calls safely (parallel table sync workers)
 - Process events in order to maintain data consistency
-- All three write-like methods use async results, but ETL waits differently:
-- `truncate_table()` waits immediately.
-- `write_table_rows()` also waits immediately, requesting the next batch only after the current one finishes for that copy partition.
-- `write_events()` is the method where ETL can keep processing while the destination finishes the current batch.
+- All three write-like methods use async results, but ETL waits differently. `drop_table_for_copy()` waits immediately before copy-scoped store cleanup. `write_table_rows()` also waits immediately, requesting the next batch only after the current one finishes for that copy partition. `write_events()` is the method where ETL can keep processing while the destination finishes the current batch.
 
 See [Event Types](events.md) for details on the events received by `write_events()`.
 
@@ -79,6 +77,11 @@ pub trait StateStore {
     fn update_table_replication_state(&self, table_id: TableId, state: TableReplicationPhase) -> impl Future<Output = EtlResult<()>> + Send;
     fn rollback_table_replication_state(&self, table_id: TableId) -> impl Future<Output = EtlResult<TableReplicationPhase>> + Send;
 
+    // Durable replication progress
+    fn get_replication_progress(&self, worker_type: WorkerType) -> impl Future<Output = EtlResult<Option<PgLsn>>> + Send;
+    fn upsert_replication_progress(&self, worker_type: WorkerType, flush_lsn: PgLsn) -> impl Future<Output = EtlResult<PgLsn>> + Send;
+    fn delete_replication_progress(&self, worker_type: WorkerType) -> impl Future<Output = EtlResult<()>> + Send;
+
     // Destination table metadata
     fn get_destination_table_metadata(&self, table_id: TableId) -> impl Future<Output = EtlResult<Option<DestinationTableMetadata>>> + Send;
     fn get_applied_destination_table_metadata(&self, table_id: TableId) -> impl Future<Output = EtlResult<Option<AppliedDestinationTableMetadata>>> + Send;
@@ -97,6 +100,18 @@ pub trait StateStore {
 | `update_table_replication_states()` | Atomically updates multiple table phases in both cache and persistent storage |
 | `update_table_replication_state()` | Updates phase in both cache and persistent storage |
 | `rollback_table_replication_state()` | Reverts table to previous phase. Returns the phase after rollback |
+
+### Durable Progress Methods
+
+Durable replication progress records the latest flushed LSN for the apply worker
+and table sync workers. It lets ETL resume from a safe boundary even when a slot
+or worker restarts.
+
+| Method | Purpose |
+|--------|---------|
+| `get_replication_progress()` | Returns stored flush progress for a worker, if present |
+| `upsert_replication_progress()` | Monotonically stores flush progress and returns the stored LSN. Implementations must not move progress backward |
+| `delete_replication_progress()` | Deletes progress when a worker slot lineage is intentionally reset |
 
 ### Destination Metadata Methods
 
@@ -126,17 +141,19 @@ Tables progress through these phases:
 
 ## CleanupStore
 
-Removes ETL metadata when tables are removed from the publication.
+Removes ETL metadata for table-copy restarts and publication removals.
 
 ```rust
 pub trait CleanupStore {
-    fn cleanup_table_state(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send;
+    fn clear_table_copy_state(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send;
+    fn delete_table_pipeline_state(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send;
 }
 ```
 
 | Method | Purpose |
 |--------|---------|
-| `cleanup_table_state()` | Deletes all stored state for a table: replication state, schema versions, and destination table metadata. Does not modify destination tables |
+| `clear_table_copy_state()` | Clears destination metadata, schema versions, and durable table-sync progress while preserving the table replication phase. This is called only after the destination object was dropped for a fresh copy |
+| `delete_table_pipeline_state()` | Deletes all stored state for a table removed from the publication. Does not modify destination tables |
 
 ## Combining Traits
 

--- a/docs/explanation/traits.md
+++ b/docs/explanation/traits.md
@@ -24,7 +24,7 @@ pub trait Destination {
 |--------|---------|
 | `name()` | Returns identifier for logging and diagnostics |
 | `shutdown()` | Called when the pipeline shuts down. Default is a no-op. Override for cleanup or bookkeeping |
-| `drop_table_for_copy()` | Drops the existing destination object and destination-private replay state before a fresh initial copy or copy retry. Receives the current replicated schema for the table |
+| `drop_table_for_copy()` | Drops the existing destination object and destination-private replay state before restarting a table copy. Receives the previously stored replicated schema for locating the old object |
 | `write_table_rows()` | Writes rows during initial table copy. Receives the current replicated schema and may get an empty vector for tables with no data |
 | `write_events()` | Processes streaming replication events (inserts, updates, deletes). Batches may span multiple tables |
 

--- a/docs/guides/custom-implementations.md
+++ b/docs/guides/custom-implementations.md
@@ -57,7 +57,7 @@ Create `src/custom_store.rs`. A store must implement three traits (see [Extensio
 
 - `SchemaStore` - Versioned table schema storage, retrieval, and pruning
 - `StateStore` - Replication progress and destination table metadata tracking
-- `CleanupStore` - Store cleanup when tables leave the publication
+- `CleanupStore` - Store cleanup for table-copy restarts and publication changes
 
 ```rust
 use std::collections::{BTreeMap, HashMap};
@@ -66,12 +66,13 @@ use tokio::sync::Mutex;
 use tracing::info;
 
 use etl::error::EtlResult;
+use etl::replication::WorkerType;
 use etl::state::{
     AppliedDestinationTableMetadata, DestinationTableMetadata, TableReplicationPhase,
 };
 use etl::store::{CleanupStore, SchemaStore, StateStore, TableReplicationStates};
 use etl::store::schema::TableSchemaRetention;
-use etl::types::{SnapshotId, TableId, TableSchema};
+use etl::types::{PgLsn, SnapshotId, TableId, TableSchema};
 
 #[derive(Debug, Clone, Default)]
 struct TableEntry {
@@ -83,6 +84,7 @@ struct TableEntry {
 #[derive(Debug, Clone)]
 pub struct CustomStore {
     tables: Arc<Mutex<HashMap<TableId, TableEntry>>>,
+    progress: Arc<Mutex<HashMap<WorkerType, PgLsn>>>,
 }
 
 impl CustomStore {
@@ -90,6 +92,7 @@ impl CustomStore {
         info!("creating custom store");
         Self {
             tables: Arc::new(Mutex::new(HashMap::new())),
+            progress: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -213,6 +216,31 @@ impl StateStore for CustomStore {
         todo!("Implement rollback if needed")
     }
 
+    async fn get_replication_progress(
+        &self,
+        worker_type: WorkerType,
+    ) -> EtlResult<Option<PgLsn>> {
+        let progress = self.progress.lock().await;
+        Ok(progress.get(&worker_type).copied())
+    }
+
+    async fn upsert_replication_progress(
+        &self,
+        worker_type: WorkerType,
+        flush_lsn: PgLsn,
+    ) -> EtlResult<PgLsn> {
+        let mut progress = self.progress.lock().await;
+        let stored_lsn = progress.entry(worker_type).or_insert(flush_lsn);
+        *stored_lsn = (*stored_lsn).max(flush_lsn);
+        Ok(*stored_lsn)
+    }
+
+    async fn delete_replication_progress(&self, worker_type: WorkerType) -> EtlResult<()> {
+        let mut progress = self.progress.lock().await;
+        progress.remove(&worker_type);
+        Ok(())
+    }
+
     async fn get_destination_table_metadata(
         &self,
         table_id: TableId,
@@ -249,9 +277,22 @@ impl StateStore for CustomStore {
 }
 
 impl CleanupStore for CustomStore {
-    async fn cleanup_table_state(&self, table_id: TableId) -> EtlResult<()> {
+    async fn clear_table_copy_state(&self, table_id: TableId) -> EtlResult<()> {
+        let mut tables = self.tables.lock().await;
+        if let Some(entry) = tables.get_mut(&table_id) {
+            entry.schemas.clear();
+            entry.destination_metadata = None;
+        }
+        let mut progress = self.progress.lock().await;
+        progress.remove(&WorkerType::TableSync { table_id });
+        Ok(())
+    }
+
+    async fn delete_table_pipeline_state(&self, table_id: TableId) -> EtlResult<()> {
         let mut tables = self.tables.lock().await;
         tables.remove(&table_id);
+        let mut progress = self.progress.lock().await;
+        progress.remove(&WorkerType::TableSync { table_id });
         Ok(())
     }
 }
@@ -264,11 +305,13 @@ impl CleanupStore for CustomStore {
 Create `src/http_destination.rs`. A destination implements the `Destination` trait with four required methods:
 
 - `name()` - Return an identifier for logging
-- `truncate_table()` - Clear table before bulk load using the current replicated table schema
+- `drop_table_for_copy()` - Idempotently drop destination table state before a fresh table copy using the current replicated table schema
 - `write_table_rows()` - Receive rows during initial copy together with the current replicated table schema
 - `write_events()` - Receive streaming changes (batches may span multiple tables)
 
 There's also an optional `shutdown()` method with a default no-op implementation. Override it if your destination needs cleanup when the pipeline shuts down.
+
+ETL clears its own schema versions, destination metadata, and table-sync progress only after `drop_table_for_copy()` succeeds. That lets the destination use the supplied replicated schema and any existing destination metadata to find the object that must be removed. If the object is already gone, return success.
 
 ```rust
 use reqwest::Client;
@@ -277,7 +320,7 @@ use std::time::Duration;
 use tracing::{info, warn};
 
 use etl::destination::{
-    Destination, TruncateTableResult, WriteEventsResult, WriteTableRowsResult,
+    Destination, DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult,
 };
 use etl::error::{ErrorKind, EtlResult};
 use etl::types::{Event, ReplicatedTableSchema, TableRow};
@@ -323,15 +366,15 @@ impl Destination for HttpDestination {
         "http"
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
         let table_name = replicated_table_schema.name().to_string();
-        info!("truncating table {}", table_name);
+        info!("dropping table before copy {}", table_name);
         let result = self
-            .post(&format!("tables/{table_name}/truncate"), json!({}))
+            .post(&format!("tables/{table_name}/drop-for-copy"), json!({}))
             .await;
         async_result.send(result);
         Ok(())

--- a/docs/guides/custom-implementations.md
+++ b/docs/guides/custom-implementations.md
@@ -305,13 +305,13 @@ impl CleanupStore for CustomStore {
 Create `src/http_destination.rs`. A destination implements the `Destination` trait with four required methods:
 
 - `name()` - Return an identifier for logging
-- `drop_table_for_copy()` - Idempotently drop destination table state before a fresh table copy using the current replicated table schema
+- `drop_table_for_copy()` - Idempotently drop destination objects and replay state before restarting a table copy using the previously stored replicated table schema
 - `write_table_rows()` - Receive rows during initial copy together with the current replicated table schema
 - `write_events()` - Receive streaming changes (batches may span multiple tables)
 
 There's also an optional `shutdown()` method with a default no-op implementation. Override it if your destination needs cleanup when the pipeline shuts down.
 
-ETL clears its own schema versions, destination metadata, and table-sync progress only after `drop_table_for_copy()` succeeds. That lets the destination use the supplied replicated schema and any existing destination metadata to find the object that must be removed. If the object is already gone, return success.
+ETL clears its own schema versions, destination metadata, and table-sync progress only after `drop_table_for_copy()` succeeds. That lets the destination use the supplied previously stored replicated schema and any existing destination metadata to find the object that must be removed. If the object is already gone, return success.
 
 ```rust
 use reqwest::Client;

--- a/docs/guides/first-pipeline.md
+++ b/docs/guides/first-pipeline.md
@@ -72,7 +72,7 @@ use etl::{
         BatchConfig, InvalidatedSlotBehavior, MemoryBackpressureConfig, PgConnectionConfig,
         PipelineConfig, TableSyncCopyConfig, TcpKeepaliveConfig, TlsConfig,
     },
-    destination::{Destination, TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+    destination::{Destination, DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     error::EtlResult,
     pipeline::Pipeline,
     store::MemoryStore,
@@ -88,12 +88,12 @@ impl Destination for LoggingDestination {
         "logging"
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         _replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        println!("starting initial table copy");
+        println!("preparing fresh table copy");
         async_result.send(Ok(()));
         Ok(())
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ use etl::{
         BatchConfig, InvalidatedSlotBehavior, MemoryBackpressureConfig, PgConnectionConfig,
         PipelineConfig, TableSyncCopyConfig, TcpKeepaliveConfig, TlsConfig,
     },
-    destination::{Destination, TruncateTableResult, WriteEventsResult, WriteTableRowsResult},
+    destination::{Destination, DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
     error::EtlResult,
     pipeline::Pipeline,
     store::MemoryStore,
@@ -65,10 +65,10 @@ impl Destination for NoopDestination {
         "noop"
     }
 
-    async fn truncate_table(
+    async fn drop_table_for_copy(
         &self,
         _replicated_table_schema: &ReplicatedTableSchema,
-        async_result: TruncateTableResult<()>,
+        async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
         async_result.send(Ok(()));
         Ok(())


### PR DESCRIPTION
## Summary

This PR tightens table reset / table-copy restart semantics so a fresh copy is treated as a new table-copy lineage instead of reusing stale destination, schema, slot, or in-memory cache state.

Key changes:

- Replaces the destination `truncate_table` hook with `drop_table_for_copy`, making the destination contract explicit: before restarting a copy, drop the destination objects and destination-private replay state associated with the previously stored replicated schema.
- On table sync startup from `Init`, `DataSync`, or `FinishedCopy`, the worker now:
  - loads the existing replicated schema if one exists,
  - drops the destination table/state through the destination,
  - deletes the table-sync slot if present,
  - clears copy-scoped destination metadata, stored table schemas, and durable table-sync progress,
  - removes any shared table-cache entry,
  - then stores a fresh `0/0` copy schema and marks the table cache ready from that fresh schema.
- Treats `FinishedCopy` as a clean-copy restart point instead of a durable catchup-resume point. This avoids a rare crash-window recovery path where no future `RELATION` message may arrive and ETL cannot soundly rebuild runtime identity masks from currently persisted metadata. Recopying is simpler and safe for this narrow window.
- Splits store cleanup into clearer scopes:
  - `clear_table_copy_state` for copy restarts, preserving table replication phase,
  - `delete_table_pipeline_state` for publication removal, deleting all table-scoped ETL state.
- Updates BigQuery reset behavior to drop the view first and then discover/drop all matching sequenced physical tables from BigQuery `INFORMATION_SCHEMA.TABLES`, instead of relying only on the local created-table cache.
- Keeps BigQuery local created-table cache aligned when old physical versions are dropped or replaced.
- Documents the shared table-cache invariants, including `Ready` vs `WaitingForRelation`, the fresh `0/0` copy-schema invariant, the single-owner rule, and the assumption that out-of-band persistent state changes require a pipeline restart.
- Updates destination docs/examples to match the new `drop_table_for_copy` contract and the `FinishedCopy` restart behavior.

## Important Invariants

- Running pipelines treat in-memory state as authoritative. If persistent state is changed outside the running pipeline, the pipeline must be restarted before that change is expected to take effect.
- A table copy always starts from a clean copy lineage: stale destination objects, table-sync slots, table schemas, destination metadata, progress, and shared cache state are removed before the fresh `0/0` schema is stored. `FinishedCopy` restarts also follow this path; recopying is preferred over persisting extra runtime decode state for a very narrow crash window.
- `SharedTableState::Ready` means row decoding is allowed. `SharedTableState::WaitingForRelation` means a durable schema exists but runtime relation masks are not ready, so row decoding must fail until a `RELATION` message refreshes the cache.
- Schema cleanup may use the shared cache to find active tables, but it still checks worker ownership before pruning. It preserves the smallest schema boundary still needed by destination metadata and durable progress.
