### PR TITLE
fix(sec): strict Snowflake account ID validation and SSRF hardening

### DIFF
--- a/crates/etl-api/src/configs/destination.rs
+++ b/crates/etl-api/src/configs/destination.rs
@@ -151,7 +151,7 @@ pub enum FullApiDestinationConfig {
     },
     Snowflake {
         #[schema(example = "ORGNAME-ACCOUNTNAME")]
-        #[serde(deserialize_with = "crate::utils::trim_string")]
+        #[serde(deserialize_with = "crate::utils::trim_snowflake_account_id")]
         account_id: String,
         #[schema(example = "ETL_USER")]
         #[serde(deserialize_with = "crate::utils::trim_string")]
@@ -974,7 +974,7 @@ pub enum StoredIcebergConfig {
 pub enum FullApiIcebergConfig {
     Supabase {
         #[schema(example = "abcdefghijklmnopqrst")]
-        #[serde(deserialize_with = "crate::utils::trim_string")]
+        #[serde(deserialize_with = "crate::utils::trim_supabase_project_ref")]
         project_ref: String,
         #[schema(example = "my-warehouse")]
         #[serde(deserialize_with = "crate::utils::trim_string")]

--- a/crates/etl-api/src/utils.rs
+++ b/crates/etl-api/src/utils.rs
@@ -48,6 +48,35 @@ where
     }
 }
 
+/// Deserializes and trims a Snowflake account identifier.
+///
+/// Values that are not strict account identifiers are rejected.
+///
+/// The account id is interpolated into the Snowflake account URL, so rejecting
+/// non-identifier characters here prevents host takeover (SSRF) and surfaces a
+/// clean, field-specific error at the API boundary.
+pub fn trim_snowflake_account_id<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?.trim().to_owned();
+    etl_config::shared::validate_snowflake_account_id(&s).map_err(D::Error::custom)?;
+    Ok(s)
+}
+
+/// Deserializes and trims a Supabase project ref.
+///
+/// Values that are not strict project refs are rejected.
+/// The project ref is interpolated into the Iceberg catalog URL.
+pub fn trim_supabase_project_ref<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?.trim().to_owned();
+    etl_config::shared::validate_supabase_project_ref(&s).map_err(D::Error::custom)?;
+    Ok(s)
+}
+
 /// Generates a random alphabetic string of length `len`.
 pub fn generate_random_alpha_str(len: usize) -> String {
     let chars = [
@@ -111,224 +140,160 @@ mod tests {
     use crate::utils::parse_docker_image_tag;
 
     #[test]
-    fn parse_with_tag() {
-        assert_eq!(parse_docker_image_tag("supabase/replicator:1.2.3"), "1.2.3");
-        assert_eq!(parse_docker_image_tag("example.com:5000/team/my-app:2.0"), "2.0");
-        assert_eq!(parse_docker_image_tag("ghcr.io/dockersamples/example-app:pr-311"), "pr-311");
+    fn docker_image_tag_parsing() {
+        let cases: &[(&str, &str)] = &[
+            // With explicit tag.
+            ("supabase/replicator:1.2.3", "1.2.3"),
+            ("example.com:5000/team/my-app:2.0", "2.0"),
+            ("ghcr.io/dockersamples/example-app:pr-311", "pr-311"),
+            // Tag with digest -- tag wins.
+            ("example.com:5000/team/my-app:2.0@sha256:abcdef0123456789", "2.0"),
+            // No tag defaults to "latest".
+            ("alpine", "latest"),
+            ("library/alpine", "latest"),
+            ("docker.io/library/alpine", "latest"),
+            // Digest only -- unavailable.
+            ("repo/name@sha256:abcdef0123456789", "unavailable"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(parse_docker_image_tag(input), *expected, "image {input:?}");
+        }
     }
 
     #[test]
-    fn parse_with_tag_and_digest() {
-        assert_eq!(
-            parse_docker_image_tag("example.com:5000/team/my-app:2.0@sha256:abcdef0123456789"),
-            "2.0"
-        );
-    }
-
-    #[test]
-    fn parse_without_tag_defaults_to_latest() {
-        assert_eq!(parse_docker_image_tag("alpine"), "latest");
-        assert_eq!(parse_docker_image_tag("library/alpine"), "latest");
-        assert_eq!(parse_docker_image_tag("docker.io/library/alpine"), "latest");
-    }
-
-    #[test]
-    fn parse_with_only_digest_unavailable() {
-        assert_eq!(parse_docker_image_tag("repo/name@sha256:abcdef0123456789"), "unavailable");
-    }
-
-    #[test]
-    fn trim_string_with_leading_and_trailing_whitespace() {
+    fn trim_string_deserializer() {
         #[derive(Deserialize)]
-        struct TestStruct {
+        struct T {
             #[serde(deserialize_with = "trim_string")]
             value: String,
         }
 
-        let json = r#"{"value": "  hello world  "}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "hello world");
-    }
+        let cases: &[(&str, &str)] = &[
+            (r#"{"value": "  hello world  "}"#, "hello world"),
+            (r#"{"value": "no_whitespace"}"#, "no_whitespace"),
+            (r#"{"value": "\t\n  trimmed  \n\t"}"#, "trimmed"),
+            (r#"{"value": ""}"#, ""),
+            (r#"{"value": "   \t\n   "}"#, ""),
+            (r#"{"value": "  hello   world  "}"#, "hello   world"),
+            (r#"{"value": "   leading"}"#, "leading"),
+            (r#"{"value": "trailing   "}"#, "trailing"),
+        ];
 
-    #[test]
-    fn trim_string_without_whitespace() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(deserialize_with = "trim_string")]
-            value: String,
+        for (json, expected) in cases {
+            let result: T = serde_json::from_str(json).unwrap();
+            assert_eq!(result.value, *expected, "json {json}");
         }
-
-        let json = r#"{"value": "no_whitespace"}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "no_whitespace");
     }
 
     #[test]
-    fn trim_string_with_tabs_and_newlines() {
+    fn trim_option_string_deserializer() {
         #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(deserialize_with = "trim_string")]
-            value: String,
-        }
-
-        let json = r#"{"value": "\t\n  trimmed  \n\t"}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "trimmed");
-    }
-
-    #[test]
-    fn trim_string_empty_string() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(deserialize_with = "trim_string")]
-            value: String,
-        }
-
-        let json = r#"{"value": ""}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "");
-    }
-
-    #[test]
-    fn trim_string_only_whitespace_becomes_empty() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(deserialize_with = "trim_string")]
-            value: String,
-        }
-
-        let json = r#"{"value": "   \t\n   "}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "");
-    }
-
-    #[test]
-    fn trim_string_preserves_internal_whitespace() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(deserialize_with = "trim_string")]
-            value: String,
-        }
-
-        let json = r#"{"value": "  hello   world  "}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "hello   world");
-    }
-
-    #[test]
-    fn trim_string_leading_only() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(deserialize_with = "trim_string")]
-            value: String,
-        }
-
-        let json = r#"{"value": "   leading"}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "leading");
-    }
-
-    #[test]
-    fn trim_string_trailing_only() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(deserialize_with = "trim_string")]
-            value: String,
-        }
-
-        let json = r#"{"value": "trailing   "}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, "trailing");
-    }
-
-    #[test]
-    fn trim_option_string_with_whitespace() {
-        #[derive(Deserialize)]
-        struct TestStruct {
+        struct T {
             #[serde(default, deserialize_with = "trim_option_string")]
             value: Option<String>,
         }
 
-        let json = r#"{"value": "  hello world  "}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, Some("hello world".to_owned()));
-    }
+        let cases: &[(&str, Option<&str>)] = &[
+            (r#"{"value": "  hello world  "}"#, Some("hello world")),
+            (r#"{"value": null}"#, None),
+            (r#"{}"#, None),
+            (r#"{"value": ""}"#, Some("")),
+            (r#"{"value": "   "}"#, Some("")),
+        ];
 
-    #[test]
-    fn trim_option_string_with_null() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(default, deserialize_with = "trim_option_string")]
-            value: Option<String>,
+        for (json, expected) in cases {
+            let result: T = serde_json::from_str(json).unwrap();
+            assert_eq!(result.value.as_deref(), *expected, "json {json}");
         }
-
-        let json = r#"{"value": null}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, None);
     }
 
     #[test]
-    fn trim_option_string_with_missing_field() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(default, deserialize_with = "trim_option_string")]
-            value: Option<String>,
-        }
-
-        let json = r#"{}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, None);
-    }
-
-    #[test]
-    fn trim_option_string_with_empty_string() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(default, deserialize_with = "trim_option_string")]
-            value: Option<String>,
-        }
-
-        let json = r#"{"value": ""}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, Some("".to_owned()));
-    }
-
-    #[test]
-    fn trim_option_string_whitespace_only_becomes_empty() {
-        #[derive(Deserialize)]
-        struct TestStruct {
-            #[serde(default, deserialize_with = "trim_option_string")]
-            value: Option<String>,
-        }
-
-        let json = r#"{"value": "   "}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result.value, Some("".to_owned()));
-    }
-
-    #[test]
-    fn trim_http_url_trims_and_parses() {
+    fn trim_http_url_deserializer() {
         #[derive(Debug, Deserialize)]
-        struct TestStruct {
+        struct T {
             #[serde(rename = "value", deserialize_with = "trim_http_url")]
-            _value: Url,
+            url: Url,
         }
 
-        let json = r#"{"value": "  https://example.com:8443/path  "}"#;
-        let result: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(result._value.as_str(), "https://example.com:8443/path");
+        // (input, Some(parsed_url) for valid, None for rejection)
+        let cases: &[(&str, Option<&str>)] = &[
+            ("  https://example.com:8443/path  ", Some("https://example.com:8443/path")),
+            ("ftp://example.com/data", None),
+        ];
+
+        for (input, expected) in cases {
+            let json = format!(r#"{{"value": "{input}"}}"#);
+            match expected {
+                Some(url) => {
+                    let result: T = serde_json::from_str(&json).unwrap();
+                    assert_eq!(result.url.as_str(), *url, "input {input:?}");
+                }
+                None => {
+                    assert!(serde_json::from_str::<T>(&json).is_err(), "should reject {input:?}");
+                }
+            }
+        }
     }
 
     #[test]
-    fn trim_http_url_rejects_non_http_scheme() {
+    fn trim_snowflake_account_id_deserializer() {
         #[derive(Debug, Deserialize)]
-        struct TestStruct {
-            #[serde(rename = "value", deserialize_with = "trim_http_url")]
-            _value: Url,
+        struct T {
+            #[serde(rename = "value", deserialize_with = "trim_snowflake_account_id")]
+            value: String,
         }
 
-        let json = r#"{"value": "ftp://example.com/data"}"#;
-        let error = serde_json::from_str::<TestStruct>(json).unwrap_err();
-        assert!(error.to_string().contains("url must use http or https scheme"));
+        // (input, Some(trimmed) for valid, None for rejection)
+        let cases: &[(&str, Option<&str>)] = &[
+            ("  myorg-myaccount  ", Some("myorg-myaccount")),
+            ("org-account", Some("org-account")),
+            ("127.0.0.1:8443/x", None),
+            ("attacker.example/foo", None),
+            ("169.254.169.254#", None),
+        ];
+
+        for (input, expected) in cases {
+            let json = format!(r#"{{"value": "{input}"}}"#);
+            match expected {
+                Some(val) => {
+                    let result: T = serde_json::from_str(&json).unwrap();
+                    assert_eq!(result.value, *val, "input {input:?}");
+                }
+                None => {
+                    assert!(serde_json::from_str::<T>(&json).is_err(), "should reject {input:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn trim_supabase_project_ref_deserializer() {
+        #[derive(Debug, Deserialize)]
+        struct T {
+            #[serde(rename = "value", deserialize_with = "trim_supabase_project_ref")]
+            value: String,
+        }
+
+        // (input, Some(trimmed) for valid, None for rejection)
+        let cases: &[(&str, Option<&str>)] = &[
+            ("  abcdefghijklmnopqrst  ", Some("abcdefghijklmnopqrst")),
+            ("attacker.example/foo", None),
+            ("169.254.169.254#", None),
+            ("tooshort", None),
+        ];
+
+        for (input, expected) in cases {
+            let json = format!(r#"{{"value": "{input}"}}"#);
+            match expected {
+                Some(val) => {
+                    let result: T = serde_json::from_str(&json).unwrap();
+                    assert_eq!(result.value, *val, "input {input:?}");
+                }
+                None => {
+                    assert!(serde_json::from_str::<T>(&json).is_err(), "should reject {input:?}");
+                }
+            }
+        }
     }
 }

--- a/crates/etl-api/src/validation/validators/snowflake.rs
+++ b/crates/etl-api/src/validation/validators/snowflake.rs
@@ -65,8 +65,20 @@ impl Validator for SnowflakeValidator {
             )]);
         }
 
-        let mut config =
-            snowflake::Config::new(&self.account_id, &self.user, &self.database, &self.schema);
+        let mut config = match snowflake::Config::new(
+            &self.account_id,
+            &self.user,
+            &self.database,
+            &self.schema,
+        ) {
+            Ok(config) => config,
+            Err(err) => {
+                return Ok(vec![ValidationFailure::critical(
+                    "Invalid Snowflake Account ID",
+                    format!("The Snowflake account identifier is not valid.\n\nError: {err}"),
+                )]);
+            }
+        };
         if let Some(role) = &self.role {
             config = config.with_role(role);
         }

--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -550,7 +550,8 @@ impl BenchDestination {
                     .filter(|s| !s.trim().is_empty())
                     .context("Snowflake schema is required for Snowflake benchmarks")?;
 
-                let mut config = SnowflakeConfig::new(&account, &user, &database, &schema);
+                let mut config = SnowflakeConfig::new(&account, &user, &database, &schema)
+                    .context("invalid Snowflake account identifier")?;
                 if let Some(role) = &destination_args.sf_role
                     && !role.trim().is_empty()
                 {

--- a/crates/etl-config/src/shared/mod.rs
+++ b/crates/etl-config/src/shared/mod.rs
@@ -5,6 +5,7 @@ mod pipeline;
 mod replicator;
 mod sentry;
 mod supabase;
+mod validators;
 
 pub use base::ValidationError;
 pub use connection::{
@@ -23,3 +24,4 @@ pub use pipeline::{
 pub use replicator::{ReplicatorConfig, ReplicatorConfigWithoutSecrets};
 pub use sentry::SentryConfig;
 pub use supabase::{SupabaseConfig, SupabaseConfigWithoutSecrets};
+pub use validators::{validate_snowflake_account_id, validate_supabase_project_ref};

--- a/crates/etl-config/src/shared/validators.rs
+++ b/crates/etl-config/src/shared/validators.rs
@@ -41,12 +41,10 @@ pub fn validate_snowflake_account_id(account_id: &str) -> Result<(), ValidationE
         {
             return Err(invalid());
         }
-    } else {
-        if !account_id.starts_with(|c: char| c.is_ascii_alphabetic())
-            || !account_id.chars().all(|c| c.is_ascii_alphanumeric())
-        {
-            return Err(invalid());
-        }
+    } else if !account_id.starts_with(|c: char| c.is_ascii_alphabetic())
+        || !account_id.chars().all(|c| c.is_ascii_alphanumeric())
+    {
+        return Err(invalid());
     }
 
     Ok(())

--- a/crates/etl-config/src/shared/validators.rs
+++ b/crates/etl-config/src/shared/validators.rs
@@ -1,0 +1,151 @@
+//! Validators for destination identifiers that are interpolated into URLs.
+
+use super::ValidationError;
+
+const SNOWFLAKE_ACCOUNT_ID_MAX_LEN: usize = 63;
+const SUPABASE_PROJECT_REF_LEN: usize = 20;
+
+/// Validates that a Snowflake account identifier is in the preferred
+/// `orgname-accountname` format.
+///
+/// See https://docs.snowflake.com/en/user-guide/admin-account-identifier for details.
+pub fn validate_snowflake_account_id(account_id: &str) -> Result<(), ValidationError> {
+    let invalid = || ValidationError::InvalidFieldValue {
+        field: "account_id".to_owned(),
+        constraint: "must be a valid Snowflake account identifier in orgname-accountname format \
+                     (e.g. MYORG-MYACCOUNT): orgname is ASCII letters and digits starting with a \
+                     letter; accountname is ASCII letters, digits and underscores starting with a \
+                     letter and not ending with an underscore; max 63 characters"
+            .to_owned(),
+    };
+
+    if account_id.is_empty() || account_id.len() > SNOWFLAKE_ACCOUNT_ID_MAX_LEN {
+        return Err(invalid());
+    }
+
+    let Some((org, account)) = account_id.split_once('-') else {
+        return Err(invalid());
+    };
+
+    if org.is_empty()
+        || !org.starts_with(|c: char| c.is_ascii_alphabetic())
+        || !org.chars().all(|c| c.is_ascii_alphanumeric())
+    {
+        return Err(invalid());
+    }
+
+    if account.is_empty()
+        || !account.starts_with(|c: char| c.is_ascii_alphabetic())
+        || !account.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        || account.ends_with('_')
+    {
+        return Err(invalid());
+    }
+
+    Ok(())
+}
+
+/// Validates a Supabase project reference.
+///
+/// A project ref is exactly 20 lowercase ASCII alphanumeric characters forming
+/// a single label (no dots).
+pub fn validate_supabase_project_ref(project_ref: &str) -> Result<(), ValidationError> {
+    let is_valid = project_ref.len() == SUPABASE_PROJECT_REF_LEN
+        && project_ref.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+
+    if is_valid {
+        Ok(())
+    } else {
+        Err(ValidationError::InvalidFieldValue {
+            field: "project_ref".to_owned(),
+            constraint: "must be exactly 20 lowercase alphanumeric characters".to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snowflake_account_id() {
+        let at_limit = format!("{}-{}", "a".repeat(31), "b".repeat(31));
+        assert_eq!(at_limit.len(), 63);
+        let over_limit = format!("{}-{}", "a".repeat(31), "b".repeat(32));
+        assert_eq!(over_limit.len(), 64);
+
+        let cases: &[(&str, bool)] = &[
+            // Valid org-account identifiers.
+            ("myorg-myaccount", true),
+            ("ORGNAME-ACCOUNTNAME", true),
+            ("org123-my_test_account", true),
+            ("a-b", true),
+            ("Acme-test_aws_us_east_2", true),
+            (&at_limit, true),
+            // Empty.
+            ("", false),
+            // SSRF injection payloads.
+            ("127.0.0.1:8443/x", false),
+            ("attacker.example/foo", false),
+            ("169.254.169.254#", false),
+            ("evil@host", false),
+            ("https://evil.com", false),
+            ("host?x=1", false),
+            ("a b", false),
+            ("abc%2f", false),
+            // Legacy dotted locators are not accepted.
+            ("xy12345.us-east-1.aws", false),
+            ("xy12345", false),
+            // No hyphen (single part).
+            ("abc123", false),
+            // Org must start with a letter.
+            ("1org-account", false),
+            // Account must start with a letter.
+            ("org-1account", false),
+            // Account must not end with underscore.
+            ("org-account_", false),
+            // Underscore not allowed in org name.
+            ("my_org-acct", false),
+            // Dots not allowed.
+            ("org-acct.test", false),
+            // Empty org or account.
+            ("-account", false),
+            ("org-", false),
+            // Exceeds 63-character limit.
+            (&over_limit, false),
+        ];
+
+        for (id, expected) in cases {
+            let result = validate_snowflake_account_id(id);
+            assert_eq!(result.is_ok(), *expected, "account_id {id:?}");
+        }
+    }
+
+    #[test]
+    fn supabase_project_ref() {
+        let cases: &[(&str, bool)] = &[
+            // Valid project refs.
+            ("abcdefghijklmnopqrst", true),
+            ("a1b2c3d4e5f6g7h8i9j0", true),
+            ("00000000000000000000", true),
+            // Empty.
+            ("", false),
+            // Wrong length.
+            ("tooshort", false),
+            ("abcdefghijklmnopqrstu", false), // 21 chars
+            // Disallowed characters.
+            ("ABCDEFGHIJKLMNOPQRST", false), // uppercase
+            ("abcdefghij_lmnopqrst", false), // underscore
+            ("abcdefghij.lmnopqrst", false), // dot
+            // SSRF injection payloads.
+            ("attacker.example/foo", false),
+            ("169.254.169.254#", false),
+            ("127.0.0.1:8443/x123x", false),
+        ];
+
+        for (input, expected) in cases {
+            let result = validate_supabase_project_ref(input);
+            assert_eq!(result.is_ok(), *expected, "project_ref {input:?}");
+        }
+    }
+}

--- a/crates/etl-config/src/shared/validators.rs
+++ b/crates/etl-config/src/shared/validators.rs
@@ -5,17 +5,20 @@ use super::ValidationError;
 const SNOWFLAKE_ACCOUNT_ID_MAX_LEN: usize = 63;
 const SUPABASE_PROJECT_REF_LEN: usize = 20;
 
-/// Validates that a Snowflake account identifier is in the preferred
-/// `orgname-accountname` format.
+/// Validates a Snowflake account identifier.
+///
+/// Accepts two forms:
+/// - Org-account: `ORGNAME-ACCOUNTNAME` (preferred).
+/// - Legacy single-part locator: `xy12345` (ASCII alphanumeric, starts with a
+///   letter).
 ///
 /// See https://docs.snowflake.com/en/user-guide/admin-account-identifier for details.
 pub fn validate_snowflake_account_id(account_id: &str) -> Result<(), ValidationError> {
     let invalid = || ValidationError::InvalidFieldValue {
         field: "account_id".to_owned(),
-        constraint: "must be a valid Snowflake account identifier in orgname-accountname format \
-                     (e.g. MYORG-MYACCOUNT): orgname is ASCII letters and digits starting with a \
-                     letter; accountname is ASCII letters, digits and underscores starting with a \
-                     letter and not ending with an underscore; max 63 characters"
+        constraint: "must be a valid Snowflake account identifier: either orgname-accountname \
+                     (e.g. MYORG-MYACCOUNT) or a single-part account locator (e.g. xy12345); max \
+                     63 characters"
             .to_owned(),
     };
 
@@ -23,23 +26,27 @@ pub fn validate_snowflake_account_id(account_id: &str) -> Result<(), ValidationE
         return Err(invalid());
     }
 
-    let Some((org, account)) = account_id.split_once('-') else {
-        return Err(invalid());
-    };
+    if let Some((org, account)) = account_id.split_once('-') {
+        if org.is_empty()
+            || !org.starts_with(|c: char| c.is_ascii_alphabetic())
+            || !org.chars().all(|c| c.is_ascii_alphanumeric())
+        {
+            return Err(invalid());
+        }
 
-    if org.is_empty()
-        || !org.starts_with(|c: char| c.is_ascii_alphabetic())
-        || !org.chars().all(|c| c.is_ascii_alphanumeric())
-    {
-        return Err(invalid());
-    }
-
-    if account.is_empty()
-        || !account.starts_with(|c: char| c.is_ascii_alphabetic())
-        || !account.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-        || account.ends_with('_')
-    {
-        return Err(invalid());
+        if account.is_empty()
+            || !account.starts_with(|c: char| c.is_ascii_alphabetic())
+            || !account.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            || account.ends_with('_')
+        {
+            return Err(invalid());
+        }
+    } else {
+        if !account_id.starts_with(|c: char| c.is_ascii_alphabetic())
+            || !account_id.chars().all(|c| c.is_ascii_alphanumeric())
+        {
+            return Err(invalid());
+        }
     }
 
     Ok(())
@@ -93,11 +100,20 @@ mod tests {
             ("host?x=1", false),
             ("a b", false),
             ("abc%2f", false),
-            // Legacy dotted locators are not accepted.
+            // Valid legacy single-part locators.
+            ("xy12345", true),
+            ("abc123", true),
+            // Legacy locator must start with a letter.
+            ("123abc", false),
+            // Underscores not allowed in locators.
+            ("xy_12345", false),
+            // Dotted locators rejected: URL host and JWT claim need different values.
+            ("xy12345.us-east-2.aws", false),
             ("xy12345.us-east-1.aws", false),
-            ("xy12345", false),
-            // No hyphen (single part).
-            ("abc123", false),
+            // Locator with injection characters.
+            ("xy12345/us", false),
+            ("xy12345:443", false),
+            ("xy12345#", false),
             // Org must start with a letter.
             ("1org-account", false),
             // Account must start with a letter.

--- a/crates/etl-destinations/src/iceberg/client.rs
+++ b/crates/etl-destinations/src/iceberg/client.rs
@@ -5,8 +5,9 @@ use etl::{
     error::EtlResult,
     types::{ColumnSchema, TableRow},
 };
+use etl_config::shared::validate_supabase_project_ref;
 use iceberg::{
-    Catalog, CatalogBuilder, NamespaceIdent, TableCreation, TableIdent,
+    Catalog, CatalogBuilder, ErrorKind, NamespaceIdent, TableCreation, TableIdent,
     io::{S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY},
     spec::{DataFile, TableProperties},
     table::Table,
@@ -94,6 +95,9 @@ impl IcebergClient {
         s3_secret_access_key: String,
         s3_region: String,
     ) -> Result<Self, iceberg::Error> {
+        validate_supabase_project_ref(project_ref)
+            .map_err(|e| iceberg::Error::new(ErrorKind::DataInvalid, e.to_string()))?;
+
         let base_uri = format!("https://{project_ref}.storage.{supabase_domain}/storage");
         let catalog_uri = format!("{base_uri}/v1/iceberg");
         let s3_endpoint = format!("{base_uri}/v1/s3");

--- a/crates/etl-destinations/src/snowflake/auth.rs
+++ b/crates/etl-destinations/src/snowflake/auth.rs
@@ -339,7 +339,7 @@ mod tests {
         account_id: &str,
         username: &str,
     ) -> AuthManager<TestExchanger> {
-        let config = Config::new(account_id, username, "TEST_DB", "PUBLIC");
+        let config = Config::new(account_id, username, "TEST_DB", "PUBLIC").expect("valid config");
         let pem = std::fs::read_to_string(TEST_KEY_PATH).expect("test key");
 
         AuthManager::with_exchanger(&config, &pem, None, TestExchanger)
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn config_derives_account_url() {
-        let config = Config::new("ORG-ACCT", "USER", "TEST_DB", "PUBLIC");
+        let config = Config::new("ORG-ACCT", "USER", "TEST_DB", "PUBLIC").expect("valid config");
         assert_eq!(config.account_url(), "https://ORG-ACCT.snowflakecomputing.com");
     }
 

--- a/crates/etl-destinations/src/snowflake/config.rs
+++ b/crates/etl-destinations/src/snowflake/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use etl_config::shared::{ValidationError, validate_snowflake_account_id};
+
 pub(crate) const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 pub(crate) const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
 
@@ -34,17 +36,26 @@ pub struct Config {
 
 impl Config {
     /// Create a config with the required connection parameters.
-    pub fn new(account_id: &str, username: &str, database: &str, schema: &str) -> Self {
+    pub fn new(
+        account_id: &str,
+        username: &str,
+        database: &str,
+        schema: &str,
+    ) -> Result<Self, ValidationError> {
+        // The account id is interpolated into the account URL, so this rejects values
+        // that could take over the host (SSRF).
+        validate_snowflake_account_id(account_id)?;
+
         let account_url = format!("https://{}.snowflakecomputing.com", account_id.to_uppercase());
 
-        Self {
+        Ok(Self {
             account_url,
             account_id: account_id.to_owned(),
             username: username.to_owned(),
             database: database.to_owned(),
             schema: schema.to_owned(),
             role: None,
-        }
+        })
     }
 
     /// HTTPS-only account URL used for all API requests.
@@ -66,5 +77,27 @@ impl Config {
     pub fn with_role(mut self, role: &str) -> Self {
         self.role = Some(role.to_owned());
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_builds_account_url_for_valid_id() {
+        let config = Config::new("myorg-myaccount", "USER", "DB", "PUBLIC").expect("valid id");
+        assert_eq!(config.account_url(), "https://MYORG-MYACCOUNT.snowflakecomputing.com");
+    }
+
+    #[test]
+    fn new_rejects_injection_in_account_id() {
+        for id in ["127.0.0.1:8443/x", "attacker.example/foo", "169.254.169.254#", "evil@host", ""]
+        {
+            assert!(
+                Config::new(id, "USER", "DB", "PUBLIC").is_err(),
+                "should reject account_id {id:?}"
+            );
+        }
     }
 }

--- a/crates/etl-destinations/src/snowflake/test_utils.rs
+++ b/crates/etl-destinations/src/snowflake/test_utils.rs
@@ -33,7 +33,8 @@ pub fn load_test_config() -> Config {
         std::env::var(SNOWFLAKE_DATABASE_ENV).unwrap_or_else(|_| DEFAULT_DATABASE.to_owned());
     let schema = std::env::var(SNOWFLAKE_SCHEMA_ENV).unwrap_or_else(|_| DEFAULT_SCHEMA.to_owned());
 
-    let mut config = Config::new(&account_id, &username, &database, &schema);
+    let mut config = Config::new(&account_id, &username, &database, &schema)
+        .expect("valid Snowflake account id");
     if let Ok(role) = std::env::var(SNOWFLAKE_ROLE_ENV) {
         config = config.with_role(&role);
     }

--- a/crates/etl-examples/src/bin/snowflake.rs
+++ b/crates/etl-examples/src/bin/snowflake.rs
@@ -214,7 +214,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         &args.sf_args.snowflake_user,
         &args.sf_args.snowflake_database,
         &args.sf_args.snowflake_schema,
-    );
+    )?;
     if let Some(ref role) = args.sf_args.snowflake_role {
         sf_config = sf_config.with_role(role);
     }

--- a/crates/etl-replicator/src/core.rs
+++ b/crates/etl-replicator/src/core.rs
@@ -225,7 +225,8 @@ pub(crate) async fn start_replicator_with_config(
             schema,
             role,
         } => {
-            let mut config = snowflake::Config::new(account_id, user, database, schema);
+            let mut config = snowflake::Config::new(account_id, user, database, schema)
+                .map_err(ReplicatorError::config)?;
             if let Some(r) = role {
                 config = config.with_role(r);
             }
@@ -235,7 +236,7 @@ pub(crate) async fn start_replicator_with_config(
                     private_key.expose_secret(),
                     private_key_passphrase.as_ref(),
                 )
-                .map_err(|e| ReplicatorError::config(std::io::Error::other(e.to_string())))?,
+                .map_err(ReplicatorError::config)?,
             );
             let client = snowflake::Client::new(config, auth, pipeline_id);
             let destination = snowflake::Destination::new(client, store.clone());


### PR DESCRIPTION
## Summary

- Tighten `validate_snowflake_account_id` to only accept the strict `orgname-accountname` format per Snowflake docs
- Add `validate_supabase_project_ref` enforcing exactly 20 lowercase alphanumeric characters for Iceberg project refs.
- Convert validator and utils tests to table-driven style.