### PR TITLE
feat(api): add Snowflake destination config

### DIFF
--- a/crates/etl-api/src/configs/destination.rs
+++ b/crates/etl-api/src/configs/destination.rs
@@ -149,6 +149,31 @@ pub enum FullApiDestinationConfig {
         #[serde(default)]
         maintenance_mode: DuckLakeMaintenanceMode,
     },
+    Snowflake {
+        #[schema(example = "ORGNAME-ACCOUNTNAME")]
+        #[serde(deserialize_with = "crate::utils::trim_string")]
+        account_id: String,
+        #[schema(example = "ETL_USER")]
+        #[serde(deserialize_with = "crate::utils::trim_string")]
+        user: String,
+        #[schema(example = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA...")]
+        private_key: SerializableSecretString,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        private_key_passphrase: Option<SerializableSecretString>,
+        #[schema(example = "ANALYTICS")]
+        #[serde(deserialize_with = "crate::utils::trim_string")]
+        database: String,
+        #[schema(example = "PUBLIC")]
+        #[serde(deserialize_with = "crate::utils::trim_string")]
+        schema: String,
+        #[schema(example = "ETL_ROLE")]
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "crate::utils::trim_option_string"
+        )]
+        role: Option<String>,
+    },
 }
 
 impl From<StoredDestinationConfig> for FullApiDestinationConfig {
@@ -239,6 +264,23 @@ impl From<StoredDestinationConfig> for FullApiDestinationConfig {
                 expire_snapshots_older_than,
                 maintenance_mode,
             },
+            StoredDestinationConfig::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
+            } => Self::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
+            },
         }
     }
 }
@@ -277,6 +319,15 @@ pub enum StoredDestinationConfig {
         maintenance_target_file_size: Option<String>,
         expire_snapshots_older_than: Option<String>,
         maintenance_mode: DuckLakeMaintenanceMode,
+    },
+    Snowflake {
+        account_id: String,
+        user: String,
+        private_key: SerializableSecretString,
+        private_key_passphrase: Option<SerializableSecretString>,
+        database: String,
+        schema: String,
+        role: Option<String>,
     },
 }
 
@@ -374,6 +425,23 @@ impl StoredDestinationConfig {
                 expire_snapshots_older_than,
                 maintenance_mode,
             },
+            Self::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
+            } => DestinationConfig::Snowflake {
+                account_id,
+                user,
+                private_key: private_key.into(),
+                private_key_passphrase: private_key_passphrase.map(Into::into),
+                database,
+                schema,
+                role,
+            },
         }
     }
 }
@@ -466,6 +534,23 @@ impl From<FullApiDestinationConfig> for StoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+            },
+            FullApiDestinationConfig::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
+            } => Self::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
             },
         }
     }
@@ -604,6 +689,31 @@ impl Encrypt<EncryptedStoredDestinationConfig> for StoredDestinationConfig {
                     maintenance_mode,
                 })
             }
+            Self::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
+            } => {
+                let encrypted_private_key =
+                    encrypt_text(private_key.expose_secret().to_owned(), encryption_key)?;
+                let encrypted_private_key_passphrase = private_key_passphrase
+                    .map(|p| encrypt_text(p.expose_secret().to_owned(), encryption_key))
+                    .transpose()?;
+
+                Ok(EncryptedStoredDestinationConfig::Snowflake {
+                    account_id,
+                    user,
+                    private_key: encrypted_private_key,
+                    private_key_passphrase: encrypted_private_key_passphrase,
+                    database,
+                    schema,
+                    role,
+                })
+            }
         }
     }
 }
@@ -648,6 +758,15 @@ pub enum EncryptedStoredDestinationConfig {
         expire_snapshots_older_than: Option<String>,
         #[serde(default)]
         maintenance_mode: DuckLakeMaintenanceMode,
+    },
+    Snowflake {
+        account_id: String,
+        user: String,
+        private_key: EncryptedValue,
+        private_key_passphrase: Option<EncryptedValue>,
+        database: String,
+        schema: String,
+        role: Option<String>,
     },
 }
 
@@ -799,6 +918,32 @@ impl Decrypt<StoredDestinationConfig> for EncryptedStoredDestinationConfig {
                 expire_snapshots_older_than,
                 maintenance_mode,
             }),
+            Self::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
+            } => {
+                let private_key =
+                    SerializableSecretString::from(decrypt_text(private_key, encryption_key)?);
+                let private_key_passphrase = private_key_passphrase
+                    .map(|p| decrypt_text(p, encryption_key))
+                    .transpose()?
+                    .map(SerializableSecretString::from);
+
+                Ok(StoredDestinationConfig::Snowflake {
+                    account_id,
+                    user,
+                    private_key,
+                    private_key_passphrase,
+                    database,
+                    schema,
+                    role,
+                })
+            }
         }
     }
 }

--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -90,6 +90,8 @@ pub enum DestinationType {
     },
     /// DuckLake destination.
     Ducklake,
+    /// Snowflake destination.
+    Snowflake,
 }
 
 impl From<&StoredDestinationConfig> for DestinationType {
@@ -102,6 +104,7 @@ impl From<&StoredDestinationConfig> for DestinationType {
                 DestinationType::ClickHouse { password_secret_required: password.is_some() }
             }
             StoredDestinationConfig::Ducklake { .. } => DestinationType::Ducklake,
+            StoredDestinationConfig::Snowflake { .. } => DestinationType::Snowflake,
         }
     }
 }
@@ -240,6 +243,22 @@ pub trait K8sClient: Send + Sync {
     ///
     /// Does nothing if the secret does not exist.
     async fn delete_ducklake_secret(&self, prefix: &str) -> Result<(), K8sError>;
+
+    /// Creates or updates the Snowflake credentials secret for a replicator.
+    ///
+    /// The secret contains the RSA private key and optionally the private key
+    /// passphrase.
+    async fn create_or_update_snowflake_secret(
+        &self,
+        prefix: &str,
+        private_key: &str,
+        private_key_passphrase: Option<&str>,
+    ) -> Result<(), K8sError>;
+
+    /// Deletes the Snowflake credentials secret for a replicator.
+    ///
+    /// Does nothing if the secret does not exist.
+    async fn delete_snowflake_secret(&self, prefix: &str) -> Result<(), K8sError>;
 
     /// Retrieves a [`ConfigMap`] by name from the data-plane namespace.
     async fn get_config_map(&self, config_map_name: &str) -> Result<ConfigMap, K8sError>;

--- a/crates/etl-api/src/k8s/cache.rs
+++ b/crates/etl-api/src/k8s/cache.rs
@@ -203,6 +203,19 @@ mod tests {
             Ok(())
         }
 
+        async fn create_or_update_snowflake_secret(
+            &self,
+            _prefix: &str,
+            _private_key: &str,
+            _private_key_passphrase: Option<&str>,
+        ) -> Result<(), K8sError> {
+            Ok(())
+        }
+
+        async fn delete_snowflake_secret(&self, _prefix: &str) -> Result<(), K8sError> {
+            Ok(())
+        }
+
         async fn get_config_map(&self, config_map_name: &str) -> Result<ConfigMap, K8sError> {
             if config_map_name == TRUSTED_ROOT_CERT_CONFIG_MAP_NAME {
                 let mut map = BTreeMap::new();

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -90,6 +90,15 @@ pub enum Secrets {
         /// S3-compatible secret access key.
         s3_secret_access_key: Option<String>,
     },
+    /// Credentials for Snowflake destinations.
+    Snowflake {
+        /// PostgreSQL source database password.
+        postgres_password: String,
+        /// RSA private key PEM contents.
+        private_key: String,
+        /// Optional passphrase for encrypted private key.
+        private_key_passphrase: Option<String>,
+    },
 }
 
 /// Creates or updates all Kubernetes resources required for a pipeline.
@@ -317,6 +326,15 @@ fn build_secrets_from_configs(
                     .map(|value| value.expose_secret().to_owned()),
             }
         }
+        StoredDestinationConfig::Snowflake { private_key, private_key_passphrase, .. } => {
+            Secrets::Snowflake {
+                postgres_password,
+                private_key: private_key.expose_secret().to_owned(),
+                private_key_passphrase: private_key_passphrase
+                    .as_ref()
+                    .map(|p| p.expose_secret().to_owned()),
+            }
+        }
     }
 }
 
@@ -409,6 +427,16 @@ async fn create_or_update_dynamic_replicator_secrets(
             } else {
                 k8s_client.delete_ducklake_secret(prefix).await?;
             }
+        }
+        Secrets::Snowflake { postgres_password, private_key, private_key_passphrase } => {
+            k8s_client.create_or_update_postgres_secret(prefix, &postgres_password).await?;
+            k8s_client
+                .create_or_update_snowflake_secret(
+                    prefix,
+                    &private_key,
+                    private_key_passphrase.as_deref(),
+                )
+                .await?;
         }
     }
 
@@ -509,6 +537,7 @@ async fn delete_dynamic_replicator_secrets(
     k8s_client.delete_clickhouse_secret(prefix).await?;
     k8s_client.delete_iceberg_secret(prefix).await?;
     k8s_client.delete_ducklake_secret(prefix).await?;
+    k8s_client.delete_snowflake_secret(prefix).await?;
 
     Ok(())
 }
@@ -667,6 +696,21 @@ mod tests {
 
         async fn delete_ducklake_secret(&self, prefix: &str) -> Result<(), K8sError> {
             self.calls.lock().unwrap().push(format!("delete-ducklake:{prefix}"));
+            Ok(())
+        }
+
+        async fn create_or_update_snowflake_secret(
+            &self,
+            prefix: &str,
+            _private_key: &str,
+            _private_key_passphrase: Option<&str>,
+        ) -> Result<(), K8sError> {
+            self.calls.lock().unwrap().push(format!("snowflake:{prefix}"));
+            Ok(())
+        }
+
+        async fn delete_snowflake_secret(&self, prefix: &str) -> Result<(), K8sError> {
+            self.calls.lock().unwrap().push(format!("delete-snowflake:{prefix}"));
             Ok(())
         }
 

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -522,6 +522,21 @@ impl K8sClient for HttpK8sClient {
         Ok(())
     }
 
+    async fn create_or_update_snowflake_secret(
+        &self,
+        _prefix: &str,
+        _private_key: &str,
+        _private_key_passphrase: Option<&str>,
+    ) -> Result<(), K8sError> {
+        // Stub: real implementation in ETL-641
+        Ok(())
+    }
+
+    async fn delete_snowflake_secret(&self, _prefix: &str) -> Result<(), K8sError> {
+        // Stub: real implementation in ETL-641
+        Ok(())
+    }
+
     async fn get_config_map(&self, config_map_name: &str) -> Result<ConfigMap, K8sError> {
         debug!("getting config map");
 
@@ -1183,6 +1198,13 @@ fn create_container_environment_json(
                     "value": ducklake_maintenance.min_active_data_files.to_string()
                 }));
             }
+        }
+        DestinationType::Snowflake => {
+            let postgres_secret_name = create_postgres_secret_name(prefix);
+            let postgres_secret_env_var_json =
+                create_postgres_secret_env_var_json(&postgres_secret_name);
+            container_environment.push(postgres_secret_env_var_json);
+            // Snowflake-specific env vars to be added in ETL-641
         }
     }
     container_environment

--- a/crates/etl-api/src/validation/validators.rs
+++ b/crates/etl-api/src/validation/validators.rs
@@ -1019,6 +1019,10 @@ impl Validator for DestinationValidator {
                 );
                 validator.validate(ctx).await
             }
+            FullApiDestinationConfig::Snowflake { .. } => {
+                // Snowflake validator added in ETL-639
+                Ok(vec![])
+            }
         }
     }
 }

--- a/crates/etl-api/tests/destinations.rs
+++ b/crates/etl-api/tests/destinations.rs
@@ -18,8 +18,9 @@ use crate::support::{
         create_default_image,
         destinations::{
             create_destination, create_destination_with_config, new_bigquery_destination_config,
-            new_iceberg_supabase_destination_config, new_name, updated_destination_config,
-            updated_iceberg_supabase_destination_config, updated_name,
+            new_iceberg_supabase_destination_config, new_name, new_snowflake_destination_config,
+            updated_destination_config, updated_iceberg_supabase_destination_config, updated_name,
+            updated_snowflake_destination_config,
         },
         pipelines::new_pipeline_config,
         sources::create_source,
@@ -335,4 +336,88 @@ async fn destination_with_inactive_pipeline_cannot_be_deleted() {
     assert!(pipeline_response.status().is_success());
 
     drop_pg_database(&source_db_config).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn snowflake_destination_can_be_created() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+    let tenant_id = &create_tenant(&app).await;
+
+    // Act
+    let destination = CreateDestinationRequest {
+        name: "Snowflake Destination".to_owned(),
+        config: new_snowflake_destination_config(),
+    };
+    let response = app.create_destination(tenant_id, &destination).await;
+
+    // Assert
+    assert!(response.status().is_success());
+    let response: CreateDestinationResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.id, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_existing_snowflake_destination_can_be_read() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+    let tenant_id = &create_tenant(&app).await;
+
+    let destination = CreateDestinationRequest {
+        name: "Snowflake Destination".to_owned(),
+        config: new_snowflake_destination_config(),
+    };
+    let response = app.create_destination(tenant_id, &destination).await;
+    let response: CreateDestinationResponse =
+        response.json().await.expect("failed to deserialize response");
+    let destination_id = response.id;
+
+    // Act
+    let response = app.read_destination(tenant_id, destination_id).await;
+
+    // Assert
+    assert!(response.status().is_success());
+    let response: ReadDestinationResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.id, destination_id);
+    assert_eq!(&response.tenant_id, tenant_id);
+    assert_eq!(response.name, destination.name);
+    insta::assert_debug_snapshot!(response.config);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_existing_snowflake_destination_can_be_updated() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+    let tenant_id = &create_tenant(&app).await;
+
+    let destination = CreateDestinationRequest {
+        name: "Snowflake Destination".to_owned(),
+        config: new_snowflake_destination_config(),
+    };
+    let response = app.create_destination(tenant_id, &destination).await;
+    let response: CreateDestinationResponse =
+        response.json().await.expect("failed to deserialize response");
+    let destination_id = response.id;
+
+    // Act
+    let updated_config = UpdateDestinationRequest {
+        name: "Snowflake Destination (Updated)".to_owned(),
+        config: updated_snowflake_destination_config(),
+    };
+    let response = app.update_destination(tenant_id, destination_id, &updated_config).await;
+
+    // Assert
+    assert!(response.status().is_success());
+    let response = app.read_destination(tenant_id, destination_id).await;
+    let response: ReadDestinationResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.id, destination_id);
+    assert_eq!(&response.tenant_id, tenant_id);
+    assert_eq!(response.name, updated_config.name);
+    insta::assert_debug_snapshot!(response.config);
 }

--- a/crates/etl-api/tests/snapshots/main__destinations__an_existing_snowflake_destination_can_be_read.snap
+++ b/crates/etl-api/tests/snapshots/main__destinations__an_existing_snowflake_destination_can_be_read.snap
@@ -1,0 +1,17 @@
+---
+source: crates/etl-api/tests/destinations.rs
+expression: response.config
+---
+Snowflake {
+    account_id: "myorg-myaccount",
+    user: "etl_user",
+    private_key: SerializableSecretString(
+        SecretBox<str>([REDACTED]),
+    ),
+    private_key_passphrase: None,
+    database: "my_database",
+    schema: "public",
+    role: Some(
+        "etl_role",
+    ),
+}

--- a/crates/etl-api/tests/snapshots/main__destinations__an_existing_snowflake_destination_can_be_updated.snap
+++ b/crates/etl-api/tests/snapshots/main__destinations__an_existing_snowflake_destination_can_be_updated.snap
@@ -1,0 +1,21 @@
+---
+source: crates/etl-api/tests/destinations.rs
+expression: response.config
+---
+Snowflake {
+    account_id: "updatedorg-updatedaccount",
+    user: "updated_etl_user",
+    private_key: SerializableSecretString(
+        SecretBox<str>([REDACTED]),
+    ),
+    private_key_passphrase: Some(
+        SerializableSecretString(
+            SecretBox<str>([REDACTED]),
+        ),
+    ),
+    database: "updated_database",
+    schema: "updated_schema",
+    role: Some(
+        "updated_role",
+    ),
+}

--- a/crates/etl-api/tests/support/k8s_client.rs
+++ b/crates/etl-api/tests/support/k8s_client.rs
@@ -147,6 +147,20 @@ impl K8sClient for MockK8sClient {
         Ok(())
     }
 
+    async fn create_or_update_snowflake_secret(
+        &self,
+        _prefix: &str,
+        _private_key: &str,
+        _private_key_passphrase: Option<&str>,
+    ) -> Result<(), K8sError> {
+        self.record_create_call();
+        Ok(())
+    }
+
+    async fn delete_snowflake_secret(&self, _prefix: &str) -> Result<(), K8sError> {
+        Ok(())
+    }
+
     async fn get_config_map(&self, config_map_name: &str) -> Result<ConfigMap, K8sError> {
         // For tests to pass the TRUSTED_ROOT_CERT_CONFIG_MAP_NAME config map expects
         // a key named TRUSTED_ROOT_CERT_KEY_NAME to be present with non-empty certs

--- a/crates/etl-api/tests/support/mocks.rs
+++ b/crates/etl-api/tests/support/mocks.rs
@@ -158,6 +158,39 @@ pub(crate) mod destinations {
         )
         .await
     }
+
+    /// Returns a default Snowflake destination config.
+    pub(crate) fn new_snowflake_destination_config() -> FullApiDestinationConfig {
+        FullApiDestinationConfig::Snowflake {
+            account_id: "myorg-myaccount".to_owned(),
+            user: "etl_user".to_owned(),
+            private_key: SerializableSecretString::from(
+                "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg...\n-----END PRIVATE KEY-----"
+                    .to_owned(),
+            ),
+            private_key_passphrase: None,
+            database: "my_database".to_owned(),
+            schema: "public".to_owned(),
+            role: Some("etl_role".to_owned()),
+        }
+    }
+
+    /// Returns an updated Snowflake destination config.
+    pub(crate) fn updated_snowflake_destination_config() -> FullApiDestinationConfig {
+        FullApiDestinationConfig::Snowflake {
+            account_id: "updatedorg-updatedaccount".to_owned(),
+            user: "updated_etl_user".to_owned(),
+            private_key: SerializableSecretString::from(
+                "-----BEGIN PRIVATE KEY-----\nUPDATED...\n-----END PRIVATE KEY-----".to_owned(),
+            ),
+            private_key_passphrase: Some(SerializableSecretString::from(
+                "passphrase123".to_owned(),
+            )),
+            database: "updated_database".to_owned(),
+            schema: "updated_schema".to_owned(),
+            role: Some("updated_role".to_owned()),
+        }
+    }
 }
 
 /// Source helpers.


### PR DESCRIPTION
## Summary

- Add Snowflake variant to the three destination config enums (`FullApiDestinationConfig`, `StoredDestinationConfig`, `EncryptedStoredDestinationConfig`).
- Wire up all trait impls: `From` conversions, `into_etl_config()`, `Encrypt`/`Decrypt`
- Add k8s and validator stubs (follow up PRs will be tackled in ETL-639 and ETL-641)
- Add CRUD integration tests with insta snapshots
  
  
Closes ETL-638
