### PR TITLE
feat(tests): Add TLS in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,8 @@ jobs:
       NUM_LOCAL_DATABASES: 4
       TESTS_DATABASE_USERNAME: postgres
       TESTS_DATABASE_PASSWORD: postgres
+      TESTS_DATABASE_TLS_ENABLED: "true"
+      TESTS_DATABASE_TLS_ROOT_CERT: ${{ github.workspace }}/target/postgres-tls/root.crt
       TESTS_CLICKHOUSE_URL: http://localhost:8123
       TESTS_CLICKHOUSE_USER: etl
       TESTS_CLICKHOUSE_PASSWORD: etl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,12 @@
   values. Prefer metadata that helps debugging without exposing values, such as
   table and column names, type names, counts, lengths, LSNs, IDs, and operation
   names.
+- When adding logs, metrics, traces, Sentry context, panic messages, or other
+  observability output, be extra careful not to leak customer data or detailed
+  table contents. Higher-level structural metadata, such as table names, column
+  names, type names, counts, lengths, IDs, and operation names, can be included
+  when useful for debugging; do not include cell values, row payloads, request
+  or response bodies, credentials, tokens, or secrets.
 - In production logs, key errors as `error = %err` or `error = %error`
   regardless of the local variable name. Do not use `err =`, `source =`, or
   debug formatting for the primary error field.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@
 - Keep top-level binaries focused on orchestration; move implementation detail into helpers or modules.
 - Prefer clear, boring code over clever abstractions.
 - Prefer existing workspace patterns over introducing new local conventions.
+- Do not add `#[must_use]` attributes unless the user explicitly asks for one.
 - Default to private visibility and only widen when a real caller requires it.
 - Prefer the narrowest working visibility in this order: private, `pub(super)`, `pub(crate)`, then `pub`.
 - Use `pub` only for intentional crate APIs consumed by other crates, integration tests, examples, or documented user-facing entrypoints.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,15 +2156,21 @@ dependencies = [
 name = "etl-postgres"
 version = "0.1.0"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
+ "const-oid 0.9.6",
  "etl-config",
+ "futures",
  "pg_escape",
+ "rustls",
  "serde_json",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-rustls",
  "tracing",
+ "x509-cert",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,11 +1948,9 @@ dependencies = [
 name = "etl"
 version = "0.1.0"
 dependencies = [
- "aws-lc-rs",
  "byteorder",
  "bytes",
  "chrono",
- "const-oid 0.9.6",
  "etl-config",
  "etl-postgres",
  "etl-telemetry",
@@ -1970,11 +1968,9 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-postgres",
- "tokio-rustls",
  "tokio-stream",
  "tracing",
  "uuid",
- "x509-cert",
 ]
 
 [[package]]
@@ -2074,13 +2070,11 @@ dependencies = [
  "etl-telemetry",
  "futures",
  "gcp-bigquery-client",
- "hex",
  "humantime",
  "iceberg",
  "iceberg-catalog-rest",
  "jsonwebtoken",
  "k8s-openapi",
- "kube",
  "metrics",
  "parking_lot",
  "parquet",
@@ -2116,7 +2110,6 @@ dependencies = [
  "etl",
  "etl-config",
  "etl-destinations",
- "etl-telemetry",
  "k8s-openapi",
  "rustls",
  "secrecy",
@@ -2134,7 +2127,6 @@ dependencies = [
  "chrono",
  "duckdb",
  "etl",
- "etl-telemetry",
  "k8s-openapi",
  "kube",
  "metrics",
@@ -2144,7 +2136,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
@@ -2177,7 +2168,6 @@ dependencies = [
 name = "etl-replicator"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "configcat",
  "etl",
  "etl-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,7 @@ iceberg-catalog-rest = { version = "0.8.0", default-features = false }
 insta = { version = "1.43.1", default-features = false }
 # aws_lc_rs backend avoids the `rsa` crate (RUSTSEC-2023-0071, unpatched timing
 # side-channel). We only sign JWTs, but cargo-deny flags the advisory regardless.
-jsonwebtoken = { version = "10.3", default-features = false, features = [
-    "aws_lc_rs",
-] }
+jsonwebtoken = { version = "10.3", default-features = false, features = ["aws_lc_rs"] }
 k8s-openapi = { version = "0.25.0", default-features = false }
 kube = { version = "1.1.0", default-features = false }
 metrics = { version = "0.24.2", default-features = false }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,6 +128,8 @@ POSTGRES_DATA_VOLUME=/path/to/data cargo x init
 
 PostgreSQL 18+ containers store data under `/var/lib/postgresql/<major>/data`, so the Docker Compose setup mounts the parent `/var/lib/postgresql` directory to keep upgrades compatible.
 
+The source PostgreSQL container started by `cargo x init` or `cargo xtask postgres start` supports TLS by default. The task runner generates a local test CA and server certificate under `target/postgres-tls/`, then copies the server certificate and key into the container. Local clients may still connect without TLS; set `TESTS_DATABASE_TLS_ENABLED=true` when running tests to require verified TLS using the generated root certificate.
+
 The same Docker Compose stack also starts ClickHouse on `http://localhost:8123` by default, which is enough for local destination development and ClickHouse integration tests.
 
 ### Manual Setup
@@ -407,6 +409,8 @@ All tests that interact with PostgreSQL require the following environment variab
 | `TESTS_DATABASE_PORT` | **Yes** | PostgreSQL server port (e.g., `5430`) |
 | `TESTS_DATABASE_USERNAME` | **Yes** | Database user (e.g., `postgres`) |
 | `TESTS_DATABASE_PASSWORD` | No | Database password (optional) |
+| `TESTS_DATABASE_TLS_ENABLED` | No | Require verified TLS for Postgres test clients when set to `true` |
+| `TESTS_DATABASE_TLS_ROOT_CERT` | No | Path to the trusted root certificate; defaults to `target/postgres-tls/root.crt` |
 
 **Note:** Each test creates a unique database with a UUID-based name to ensure test isolation. The test databases are automatically cleaned up after tests complete.
 
@@ -477,6 +481,8 @@ export TESTS_DATABASE_HOST=localhost
 export TESTS_DATABASE_PORT=5430
 export TESTS_DATABASE_USERNAME=postgres
 export TESTS_DATABASE_PASSWORD=postgres
+# Optional when using the local Docker Compose Postgres from cargo x init.
+export TESTS_DATABASE_TLS_ENABLED=true
 
 # BigQuery test configuration (optional - only needed for BigQuery tests)
 export TESTS_BIGQUERY_PROJECT_ID=your-gcp-project-id

--- a/crates/etl-api/tests/support/database.rs
+++ b/crates/etl-api/tests/support/database.rs
@@ -6,12 +6,12 @@ use etl_api::{
 };
 use etl_config::{
     SerializableSecretString,
-    shared::{
-        ETL_MIGRATION_OPTIONS, IntoConnectOptions, PgConnectionConfig, TcpKeepaliveConfig,
-        TlsConfig,
-    },
+    shared::{ETL_MIGRATION_OPTIONS, IntoConnectOptions, PgConnectionConfig, TcpKeepaliveConfig},
 };
-use etl_postgres::sqlx::test_utils::create_pg_database;
+use etl_postgres::{
+    sqlx::test_utils::create_pg_database,
+    test_utils::{local_tls_config_from_env, test_tls_enabled_from_env},
+};
 use pg_escape::{quote_identifier, quote_literal};
 use secrecy::ExposeSecret;
 use sqlx::{AssertSqlSafe, Connection, PgConnection, PgPool};
@@ -23,7 +23,6 @@ const DEFAULT_DATABASE_HOST: &str = "localhost";
 const DEFAULT_DATABASE_PORT: &str = "5430";
 const DEFAULT_DATABASE_USERNAME: &str = "postgres";
 const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
-
 /// Creates a database configuration from TESTS_DATABASE_* environment
 /// variables.
 ///
@@ -44,7 +43,7 @@ pub(crate) fn get_test_db_config() -> PgConnectionConfig {
             .ok()
             .or(Some(DEFAULT_DATABASE_PASSWORD.into()))
             .map(Into::into),
-        tls: TlsConfig::disabled(),
+        tls: local_tls_config_from_env(),
         keepalive: TcpKeepaliveConfig::default(),
     }
 }
@@ -62,6 +61,16 @@ pub(crate) async fn create_etl_api_database(config: &PgConnectionConfig) -> PgPo
         .run(&connection_pool)
         .await
         .expect("Failed to migrate the database");
+
+    if test_tls_enabled_from_env() {
+        let ssl = sqlx::query_scalar::<_, bool>(
+            "select ssl from pg_stat_ssl where pid = pg_backend_pid()",
+        )
+        .fetch_one(&connection_pool)
+        .await
+        .expect("failed to inspect API database TLS mode");
+        assert!(ssl, "ETL API test database connection must use TLS");
+    }
 
     connection_pool
 }

--- a/crates/etl-api/tests/support/k8s_client.rs
+++ b/crates/etl-api/tests/support/k8s_client.rs
@@ -17,6 +17,7 @@ use etl_api::{
         http::{TRUSTED_ROOT_CERT_CONFIG_MAP_NAME, TRUSTED_ROOT_CERT_KEY_NAME},
     },
 };
+use etl_postgres::test_utils::test_tls_root_certs_from_env;
 use k8s_openapi::api::core::v1::ConfigMap;
 use tokio::sync::RwLock;
 
@@ -151,12 +152,10 @@ impl K8sClient for MockK8sClient {
         // a key named TRUSTED_ROOT_CERT_KEY_NAME to be present with non-empty certs
         if config_map_name == TRUSTED_ROOT_CERT_CONFIG_MAP_NAME {
             let mut map = BTreeMap::new();
-            // Use a dummy certificate for tests - the actual TLS connection won't use this
-            // since test postgres doesn't have TLS enabled
-            map.insert(
-                TRUSTED_ROOT_CERT_KEY_NAME.to_owned(),
-                "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----".to_owned(),
-            );
+            let certs = test_tls_root_certs_from_env().unwrap_or_else(|| {
+                "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----".to_owned()
+            });
+            map.insert(TRUSTED_ROOT_CERT_KEY_NAME.to_owned(), certs);
             let cm = ConfigMap { data: Some(map), ..ConfigMap::default() };
             Ok(cm)
         } else {

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -31,7 +31,7 @@ use etl_api::{
     startup::run,
 };
 use etl_config::{Environment, shared::PgConnectionConfig};
-use etl_postgres::sqlx::test_utils::drop_pg_database;
+use etl_postgres::{sqlx::test_utils::drop_pg_database, test_utils::test_tls_enabled_from_env};
 use reqwest::{IntoUrl, RequestBuilder};
 use tokio::{runtime::Handle, time::sleep};
 
@@ -585,7 +585,10 @@ async fn spawn_test_app_with_services(
         sentry: None,
         supabase_api_url: None,
         configcat_sdk_key: None,
-        source: SourceConfig { tls_enabled: false, trusted_username: trusted_source_username },
+        source: SourceConfig {
+            tls_enabled: test_tls_enabled_from_env(),
+            trusted_username: trusted_source_username,
+        },
     };
 
     let server = run(

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -9,9 +9,6 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["k8s-openapi"]
-
 [lib]
 doctest = false
 

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -9,6 +9,9 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["k8s-openapi"]
+
 [lib]
 doctest = false
 
@@ -69,7 +72,6 @@ clickhouse = [
 snowflake = [
     "dep:base64",
     "dep:bytes",
-    "dep:hex",
     "dep:jsonwebtoken",
     "dep:metrics",
     "dep:reqwest",
@@ -104,12 +106,10 @@ etl-config = { workspace = true }
 etl-maintenance = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 gcp-bigquery-client = { workspace = true, optional = true, features = ["rust-tls", "aws-lc-rs"] }
-hex = { workspace = true, optional = true }
 humantime = { workspace = true, optional = true }
 iceberg = { workspace = true, optional = true }
 iceberg-catalog-rest = { workspace = true, optional = true }
 jsonwebtoken = { workspace = true, optional = true }
-kube = { workspace = true, optional = true, features = ["client", "rustls-tls"] }
 metrics = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 parquet = { workspace = true, optional = true, features = ["async", "arrow"] }

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -1623,7 +1623,7 @@ mod tests {
 
     use duckdb::{Config, Connection};
     use etl::{
-        config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig},
+        config::{PgConnectionConfig, TcpKeepaliveConfig},
         store::{both::memory::MemoryStore, schema::SchemaStore},
         types::{
             Cell, ColumnSchema, IdentityMask, PartialTableRow, ReplicationMask, TableRow,
@@ -1631,7 +1631,7 @@ mod tests {
         },
     };
     use etl_maintenance::ducklake::flush_table_inlined_data;
-    use etl_postgres::tokio::test_utils::PgDatabase;
+    use etl_postgres::{test_utils::local_tls_config_from_env, tokio::test_utils::PgDatabase};
     use pg_escape::{quote_identifier, quote_literal};
     use tempfile::TempDir;
     use tokio_postgres::Client;
@@ -1745,7 +1745,7 @@ mod tests {
             username: env::var("TESTS_DATABASE_USERNAME")
                 .expect("TESTS_DATABASE_USERNAME must be set"),
             password: env::var("TESTS_DATABASE_PASSWORD").ok().map(Into::into),
-            tls: TlsConfig { trusted_root_certs: String::new(), enabled: false },
+            tls: local_tls_config_from_env(),
             keepalive: TcpKeepaliveConfig::default(),
         }
     }

--- a/crates/etl-destinations/tests/support/ducklake.rs
+++ b/crates/etl-destinations/tests/support/ducklake.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use duckdb::{Config, Connection};
-use etl::config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig};
-use etl_postgres::tokio::test_utils::PgDatabase;
+use etl::config::{PgConnectionConfig, TcpKeepaliveConfig};
+use etl_postgres::{test_utils::local_tls_config_from_env, tokio::test_utils::PgDatabase};
 use pg_escape::quote_literal;
 use tokio_postgres::{
     Client, Config as PgConfig,
@@ -20,7 +20,6 @@ use uuid::Uuid;
 const DUCKDB_EXTENSION_VERSION: &str = "1.5.2";
 const DUCKLAKE_EXTENSION_FILE: &str = "ducklake.duckdb_extension";
 const POSTGRES_SCANNER_EXTENSION_FILE: &str = "postgres_scanner.duckdb_extension";
-
 pub struct DuckLakeTestEnv {
     _catalog_database: PgDatabase<Client>,
     pub catalog_url: Url,
@@ -162,7 +161,7 @@ fn local_pg_connection_config(database_name: String) -> PgConnectionConfig {
         name: database_name,
         username: env::var("TESTS_DATABASE_USERNAME").expect("TESTS_DATABASE_USERNAME must be set"),
         password: env::var("TESTS_DATABASE_PASSWORD").ok().map(Into::into),
-        tls: TlsConfig { trusted_root_certs: String::new(), enabled: false },
+        tls: local_tls_config_from_env(),
         keepalive: TcpKeepaliveConfig::default(),
     }
 }

--- a/crates/etl-examples/Cargo.toml
+++ b/crates/etl-examples/Cargo.toml
@@ -8,6 +8,9 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["k8s-openapi"]
+
 [[bin]]
 name = "bigquery"
 path = "src/bin/bigquery.rs"
@@ -37,30 +40,20 @@ default = []
 bigquery = ["etl-destinations/bigquery"]
 clickhouse = ["etl-destinations/clickhouse"]
 ducklake = ["etl-destinations/ducklake"]
-snowflake = [
-    "etl-destinations/snowflake",
-    "dep:secrecy",
-]
+snowflake = ["etl-destinations/snowflake", "dep:secrecy"]
 
 [dependencies]
 
-clap = { workspace = true, default-features = true, features = [
-    "std",
-    "derive",
-    "env",
-] }
+clap = { workspace = true, default-features = true, features = ["std", "derive", "env"] }
 etl = { workspace = true }
 etl-config = { workspace = true }
 etl-destinations = { workspace = true }
-etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 secrecy = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "signal", "time"] }
 tracing = { workspace = true, default-features = true }
-tracing-subscriber = { workspace = true, default-features = true, features = [
-    "env-filter",
-] }
+tracing-subscriber = { workspace = true, default-features = true, features = ["env-filter"] }
 url = { workspace = true }
 
 [lints]

--- a/crates/etl-examples/Cargo.toml
+++ b/crates/etl-examples/Cargo.toml
@@ -8,9 +8,6 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["k8s-openapi"]
-
 [[bin]]
 name = "bigquery"
 path = "src/bin/bigquery.rs"

--- a/crates/etl-maintenance/Cargo.toml
+++ b/crates/etl-maintenance/Cargo.toml
@@ -7,9 +7,6 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["k8s-openapi"]
-
 [lib]
 doctest = false
 

--- a/crates/etl-maintenance/Cargo.toml
+++ b/crates/etl-maintenance/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["k8s-openapi"]
+
 [lib]
 doctest = false
 
@@ -45,10 +48,8 @@ tracing = { workspace = true, default-features = true }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]
-etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [lints]

--- a/crates/etl-postgres/Cargo.toml
+++ b/crates/etl-postgres/Cargo.toml
@@ -20,12 +20,12 @@ replication = ["sqlx"]
 
 [dependencies]
 
-bytes = { workspace = true }
 aws-lc-rs = { workspace = true }
+bytes = { workspace = true }
 const-oid = { workspace = true }
 etl-config = { workspace = true }
-pg_escape = { workspace = true }
 futures = { workspace = true }
+pg_escape = { workspace = true }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "macros", "postgres", "json", "migrate"] }

--- a/crates/etl-postgres/Cargo.toml
+++ b/crates/etl-postgres/Cargo.toml
@@ -21,14 +21,20 @@ replication = ["sqlx"]
 [dependencies]
 
 bytes = { workspace = true }
+aws-lc-rs = { workspace = true }
+const-oid = { workspace = true }
 etl-config = { workspace = true }
 pg_escape = { workspace = true }
+futures = { workspace = true }
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "macros", "postgres", "json", "migrate"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { workspace = true, features = ["runtime", "with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
+tokio-rustls = { workspace = true }
 tracing = { workspace = true }
+x509-cert = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/etl-postgres/src/lib.rs
+++ b/crates/etl-postgres/src/lib.rs
@@ -8,6 +8,8 @@
 pub mod replication;
 #[cfg(feature = "sqlx")]
 pub mod sqlx;
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
 #[cfg(feature = "tokio")]
 pub mod tokio;
 pub mod types;

--- a/crates/etl-postgres/src/test_utils.rs
+++ b/crates/etl-postgres/src/test_utils.rs
@@ -1,0 +1,49 @@
+use std::path::{Path, PathBuf};
+
+use etl_config::shared::TlsConfig;
+
+const DEFAULT_DATABASE_TLS_ROOT_CERT: &str = "target/postgres-tls/root.crt";
+
+/// Returns whether test database clients should require TLS.
+#[must_use]
+pub fn test_tls_enabled_from_env() -> bool {
+    std::env::var("TESTS_DATABASE_TLS_ENABLED")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// Returns TLS settings for local test database clients.
+#[must_use]
+pub fn local_tls_config_from_env() -> TlsConfig {
+    if !test_tls_enabled_from_env() {
+        return TlsConfig::disabled();
+    }
+
+    let root_cert_path = test_tls_root_cert_path();
+    let trusted_root_certs = std::fs::read_to_string(&root_cert_path).unwrap_or_else(|_| {
+        panic!("Failed to read TESTS_DATABASE_TLS_ROOT_CERT at {}", root_cert_path.display())
+    });
+
+    TlsConfig { trusted_root_certs, enabled: true }
+}
+
+/// Returns the trusted root certificate path for local test TLS.
+#[must_use]
+pub fn test_tls_root_cert_path() -> PathBuf {
+    std::env::var_os("TESTS_DATABASE_TLS_ROOT_CERT")
+        .map_or_else(|| workspace_root().join(DEFAULT_DATABASE_TLS_ROOT_CERT), PathBuf::from)
+}
+
+/// Returns trusted root certificates for local test TLS when enabled.
+#[must_use]
+pub fn test_tls_root_certs_from_env() -> Option<String> {
+    test_tls_enabled_from_env().then(|| local_tls_config_from_env().trusted_root_certs)
+}
+
+/// Returns the repository workspace root from this crate's manifest path.
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("etl-postgres should live under crates/")
+}

--- a/crates/etl-postgres/src/test_utils.rs
+++ b/crates/etl-postgres/src/test_utils.rs
@@ -5,7 +5,6 @@ use etl_config::shared::TlsConfig;
 const DEFAULT_DATABASE_TLS_ROOT_CERT: &str = "target/postgres-tls/root.crt";
 
 /// Returns whether test database clients should require TLS.
-#[must_use]
 pub fn test_tls_enabled_from_env() -> bool {
     std::env::var("TESTS_DATABASE_TLS_ENABLED")
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
@@ -13,7 +12,6 @@ pub fn test_tls_enabled_from_env() -> bool {
 }
 
 /// Returns TLS settings for local test database clients.
-#[must_use]
 pub fn local_tls_config_from_env() -> TlsConfig {
     if !test_tls_enabled_from_env() {
         return TlsConfig::disabled();
@@ -27,14 +25,12 @@ pub fn local_tls_config_from_env() -> TlsConfig {
 }
 
 /// Returns the trusted root certificate path for local test TLS.
-#[must_use]
 pub fn test_tls_root_cert_path() -> PathBuf {
     std::env::var_os("TESTS_DATABASE_TLS_ROOT_CERT")
         .map_or_else(|| workspace_root().join(DEFAULT_DATABASE_TLS_ROOT_CERT), PathBuf::from)
 }
 
 /// Returns trusted root certificates for local test TLS when enabled.
-#[must_use]
 pub fn test_tls_root_certs_from_env() -> Option<String> {
     test_tls_enabled_from_env().then(|| local_tls_config_from_env().trusted_root_certs)
 }

--- a/crates/etl-postgres/src/test_utils.rs
+++ b/crates/etl-postgres/src/test_utils.rs
@@ -20,9 +20,8 @@ pub fn local_tls_config_from_env() -> TlsConfig {
     }
 
     let root_cert_path = test_tls_root_cert_path();
-    let trusted_root_certs = std::fs::read_to_string(&root_cert_path).unwrap_or_else(|_| {
-        panic!("Failed to read TESTS_DATABASE_TLS_ROOT_CERT at {}", root_cert_path.display())
-    });
+    let trusted_root_certs = std::fs::read_to_string(&root_cert_path)
+        .expect("Failed to read TESTS_DATABASE_TLS_ROOT_CERT");
 
     TlsConfig { trusted_root_certs, enabled: true }
 }

--- a/crates/etl-postgres/src/tokio/mod.rs
+++ b/crates/etl-postgres/src/tokio/mod.rs
@@ -1,2 +1,4 @@
+pub mod tls;
+
 #[cfg(feature = "test-utils")]
 pub mod test_utils;

--- a/crates/etl-postgres/src/tokio/test_utils.rs
+++ b/crates/etl-postgres/src/tokio/test_utils.rs
@@ -2,6 +2,10 @@ use std::{num::NonZeroI32, time::Duration};
 
 use etl_config::shared::{IntoConnectOptions, PgConnectionConfig};
 use pg_escape::quote_identifier;
+use rustls::{
+    ClientConfig, RootCertStore,
+    pki_types::{CertificateDer, pem::PemObject},
+};
 use tokio::runtime::Handle;
 use tokio_postgres::{
     Client, GenericClient, NoTls, Transaction,
@@ -12,6 +16,7 @@ use tracing::info;
 use crate::{
     replication::extract_server_version,
     requires_version,
+    tokio::tls::MakeRustlsConnect,
     types::{ColumnSchema, TableId, TableName},
     version::POSTGRES_15,
 };
@@ -668,6 +673,65 @@ pub fn id_column_schema() -> ColumnSchema {
     ColumnSchema::new("id".to_owned(), Type::INT8, -1, 1, Some(1), false)
 }
 
+/// Connects with the TLS mode described by the test database configuration.
+async fn connect_with_config(
+    config: tokio_postgres::Config,
+    pg_connection_config: &PgConnectionConfig,
+) -> (Client, Option<NonZeroI32>) {
+    try_connect_with_config(config, pg_connection_config)
+        .await
+        .expect("failed to connect to Postgres")
+}
+
+/// Tries to connect with the TLS mode described by the test database
+/// configuration.
+async fn try_connect_with_config(
+    config: tokio_postgres::Config,
+    pg_connection_config: &PgConnectionConfig,
+) -> Result<(Client, Option<NonZeroI32>), String> {
+    if pg_connection_config.tls.enabled {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        let mut root_store = RootCertStore::empty();
+        for cert in
+            CertificateDer::pem_slice_iter(pg_connection_config.tls.trusted_root_certs.as_bytes())
+        {
+            let cert = cert.map_err(|error| error.to_string())?;
+            root_store.add(cert).map_err(|error| error.to_string())?;
+        }
+
+        let tls_config =
+            ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth();
+        let (client, connection) = config
+            .connect(MakeRustlsConnect::new(tls_config))
+            .await
+            .map_err(|error| error.to_string())?;
+        let server_version =
+            connection.parameter("server_version").and_then(extract_server_version);
+
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                info!(error = %e, "connection error");
+            }
+        });
+
+        Ok((client, server_version))
+    } else {
+        let (client, connection) =
+            config.connect(NoTls).await.map_err(|error| error.to_string())?;
+        let server_version =
+            connection.parameter("server_version").and_then(extract_server_version);
+
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                info!(error = %e, "connection error");
+            }
+        });
+
+        Ok((client, server_version))
+    }
+}
+
 /// Creates a new Postgres database and returns a connected client.
 ///
 /// Establishes connection to Postgres server, creates a new database,
@@ -677,17 +741,8 @@ pub fn id_column_schema() -> ColumnSchema {
 /// Panics if connection or database creation fails.
 pub async fn create_pg_database(config: &PgConnectionConfig) -> (Client, Option<NonZeroI32>) {
     // Create the database via a single connection
-    let (client, connection) = {
-        let config: tokio_postgres::Config = config.without_db(None);
-        config.connect(NoTls).await.expect("failed to connect to Postgres")
-    };
-
-    // Spawn the connection on a new task
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            info!(error = %e, "connection error");
-        }
-    });
+    let admin_config: tokio_postgres::Config = config.without_db(None);
+    let (client, _) = connect_with_config(admin_config, config).await;
 
     // Create the database
     client
@@ -710,20 +765,8 @@ pub async fn create_pg_database(config: &PgConnectionConfig) -> (Client, Option<
 /// Panics if connection fails.
 pub async fn connect_to_pg_database(config: &PgConnectionConfig) -> (Client, Option<NonZeroI32>) {
     // Create a new client connected to the created database
-    let (client, connection) = {
-        let config: tokio_postgres::Config = config.with_db(None);
-        config.connect(NoTls).await.expect("failed to connect to Postgres")
-    };
-    let server_version = connection.parameter("server_version").and_then(extract_server_version);
-
-    // Spawn the connection on a new task
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            info!(error = %e, "connection error");
-        }
-    });
-
-    (client, server_version)
+    let database_config: tokio_postgres::Config = config.with_db(None);
+    connect_with_config(database_config, config).await
 }
 
 /// Drops a Postgres database and cleans up all resources.
@@ -736,23 +779,14 @@ pub async fn connect_to_pg_database(config: &PgConnectionConfig) -> (Client, Opt
 /// or connections can't be established.
 pub async fn drop_pg_database(config: &PgConnectionConfig) {
     // Connect to the default database
-    let (client, connection) = {
-        let config: tokio_postgres::Config = config.without_db(None);
-        match config.connect(NoTls).await {
-            Ok(conn) => conn,
-            Err(e) => {
-                eprintln!("warning: failed to connect to Postgres for cleanup: {e}");
-                return;
-            }
+    let admin_config: tokio_postgres::Config = config.without_db(None);
+    let client = match try_connect_with_config(admin_config, config).await {
+        Ok((client, _)) => client,
+        Err(e) => {
+            eprintln!("warning: failed to connect to Postgres for cleanup: {e}");
+            return;
         }
     };
-
-    // Spawn the connection on a new task
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            info!(error = %e, "connection error");
-        }
-    });
 
     // Forcefully terminate any remaining connections to the database
     if let Err(e) = client

--- a/crates/etl-postgres/src/tokio/tls.rs
+++ b/crates/etl-postgres/src/tokio/tls.rs
@@ -1,0 +1,175 @@
+// This code is copied from the tokio-postgres-rustls library (https://github.com/jbg/tokio-postgres-rustls),
+// available under the MIT License, which provides Rustls-based TLS support for
+// secure asynchronous Postgres connections using the tokio-postgres client.
+
+use std::{
+    io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use aws_lc_rs::digest;
+use const_oid::db::{
+    rfc5912::{
+        ECDSA_WITH_SHA_256, ECDSA_WITH_SHA_384, ID_SHA_1, ID_SHA_256, ID_SHA_384, ID_SHA_512,
+        SHA_1_WITH_RSA_ENCRYPTION, SHA_256_WITH_RSA_ENCRYPTION, SHA_384_WITH_RSA_ENCRYPTION,
+        SHA_512_WITH_RSA_ENCRYPTION,
+    },
+    rfc8410::ID_ED_25519,
+};
+use futures::FutureExt;
+use rustls::{ClientConfig, pki_types::ServerName};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_postgres::tls::{ChannelBinding, MakeTlsConnect, TlsConnect};
+use tokio_rustls::{TlsConnector, client::TlsStream};
+use x509_cert::{TbsCertificate, der::Decode};
+
+/// A `MakeTlsConnect` implementation using `rustls`.
+///
+/// That way you can connect to Postgres using `rustls` as the TLS stack.
+#[derive(Clone)]
+pub struct MakeRustlsConnect {
+    config: Arc<ClientConfig>,
+}
+
+impl MakeRustlsConnect {
+    /// Creates a new `MakeRustlsConnect` from the provided `ClientConfig`.
+    #[must_use]
+    pub fn new(config: ClientConfig) -> Self {
+        Self { config: Arc::new(config) }
+    }
+}
+
+impl<S> MakeTlsConnect<S> for MakeRustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsStream<S>;
+    type TlsConnect = RustlsConnect;
+    type Error = rustls::pki_types::InvalidDnsNameError;
+
+    fn make_tls_connect(&mut self, hostname: &str) -> Result<Self::TlsConnect, Self::Error> {
+        ServerName::try_from(hostname).map(|dns_name| {
+            RustlsConnect(RustlsConnectData {
+                hostname: dns_name.to_owned(),
+                connector: Arc::clone(&self.config).into(),
+            })
+        })
+    }
+}
+
+pub struct TlsConnectFuture<S> {
+    inner: tokio_rustls::Connect<S>,
+}
+
+impl<S> Future for TlsConnectFuture<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    type Output = io::Result<RustlsStream<S>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().inner.poll_unpin(cx).map_ok(RustlsStream)
+    }
+}
+
+pub struct RustlsConnect(RustlsConnectData);
+
+pub struct RustlsConnectData {
+    hostname: ServerName<'static>,
+    connector: TlsConnector,
+}
+
+impl<S> TlsConnect<S> for RustlsConnect
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Stream = RustlsStream<S>;
+    type Error = io::Error;
+    type Future = TlsConnectFuture<S>;
+
+    fn connect(self, stream: S) -> Self::Future {
+        TlsConnectFuture { inner: self.0.connector.connect(self.0.hostname, stream) }
+    }
+}
+
+pub struct RustlsStream<S>(TlsStream<S>);
+
+impl<S> RustlsStream<S>
+where
+    S: Unpin,
+{
+    fn project_stream(self: Pin<&mut Self>) -> Pin<&mut TlsStream<S>> {
+        Pin::new(&mut self.get_mut().0)
+    }
+}
+
+impl<S> tokio_postgres::tls::TlsStream for RustlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn channel_binding(&self) -> ChannelBinding {
+        let (_, session) = self.0.get_ref();
+        match session.peer_certificates() {
+            Some(certs) if !certs.is_empty() => TbsCertificate::from_der(&certs[0])
+                .ok()
+                .and_then(|cert| {
+                    let digest = match cert.signature.oid {
+                        // Note: SHA1 is upgraded to SHA256 as per https://datatracker.ietf.org/doc/html/rfc5929#section-4.1
+                        ID_SHA_1
+                        | ID_SHA_256
+                        | SHA_1_WITH_RSA_ENCRYPTION
+                        | SHA_256_WITH_RSA_ENCRYPTION
+                        | ECDSA_WITH_SHA_256 => &digest::SHA256,
+                        ID_SHA_384 | SHA_384_WITH_RSA_ENCRYPTION | ECDSA_WITH_SHA_384 => {
+                            &digest::SHA384
+                        }
+                        ID_SHA_512 | SHA_512_WITH_RSA_ENCRYPTION | ID_ED_25519 => &digest::SHA512,
+                        _ => return None,
+                    };
+
+                    Some(digest)
+                })
+                .map_or_else(ChannelBinding::none, |algorithm| {
+                    let hash = digest::digest(algorithm, certs[0].as_ref());
+                    ChannelBinding::tls_server_end_point(hash.as_ref().into())
+                }),
+            _ => ChannelBinding::none(),
+        }
+    }
+}
+
+impl<S> AsyncRead for RustlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.project_stream().poll_read(cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for RustlsStream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project_stream().poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project_stream().poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project_stream().poll_shutdown(cx)
+    }
+}

--- a/crates/etl-postgres/src/tokio/tls.rs
+++ b/crates/etl-postgres/src/tokio/tls.rs
@@ -35,7 +35,6 @@ pub struct MakeRustlsConnect {
 
 impl MakeRustlsConnect {
     /// Creates a new `MakeRustlsConnect` from the provided `ClientConfig`.
-    #[must_use]
     pub fn new(config: ClientConfig) -> Self {
         Self { config: Arc::new(config) }
     }

--- a/crates/etl-replicator/Cargo.toml
+++ b/crates/etl-replicator/Cargo.toml
@@ -7,9 +7,6 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["k8s-openapi"]
-
 [features]
 default = []
 egress = ["etl/egress", "etl-destinations/egress"]

--- a/crates/etl-replicator/Cargo.toml
+++ b/crates/etl-replicator/Cargo.toml
@@ -7,13 +7,15 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["k8s-openapi"]
+
 [features]
 default = []
 egress = ["etl/egress", "etl-destinations/egress"]
 
 [dependencies]
 
-chrono = { workspace = true }
 configcat = { workspace = true }
 etl = { workspace = true }
 etl-config = { workspace = true, features = ["supabase"] }

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -17,11 +17,9 @@ default = []
 
 [dependencies]
 
-aws-lc-rs = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
-const-oid = { workspace = true, default-features = false }
 etl-config = { workspace = true }
 etl-postgres = { workspace = true, features = ["tokio", "replication"] }
 fail = { workspace = true }
@@ -38,11 +36,9 @@ sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres"
 sysinfo = { workspace = true, features = ["system"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 tokio-postgres = { workspace = true, features = ["runtime", "with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
-tokio-rustls = { workspace = true, default-features = false }
 tokio-stream = { workspace = true }
 tracing = { workspace = true, default-features = true }
 uuid = { workspace = true, features = ["v4"] }
-x509-cert = { workspace = true, default-features = false }
 
 [dev-dependencies]
 etl-postgres = { workspace = true, features = ["tokio", "replication", "test-utils"] }

--- a/crates/etl/src/replication/client.rs
+++ b/crates/etl/src/replication/client.rs
@@ -34,6 +34,17 @@ const DELETE_SLOT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Default duration unit used when `pg_settings.unit` is empty.
 const PG_SETTINGS_DEFAULT_DURATION_UNIT: &str = "ms";
 
+/// Builds a rustls client config from PEM-encoded trusted root certificates.
+fn tls_client_config_from_root_certs(trusted_root_certs: &str) -> EtlResult<ClientConfig> {
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in CertificateDer::pem_slice_iter(trusted_root_certs.as_bytes()) {
+        let cert = cert?;
+        root_store.add(cert)?;
+    }
+
+    Ok(ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth())
+}
+
 /// Spawns a background task to monitor a Postgres connection until it
 /// terminates.
 fn spawn_postgres_connection<T>(
@@ -440,19 +451,8 @@ impl PgReplicationClient {
             pg_connection_config.clone().with_db(Some(&ETL_REPLICATION_OPTIONS));
         config.replication_mode(ReplicationMode::Logical);
 
-        let mut root_store = rustls::RootCertStore::empty();
-        if pg_connection_config.tls.enabled {
-            for cert in CertificateDer::pem_slice_iter(
-                pg_connection_config.tls.trusted_root_certs.as_bytes(),
-            ) {
-                let cert = cert?;
-                root_store.add(cert)?;
-            }
-        };
-
         let tls_config =
-            ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth();
-
+            tls_client_config_from_root_certs(&pg_connection_config.tls.trusted_root_certs)?;
         let (client, connection) = config.connect(MakeRustlsConnect::new(tls_config)).await?;
 
         let server_version =
@@ -493,17 +493,8 @@ impl PgReplicationClient {
         let config: Config =
             self.pg_connection_config.as_ref().clone().with_db(Some(&ETL_REPLICATION_OPTIONS));
 
-        let mut root_store = rustls::RootCertStore::empty();
-        for cert in CertificateDer::pem_slice_iter(
-            self.pg_connection_config.tls.trusted_root_certs.as_bytes(),
-        ) {
-            let cert = cert?;
-            root_store.add(cert)?;
-        }
-
         let tls_config =
-            ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth();
-
+            tls_client_config_from_root_certs(&self.pg_connection_config.tls.trusted_root_certs)?;
         let (client, connection) = config.connect(MakeRustlsConnect::new(tls_config)).await?;
         let connection_updates_rx = spawn_postgres_connection::<MakeRustlsConnect>(connection);
 

--- a/crates/etl/src/replication/client.rs
+++ b/crates/etl/src/replication/client.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashSet, fmt, num::NonZeroI32, sync::Arc, time::Duration};
 
-use etl_postgres::{below_version, replication::extract_server_version, version::POSTGRES_15};
+use etl_postgres::{
+    below_version, replication::extract_server_version, tokio::tls::MakeRustlsConnect,
+    version::POSTGRES_15,
+};
 use pg_escape::{quote_identifier, quote_literal};
 use postgres_replication::LogicalReplicationStream;
 use rustls::{
@@ -21,7 +24,6 @@ use crate::{
     error::{ErrorKind, EtlResult},
     etl_error,
     types::{ColumnSchema, PgLsn, SnapshotId, TableId, TableName, TableSchema},
-    utils::MakeRustlsConnect,
 };
 
 /// Maximum time to wait for a replication slot deletion to complete.

--- a/crates/etl/src/test_utils/database.rs
+++ b/crates/etl/src/test_utils/database.rs
@@ -19,8 +19,10 @@
 //!
 //! See `scripts/docker-compose.yaml` for the test database configuration.
 
-use etl_config::shared::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig};
-use etl_postgres::{tokio::test_utils::PgDatabase, types::TableName};
+use etl_config::shared::{PgConnectionConfig, TcpKeepaliveConfig};
+use etl_postgres::{
+    test_utils::local_tls_config_from_env, tokio::test_utils::PgDatabase, types::TableName,
+};
 use pg_escape::quote_identifier;
 use tokio_postgres::Client;
 use uuid::Uuid;
@@ -37,7 +39,6 @@ const DEFAULT_DATABASE_HOST: &str = "localhost";
 const DEFAULT_DATABASE_PORT: &str = "5430";
 const DEFAULT_DATABASE_USERNAME: &str = "postgres";
 const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
-
 /// Creates a [`TableName`] in the test schema.
 ///
 /// This helper function constructs a [`TableName`] with the schema set to the
@@ -60,6 +61,9 @@ pub fn test_table_name(name: &str) -> TableName {
 /// - `TESTS_DATABASE_PORT`: Postgres server port (default: `5430`)
 /// - `TESTS_DATABASE_USERNAME`: Database user (default: `postgres`)
 /// - `TESTS_DATABASE_PASSWORD`: Database password (default: `postgres`)
+/// - `TESTS_DATABASE_TLS_ENABLED`: Whether test clients use TLS (default:
+///   `false`)
+/// - `TESTS_DATABASE_TLS_ROOT_CERT`: Path to the trusted root certificate
 fn local_pg_connection_config() -> PgConnectionConfig {
     PgConnectionConfig {
         host: std::env::var("TESTS_DATABASE_HOST").unwrap_or(DEFAULT_DATABASE_HOST.into()),
@@ -75,7 +79,7 @@ fn local_pg_connection_config() -> PgConnectionConfig {
             .ok()
             .or(Some(DEFAULT_DATABASE_PASSWORD.into()))
             .map(Into::into),
-        tls: TlsConfig { trusted_root_certs: String::new(), enabled: false },
+        tls: local_tls_config_from_env(),
         keepalive: TcpKeepaliveConfig::default(),
     }
 }

--- a/crates/etl/src/utils/mod.rs
+++ b/crates/etl/src/utils/mod.rs
@@ -1,3 +1,1 @@
 mod tokio;
-
-pub(crate) use tokio::MakeRustlsConnect;

--- a/crates/etl/src/utils/tokio.rs
+++ b/crates/etl/src/utils/tokio.rs
@@ -28,9 +28,8 @@ mod tests {
         let password =
             std::env::var("TESTS_DATABASE_PASSWORD").unwrap_or_else(|_| "postgres".to_owned());
         let root_cert_path = test_tls_root_cert_path();
-        let trusted_root_certs = std::fs::read_to_string(&root_cert_path).unwrap_or_else(|_| {
-            panic!("Failed to read TESTS_DATABASE_TLS_ROOT_CERT at {}", root_cert_path.display())
-        });
+        let trusted_root_certs = std::fs::read_to_string(&root_cert_path)
+            .expect("Failed to read TESTS_DATABASE_TLS_ROOT_CERT");
 
         let mut root_store = RootCertStore::empty();
         for cert in CertificateDer::pem_slice_iter(trusted_root_certs.as_bytes()) {

--- a/crates/etl/src/utils/tokio.rs
+++ b/crates/etl/src/utils/tokio.rs
@@ -1,256 +1,50 @@
-// This code is copied from the tokio-postgres-rustls library (https://github.com/jbg/tokio-postgres-rustls),
-// available under the MIT License, which provides Rustls-based TLS support for
-// secure asynchronous Postgres connections using the tokio-postgres client.
-
-use std::{
-    io,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
-
-use aws_lc_rs::digest;
-use const_oid::db::{
-    rfc5912::{
-        ECDSA_WITH_SHA_256, ECDSA_WITH_SHA_384, ID_SHA_1, ID_SHA_256, ID_SHA_384, ID_SHA_512,
-        SHA_1_WITH_RSA_ENCRYPTION, SHA_256_WITH_RSA_ENCRYPTION, SHA_384_WITH_RSA_ENCRYPTION,
-        SHA_512_WITH_RSA_ENCRYPTION,
-    },
-    rfc8410::ID_ED_25519,
-};
-use futures::FutureExt;
-use rustls::{ClientConfig, pki_types::ServerName};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio_postgres::tls::{ChannelBinding, MakeTlsConnect, TlsConnect};
-use tokio_rustls::{TlsConnector, client::TlsStream};
-use x509_cert::{TbsCertificate, der::Decode};
-
-/// A `MakeTlsConnect` implementation using `rustls`.
-///
-/// That way you can connect to Postgres using `rustls` as the TLS stack.
-#[derive(Clone)]
-pub(crate) struct MakeRustlsConnect {
-    config: Arc<ClientConfig>,
-}
-
-impl MakeRustlsConnect {
-    /// Creates a new `MakeRustlsConnect` from the provided `ClientConfig`.
-    #[must_use]
-    pub(crate) fn new(config: ClientConfig) -> Self {
-        Self { config: Arc::new(config) }
-    }
-}
-
-impl<S> MakeTlsConnect<S> for MakeRustlsConnect
-where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-{
-    type Stream = RustlsStream<S>;
-    type TlsConnect = RustlsConnect;
-    type Error = rustls::pki_types::InvalidDnsNameError;
-
-    fn make_tls_connect(&mut self, hostname: &str) -> Result<Self::TlsConnect, Self::Error> {
-        ServerName::try_from(hostname).map(|dns_name| {
-            RustlsConnect(RustlsConnectData {
-                hostname: dns_name.to_owned(),
-                connector: Arc::clone(&self.config).into(),
-            })
-        })
-    }
-}
-
-pub(crate) struct TlsConnectFuture<S> {
-    inner: tokio_rustls::Connect<S>,
-}
-
-impl<S> Future for TlsConnectFuture<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    type Output = io::Result<RustlsStream<S>>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.get_mut().inner.poll_unpin(cx).map_ok(RustlsStream)
-    }
-}
-
-pub(crate) struct RustlsConnect(RustlsConnectData);
-
-pub(crate) struct RustlsConnectData {
-    hostname: ServerName<'static>,
-    connector: TlsConnector,
-}
-
-impl<S> TlsConnect<S> for RustlsConnect
-where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-{
-    type Stream = RustlsStream<S>;
-    type Error = io::Error;
-    type Future = TlsConnectFuture<S>;
-
-    fn connect(self, stream: S) -> Self::Future {
-        TlsConnectFuture { inner: self.0.connector.connect(self.0.hostname, stream) }
-    }
-}
-
-pub(crate) struct RustlsStream<S>(TlsStream<S>);
-
-impl<S> RustlsStream<S>
-where
-    S: Unpin,
-{
-    fn project_stream(self: Pin<&mut Self>) -> Pin<&mut TlsStream<S>> {
-        Pin::new(&mut self.get_mut().0)
-    }
-}
-
-impl<S> tokio_postgres::tls::TlsStream for RustlsStream<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    fn channel_binding(&self) -> ChannelBinding {
-        let (_, session) = self.0.get_ref();
-        match session.peer_certificates() {
-            Some(certs) if !certs.is_empty() => TbsCertificate::from_der(&certs[0])
-                .ok()
-                .and_then(|cert| {
-                    let digest = match cert.signature.oid {
-                        // Note: SHA1 is upgraded to SHA256 as per https://datatracker.ietf.org/doc/html/rfc5929#section-4.1
-                        ID_SHA_1
-                        | ID_SHA_256
-                        | SHA_1_WITH_RSA_ENCRYPTION
-                        | SHA_256_WITH_RSA_ENCRYPTION
-                        | ECDSA_WITH_SHA_256 => &digest::SHA256,
-                        ID_SHA_384 | SHA_384_WITH_RSA_ENCRYPTION | ECDSA_WITH_SHA_384 => {
-                            &digest::SHA384
-                        }
-                        ID_SHA_512 | SHA_512_WITH_RSA_ENCRYPTION | ID_ED_25519 => &digest::SHA512,
-                        _ => return None,
-                    };
-
-                    Some(digest)
-                })
-                .map_or_else(ChannelBinding::none, |algorithm| {
-                    let hash = digest::digest(algorithm, certs[0].as_ref());
-                    ChannelBinding::tls_server_end_point(hash.as_ref().into())
-                }),
-            _ => ChannelBinding::none(),
-        }
-    }
-}
-
-impl<S> AsyncRead for RustlsStream<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        self.project_stream().poll_read(cx, buf)
-    }
-}
-
-impl<S> AsyncWrite for RustlsStream<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        self.project_stream().poll_write(cx, buf)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.project_stream().poll_flush(cx)
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.project_stream().poll_shutdown(cx)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use rustls::{
-        Error, SignatureScheme,
-        client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
-        pki_types::{CertificateDer, UnixTime},
+    use etl_postgres::{
+        test_utils::{test_tls_enabled_from_env, test_tls_root_cert_path},
+        tokio::tls::MakeRustlsConnect,
     };
+    use rustls::{
+        ClientConfig, RootCertStore,
+        pki_types::{CertificateDer, pem::PemObject},
+    };
+    use tokio_postgres::config::SslMode;
 
-    use super::*;
-
-    #[derive(Debug)]
-    struct AcceptAllVerifier {}
-    impl ServerCertVerifier for AcceptAllVerifier {
-        fn verify_server_cert(
-            &self,
-            _end_entity: &CertificateDer<'_>,
-            _intermediates: &[CertificateDer<'_>],
-            _server_name: &ServerName<'_>,
-            _ocsp_response: &[u8],
-            _now: UnixTime,
-        ) -> Result<ServerCertVerified, Error> {
-            Ok(ServerCertVerified::assertion())
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _dss: &rustls::DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _dss: &rustls::DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-            vec![
-                SignatureScheme::ECDSA_NISTP384_SHA384,
-                SignatureScheme::ECDSA_NISTP256_SHA256,
-                SignatureScheme::RSA_PSS_SHA512,
-                SignatureScheme::RSA_PSS_SHA384,
-                SignatureScheme::RSA_PSS_SHA256,
-                SignatureScheme::ED25519,
-            ]
-        }
-    }
-
-    // TODO: setup Postgres with TLS in CI to have this test pass.
     #[tokio::test]
-    #[ignore]
-    async fn it_works() {
-        rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .expect("failed to install default crypto provider");
+    async fn connects_with_rustls_when_test_tls_is_enabled() {
+        if !test_tls_enabled_from_env() {
+            return;
+        }
 
-        let mut config = ClientConfig::builder()
-            .with_root_certificates(rustls::RootCertStore::empty())
-            .with_no_client_auth();
-        config.dangerous().set_certificate_verifier(Arc::new(AcceptAllVerifier {}));
-
-        let tls = MakeRustlsConnect::new(config);
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         let host = std::env::var("TESTS_DATABASE_HOST").unwrap_or_else(|_| "localhost".to_owned());
-        let port = std::env::var("TESTS_DATABASE_PORT").unwrap_or_else(|_| "5430".to_owned());
+        let port = std::env::var("TESTS_DATABASE_PORT")
+            .unwrap_or_else(|_| "5430".to_owned())
+            .parse()
+            .expect("TESTS_DATABASE_PORT must be a valid port number");
         let user =
             std::env::var("TESTS_DATABASE_USERNAME").unwrap_or_else(|_| "postgres".to_owned());
-        let connection_string = format!("sslmode=require host={host} port={port} user={user}");
+        let password =
+            std::env::var("TESTS_DATABASE_PASSWORD").unwrap_or_else(|_| "postgres".to_owned());
+        let root_cert_path = test_tls_root_cert_path();
+        let trusted_root_certs = std::fs::read_to_string(&root_cert_path).unwrap_or_else(|_| {
+            panic!("Failed to read TESTS_DATABASE_TLS_ROOT_CERT at {}", root_cert_path.display())
+        });
 
-        let (client, conn) =
-            tokio_postgres::connect(&connection_string, tls).await.expect("connect");
+        let mut root_store = RootCertStore::empty();
+        for cert in CertificateDer::pem_slice_iter(trusted_root_certs.as_bytes()) {
+            root_store.add(cert.expect("failed to parse root certificate")).unwrap();
+        }
+
+        let tls_config =
+            ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth();
+        let tls = MakeRustlsConnect::new(tls_config);
+
+        let mut config = tokio_postgres::Config::new();
+        config.host(host).port(port).user(user).password(password).ssl_mode(SslMode::VerifyFull);
+
+        let (client, conn) = config.connect(tls).await.expect("connect");
 
         tokio::task::spawn(async move { conn.await.map_err(|e| panic!("{e:?}")) });
 

--- a/crates/etl/tests/migrations.rs
+++ b/crates/etl/tests/migrations.rs
@@ -4,14 +4,13 @@ use etl::{
     config::{
         BatchConfig, ETL_MIGRATION_OPTIONS, IntoConnectOptions, InvalidatedSlotBehavior,
         MemoryBackpressureConfig, PgConnectionConfig, PipelineConfig, TableSyncCopyConfig,
-        TlsConfig,
     },
     migrations::run_source_migrations,
     pipeline::Pipeline,
     store::{MemoryStore, PostgresStore},
     test_utils::memory_destination::MemoryDestination,
 };
-use etl_postgres::tokio::test_utils::PgDatabase;
+use etl_postgres::{test_utils::local_tls_config_from_env, tokio::test_utils::PgDatabase};
 use etl_telemetry::tracing::init_test_tracing;
 use sqlx::{Connection, Executor, PgConnection, migrate::Migrator, postgres::PgConnectOptions};
 use tokio_postgres::Client;
@@ -21,7 +20,6 @@ const DEFAULT_DATABASE_HOST: &str = "localhost";
 const DEFAULT_DATABASE_PORT: &str = "5430";
 const DEFAULT_DATABASE_USERNAME: &str = "postgres";
 const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
-
 const POSTGRES_STORE_BASE_VERSION: i64 = 20250827000000;
 
 fn local_pg_connection_config() -> PgConnectionConfig {
@@ -39,7 +37,7 @@ fn local_pg_connection_config() -> PgConnectionConfig {
             .ok()
             .or(Some(DEFAULT_DATABASE_PASSWORD.into()))
             .map(Into::into),
-        tls: TlsConfig { trusted_root_certs: String::new(), enabled: false },
+        tls: local_tls_config_from_env(),
         keepalive: Default::default(),
     }
 }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -6,21 +6,9 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true, features = [
-    "derive",
-    "std",
-    "help",
-    "usage",
-    "error-context",
-    "env",
-] }
+clap = { workspace = true, features = ["derive", "std", "help", "usage", "error-context", "env"] }
 k8s-openapi = { workspace = true, features = ["latest"] }
-kube = { workspace = true, features = [
-    "client",
-    "derive",
-    "rustls-tls",
-    "ring",
-] }
+kube = { workspace = true, features = ["client", "derive", "rustls-tls", "ring"] }
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }
 schemars = "0.8"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/xtask/src/commands/postgres.rs
+++ b/crates/xtask/src/commands/postgres.rs
@@ -1,4 +1,6 @@
 use std::{
+    fs,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     thread,
     time::Duration,
@@ -30,6 +32,17 @@ fn docker_compose_command() -> (&'static str, &'static [&'static str]) {
 const DEFAULT_PG_VERSION: &str = "18";
 const DEFAULT_PG_USER: &str = "postgres";
 const HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+const TLS_CERT_DIR: &str = "target/postgres-tls";
+const TLS_ROOT_CERT_FILE: &str = "root.crt";
+const TLS_ROOT_KEY_FILE: &str = "root.key";
+const TLS_SERVER_CERT_FILE: &str = "server.crt";
+const TLS_SERVER_KEY_FILE: &str = "server.key";
+const TLS_SERVER_CSR_FILE: &str = "server.csr";
+const TLS_SERVER_EXT_FILE: &str = "server.ext";
+const POSTGRES_TLS_CERT_PATH: &str = "/var/lib/postgresql/server.crt";
+const POSTGRES_TLS_KEY_PATH: &str = "/var/lib/postgresql/server.key";
+const POSTGRES_SSL_ARGS: &str = "-c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c \
+                                 ssl_key_file=/var/lib/postgresql/server.key";
 
 #[derive(Args)]
 pub(crate) struct PostgresArgs {
@@ -61,6 +74,19 @@ struct StartArgs {
     /// Start only source Postgres instead of the full local development stack.
     #[arg(long, default_value_t = false)]
     source_only: bool,
+    /// Skip TLS support in the spawned source Postgres containers.
+    #[arg(long, default_value_t = false)]
+    no_tls: bool,
+}
+
+/// Paths to generated TLS files used by local Postgres containers.
+struct TlsFiles {
+    /// Trusted root certificate used by test clients.
+    root_cert: PathBuf,
+    /// Server certificate copied into Postgres containers.
+    server_cert: PathBuf,
+    /// Server private key copied into Postgres containers.
+    server_key: PathBuf,
 }
 
 impl PostgresArgs {
@@ -90,16 +116,18 @@ impl StartArgs {
             if self.source_only { " with source Postgres only" } else { "" },
         );
 
+        let tls_files = if self.no_tls { None } else { Some(self.prepare_tls_files()?) };
+
         // Start the full stack on the base port unless the caller only needs source
         // Postgres.
         let first_shard_services = if self.source_only { &["source-postgres"][..] } else { &[] };
-        self.docker_compose_up(&self.pg_version, None, first_shard_services)?;
+        self.start_cluster(None, first_shard_services, tls_files.as_ref())?;
 
         // Start additional source-postgres containers on subsequent ports.
         for shard in 2..=self.shards {
             let port = self.base_port + shard - 1;
             let project = format!("etl-stack-pg-{}-shard-{shard}", self.pg_version);
-            self.docker_compose_up(&self.pg_version, Some((&project, port)), &["source-postgres"])?;
+            self.start_cluster(Some((&project, port)), &["source-postgres"], tls_files.as_ref())?;
         }
 
         // Wait for all clusters to accept connections.
@@ -108,30 +136,127 @@ impl StartArgs {
             self.wait_for_pg(port)?;
         }
 
+        if let Some(tls_files) = tls_files {
+            eprintln!(
+                "source Postgres supports TLS using root certificate {}. Local tests use \
+                 plaintext by default; set TESTS_DATABASE_TLS_ENABLED=true to require verified \
+                 TLS.",
+                tls_files.root_cert.display()
+            );
+        }
+
         Ok(())
+    }
+
+    /// Starts one source Postgres cluster, enabling server-side TLS when
+    /// certificate files are available.
+    fn start_cluster(
+        &self,
+        project_and_port: Option<(&str, u16)>,
+        services: &[&str],
+        tls_files: Option<&TlsFiles>,
+    ) -> Result<()> {
+        self.docker_compose_up(project_and_port, services, false, false)?;
+
+        if let Some(tls_files) = tls_files {
+            self.install_tls_files(project_and_port, tls_files)?;
+            self.docker_compose_up(project_and_port, &["source-postgres"], true, true)?;
+        }
+
+        Ok(())
+    }
+
+    /// Generates a local certificate authority and server certificate for the
+    /// source Postgres test containers.
+    fn prepare_tls_files(&self) -> Result<TlsFiles> {
+        let cert_dir = PathBuf::from(TLS_CERT_DIR);
+        let root_cert = cert_dir.join(TLS_ROOT_CERT_FILE);
+        let root_key = cert_dir.join(TLS_ROOT_KEY_FILE);
+        let server_cert = cert_dir.join(TLS_SERVER_CERT_FILE);
+        let server_key = cert_dir.join(TLS_SERVER_KEY_FILE);
+        let server_csr = cert_dir.join(TLS_SERVER_CSR_FILE);
+        let server_ext = cert_dir.join(TLS_SERVER_EXT_FILE);
+
+        if root_cert.is_file() && server_cert.is_file() && server_key.is_file() {
+            return Ok(TlsFiles { root_cert, server_cert, server_key });
+        }
+
+        fs::create_dir_all(&cert_dir).context("failed to create Postgres TLS certificate dir")?;
+        fs::write(
+            &server_ext,
+            "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1\nextendedKeyUsage=serverAuth\n",
+        )
+        .context("failed to write Postgres TLS certificate extension file")?;
+
+        run_openssl(["genrsa", "-out", path_str(&root_key)?, "2048"])?;
+        run_openssl([
+            "req",
+            "-x509",
+            "-new",
+            "-nodes",
+            "-key",
+            path_str(&root_key)?,
+            "-sha256",
+            "-days",
+            "3650",
+            "-subj",
+            "/CN=etl local test root",
+            "-out",
+            path_str(&root_cert)?,
+        ])?;
+        run_openssl(["genrsa", "-out", path_str(&server_key)?, "2048"])?;
+        run_openssl([
+            "req",
+            "-new",
+            "-key",
+            path_str(&server_key)?,
+            "-subj",
+            "/CN=localhost",
+            "-out",
+            path_str(&server_csr)?,
+        ])?;
+        run_openssl([
+            "x509",
+            "-req",
+            "-in",
+            path_str(&server_csr)?,
+            "-CA",
+            path_str(&root_cert)?,
+            "-CAkey",
+            path_str(&root_key)?,
+            "-CAcreateserial",
+            "-out",
+            path_str(&server_cert)?,
+            "-days",
+            "3650",
+            "-sha256",
+            "-extfile",
+            path_str(&server_ext)?,
+        ])?;
+
+        Ok(TlsFiles { root_cert, server_cert, server_key })
     }
 
     fn docker_compose_up(
         &self,
-        pg_version: &str,
         project_and_port: Option<(&str, u16)>,
         services: &[&str],
+        tls: bool,
+        force_recreate: bool,
     ) -> Result<()> {
-        let postgres_image =
-            std::env::var("POSTGRES_IMAGE").unwrap_or_else(|_| format!("postgres:{pg_version}"));
-        let (program, compose_args) = docker_compose_command();
-        let mut cmd = Command::new(program);
-        cmd.args(compose_args);
-        cmd.args(["-f", COMPOSE_FILE]);
-        cmd.env("POSTGRES_VERSION", pg_version);
+        let postgres_image = std::env::var("POSTGRES_IMAGE")
+            .unwrap_or_else(|_| format!("postgres:{}", self.pg_version));
+        let mut cmd = self.docker_compose_base_command(project_and_port);
         cmd.env("POSTGRES_IMAGE", &postgres_image);
 
-        if let Some((project, port)) = project_and_port {
-            cmd.args(["-p", project]);
-            cmd.env("POSTGRES_PORT", port.to_string());
+        if tls {
+            cmd.env("POSTGRES_SSL_ARGS", POSTGRES_SSL_ARGS);
         }
 
         cmd.args(["up", "-d"]);
+        if force_recreate {
+            cmd.arg("--force-recreate");
+        }
         cmd.args(services);
 
         let status = cmd.status().context("failed to run docker compose")?;
@@ -141,6 +266,55 @@ impl StartArgs {
         }
 
         Ok(())
+    }
+
+    /// Copies generated TLS files into a source Postgres container and fixes
+    /// ownership and permissions for the Postgres server.
+    fn install_tls_files(
+        &self,
+        project_and_port: Option<(&str, u16)>,
+        tls_files: &TlsFiles,
+    ) -> Result<()> {
+        self.docker_compose_cp(project_and_port, &tls_files.server_cert, POSTGRES_TLS_CERT_PATH)?;
+        self.docker_compose_cp(project_and_port, &tls_files.server_key, POSTGRES_TLS_KEY_PATH)?;
+
+        let permissions_command = format!(
+            "chown postgres:postgres {POSTGRES_TLS_CERT_PATH} {POSTGRES_TLS_KEY_PATH} && chmod \
+             0644 {POSTGRES_TLS_CERT_PATH} && chmod 0600 {POSTGRES_TLS_KEY_PATH}"
+        );
+        let mut cmd = self.docker_compose_base_command(project_and_port);
+        cmd.args(["exec", "-T", "-u", "root", "source-postgres", "sh", "-c", &permissions_command]);
+        run_command(cmd, "failed to prepare Postgres TLS files")?;
+
+        Ok(())
+    }
+
+    /// Copies a file from the host into the source Postgres container.
+    fn docker_compose_cp(
+        &self,
+        project_and_port: Option<(&str, u16)>,
+        source: &Path,
+        destination: &str,
+    ) -> Result<()> {
+        let mut cmd = self.docker_compose_base_command(project_and_port);
+        cmd.args(["cp", path_str(source)?, &format!("source-postgres:{destination}")]);
+        run_command(cmd, "failed to copy Postgres TLS file into container")
+    }
+
+    /// Returns a configured docker compose command for this Postgres version.
+    fn docker_compose_base_command(&self, project_and_port: Option<(&str, u16)>) -> Command {
+        let (program, compose_args) = docker_compose_command();
+        let mut cmd = Command::new(program);
+        cmd.args(compose_args);
+        cmd.args(["-f", COMPOSE_FILE]);
+        cmd.env("POSTGRES_VERSION", &self.pg_version);
+
+        if let Some((project, port)) = project_and_port {
+            cmd.args(["-p", project]);
+            cmd.env("POSTGRES_PORT", port.to_string());
+        }
+
+        cmd
     }
 
     fn wait_for_pg(&self, port: u16) -> Result<()> {
@@ -157,4 +331,27 @@ impl StartArgs {
             thread::sleep(HEALTH_CHECK_INTERVAL);
         }
     }
+}
+
+/// Converts a path to UTF-8 for command arguments.
+fn path_str(path: &Path) -> Result<&str> {
+    path.to_str().context("path is not valid UTF-8")
+}
+
+/// Runs an openssl command and fails if it exits unsuccessfully.
+fn run_openssl<const N: usize>(args: [&str; N]) -> Result<()> {
+    let mut cmd = Command::new("openssl");
+    cmd.args(args);
+    run_command(cmd, "failed to run openssl")
+}
+
+/// Runs a command and fails if it exits unsuccessfully.
+fn run_command(mut cmd: Command, context: &'static str) -> Result<()> {
+    let status = cmd.status().context(context)?;
+
+    if !status.success() {
+        bail!("{context}");
+    }
+
+    Ok(())
 }

--- a/crates/xtask/src/commands/postgres.rs
+++ b/crates/xtask/src/commands/postgres.rs
@@ -81,8 +81,6 @@ struct StartArgs {
 
 /// Paths to generated TLS files used by local Postgres containers.
 struct TlsFiles {
-    /// Trusted root certificate used by test clients.
-    root_cert: PathBuf,
     /// Server certificate copied into Postgres containers.
     server_cert: PathBuf,
     /// Server private key copied into Postgres containers.
@@ -136,12 +134,10 @@ impl StartArgs {
             self.wait_for_pg(port)?;
         }
 
-        if let Some(tls_files) = tls_files {
+        if tls_files.is_some() {
             eprintln!(
-                "source Postgres supports TLS using root certificate {}. Local tests use \
-                 plaintext by default; set TESTS_DATABASE_TLS_ENABLED=true to require verified \
-                 TLS.",
-                tls_files.root_cert.display()
+                "source Postgres supports TLS. Local tests use plaintext by default; set \
+                 TESTS_DATABASE_TLS_ENABLED=true to require verified TLS.",
             );
         }
 
@@ -178,7 +174,7 @@ impl StartArgs {
         let server_ext = cert_dir.join(TLS_SERVER_EXT_FILE);
 
         if root_cert.is_file() && server_cert.is_file() && server_key.is_file() {
-            return Ok(TlsFiles { root_cert, server_cert, server_key });
+            return Ok(TlsFiles { server_cert, server_key });
         }
 
         fs::create_dir_all(&cert_dir).context("failed to create Postgres TLS certificate dir")?;
@@ -234,7 +230,7 @@ impl StartArgs {
             path_str(&server_ext)?,
         ])?;
 
-        Ok(TlsFiles { root_cert, server_cert, server_key })
+        Ok(TlsFiles { server_cert, server_key })
     }
 
     fn docker_compose_up(

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       -c max_wal_senders=100
       -c max_replication_slots=100
       -c wal_sender_timeout=10s
+      ${POSTGRES_SSL_ARGS:-}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]

--- a/scripts/run_migrations.sh
+++ b/scripts/run_migrations.sh
@@ -49,6 +49,13 @@ setup_database_url() {
   DB_HOST="${POSTGRES_HOST:=localhost}"
 
   export DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+
+  if [[ "${TESTS_DATABASE_TLS_ENABLED:-false}" =~ ^(1|true|TRUE|yes|on)$ ]]; then
+    local ssl_root_cert="${TESTS_DATABASE_TLS_ROOT_CERT:-${ROOT_DIR}/target/postgres-tls/root.crt}"
+    export DATABASE_URL="${DATABASE_URL}?sslmode=verify-full&sslrootcert=${ssl_root_cert}"
+    export PGSSLMODE="verify-full"
+    export PGSSLROOTCERT="${ssl_root_cert}"
+  fi
 }
 
 run_etl_api_migrations() {
@@ -88,7 +95,11 @@ run_etl_migrations() {
   # Create a temporary sqlx-cli compatible database URL that sets the search_path.
   # This ensures the _sqlx_migrations table is created in the etl schema.
   local sqlx_migrations_opts="options=-csearch_path%3Detl"
-  local migration_url="${DATABASE_URL}?${sqlx_migrations_opts}"
+  local separator="?"
+  if [[ "${DATABASE_URL}" == *\?* ]]; then
+    separator="&"
+  fi
+  local migration_url="${DATABASE_URL}${separator}${sqlx_migrations_opts}"
 
   sqlx database create --database-url "${DATABASE_URL}"
   sqlx migrate run --source "$store_migrations_dir" --database-url "${migration_url}" --ignore-missing


### PR DESCRIPTION
## Summary

- enable local Docker Compose Postgres clusters to support TLS by generating test certificates and installing them into source Postgres containers
- add shared test TLS helpers plus a reusable rustls connector in etl-postgres, then wire Postgres-backed tests to TESTS_DATABASE_TLS_ENABLED / TESTS_DATABASE_TLS_ROOT_CERT
- run CI Postgres tests and migration scripts with verified TLS enabled
- clean up dependency declarations after moving the rustls connector out of etl