### PR TITLE
feat(k8s): Snowflake secret management and container env vars

### DIFF
--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -91,7 +91,11 @@ pub enum DestinationType {
     /// DuckLake destination.
     Ducklake,
     /// Snowflake destination.
-    Snowflake,
+    Snowflake {
+        /// Whether the StatefulSet must reference the Snowflake passphrase
+        /// secret entry.
+        passphrase_secret_required: bool,
+    },
 }
 
 impl From<&StoredDestinationConfig> for DestinationType {
@@ -104,7 +108,11 @@ impl From<&StoredDestinationConfig> for DestinationType {
                 DestinationType::ClickHouse { password_secret_required: password.is_some() }
             }
             StoredDestinationConfig::Ducklake { .. } => DestinationType::Ducklake,
-            StoredDestinationConfig::Snowflake { .. } => DestinationType::Snowflake,
+            StoredDestinationConfig::Snowflake { private_key_passphrase, .. } => {
+                DestinationType::Snowflake {
+                    passphrase_secret_required: private_key_passphrase.is_some(),
+                }
+            }
         }
     }
 }

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -623,6 +623,22 @@ mod tests {
         }
     }
 
+    fn snowflake_destination_config(passphrase: Option<&str>) -> StoredDestinationConfig {
+        StoredDestinationConfig::Snowflake {
+            account_id: "myorg-myaccount".to_owned(),
+            user: "etl_user".to_owned(),
+            private_key: SerializableSecretString::from(
+                "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----".to_owned(),
+            ),
+            private_key_passphrase: passphrase
+                .map(ToOwned::to_owned)
+                .map(SerializableSecretString::from),
+            database: "my_database".to_owned(),
+            schema: "public".to_owned(),
+            role: Some("etl_role".to_owned()),
+        }
+    }
+
     #[async_trait]
     impl K8sClient for RecordingK8sClient {
         async fn create_or_update_postgres_secret(
@@ -885,6 +901,22 @@ mod tests {
                 "postgres:tenant-42:password".to_owned(),
                 "delete-clickhouse:tenant-42".to_owned(),
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn snowflake_creates_postgres_and_snowflake_secrets() {
+        let source_config = source_config_with_password();
+        let destination_config = snowflake_destination_config(Some("passphrase123"));
+
+        let secrets = build_secrets_from_configs(&source_config, &destination_config);
+        let client = RecordingK8sClient::default();
+
+        create_or_update_dynamic_replicator_secrets(&client, "tenant-42", secrets).await.unwrap();
+
+        assert_eq!(
+            client.calls(),
+            vec!["postgres:tenant-42:password".to_owned(), "snowflake:tenant-42".to_owned(),]
         );
     }
 

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -57,6 +57,13 @@ const DUCKLAKE_SECRET_NAME_SUFFIX: &str = "ducklake";
 const DUCKLAKE_S3_ACCESS_KEY_ID_KEY_NAME: &str = "s3-access-key-id";
 /// Name of s3 secret access key in the ducklake secret and its reference.
 const DUCKLAKE_S3_SECRET_ACCESS_KEY_KEY_NAME: &str = "s3-secret-access-key";
+/// Secret name suffix for Snowflake credentials.
+const SNOWFLAKE_SECRET_NAME_SUFFIX: &str = "snowflake";
+/// Name of the private key entry in the Snowflake secret and its reference.
+const SNOWFLAKE_PRIVATE_KEY_NAME: &str = "private-key";
+/// Name of the private key passphrase entry in the Snowflake secret and its
+/// reference.
+const SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME: &str = "private-key-passphrase";
 /// Secret name suffix for the Postgres password.
 const POSTGRES_SECRET_NAME_SUFFIX: &str = "postgres-password";
 /// ConfigMap name suffix for the replicator configuration files.
@@ -524,16 +531,36 @@ impl K8sClient for HttpK8sClient {
 
     async fn create_or_update_snowflake_secret(
         &self,
-        _prefix: &str,
-        _private_key: &str,
-        _private_key_passphrase: Option<&str>,
+        prefix: &str,
+        private_key: &str,
+        private_key_passphrase: Option<&str>,
     ) -> Result<(), K8sError> {
-        // Stub: real implementation in ETL-641
+        debug!("patching snowflake secret");
+
+        let snowflake_secret_name = create_snowflake_secret_name(prefix);
+        let replicator_app_name = create_replicator_app_name(prefix);
+        let secret = create_snowflake_secret(
+            &snowflake_secret_name,
+            &replicator_app_name,
+            private_key,
+            private_key_passphrase,
+        );
+
+        let pp = PatchParams::apply(&snowflake_secret_name).force();
+        self.secrets_api.patch(&snowflake_secret_name, &pp, &Patch::Apply(secret)).await?;
+
         Ok(())
     }
 
-    async fn delete_snowflake_secret(&self, _prefix: &str) -> Result<(), K8sError> {
-        // Stub: real implementation in ETL-641
+    async fn delete_snowflake_secret(&self, prefix: &str) -> Result<(), K8sError> {
+        debug!("deleting snowflake secret");
+
+        let snowflake_secret_name = create_snowflake_secret_name(prefix);
+        let dp = DeleteParams::default();
+        Self::handle_delete_with_404_ignore(
+            self.secrets_api.delete(&snowflake_secret_name, &dp).await,
+        )?;
+
         Ok(())
     }
 
@@ -773,6 +800,10 @@ fn create_ducklake_secret_name(prefix: &str) -> String {
     format!("{prefix}-{DUCKLAKE_SECRET_NAME_SUFFIX}")
 }
 
+fn create_snowflake_secret_name(prefix: &str) -> String {
+    format!("{prefix}-{SNOWFLAKE_SECRET_NAME_SUFFIX}")
+}
+
 fn create_ducklake_maintenance_name(prefix: &str) -> String {
     prefix.to_owned()
 }
@@ -875,6 +906,33 @@ fn create_clickhouse_password_secret(
             CLICKHOUSE_PASSWORD_NAME.to_owned(),
             clickhouse_password.to_owned(),
         )])),
+        ..Secret::default()
+    }
+}
+
+fn create_snowflake_secret(
+    secret_name: &str,
+    replicator_app_name: &str,
+    private_key: &str,
+    private_key_passphrase: Option<&str>,
+) -> Secret {
+    let mut string_data =
+        BTreeMap::from([(SNOWFLAKE_PRIVATE_KEY_NAME.to_owned(), private_key.to_owned())]);
+    if let Some(passphrase) = private_key_passphrase {
+        string_data.insert(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME.to_owned(), passphrase.to_owned());
+    }
+    Secret {
+        metadata: ObjectMeta {
+            name: Some(secret_name.to_owned()),
+            namespace: Some(DATA_PLANE_NAMESPACE.to_owned()),
+            labels: Some(BTreeMap::from([
+                ("etl.supabase.com/app-name".to_owned(), replicator_app_name.to_owned()),
+                ("etl.supabase.com/app-type".to_owned(), REPLICATOR_APP_LABEL.to_owned()),
+            ])),
+            ..ObjectMeta::default()
+        },
+        type_: Some("Opaque".to_owned()),
+        string_data: Some(string_data),
         ..Secret::default()
     }
 }
@@ -1199,12 +1257,19 @@ fn create_container_environment_json(
                 }));
             }
         }
-        DestinationType::Snowflake => {
+        DestinationType::Snowflake { passphrase_secret_required } => {
             let postgres_secret_name = create_postgres_secret_name(prefix);
             let postgres_secret_env_var_json =
                 create_postgres_secret_env_var_json(&postgres_secret_name);
             container_environment.push(postgres_secret_env_var_json);
-            // Snowflake-specific env vars to be added in ETL-641
+
+            let snowflake_secret_name = create_snowflake_secret_name(prefix);
+            container_environment
+                .push(create_snowflake_private_key_env_var_json(&snowflake_secret_name));
+            if passphrase_secret_required {
+                container_environment
+                    .push(create_snowflake_passphrase_env_var_json(&snowflake_secret_name));
+            }
         }
     }
     container_environment
@@ -1424,6 +1489,30 @@ fn create_ducklake_s3_secret_access_key_env_var_json(
           "name": ducklake_secret_name,
           "key": DUCKLAKE_S3_SECRET_ACCESS_KEY_KEY_NAME,
           "optional": true
+        }
+      }
+    })
+}
+
+fn create_snowflake_private_key_env_var_json(snowflake_secret_name: &str) -> serde_json::Value {
+    json!({
+      "name": "APP_DESTINATION__SNOWFLAKE__PRIVATE_KEY",
+      "valueFrom": {
+        "secretKeyRef": {
+          "name": snowflake_secret_name,
+          "key": SNOWFLAKE_PRIVATE_KEY_NAME
+        }
+      }
+    })
+}
+
+fn create_snowflake_passphrase_env_var_json(snowflake_secret_name: &str) -> serde_json::Value {
+    json!({
+      "name": "APP_DESTINATION__SNOWFLAKE__PRIVATE_KEY_PASSPHRASE",
+      "valueFrom": {
+        "secretKeyRef": {
+          "name": snowflake_secret_name,
+          "key": SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME
         }
       }
     })
@@ -1661,6 +1750,7 @@ mod tests {
         let bq_secret_name = create_bq_secret_name(&prefix);
         let iceberg_secret_name = create_iceberg_secret_name(&prefix);
         let ducklake_secret_name = create_ducklake_secret_name(&prefix);
+        let snowflake_secret_name = create_snowflake_secret_name(&prefix);
         let config_map_name = create_replicator_config_map_name(&prefix);
         let ducklake_maintenance_name = create_ducklake_maintenance_name(&prefix);
         let stateful_set_name = create_stateful_set_name(&prefix);
@@ -1730,6 +1820,16 @@ mod tests {
                     "secret",
                     "secret",
                 ),
+            ),
+            (
+                "snowflake secret",
+                serde_json::to_value(create_snowflake_secret(
+                    &snowflake_secret_name,
+                    &replicator_app_name,
+                    "secret",
+                    Some("secret"),
+                ))
+                .unwrap(),
             ),
             (
                 "replicator config map",
@@ -2204,6 +2304,99 @@ mod tests {
             &container_environment,
             "APP_DESTINATION__CLICKHOUSE__PASSWORD",
         ));
+    }
+
+    #[test]
+    fn snowflake_with_passphrase_references_both_secrets() {
+        let prefix = create_k8s_object_prefix(TENANT_ID, 42);
+        let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
+
+        let container_environment = create_container_environment_json(
+            &prefix,
+            &Environment::Dev,
+            replicator_image,
+            DestinationType::Snowflake { passphrase_secret_required: true },
+            None,
+            LogLevel::Info,
+        );
+
+        assert!(container_environment_has_var(
+            &container_environment,
+            "APP_PIPELINE__PG_CONNECTION__PASSWORD",
+        ));
+        assert!(container_environment_has_var(
+            &container_environment,
+            "APP_DESTINATION__SNOWFLAKE__PRIVATE_KEY",
+        ));
+        assert!(container_environment_has_var(
+            &container_environment,
+            "APP_DESTINATION__SNOWFLAKE__PRIVATE_KEY_PASSPHRASE",
+        ));
+    }
+
+    #[test]
+    fn snowflake_without_passphrase_omits_passphrase_secret() {
+        let prefix = create_k8s_object_prefix(TENANT_ID, 42);
+        let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
+
+        let container_environment = create_container_environment_json(
+            &prefix,
+            &Environment::Dev,
+            replicator_image,
+            DestinationType::Snowflake { passphrase_secret_required: false },
+            None,
+            LogLevel::Info,
+        );
+
+        assert!(container_environment_has_var(
+            &container_environment,
+            "APP_PIPELINE__PG_CONNECTION__PASSWORD",
+        ));
+        assert!(container_environment_has_var(
+            &container_environment,
+            "APP_DESTINATION__SNOWFLAKE__PRIVATE_KEY",
+        ));
+        assert!(!container_environment_has_var(
+            &container_environment,
+            "APP_DESTINATION__SNOWFLAKE__PRIVATE_KEY_PASSPHRASE",
+        ));
+    }
+
+    #[test]
+    fn snowflake_secret_contains_private_key() {
+        let secret = create_snowflake_secret(
+            "tenant-42-snowflake",
+            "tenant-42-replicator-app",
+            "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+            None,
+        );
+
+        assert_eq!(secret.metadata.name.as_deref(), Some("tenant-42-snowflake"),);
+        assert_eq!(secret.metadata.namespace.as_deref(), Some(DATA_PLANE_NAMESPACE));
+        assert_eq!(secret.type_.as_deref(), Some("Opaque"));
+
+        let labels = secret.metadata.labels.as_ref().unwrap();
+        assert_eq!(labels["etl.supabase.com/app-name"], "tenant-42-replicator-app");
+        assert_eq!(labels["etl.supabase.com/app-type"], REPLICATOR_APP_LABEL);
+
+        let string_data = secret.string_data.as_ref().unwrap();
+        assert!(string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_NAME));
+        assert!(!string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME));
+    }
+
+    #[test]
+    fn snowflake_secret_contains_private_key_and_passphrase() {
+        let secret = create_snowflake_secret(
+            "tenant-42-snowflake",
+            "tenant-42-replicator-app",
+            "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+            Some("my-passphrase"),
+        );
+
+        let string_data = secret.string_data.as_ref().unwrap();
+        assert!(string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_NAME));
+        assert!(string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME));
+        assert_eq!(string_data[SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME], "my-passphrase");
     }
 
     #[test]

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -537,14 +537,18 @@ impl K8sClient for HttpK8sClient {
     ) -> Result<(), K8sError> {
         debug!("patching snowflake secret");
 
+        let encoded_private_key = BASE64_STANDARD.encode(private_key);
+        let encoded_passphrase = private_key_passphrase.map(|p| BASE64_STANDARD.encode(p));
+
         let snowflake_secret_name = create_snowflake_secret_name(prefix);
         let replicator_app_name = create_replicator_app_name(prefix);
-        let secret = create_snowflake_secret(
+        let snowflake_secret_json = create_snowflake_secret_json(
             &snowflake_secret_name,
             &replicator_app_name,
-            private_key,
-            private_key_passphrase,
+            &encoded_private_key,
+            encoded_passphrase.as_deref(),
         );
+        let secret: Secret = serde_json::from_value(snowflake_secret_json)?;
 
         let pp = PatchParams::apply(&snowflake_secret_name).force();
         self.secrets_api.patch(&snowflake_secret_name, &pp, &Patch::Apply(secret)).await?;
@@ -910,31 +914,37 @@ fn create_clickhouse_password_secret(
     }
 }
 
-fn create_snowflake_secret(
+fn create_snowflake_secret_json(
     secret_name: &str,
     replicator_app_name: &str,
-    private_key: &str,
-    private_key_passphrase: Option<&str>,
-) -> Secret {
-    let mut string_data =
-        BTreeMap::from([(SNOWFLAKE_PRIVATE_KEY_NAME.to_owned(), private_key.to_owned())]);
-    if let Some(passphrase) = private_key_passphrase {
-        string_data.insert(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME.to_owned(), passphrase.to_owned());
+    encoded_private_key: &str,
+    encoded_private_key_passphrase: Option<&str>,
+) -> serde_json::Value {
+    let mut data = serde_json::Map::new();
+    data.insert(
+        SNOWFLAKE_PRIVATE_KEY_NAME.to_owned(),
+        serde_json::Value::String(encoded_private_key.to_owned()),
+    );
+    if let Some(encoded_passphrase) = encoded_private_key_passphrase {
+        data.insert(
+            SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME.to_owned(),
+            serde_json::Value::String(encoded_passphrase.to_owned()),
+        );
     }
-    Secret {
-        metadata: ObjectMeta {
-            name: Some(secret_name.to_owned()),
-            namespace: Some(DATA_PLANE_NAMESPACE.to_owned()),
-            labels: Some(BTreeMap::from([
-                ("etl.supabase.com/app-name".to_owned(), replicator_app_name.to_owned()),
-                ("etl.supabase.com/app-type".to_owned(), REPLICATOR_APP_LABEL.to_owned()),
-            ])),
-            ..ObjectMeta::default()
-        },
-        type_: Some("Opaque".to_owned()),
-        string_data: Some(string_data),
-        ..Secret::default()
-    }
+    json!({
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": secret_name,
+        "namespace": DATA_PLANE_NAMESPACE,
+        "labels": {
+          "etl.supabase.com/app-name": replicator_app_name,
+          "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
+        }
+      },
+      "type": "Opaque",
+      "data": data
+    })
 }
 
 fn create_bq_service_account_key_secret_json(
@@ -1823,13 +1833,12 @@ mod tests {
             ),
             (
                 "snowflake secret",
-                serde_json::to_value(create_snowflake_secret(
+                create_snowflake_secret_json(
                     &snowflake_secret_name,
                     &replicator_app_name,
-                    "secret",
-                    Some("secret"),
-                ))
-                .unwrap(),
+                    &BASE64_STANDARD.encode("secret"),
+                    Some(&BASE64_STANDARD.encode("secret")),
+                ),
             ),
             (
                 "replicator config map",
@@ -2364,14 +2373,17 @@ mod tests {
 
     #[test]
     fn snowflake_secret_contains_private_key() {
-        let secret = create_snowflake_secret(
+        let private_key = "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----";
+        let encoded_private_key = BASE64_STANDARD.encode(private_key);
+        let snowflake_secret_json = create_snowflake_secret_json(
             "tenant-42-snowflake",
             "tenant-42-replicator-app",
-            "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+            &encoded_private_key,
             None,
         );
+        let secret: Secret = serde_json::from_value(snowflake_secret_json).unwrap();
 
-        assert_eq!(secret.metadata.name.as_deref(), Some("tenant-42-snowflake"),);
+        assert_eq!(secret.metadata.name.as_deref(), Some("tenant-42-snowflake"));
         assert_eq!(secret.metadata.namespace.as_deref(), Some(DATA_PLANE_NAMESPACE));
         assert_eq!(secret.type_.as_deref(), Some("Opaque"));
 
@@ -2379,24 +2391,31 @@ mod tests {
         assert_eq!(labels["etl.supabase.com/app-name"], "tenant-42-replicator-app");
         assert_eq!(labels["etl.supabase.com/app-type"], REPLICATOR_APP_LABEL);
 
-        let string_data = secret.string_data.as_ref().unwrap();
-        assert!(string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_NAME));
-        assert!(!string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME));
+        let data = secret.data.as_ref().unwrap();
+        let stored_private_key = data.get(SNOWFLAKE_PRIVATE_KEY_NAME).unwrap();
+        assert_eq!(stored_private_key.0, private_key.as_bytes());
+        assert!(!data.contains_key(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME));
     }
 
     #[test]
     fn snowflake_secret_contains_private_key_and_passphrase() {
-        let secret = create_snowflake_secret(
+        let private_key = "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----";
+        let passphrase = "my-passphrase";
+        let encoded_private_key = BASE64_STANDARD.encode(private_key);
+        let encoded_passphrase = BASE64_STANDARD.encode(passphrase);
+        let snowflake_secret_json = create_snowflake_secret_json(
             "tenant-42-snowflake",
             "tenant-42-replicator-app",
-            "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
-            Some("my-passphrase"),
+            &encoded_private_key,
+            Some(&encoded_passphrase),
         );
+        let secret: Secret = serde_json::from_value(snowflake_secret_json).unwrap();
 
-        let string_data = secret.string_data.as_ref().unwrap();
-        assert!(string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_NAME));
-        assert!(string_data.contains_key(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME));
-        assert_eq!(string_data[SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME], "my-passphrase");
+        let data = secret.data.as_ref().unwrap();
+        let stored_private_key = data.get(SNOWFLAKE_PRIVATE_KEY_NAME).unwrap();
+        let stored_passphrase = data.get(SNOWFLAKE_PRIVATE_KEY_PASSPHRASE_NAME).unwrap();
+        assert_eq!(stored_private_key.0, private_key.as_bytes());
+        assert_eq!(stored_passphrase.0, passphrase.as_bytes());
     }
 
     #[test]

--- a/crates/etl-api/tests/destinations_pipelines.rs
+++ b/crates/etl-api/tests/destinations_pipelines.rs
@@ -21,8 +21,8 @@ use crate::support::{
         create_default_image,
         destinations::{
             create_destination, new_bigquery_destination_config,
-            new_iceberg_supabase_destination_config, new_name, updated_destination_config,
-            updated_iceberg_supabase_destination_config, updated_name,
+            new_iceberg_supabase_destination_config, new_name, new_snowflake_destination_config,
+            updated_destination_config, updated_iceberg_supabase_destination_config, updated_name,
         },
         pipelines::{new_pipeline_config, updated_pipeline_config},
         sources::create_source,
@@ -128,6 +128,52 @@ async fn iceberg_supabase_destination_and_pipeline_can_be_created() {
     let destination_pipeline = CreateDestinationPipelineRequest {
         destination_name: "Iceberg Supabase Destination".to_owned(),
         destination_config: new_iceberg_supabase_destination_config(),
+        source_id,
+        pipeline_config: new_pipeline_config(),
+    };
+    let response = app.create_destination_pipeline(tenant_id, &destination_pipeline).await;
+
+    // Assert
+    assert!(response.status().is_success());
+    let response: CreateDestinationPipelineResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.destination_id, 1);
+    assert_eq!(response.pipeline_id, 1);
+
+    let destination_id = response.destination_id;
+    let pipeline_id = response.pipeline_id;
+
+    let response = app.read_destination(tenant_id, destination_id).await;
+    let response: ReadDestinationResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.id, destination_id);
+    assert_eq!(response.name, destination_pipeline.destination_name);
+    insta::assert_debug_snapshot!(response.config);
+
+    let response = app.read_pipeline(tenant_id, pipeline_id).await;
+    let response: ReadPipelineResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.id, pipeline_id);
+    assert_eq!(&response.tenant_id, tenant_id);
+    assert_eq!(response.source_id, source_id);
+    assert_eq!(response.destination_id, destination_id);
+    assert_eq!(response.replicator_id, 1);
+    insta::assert_debug_snapshot!(response.config);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn snowflake_destination_and_pipeline_can_be_created() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+    let tenant_id = &create_tenant(&app).await;
+    let source_id = create_source(&app, tenant_id).await;
+    create_default_image(&app).await;
+
+    // Act
+    let destination_pipeline = CreateDestinationPipelineRequest {
+        destination_name: "Snowflake Destination".to_owned(),
+        destination_config: new_snowflake_destination_config(),
         source_id,
         pipeline_config: new_pipeline_config(),
     };

--- a/crates/etl-api/tests/snapshots/main__destinations_pipelines__snowflake_destination_and_pipeline_can_be_created-2.snap
+++ b/crates/etl-api/tests/snapshots/main__destinations_pipelines__snowflake_destination_and_pipeline_can_be_created-2.snap
@@ -1,0 +1,46 @@
+---
+source: crates/etl-api/tests/destinations_pipelines.rs
+expression: response.config
+---
+FullApiPipelineConfig {
+    publication_name: "publication",
+    batch: Some(
+        BatchConfig {
+            max_fill_ms: 5,
+            memory_budget_ratio: 0.2,
+            max_bytes: 8388608,
+        },
+    ),
+    table_error_retry_delay_ms: Some(
+        10000,
+    ),
+    table_error_retry_max_attempts: Some(
+        5,
+    ),
+    max_table_sync_workers: Some(
+        2,
+    ),
+    max_copy_connections_per_table: Some(
+        2,
+    ),
+    memory_refresh_interval_ms: Some(
+        100,
+    ),
+    memory_backpressure: Some(
+        MemoryBackpressureConfig {
+            activate_threshold: 0.85,
+            resume_threshold: 0.75,
+        },
+    ),
+    table_sync_copy: Some(
+        IncludeAllTables,
+    ),
+    invalidated_slot_behavior: Some(
+        Error,
+    ),
+    replicator_resources: None,
+    ducklake_maintenance: None,
+    log_level: Some(
+        Info,
+    ),
+}

--- a/crates/etl-api/tests/snapshots/main__destinations_pipelines__snowflake_destination_and_pipeline_can_be_created.snap
+++ b/crates/etl-api/tests/snapshots/main__destinations_pipelines__snowflake_destination_and_pipeline_can_be_created.snap
@@ -1,0 +1,17 @@
+---
+source: crates/etl-api/tests/destinations_pipelines.rs
+expression: response.config
+---
+Snowflake {
+    account_id: "myorg-myaccount",
+    user: "etl_user",
+    private_key: SerializableSecretString(
+        SecretBox<str>([REDACTED]),
+    ),
+    private_key_passphrase: None,
+    database: "my_database",
+    schema: "public",
+    role: Some(
+        "etl_role",
+    ),
+}


### PR DESCRIPTION
## Summary

- Register Snowflake private key (and optional passphrase) as a k8s secret
- Fill in `create_or_update_snowflake_secret`, `delete_snowflake_secret`, and the `DestinationType::Snowflake` container env-var arm in `http.rs`
- Change `DestinationType::Snowflake` from a unit variant to `Snowflake { passphrase_secret_required: bool }` to conditionally emit the passphrase env var (password for the key is optional)

