### PR TITLE
perf: xtask sccache

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
+# Build the task runner into its own target dir so alternating between
+# `cargo x ...` and `cargo build`/`cargo run` stops invalidating shared crates.io
+# deps whose unified feature sets differ between the two graphs.
 [alias]
-xtask = "run --package xtask --"
-x = "run --package xtask --"
+xtask = "run --target-dir target/xtask --package xtask --"
+x = "run --target-dir target/xtask --package xtask --"
 
 # Use lld linker for faster linking (1.5-2x faster than default ld)
 # lld is part of the LLVM toolchain and widely available

--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,10 @@ export BENCH_SNOWFLAKE_PRIVATE_KEY=$TESTS_SNOWFLAKE_PRIVATE_KEY_PATH
 export BENCH_SNOWFLAKE_DATABASE=$TESTS_SNOWFLAKE_DATABASE
 export BENCH_SNOWFLAKE_SCHEMA=$TESTS_SNOWFLAKE_SCHEMA
 export BENCH_SNOWFLAKE_ROLE=$TESTS_SNOWFLAKE_ROLE
+
+# sccache (optional build cache)
+#
+# Enable per-command instead with: cargo x check --sccache
+#
+# Uncomment below to enable for all `cargo x` commands (check, fix):
+# export ETL_SCCACHE=1

--- a/crates/xtask/src/commands/check.rs
+++ b/crates/xtask/src/commands/check.rs
@@ -2,10 +2,15 @@ use anyhow::Result;
 use clap::Args;
 use xshell::{Shell, cmd};
 
-use super::shared::NIGHTLY_TOOLCHAIN;
+use super::shared::{NIGHTLY_TOOLCHAIN, maybe_with_sccache};
 
 #[derive(Args)]
-pub(crate) struct CheckArgs {}
+pub(crate) struct CheckArgs {
+    /// Enable `sccache`.
+    /// Also enabled via `ETL_SCCACHE=1`.
+    #[arg(long)]
+    sccache: bool,
+}
 
 impl CheckArgs {
     pub(crate) fn run(self) -> Result<()> {
@@ -21,7 +26,11 @@ impl CheckArgs {
         cmd!(sh, "cargo sort --workspace --grouped --check").run()?;
 
         println!("[clippy]");
-        cmd!(sh, "cargo clippy --all-targets --all-features --no-deps").run()?;
+        maybe_with_sccache(
+            cmd!(sh, "cargo clippy --all-targets --all-features --no-deps"),
+            self.sccache,
+        )
+        .run()?;
 
         Ok(())
     }

--- a/crates/xtask/src/commands/fix.rs
+++ b/crates/xtask/src/commands/fix.rs
@@ -2,17 +2,26 @@ use anyhow::Result;
 use clap::Args;
 use xshell::{Shell, cmd};
 
-use super::shared::NIGHTLY_TOOLCHAIN;
+use super::shared::{NIGHTLY_TOOLCHAIN, maybe_with_sccache};
 
 #[derive(Args)]
-pub(crate) struct FixArgs {}
+pub(crate) struct FixArgs {
+    /// Enable `sccache`.
+    /// Also enabled via `ETL_SCCACHE=1`.
+    #[arg(long)]
+    sccache: bool,
+}
 
 impl FixArgs {
     pub(crate) fn run(self) -> Result<()> {
         let sh = Shell::new()?;
 
         println!("[clippy fix]");
-        cmd!(sh, "cargo clippy --fix --allow-dirty --allow-staged").run()?;
+        maybe_with_sccache(
+            cmd!(sh, "cargo clippy --fix --allow-dirty --allow-staged"),
+            self.sccache,
+        )
+        .run()?;
 
         println!("[fmt]");
         let toolchain = std::env::var("RUSTFMT_NIGHTLY_TOOLCHAIN")

--- a/crates/xtask/src/commands/shared.rs
+++ b/crates/xtask/src/commands/shared.rs
@@ -30,9 +30,12 @@ pub(crate) fn maybe_with_sccache(cmd: Cmd<'_>, flag: bool) -> Cmd<'_> {
         return cmd;
     }
 
+    let cc = std::env::var("CC").unwrap_or_else(|_| "cc".into());
+    let cxx = std::env::var("CXX").unwrap_or_else(|_| "c++".into());
+
     cmd.env("RUSTC_WRAPPER", "sccache")
-        .env("CC", "sccache cc")
-        .env("CXX", "sccache c++")
+        .env("CC", format!("sccache {cc}"))
+        .env("CXX", format!("sccache {cxx}"))
         .env("CARGO_INCREMENTAL", "0")
         .env("SCCACHE_CACHE_SIZE", "20G")
 }

--- a/crates/xtask/src/commands/shared.rs
+++ b/crates/xtask/src/commands/shared.rs
@@ -1,3 +1,43 @@
+use xshell::Cmd;
+
 pub(crate) const DEFAULT_PG_SHARD_COUNT: u16 = 3;
 pub(crate) const DEFAULT_BASE_PORT: u16 = 5430;
 pub(crate) const NIGHTLY_TOOLCHAIN: &str = "nightly-2026-04-15";
+
+/// Returns whether sccache should be enabled for the spawned build.
+///
+/// Enabled when the `--sccache` flag is passed (`flag`) or when the
+/// `ETL_SCCACHE` environment variable is set to `1`.
+pub(crate) fn sccache_enabled(flag: bool) -> bool {
+    flag || std::env::var("ETL_SCCACHE").is_ok_and(|value| value == "1")
+}
+
+/// Conditionally injects the sccache environment into a cargo command.
+///
+/// `CARGO_INCREMENTAL=0` is required because sccache cannot cache incremental
+/// compilation. When disabled, the command is returned unchanged so the default
+/// inner loop keeps incremental.
+pub(crate) fn maybe_with_sccache(cmd: Cmd<'_>, flag: bool) -> Cmd<'_> {
+    if !sccache_enabled(flag) {
+        return cmd;
+    }
+
+    if !sccache_available() {
+        eprintln!(
+            "⚠️  sccache requested (--sccache / ETL_SCCACHE=1) but not found on PATH; continuing \
+             without it. Install it with `brew install sccache`."
+        );
+        return cmd;
+    }
+
+    cmd.env("RUSTC_WRAPPER", "sccache")
+        .env("CC", "sccache cc")
+        .env("CXX", "sccache c++")
+        .env("CARGO_INCREMENTAL", "0")
+        .env("SCCACHE_CACHE_SIZE", "20G")
+}
+
+/// Returns whether the `sccache` binary is callable on the current PATH.
+fn sccache_available() -> bool {
+    std::process::Command::new("sccache").arg("--version").output().is_ok()
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- `cargo x` command gets its own target directory, so that normal `cargo cmd` doesn't invalidate compiled deps (and `xtask` doesn't have to rebuild when source code changes, unless it is `xtask`'s code itself)
- Add ability to either prepend with `ETL_SCCACHE=1` or `--sccache` for command to rely on `sccache` (provided it is intalled). Helps a lot with those `libduckdb.sys` recompilations, local builds are faster now.

Deliberately made the sccache an opt-in feature, use `source .env` (created from `.env.example`) should you want to have a quick way to enable it for all `cargo x` commands.