### PR TITLE
ref(snowflake): replace rsa key file with pem string

### DIFF
--- a/crates/etl-config/src/shared/destination.rs
+++ b/crates/etl-config/src/shared/destination.rs
@@ -157,8 +157,8 @@ pub enum DestinationConfig {
         account_id: String,
         /// Snowflake user with RSA public key configured.
         user: String,
-        /// Path to RSA private key file (PEM/PKCS8 format).
-        private_key_path: String,
+        /// RSA private key in PEM format (PKCS#8 or PKCS#1).
+        private_key: SecretString,
         /// Optional passphrase for encrypted private key.
         private_key_passphrase: Option<SecretString>,
         /// Target database name.
@@ -371,8 +371,6 @@ pub enum DestinationConfigWithoutSecrets {
         account_id: String,
         /// Snowflake user with RSA public key configured.
         user: String,
-        /// Path to RSA private key file (PEM/PKCS8 format).
-        private_key_path: String,
         /// Target database name.
         database: String,
         /// Target schema name.
@@ -436,7 +434,7 @@ impl From<DestinationConfig> for DestinationConfigWithoutSecrets {
             DestinationConfig::Snowflake {
                 account_id,
                 user,
-                private_key_path,
+                private_key: _,
                 private_key_passphrase: _,
                 database,
                 schema,
@@ -444,7 +442,6 @@ impl From<DestinationConfig> for DestinationConfigWithoutSecrets {
             } => DestinationConfigWithoutSecrets::Snowflake {
                 account_id,
                 user,
-                private_key_path,
                 database,
                 schema,
                 role,

--- a/crates/etl-destinations/src/snowflake/auth.rs
+++ b/crates/etl-destinations/src/snowflake/auth.rs
@@ -126,17 +126,17 @@ pub struct AuthManager<E = HttpExchanger> {
 }
 
 impl AuthManager<HttpExchanger> {
-    /// Build an `AuthManager` from an RSA private key on disk.
+    /// Build an `AuthManager` from PEM-encoded RSA private key text.
     ///
     /// Creates its own internal `reqwest::Client` via `HttpExchanger`.
     pub fn new(
         config: &Config,
-        private_key_path: &str,
+        private_key_pem: &str,
         passphrase: Option<&secrecy::SecretString>,
     ) -> Result<Self> {
         Self::with_exchanger(
             config,
-            private_key_path,
+            private_key_pem,
             passphrase,
             HttpExchanger::new(
                 reqwest::Client::builder()
@@ -150,20 +150,17 @@ impl AuthManager<HttpExchanger> {
 }
 
 impl<E: TokenExchanger> AuthManager<E> {
-    /// Build an `AuthManager` with a custom token exchanger.
+    /// Build an `AuthManager` from PEM-encoded RSA private key text.
     ///
     /// The public-key fingerprint is derived and reused for every JWT.
     /// Accepts PKCS#8 (encrypted or plain) and PKCS#1 PEM formats.
     pub fn with_exchanger(
         config: &Config,
-        private_key_path: &str,
+        private_key_pem: &str,
         passphrase: Option<&secrecy::SecretString>,
         exchanger: E,
     ) -> Result<Self> {
-        let pem_text = std::fs::read_to_string(private_key_path)
-            .map_err(|e| Error::Config(format!("failed to read private key file: {e}")))?;
-
-        let (pkcs1_der, key_pair) = decode_and_load_rsa_key(&pem_text, passphrase)?;
+        let (pkcs1_der, key_pair) = decode_and_load_rsa_key(private_key_pem, passphrase)?;
 
         // Snowflake identifies keys by SHA-256(DER-encoded public key).
         let pub_der = key_pair
@@ -343,8 +340,9 @@ mod tests {
         username: &str,
     ) -> AuthManager<TestExchanger> {
         let config = Config::new(account_id, username, "TEST_DB", "PUBLIC");
+        let pem = std::fs::read_to_string(TEST_KEY_PATH).expect("test key");
 
-        AuthManager::with_exchanger(&config, TEST_KEY_PATH, None, TestExchanger)
+        AuthManager::with_exchanger(&config, &pem, None, TestExchanger)
             .expect("AuthManager::with_exchanger")
     }
 

--- a/crates/etl-destinations/src/snowflake/test_utils.rs
+++ b/crates/etl-destinations/src/snowflake/test_utils.rs
@@ -41,11 +41,17 @@ pub fn load_test_config() -> Config {
 }
 
 /// Load the private key path from `TESTS_SNOWFLAKE_PRIVATE_KEY_PATH`.
-pub fn load_test_private_key_path() -> PathBuf {
+fn load_test_private_key_path() -> PathBuf {
     PathBuf::from(
         std::env::var(SNOWFLAKE_PRIVATE_KEY_PATH_ENV)
             .unwrap_or_else(|_| panic!("{SNOWFLAKE_PRIVATE_KEY_PATH_ENV} must be set")),
     )
+}
+
+/// Load the private key PEM text.
+pub fn load_test_private_key_pem() -> String {
+    std::fs::read_to_string(load_test_private_key_path())
+        .unwrap_or_else(|e| panic!("failed to read {SNOWFLAKE_PRIVATE_KEY_PATH_ENV}: {e}"))
 }
 
 /// Execute a SELECT query and return result rows. Requires an active warehouse.

--- a/crates/etl-destinations/tests/snowflake/auth.rs
+++ b/crates/etl-destinations/tests/snowflake/auth.rs
@@ -1,16 +1,15 @@
 use etl_destinations::snowflake::{
     AuthManager, TokenProvider,
-    test_utils::{load_test_config, load_test_private_key_path},
+    test_utils::{load_test_config, load_test_private_key_pem},
 };
 
 #[tokio::test]
 #[ignore = "requires Snowflake credentials — see etl-destinations/src/snowflake/README.md"]
 async fn authenticate_against_snowflake() {
     let config = load_test_config();
-    let key_path = load_test_private_key_path();
+    let pem = load_test_private_key_pem();
 
-    let auth = AuthManager::new(&config, key_path.to_str().unwrap(), None)
-        .expect("AuthManager creation failed");
+    let auth = AuthManager::new(&config, &pem, None).expect("AuthManager creation failed");
 
     let token = auth.get_token().await.expect("authentication failed");
     assert!(!token.is_empty(), "token should not be empty");

--- a/crates/etl-destinations/tests/snowflake/common.rs
+++ b/crates/etl-destinations/tests/snowflake/common.rs
@@ -3,17 +3,14 @@ use std::sync::Arc;
 use etl_destinations::snowflake::{
     AuthManager, Config, Destination, HttpExchanger, OffsetToken, RestStreamClient, SqlClient,
     StreamClient,
-    test_utils::{load_test_config, load_test_private_key_path},
+    test_utils::{load_test_config, load_test_private_key_pem},
 };
 use futures::FutureExt;
 
 pub fn build_auth() -> Arc<AuthManager<HttpExchanger>> {
     let config = load_test_config();
-    let key_path = load_test_private_key_path();
-    Arc::new(
-        AuthManager::new(&config, key_path.to_str().unwrap(), None)
-            .expect("AuthManager creation failed"),
-    )
+    let pem = load_test_private_key_pem();
+    Arc::new(AuthManager::new(&config, &pem, None).expect("AuthManager creation failed"))
 }
 
 pub async fn with_table_cleanup<F, Fut>(

--- a/crates/etl-examples/src/bin/snowflake.rs
+++ b/crates/etl-examples/src/bin/snowflake.rs
@@ -221,11 +221,9 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
     // Build the auth manager using key-pair authentication
     let passphrase: Option<SecretString> =
         args.sf_args.snowflake_private_key_passphrase.map(SecretString::from);
-    let auth = Arc::new(AuthManager::new(
-        &sf_config,
-        &args.sf_args.snowflake_private_key_path,
-        passphrase.as_ref(),
-    )?);
+    let private_key_pem = std::fs::read_to_string(&args.sf_args.snowflake_private_key_path)
+        .expect("failed to read private key file");
+    let auth = Arc::new(AuthManager::new(&sf_config, &private_key_pem, passphrase.as_ref())?);
 
     // Initialize Snowflake destination -- tables will be automatically created
     // to match the Postgres schema

--- a/crates/etl-replicator/src/core.rs
+++ b/crates/etl-replicator/src/core.rs
@@ -223,7 +223,7 @@ pub(crate) async fn start_replicator_with_config(
         DestinationConfig::Snowflake {
             account_id,
             user,
-            private_key_path,
+            private_key,
             private_key_passphrase,
             database,
             schema,
@@ -236,7 +236,7 @@ pub(crate) async fn start_replicator_with_config(
             let auth = std::sync::Arc::new(
                 snowflake::AuthManager::new(
                     &config,
-                    private_key_path,
+                    private_key.expose_secret(),
                     private_key_passphrase.as_ref(),
                 )
                 .map_err(|e| ReplicatorError::config(std::io::Error::other(e.to_string())))?,


### PR DESCRIPTION
## Summary

Change `AuthManager::new()` to accept PEM text directly instead of a file path

This makes Snowflake consistent with every other destination, which passes secrets as in-memory strings. Removes the need for volume mounts in k8s and simplifies the upcoming API config work.

Related to ETL-641