### PR TITLE
fix(ducklake): enable expire snapshot by default for ducklake

### DIFF
--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_maintenance_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_maintenance_json.snap
@@ -27,7 +27,7 @@ expression: "serde_json::to_string_pretty(&ducklake_maintenance_json).unwrap()"
         "enabled": true
       },
       "expireSnapshots": {
-        "enabled": false
+        "enabled": true
       },
       "inlineFlush": {
         "enabled": true,

--- a/crates/etl-maintenance/src/coordination.rs
+++ b/crates/etl-maintenance/src/coordination.rs
@@ -228,7 +228,7 @@ impl Default for ExternalMaintenanceOperationPolicy {
             inline_flush_enabled: true,
             merge_adjacent_files_enabled: true,
             rewrite_data_files_enabled: true,
-            expire_snapshots_enabled: false,
+            expire_snapshots_enabled: true,
             cleanup_old_files_enabled: true,
         }
     }

--- a/crates/etl-maintenance/src/coordination/kubernetes.rs
+++ b/crates/etl-maintenance/src/coordination/kubernetes.rs
@@ -308,7 +308,7 @@ fn operation_policy(resource: &DynamicObject) -> ExternalMaintenanceOperationPol
         inline_flush_enabled: enabled_value(inline_flush, true),
         merge_adjacent_files_enabled: enabled_value(merge_adjacent_files, true),
         rewrite_data_files_enabled: enabled_value(rewrite_data_files, true),
-        expire_snapshots_enabled: enabled_value(expire_snapshots, false),
+        expire_snapshots_enabled: enabled_value(expire_snapshots, true),
         cleanup_old_files_enabled: enabled_value(cleanup_old_files, true),
     }
 }
@@ -340,7 +340,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn operation_policy_defaults_expire_snapshots_disabled() {
+    fn operation_policy_defaults_expire_snapshots_enabled() {
         let resource: DynamicObject = serde_json::from_value(json!({
             "apiVersion": "etl.supabase.com/v1alpha1",
             "kind": "DuckLakeMaintenance",
@@ -360,6 +360,6 @@ mod tests {
 
         assert!(policy.inline_flush_enabled);
         assert!(policy.rewrite_data_files_enabled);
-        assert!(!policy.expire_snapshots_enabled);
+        assert!(policy.expire_snapshots_enabled);
     }
 }

--- a/crates/etl-replicator/src/bin/etl-ducklake-maintenance.rs
+++ b/crates/etl-replicator/src/bin/etl-ducklake-maintenance.rs
@@ -120,7 +120,7 @@ async fn run(config: ReplicatorConfig) -> MaintenanceResult<()> {
             )?,
         },
         expire_snapshots: ExpireSnapshotsMaintenanceConfig {
-            enabled: env_bool("ETL_DUCKLAKE_MAINTENANCE__EXPIRE_SNAPSHOTS__ENABLED", false),
+            enabled: env_bool("ETL_DUCKLAKE_MAINTENANCE__EXPIRE_SNAPSHOTS__ENABLED", true),
             older_than: expire_snapshots_older_than.clone().unwrap_or_else(|| "7 days".to_owned()),
         },
         cleanup_old_files: CleanupOldFilesMaintenanceConfig {


### PR DESCRIPTION
We need to expire snapshot by default, if not it creates too much files and useless data which requires more resources to query.
