### PR TITLE
ref(api): Remove usage of 'ONLY'

### DIFF
--- a/crates/etl-api/src/data/publications.rs
+++ b/crates/etl-api/src/data/publications.rs
@@ -29,7 +29,7 @@ pub async fn create_publication(
     query.push_str("create publication ");
     query.push_str(&quoted_publication_name);
     if !publication.tables.is_empty() {
-        query.push_str(" for table only ");
+        query.push_str(" for table ");
     }
 
     for (i, table) in publication.tables.iter().enumerate() {
@@ -60,7 +60,7 @@ pub async fn update_publication(
     let quoted_publication_name = quote_identifier(&publication.name);
     query.push_str("alter publication ");
     query.push_str(&quoted_publication_name);
-    query.push_str(" set table only ");
+    query.push_str(" set table ");
 
     for (i, table) in publication.tables.iter().enumerate() {
         let quoted_schema = quote_identifier(&table.schema);
@@ -158,7 +158,7 @@ pub async fn add_tables_to_publication(
     pool: &PgPool,
 ) -> Result<(), PublicationsDbError> {
     let query = format!(
-        "alter publication {} add table only {}",
+        "alter publication {} add table {}",
         quote_identifier(&publication.name),
         format_table_list(&publication.tables),
     );
@@ -171,7 +171,7 @@ pub async fn drop_tables_from_publication(
     pool: &PgPool,
 ) -> Result<(), PublicationsDbError> {
     let query = format!(
-        "alter publication {} drop table only {}",
+        "alter publication {} drop table {}",
         quote_identifier(&publication.name),
         format_table_list(&publication.tables),
     );


### PR DESCRIPTION
This PR removes the usage of `ONLY` when creating publications for table that was problematic since it was applied only on the first of the tables and also would cause unexpected behavior. For the sake of simplicity now we use Postgres' default behavior which is to include all children tables in case of a setup like:

```
create table parent (id int, note text);
create table child (extra text) inherits (parent);
```

Fixes https://github.com/supabase/etl/issues/758