### PR TITLE
feat(snowflake): api validation

### DIFF
--- a/crates/etl-api/Cargo.toml
+++ b/crates/etl-api/Cargo.toml
@@ -31,12 +31,23 @@ configcat = { workspace = true }
 constant_time_eq = { workspace = true }
 etl = { workspace = true }
 etl-config = { workspace = true, features = ["utoipa", "supabase"] }
-etl-destinations = { workspace = true, features = ["bigquery", "clickhouse", "ducklake", "iceberg"] }
+etl-destinations = { workspace = true, features = [
+  "bigquery",
+  "clickhouse",
+  "ducklake",
+  "iceberg",
+  "snowflake",
+] }
 etl-maintenance = { workspace = true }
 etl-postgres = { workspace = true, features = ["replication"] }
 etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
-kube = { workspace = true, features = ["runtime", "derive", "client", "rustls-tls"] }
+kube = { workspace = true, features = [
+  "runtime",
+  "derive",
+  "client",
+  "rustls-tls",
+] }
 metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 pg_escape = { workspace = true }
 rand = { workspace = true, features = ["std"] }
@@ -45,7 +56,14 @@ secrecy = { workspace = true }
 sentry = { workspace = true, features = ["actix"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "macros", "postgres", "json", "migrate"] }
+sqlx = { workspace = true, features = [
+  "runtime-tokio",
+  "tls-rustls",
+  "macros",
+  "postgres",
+  "json",
+  "migrate",
+] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true, default-features = false }
@@ -55,7 +73,14 @@ utoipa = { workspace = true, features = ["actix_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["actix-web"] }
 
 [dev-dependencies]
-etl-destinations = { workspace = true, features = ["test-utils", "bigquery", "clickhouse", "ducklake", "iceberg"] }
+etl-destinations = { workspace = true, features = [
+  "test-utils",
+  "bigquery",
+  "clickhouse",
+  "ducklake",
+  "iceberg",
+  "snowflake",
+] }
 etl-postgres = { workspace = true, features = ["test-utils", "sqlx"] }
 
 insta = { workspace = true, features = ["json", "redactions"] }

--- a/crates/etl-api/src/validation/validators/mod.rs
+++ b/crates/etl-api/src/validation/validators/mod.rs
@@ -11,13 +11,13 @@ use bigquery::BigQueryValidator;
 use clickhouse::ClickHouseValidator;
 use ducklake::DucklakeValidator;
 use iceberg::IcebergValidator;
-use snowflake::SnowflakeValidator;
 use pipeline::{
     GeneratedColumnsValidator, PrimaryKeysValidator, PublicationExistsValidator,
     PublicationHasTablesValidator, ReplicationPermissionsValidator, ReplicationSlotsValidator,
     WalLevelValidator,
 };
 use secrecy::ExposeSecret;
+use snowflake::SnowflakeValidator;
 pub(super) use source::SourceValidator;
 
 use super::{ValidationContext, ValidationError, ValidationFailure, Validator};

--- a/crates/etl-api/src/validation/validators/mod.rs
+++ b/crates/etl-api/src/validation/validators/mod.rs
@@ -3,6 +3,7 @@ mod clickhouse;
 mod ducklake;
 mod iceberg;
 mod pipeline;
+mod snowflake;
 mod source;
 
 use async_trait::async_trait;
@@ -10,6 +11,7 @@ use bigquery::BigQueryValidator;
 use clickhouse::ClickHouseValidator;
 use ducklake::DucklakeValidator;
 use iceberg::IcebergValidator;
+use snowflake::SnowflakeValidator;
 use pipeline::{
     GeneratedColumnsValidator, PrimaryKeysValidator, PublicationExistsValidator,
     PublicationHasTablesValidator, ReplicationPermissionsValidator, ReplicationSlotsValidator,
@@ -144,9 +146,25 @@ impl Validator for DestinationValidator {
                 );
                 validator.validate(ctx).await
             }
-            FullApiDestinationConfig::Snowflake { .. } => {
-                // Snowflake validator added in ETL-639
-                Ok(vec![])
+            FullApiDestinationConfig::Snowflake {
+                account_id,
+                user,
+                private_key,
+                private_key_passphrase,
+                database,
+                schema,
+                role,
+            } => {
+                let validator = SnowflakeValidator::new(
+                    account_id.clone(),
+                    user.clone(),
+                    private_key.clone(),
+                    private_key_passphrase.clone(),
+                    database.clone(),
+                    schema.clone(),
+                    role.clone(),
+                );
+                validator.validate(ctx).await
             }
         }
     }

--- a/crates/etl-api/src/validation/validators/snowflake.rs
+++ b/crates/etl-api/src/validation/validators/snowflake.rs
@@ -87,15 +87,13 @@ impl Validator for SnowflakeValidator {
                      key is encrypted)\n(3) The key is registered for this user\n\nError: {msg}"
                 ),
             )]),
-            Err(snowflake::Error::DatabaseNotFound(db)) => {
-                Ok(vec![ValidationFailure::critical(
-                    "Snowflake Database Not Found",
-                    format!(
-                        "Database '{db}' does not exist.\n\nPlease verify:\n(1) The database name \
-                         is correct\n(2) The user has USAGE privilege on the database"
-                    ),
-                )])
-            }
+            Err(snowflake::Error::DatabaseNotFound(db)) => Ok(vec![ValidationFailure::critical(
+                "Snowflake Database Not Found",
+                format!(
+                    "Database '{db}' does not exist.\n\nPlease verify:\n(1) The database name is \
+                     correct\n(2) The user has USAGE privilege on the database"
+                ),
+            )]),
             Err(snowflake::Error::SchemaNotFound { database, schema }) => {
                 Ok(vec![ValidationFailure::critical(
                     "Snowflake Schema Not Found",
@@ -109,9 +107,8 @@ impl Validator for SnowflakeValidator {
             Err(err) => Ok(vec![ValidationFailure::critical(
                 "Snowflake Connection Failed",
                 format!(
-                    "Cannot connect to Snowflake.\n\nPlease verify:\n(1) The account \
-                     identifier is correct\n(2) Network connectivity to Snowflake\n\nError: \
-                     {err}"
+                    "Cannot connect to Snowflake.\n\nPlease verify:\n(1) The account identifier \
+                     is correct\n(2) Network connectivity to Snowflake\n\nError: {err}"
                 ),
             )]),
         }

--- a/crates/etl-api/src/validation/validators/snowflake.rs
+++ b/crates/etl-api/src/validation/validators/snowflake.rs
@@ -1,0 +1,119 @@
+use async_trait::async_trait;
+use etl_config::SerializableSecretString;
+use etl_destinations::snowflake;
+use secrecy::ExposeSecret;
+
+use super::super::{ValidationContext, ValidationError, ValidationFailure, Validator};
+
+/// Validates a Snowflake destination.
+#[derive(Debug)]
+pub(super) struct SnowflakeValidator {
+    account_id: String,
+    user: String,
+    private_key: SerializableSecretString,
+    private_key_passphrase: Option<SerializableSecretString>,
+    database: String,
+    schema: String,
+    role: Option<String>,
+}
+
+impl SnowflakeValidator {
+    pub(super) fn new(
+        account_id: String,
+        user: String,
+        private_key: SerializableSecretString,
+        private_key_passphrase: Option<SerializableSecretString>,
+        database: String,
+        schema: String,
+        role: Option<String>,
+    ) -> Self {
+        Self { account_id, user, private_key, private_key_passphrase, database, schema, role }
+    }
+}
+
+#[async_trait]
+impl Validator for SnowflakeValidator {
+    async fn validate(
+        &self,
+        _ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        if self.account_id.is_empty() {
+            return Ok(vec![ValidationFailure::critical(
+                "Snowflake Account ID Required",
+                "Snowflake account identifier must not be empty.",
+            )]);
+        }
+
+        if self.user.is_empty() {
+            return Ok(vec![ValidationFailure::critical(
+                "Snowflake User Required",
+                "Snowflake user must not be empty.",
+            )]);
+        }
+
+        if self.database.is_empty() {
+            return Ok(vec![ValidationFailure::critical(
+                "Snowflake Database Required",
+                "Snowflake database must not be empty.",
+            )]);
+        }
+
+        if self.schema.is_empty() {
+            return Ok(vec![ValidationFailure::critical(
+                "Snowflake Schema Required",
+                "Snowflake schema must not be empty.",
+            )]);
+        }
+
+        let mut config =
+            snowflake::Config::new(&self.account_id, &self.user, &self.database, &self.schema);
+        if let Some(role) = &self.role {
+            config = config.with_role(role);
+        }
+
+        match snowflake::Client::validate_connectivity(
+            &config,
+            self.private_key.expose_secret(),
+            self.private_key_passphrase.as_deref(),
+        )
+        .await
+        {
+            Ok(()) => Ok(vec![]),
+            Err(snowflake::Error::Auth(msg)) => Ok(vec![ValidationFailure::critical(
+                "Snowflake Authentication Failed",
+                format!(
+                    "Failed to authenticate with Snowflake.\n\nPlease verify:\n(1) The private \
+                     key is a valid PEM-encoded RSA key\n(2) The passphrase is correct (if the \
+                     key is encrypted)\n(3) The key is registered for this user\n\nError: {msg}"
+                ),
+            )]),
+            Err(snowflake::Error::DatabaseNotFound(db)) => {
+                Ok(vec![ValidationFailure::critical(
+                    "Snowflake Database Not Found",
+                    format!(
+                        "Database '{db}' does not exist.\n\nPlease verify:\n(1) The database name \
+                         is correct\n(2) The user has USAGE privilege on the database"
+                    ),
+                )])
+            }
+            Err(snowflake::Error::SchemaNotFound { database, schema }) => {
+                Ok(vec![ValidationFailure::critical(
+                    "Snowflake Schema Not Found",
+                    format!(
+                        "Schema '{schema}' not found in database '{database}'.\n\nPlease \
+                         verify:\n(1) The schema name is correct\n(2) The user has USAGE \
+                         privilege on the schema"
+                    ),
+                )])
+            }
+            Err(err) => Ok(vec![ValidationFailure::critical(
+                "Snowflake Connection Failed",
+                format!(
+                    "Cannot connect to Snowflake.\n\nPlease verify:\n(1) The account \
+                     identifier is correct\n(2) Network connectivity to Snowflake\n\nError: \
+                     {err}"
+                ),
+            )]),
+        }
+    }
+}

--- a/crates/etl-api/tests/validators/mod.rs
+++ b/crates/etl-api/tests/validators/mod.rs
@@ -1,6 +1,7 @@
 mod bigquery;
 mod iceberg;
 mod pipeline;
+mod snowflake;
 
 use etl_api::{configs::pipeline::FullApiPipelineConfig, validation::ValidationContext};
 use etl_config::{Environment, shared::BatchConfig};

--- a/crates/etl-api/tests/validators/snowflake.rs
+++ b/crates/etl-api/tests/validators/snowflake.rs
@@ -67,7 +67,7 @@ fn create_snowflake_config(
             .map(|p| SerializableSecretString::from(p.to_owned())),
         database: database.to_owned(),
         schema: schema.to_owned(),
-        role: role.map(|r| r.to_owned()),
+        role: role.map(str::to_owned),
     }
 }
 

--- a/crates/etl-api/tests/validators/snowflake.rs
+++ b/crates/etl-api/tests/validators/snowflake.rs
@@ -1,0 +1,175 @@
+use etl_api::{
+    configs::destination::FullApiDestinationConfig,
+    validation::{FailureType, validate_destination},
+};
+use etl_config::SerializableSecretString;
+
+use super::create_validation_context;
+
+fn skip_if_missing_snowflake_env_vars() -> bool {
+    std::env::var("TESTS_SNOWFLAKE_ACCOUNT").is_err()
+}
+
+struct SnowflakeTestEnv {
+    account_id: String,
+    user: String,
+    private_key: String,
+    database: String,
+    schema: String,
+    role: Option<String>,
+}
+
+impl SnowflakeTestEnv {
+    fn load() -> Self {
+        Self {
+            account_id: std::env::var("TESTS_SNOWFLAKE_ACCOUNT")
+                .expect("TESTS_SNOWFLAKE_ACCOUNT must be set"),
+            user: std::env::var("TESTS_SNOWFLAKE_USER").expect("TESTS_SNOWFLAKE_USER must be set"),
+            private_key: std::fs::read_to_string(
+                std::env::var("TESTS_SNOWFLAKE_PRIVATE_KEY_PATH")
+                    .expect("TESTS_SNOWFLAKE_PRIVATE_KEY_PATH must be set"),
+            )
+            .expect("failed to read private key file"),
+            database: std::env::var("TESTS_SNOWFLAKE_DATABASE")
+                .unwrap_or_else(|_| "ETL_DEV".to_owned()),
+            schema: std::env::var("TESTS_SNOWFLAKE_SCHEMA").unwrap_or_else(|_| "PUBLIC".to_owned()),
+            role: std::env::var("TESTS_SNOWFLAKE_ROLE").ok(),
+        }
+    }
+
+    fn config(&self, database: &str, schema: &str) -> FullApiDestinationConfig {
+        create_snowflake_config(
+            &self.account_id,
+            &self.user,
+            &self.private_key,
+            None,
+            database,
+            schema,
+            self.role.as_deref(),
+        )
+    }
+}
+
+fn create_snowflake_config(
+    account_id: &str,
+    user: &str,
+    private_key: &str,
+    private_key_passphrase: Option<&str>,
+    database: &str,
+    schema: &str,
+    role: Option<&str>,
+) -> FullApiDestinationConfig {
+    FullApiDestinationConfig::Snowflake {
+        account_id: account_id.to_owned(),
+        user: user.to_owned(),
+        private_key: SerializableSecretString::from(private_key.to_owned()),
+        private_key_passphrase: private_key_passphrase
+            .map(|p| SerializableSecretString::from(p.to_owned())),
+        database: database.to_owned(),
+        schema: schema.to_owned(),
+        role: role.map(|r| r.to_owned()),
+    }
+}
+
+#[tokio::test]
+async fn validate_snowflake_empty_account_id() {
+    let ctx = create_validation_context();
+    let config = create_snowflake_config("", "ETL_USER", "fake-key", None, "DB", "PUBLIC", None);
+    let failures = validate_destination(&ctx, &config).await.unwrap();
+
+    assert!(!failures.is_empty(), "Expected validation failure");
+    assert_eq!(failures[0].name, "Snowflake Account ID Required");
+    assert_eq!(failures[0].failure_type, FailureType::Critical);
+}
+
+#[tokio::test]
+async fn validate_snowflake_empty_user() {
+    let ctx = create_validation_context();
+    let config = create_snowflake_config("ORG-ACCT", "", "fake-key", None, "DB", "PUBLIC", None);
+    let failures = validate_destination(&ctx, &config).await.unwrap();
+
+    assert!(!failures.is_empty(), "Expected validation failure");
+    assert_eq!(failures[0].name, "Snowflake User Required");
+    assert_eq!(failures[0].failure_type, FailureType::Critical);
+}
+
+#[tokio::test]
+async fn validate_snowflake_invalid_private_key() {
+    let ctx = create_validation_context();
+    let config = create_snowflake_config(
+        "ORG-ACCT",
+        "ETL_USER",
+        "not-a-valid-pem-key",
+        None,
+        "ANALYTICS",
+        "PUBLIC",
+        None,
+    );
+    let failures = validate_destination(&ctx, &config).await.unwrap();
+
+    assert!(!failures.is_empty(), "Expected validation failure");
+    assert_eq!(failures[0].name, "Snowflake Authentication Failed");
+    assert_eq!(failures[0].failure_type, FailureType::Critical);
+}
+
+#[tokio::test]
+#[ignore]
+async fn validate_snowflake_connection_success() {
+    if skip_if_missing_snowflake_env_vars() {
+        return;
+    }
+    let env = SnowflakeTestEnv::load();
+    let ctx = create_validation_context();
+    let config = env.config(&env.database, &env.schema);
+    let failures = validate_destination(&ctx, &config).await.unwrap();
+
+    assert!(failures.is_empty(), "Expected no validation failures, got: {failures:?}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn validate_snowflake_wrong_database() {
+    if skip_if_missing_snowflake_env_vars() {
+        return;
+    }
+    let env = SnowflakeTestEnv::load();
+    let ctx = create_validation_context();
+    let config = env.config("NONEXISTENT_DB_12345", &env.schema);
+    let failures = validate_destination(&ctx, &config).await.unwrap();
+
+    assert!(!failures.is_empty(), "Expected validation failure");
+    assert_eq!(failures[0].name, "Snowflake Database Not Found");
+    assert_eq!(failures[0].failure_type, FailureType::Critical);
+}
+
+#[tokio::test]
+#[ignore]
+async fn validate_snowflake_wrong_schema() {
+    if skip_if_missing_snowflake_env_vars() {
+        return;
+    }
+    let env = SnowflakeTestEnv::load();
+    let ctx = create_validation_context();
+    let config = env.config(&env.database, "NONEXISTENT_SCHEMA_12345");
+    let failures = validate_destination(&ctx, &config).await.unwrap();
+
+    assert!(!failures.is_empty(), "Expected validation failure");
+    assert_eq!(failures[0].name, "Snowflake Schema Not Found");
+    assert_eq!(failures[0].failure_type, FailureType::Critical);
+}
+
+#[tokio::test]
+#[ignore]
+async fn validate_snowflake_empty_database() {
+    if skip_if_missing_snowflake_env_vars() {
+        return;
+    }
+    let env = SnowflakeTestEnv::load();
+    let ctx = create_validation_context();
+    let config = env.config("", &env.schema);
+    let failures = validate_destination(&ctx, &config).await.unwrap();
+
+    assert!(!failures.is_empty(), "Expected validation failure");
+    assert_eq!(failures[0].name, "Snowflake Database Required");
+    assert_eq!(failures[0].failure_type, FailureType::Critical);
+}

--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -90,7 +90,11 @@ impl Client<AuthManager<HttpExchanger>> {
         // `SHOW DATABASES` runs on Cloud Services (no warehouse needed).
         let db_pattern = quote_string_literal(&config.database);
         let resp = sql.execute_statement(&format!("SHOW DATABASES LIKE {db_pattern}")).await?;
-        if resp.data.is_none_or(|rows| rows.is_empty()) {
+        let db_exists = resp.data.is_some_and(|rows| {
+            rows.iter()
+                .any(|row| row.get(1).and_then(serde_json::Value::as_str) == Some(&config.database))
+        });
+        if !db_exists {
             return Err(Error::DatabaseNotFound(config.database.clone()));
         }
 
@@ -102,7 +106,11 @@ impl Client<AuthManager<HttpExchanger>> {
                 "SHOW SCHEMAS LIKE {schema_pattern} IN DATABASE {db_ident}"
             ))
             .await?;
-        if resp.data.is_none_or(|rows| rows.is_empty()) {
+        let schema_exists = resp.data.is_some_and(|rows| {
+            rows.iter()
+                .any(|row| row.get(1).and_then(serde_json::Value::as_str) == Some(&config.schema))
+        });
+        if !schema_exists {
             return Err(Error::SchemaNotFound {
                 database: config.database.clone(),
                 schema: config.schema.clone(),

--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -9,6 +9,7 @@ use crate::snowflake::{
     auth::{AuthManager, HttpExchanger, TokenProvider},
     config::{HTTP_CONNECT_TIMEOUT, HTTP_REQUEST_TIMEOUT},
     schema,
+    sql::{quote_identifier, quote_string_literal},
     sql_client::SqlClient,
     streaming::{ChannelHandle, OffsetToken, RestStreamClient, RowBatch, StreamClient},
 };
@@ -62,6 +63,53 @@ impl Client<AuthManager<HttpExchanger>> {
         ));
         let sql_client = SqlClient::new(config, auth, http);
         Self::with_clients(sql_client, stream_client, database, schema, pipeline_id)
+    }
+
+    /// Verify Snowflake connectivity.
+    ///
+    /// Check that credentials are valid and the target database and schema
+    /// exist.
+    pub async fn validate_connectivity(
+        config: &Config,
+        private_key_pem: &str,
+        passphrase: Option<&secrecy::SecretString>,
+    ) -> Result<()> {
+        let auth = Arc::new(
+            AuthManager::new(config, private_key_pem, passphrase)
+                .map_err(|e| Error::Auth(e.to_string()))?,
+        );
+
+        let http = reqwest::Client::builder()
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .build()
+            .map_err(Error::HttpTransport)?;
+
+        let sql = SqlClient::new(config.clone(), auth, http);
+
+        // `SHOW DATABASES` runs on Cloud Services (no warehouse needed).
+        let db_pattern = quote_string_literal(&config.database);
+        let resp = sql.execute_statement(&format!("SHOW DATABASES LIKE {db_pattern}")).await?;
+        if !resp.data.is_some_and(|rows| !rows.is_empty()) {
+            return Err(Error::DatabaseNotFound(config.database.clone()));
+        }
+
+        // `SHOW SCHEMAS` also runs on Cloud Services.
+        let db_ident = quote_identifier(&config.database);
+        let schema_pattern = quote_string_literal(&config.schema);
+        let resp = sql
+            .execute_statement(&format!(
+                "SHOW SCHEMAS LIKE {schema_pattern} IN DATABASE {db_ident}"
+            ))
+            .await?;
+        if !resp.data.is_some_and(|rows| !rows.is_empty()) {
+            return Err(Error::SchemaNotFound {
+                database: config.database.clone(),
+                schema: config.schema.clone(),
+            });
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -90,7 +90,7 @@ impl Client<AuthManager<HttpExchanger>> {
         // `SHOW DATABASES` runs on Cloud Services (no warehouse needed).
         let db_pattern = quote_string_literal(&config.database);
         let resp = sql.execute_statement(&format!("SHOW DATABASES LIKE {db_pattern}")).await?;
-        if !resp.data.is_some_and(|rows| !rows.is_empty()) {
+        if resp.data.is_none_or(|rows| rows.is_empty()) {
             return Err(Error::DatabaseNotFound(config.database.clone()));
         }
 
@@ -102,7 +102,7 @@ impl Client<AuthManager<HttpExchanger>> {
                 "SHOW SCHEMAS LIKE {schema_pattern} IN DATABASE {db_ident}"
             ))
             .await?;
-        if !resp.data.is_some_and(|rows| !rows.is_empty()) {
+        if resp.data.is_none_or(|rows| rows.is_empty()) {
             return Err(Error::SchemaNotFound {
                 database: config.database.clone(),
                 schema: config.schema.clone(),

--- a/crates/etl-destinations/src/snowflake/error.rs
+++ b/crates/etl-destinations/src/snowflake/error.rs
@@ -26,6 +26,12 @@ pub enum Error {
 
     #[error("Configuration error: {0}")]
     Config(String),
+
+    #[error("database '{0}' not found")]
+    DatabaseNotFound(String),
+
+    #[error("schema '{schema}' not found in database '{database}'")]
+    SchemaNotFound { database: String, schema: String },
 }
 
 impl From<Error> for EtlError {
@@ -44,6 +50,8 @@ impl From<Error> for EtlError {
             Error::Channel(_) => (ErrorKind::DestinationError, "Snowflake channel error"),
             Error::Encoding(_) => (ErrorKind::InvalidData, "Snowflake encoding error"),
             Error::Config(_) => (ErrorKind::ConfigError, "Snowflake configuration error"),
+            Error::DatabaseNotFound(_) => (ErrorKind::ConfigError, "Snowflake database not found"),
+            Error::SchemaNotFound { .. } => (ErrorKind::ConfigError, "Snowflake schema not found"),
         };
         etl::etl_error!(kind, description, err.to_string())
     }


### PR DESCRIPTION
## Summary

- Extend API validators with Snowflake destination.
- Validates both structurally (missing username etc) and by actually checking connectivity (right credentials, target database/schema exist)

Closes ETL-639