### PR TITLE
ref(errors): Improve error messages

### DIFF
--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -10,7 +10,9 @@ use gcp_bigquery_client::{
     client_builder::ClientBuilder,
     error::BQError,
     google::{
-        cloud::bigquery::storage::v1::{RowError, StorageError, storage_error::StorageErrorCode},
+        cloud::bigquery::storage::v1::{
+            RowError, StorageError, row_error::RowErrorCode, storage_error::StorageErrorCode,
+        },
         rpc::Status as GoogleRpcStatus,
     },
     model::{
@@ -285,7 +287,19 @@ fn storage_write_metadata_lag_timeout_error(detail: &str) -> EtlError {
 
 /// Converts BigQuery row errors to ETL destination errors.
 fn row_error_to_etl_error(err: RowError) -> EtlError {
-    etl_error!(ErrorKind::DestinationError, "BigQuery row error", format!("{err:?}"))
+    let code = RowErrorCode::try_from(err.code)
+        .map(|code| code.as_str_name())
+        .unwrap_or("UNKNOWN_ROW_ERROR_CODE");
+
+    etl_error!(
+        ErrorKind::DestinationError,
+        "BigQuery rejected a row in the append request",
+        format!(
+            "BigQuery rejected row {} with code {}. The detailed BigQuery message was omitted to \
+             avoid exposing source row values.",
+            err.index, code
+        )
+    )
 }
 
 /// Converts a request-level append error into a [`BatchProcessResult`].
@@ -1464,6 +1478,25 @@ mod tests {
                 append_rows_response::AppendResult { offset: None },
             )),
         }
+    }
+
+    #[test]
+    fn row_error_omits_provider_message() {
+        let error = row_error_to_etl_error(RowError {
+            index: 7,
+            code: RowErrorCode::FieldsError as i32,
+            message: "invalid value: customer@example.com".to_owned(),
+        });
+
+        assert_eq!(error.description(), Some("BigQuery rejected a row in the append request"));
+        assert_eq!(
+            error.detail(),
+            Some(
+                "BigQuery rejected row 7 with code FIELDS_ERROR. The detailed BigQuery message \
+                 was omitted to avoid exposing source row values."
+            )
+        );
+        assert!(!error.to_string().contains("customer@example.com"));
     }
 
     /// Creates a test column schema with common defaults.

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -689,12 +689,11 @@ where
             // have been recorded during write_table_rows before any Relation event.
             bail!(
                 ErrorKind::CorruptedTableSchema,
-                "Missing destination table metadata",
+                "Destination metadata missing for BigQuery schema change",
                 format!(
-                    "No destination table metadata found for table {} when processing schema \
-                     change. This indicates a broken invariant, the metadata should have been \
-                     recorded during initial table synchronization.",
-                    table_id
+                    "Table {} received schema snapshot {}, but destination metadata from initial \
+                     synchronization was not found.",
+                    table_id, new_snapshot_id
                 )
             );
         };
@@ -731,10 +730,11 @@ where
                 || {
                     etl_error!(
                         ErrorKind::InvalidState,
-                        "Old schema not found",
+                        "Stored schema snapshot missing for BigQuery schema change",
                         format!(
-                            "Could not find schema for table {} at snapshot_id {}",
-                            table_id, current_snapshot_id
+                            "Table {} needs stored schema snapshot {} to compare with incoming \
+                             snapshot {}, but it was not found.",
+                            table_id, current_snapshot_id, new_snapshot_id
                         )
                     )
                 },

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -33,6 +33,8 @@ use crate::{
     table_name::try_stringify_table_name,
 };
 
+const MAX_ERROR_COLUMN_NAMES: usize = 12;
+
 /// Postgres CDC operation kind. Written to the `cdc_operation` column as the
 /// matching uppercase string (`"INSERT"`, `"UPDATE"`, `"DELETE"`) so downstream
 /// consumers (ReplacingMergeTree dedup, materialized views, etc.) can filter
@@ -128,6 +130,19 @@ fn expected_clickhouse_column_names(
         .collect()
 }
 
+/// Formats column names for error details without overwhelming wide tables.
+fn summarize_column_names<'a>(column_names: impl IntoIterator<Item = &'a str>) -> String {
+    let column_names = column_names.into_iter().collect::<Vec<_>>();
+    let shown = column_names.iter().take(MAX_ERROR_COLUMN_NAMES).copied().collect::<Vec<_>>();
+    let mut summary = shown.join(", ");
+
+    if column_names.len() > MAX_ERROR_COLUMN_NAMES {
+        summary.push_str(&format!(", ... ({} more)", column_names.len() - MAX_ERROR_COLUMN_NAMES));
+    }
+
+    summary
+}
+
 /// Derives RowBinary nullable flags from the actual ClickHouse table schema.
 ///
 /// RowBinary requires a leading null-marker byte before each `Nullable(T)`
@@ -149,12 +164,15 @@ fn nullable_flags_from_clickhouse_columns(
     if actual_columns.len() != expected_column_names.len() {
         return Err(etl_error!(
             ErrorKind::CorruptedTableSchema,
-            "ClickHouse table schema does not match replicated schema",
+            "ClickHouse destination table columns do not match the stored replication schema",
             format!(
-                "table '{}' has {} columns, but {} were expected",
+                "Destination table '{}' has {} columns, but the stored replication schema expects \
+                 {}. Expected columns: {}. Actual columns: {}.",
                 clickhouse_table_name,
                 actual_columns.len(),
-                expected_column_names.len()
+                expected_column_names.len(),
+                summarize_column_names(expected_column_names.iter().map(String::as_str)),
+                summarize_column_names(actual_columns.iter().map(|column| column.name.as_str()))
             )
         ));
     }
@@ -166,13 +184,18 @@ fn nullable_flags_from_clickhouse_columns(
         if actual_column.name != *expected_name {
             return Err(etl_error!(
                 ErrorKind::CorruptedTableSchema,
-                "ClickHouse table schema does not match replicated schema",
+                "ClickHouse destination table columns do not match the stored replication schema",
                 format!(
-                    "table '{}' column {} is named '{}', but '{}' was expected",
+                    "Destination table '{}' has column '{}' at position {}, but the stored \
+                     replication schema expects '{}'. Expected columns: {}. Actual columns: {}.",
                     clickhouse_table_name,
-                    index + 1,
                     actual_column.name,
-                    expected_name
+                    index + 1,
+                    expected_name,
+                    summarize_column_names(expected_column_names.iter().map(String::as_str)),
+                    summarize_column_names(
+                        actual_columns.iter().map(|column| column.name.as_str())
+                    )
                 )
             ));
         }
@@ -576,9 +599,10 @@ where
                         || {
                             etl_error!(
                                 ErrorKind::InvalidState,
-                                "Old schema not found for recovery",
+                                "Stored schema snapshot missing for ClickHouse schema recovery",
                                 format!(
-                                    "Cannot find schema for table {} at snapshot_id {}",
+                                    "Table {} needs stored schema snapshot {} to recover the \
+                                     destination table, but it was not found.",
                                     table_id, prev_snapshot_id
                                 )
                             )
@@ -669,12 +693,11 @@ where
                 || {
                     etl_error!(
                         ErrorKind::CorruptedTableSchema,
-                        "Missing destination table metadata",
+                        "Destination metadata missing for ClickHouse schema change",
                         format!(
-                            "No destination table metadata found for table {} when processing \
-                             schema change. The metadata should have been recorded during initial \
-                             table synchronization.",
-                            table_id
+                            "Table {} received schema snapshot {}, but destination metadata from \
+                             initial synchronization was not found.",
+                            table_id, new_snapshot_id
                         )
                     )
                 },
@@ -701,10 +724,11 @@ where
                 || {
                     etl_error!(
                         ErrorKind::InvalidState,
-                        "Old schema not found",
+                        "Stored schema snapshot missing for ClickHouse schema change",
                         format!(
-                            "Could not find schema for table {} at snapshot_id {}",
-                            table_id, current_snapshot_id
+                            "Table {} needs stored schema snapshot {} to compare with incoming \
+                             snapshot {}, but it was not found.",
+                            table_id, current_snapshot_id, new_snapshot_id
                         )
                     )
                 },
@@ -1614,7 +1638,17 @@ mod tests {
                 .unwrap_err();
 
         assert_eq!(err.kind(), ErrorKind::CorruptedTableSchema);
-        assert_eq!(err.detail(), Some("table 'test_table' has 1 columns, but 2 were expected"));
+        assert_eq!(
+            err.description(),
+            Some("ClickHouse destination table columns do not match the stored replication schema")
+        );
+        assert_eq!(
+            err.detail(),
+            Some(
+                "Destination table 'test_table' has 1 columns, but the stored replication schema \
+                 expects 2. Expected columns: id, cdc_operation. Actual columns: id."
+            )
+        );
     }
 
     #[test]
@@ -1629,8 +1663,16 @@ mod tests {
 
         assert_eq!(err.kind(), ErrorKind::CorruptedTableSchema);
         assert_eq!(
+            err.description(),
+            Some("ClickHouse destination table columns do not match the stored replication schema")
+        );
+        assert_eq!(
             err.detail(),
-            Some("table 'test_table' column 1 is named 'name', but 'id' was expected")
+            Some(
+                "Destination table 'test_table' has column 'name' at position 1, but the stored \
+                 replication schema expects 'id'. Expected columns: id, name. Actual columns: \
+                 name, id."
+            )
         );
     }
 }

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -1317,12 +1317,11 @@ where
             self.store.get_destination_table_metadata(table_id).await?.ok_or_else(|| {
                 etl_error!(
                     ErrorKind::CorruptedTableSchema,
-                    "Missing destination table metadata",
+                    "Destination metadata missing for DuckLake schema change",
                     format!(
-                        "No destination table metadata found for table {} when processing schema \
-                         change. The metadata should have been recorded during initial table \
-                         synchronization.",
-                        table_id
+                        "Table {} received schema snapshot {}, but destination metadata from \
+                         initial synchronization was not found.",
+                        table_id, new_snapshot_id
                     )
                 )
             })?;
@@ -1365,7 +1364,11 @@ where
         );
 
         let current_table_schema = self
-            .load_exact_table_schema(table_id, current_snapshot_id, "Old schema not found")
+            .load_exact_table_schema(
+                table_id,
+                current_snapshot_id,
+                "Stored schema snapshot missing for DuckLake schema change",
+            )
             .await?;
         let current_schema = ReplicatedTableSchema::from_mask(
             current_table_schema,
@@ -2042,7 +2045,7 @@ where
                     ErrorKind::InvalidState,
                     missing_schema_description,
                     format!(
-                        "Could not find schema for table {} at snapshot_id {}",
+                        "Table {} needs stored schema snapshot {}, but it was not found.",
                         table_id, snapshot_id
                     )
                 )
@@ -2053,8 +2056,7 @@ where
                 ErrorKind::InvalidState,
                 missing_schema_description,
                 format!(
-                    "Could not find exact schema for table {} at snapshot_id {}; found nearest \
-                     schema at snapshot_id {}",
+                    "Table {} needs exact schema snapshot {}, but only snapshot {} was found.",
                     table_id, snapshot_id, table_schema.snapshot_id
                 )
             ));
@@ -2076,7 +2078,8 @@ where
                         ErrorKind::InvalidState,
                         "DuckLake schema recovery previous schema not found",
                         format!(
-                            "Could not find schema for table {} at or before snapshot_id {}",
+                            "Table {} needs stored schema snapshot {} to recover the destination \
+                             table, but it was not found.",
                             table_id, previous_snapshot_id
                         )
                     )

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -333,10 +333,10 @@ where
         else {
             bail!(
                 ErrorKind::CorruptedTableSchema,
-                "Missing destination table metadata",
+                "Destination metadata missing for Snowflake schema change",
                 format!(
-                    "No destination table metadata found for table {table_id} when processing \
-                     schema change"
+                    "Table {table_id} received schema snapshot {new_snapshot_id}, but destination \
+                     metadata from initial synchronization was not found."
                 )
             );
         };
@@ -357,19 +357,20 @@ where
             "schema change detected: snapshot_id {current_snapshot_id} -> {new_snapshot_id}"
         );
 
-        let current_table_schema =
-            self.store.get_table_schema(&table_id, current_snapshot_id).await?.ok_or_else(
-                || {
-                    etl_error!(
-                        ErrorKind::InvalidState,
-                        "Old schema not found",
-                        format!(
-                            "Could not find schema for table {table_id} at snapshot_id \
-                             {current_snapshot_id}"
-                        )
+        let current_table_schema = self
+            .store
+            .get_table_schema(&table_id, current_snapshot_id)
+            .await?
+            .ok_or_else(|| {
+                etl_error!(
+                    ErrorKind::InvalidState,
+                    "Stored schema snapshot missing for Snowflake schema change",
+                    format!(
+                        "Table {table_id} needs stored schema snapshot {current_snapshot_id} to \
+                         compare with incoming snapshot {new_snapshot_id}, but it was not found."
                     )
-                },
-            )?;
+                )
+            })?;
 
         let current_schema = ReplicatedTableSchema::from_mask(
             current_table_schema,

--- a/crates/etl/src/conversions/table_row.rs
+++ b/crates/etl/src/conversions/table_row.rs
@@ -106,10 +106,11 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
                 let actual_column_count = values.len() + 1;
                 bail!(
                     ErrorKind::ConversionError,
-                    "Column count mismatch between schema and row",
+                    "Postgres COPY row contains more columns than the table schema",
                     format!(
-                        "Expected {} columns but row contains at least {} columns",
-                        expected_column_count, actual_column_count
+                        "The table schema expects {} replicated columns, but the COPY row \
+                         contains at least {}. The first extra field is at position {}.",
+                        expected_column_count, actual_column_count, actual_column_count
                     )
                 );
             };
@@ -149,14 +150,18 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
     // Validate that all expected columns were present in the row
     // If there are still columns left in the schema iterator, it means the row
     // had fewer fields than expected, which is an error
-    if column_schemas.next().is_some() {
+    if let Some(missing_column_schema) = column_schemas.next() {
         let actual_column_count = values.len();
         bail!(
             ErrorKind::ConversionError,
-            "Column count mismatch between schema and row",
+            "Postgres COPY row contains fewer columns than the table schema",
             format!(
-                "Expected {} columns but row contains {} columns",
-                expected_column_count, actual_column_count
+                "The table schema expects {} replicated columns, but the COPY row contains {}. \
+                 The next missing column is '{}' at position {}.",
+                expected_column_count,
+                actual_column_count,
+                missing_column_schema.name,
+                actual_column_count + 1
             )
         );
     }
@@ -292,26 +297,46 @@ mod tests {
 
     #[test]
     fn try_from_column_count_mismatch() {
-        let column_schemas = create_test_column_schemas(); // Expects 3 columns
-        let row_data = b"123\tJohn\n"; // Only 2 values - this should actually fail at parsing the bool because there's no third column
+        let column_schemas = create_test_column_schemas();
+        let row_data = b"123\tJohn\n";
 
         let result_empty =
             parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
         assert!(result_empty.is_err());
         let err = result_empty.unwrap_err();
-        assert!(err.to_string().contains("Expected 3 columns but row contains 2 columns"));
+        assert_eq!(
+            err.description(),
+            Some("Postgres COPY row contains fewer columns than the table schema")
+        );
+        assert_eq!(
+            err.detail(),
+            Some(
+                "The table schema expects 3 replicated columns, but the COPY row contains 2. The \
+                 next missing column is 'active' at position 3."
+            )
+        );
     }
 
     #[test]
     fn try_from_too_many_columns() {
-        let column_schemas = create_test_column_schemas(); // Expects 3 columns
+        let column_schemas = create_test_column_schemas();
         let row_data = b"123\tJohn\tt\textra\n";
 
         let result = parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
 
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("Expected 3 columns but row contains at least 4 columns"));
+        assert_eq!(
+            err.description(),
+            Some("Postgres COPY row contains more columns than the table schema")
+        );
+        assert_eq!(
+            err.detail(),
+            Some(
+                "The table schema expects 3 replicated columns, but the COPY row contains at \
+                 least 4. The first extra field is at position 4."
+            )
+        );
     }
 
     #[test]

--- a/crates/etl/src/error.rs
+++ b/crates/etl/src/error.rs
@@ -15,6 +15,8 @@ use std::{
 
 use crate::conversions::ParseNumericError;
 
+const MAX_SCHEMA_ERROR_COLUMN_NAMES: usize = 12;
+
 /// Convenient result type for ETL operations using [`EtlError`] as the error
 /// type.
 ///
@@ -1008,15 +1010,9 @@ impl From<crate::types::SchemaError> for EtlError {
                 EtlError::from_components(
                     ErrorKind::CorruptedTableSchema,
                     Cow::Borrowed(
-                        "Received columns during replication that are not in the stored table \
-                         schema",
+                        "Replication stream contains columns missing from the stored table schema",
                     ),
-                    Some(Cow::Owned(format!(
-                        "Unknown columns: {columns:?}\n\nCause: The pipeline crashed after a \
-                         schema change but before reporting progress back to Postgres. On \
-                         restart, event streaming resumed from past events with an outdated \
-                         schema."
-                    ))),
+                    Some(Cow::Owned(unknown_replicated_columns_detail(&columns))),
                     None,
                 )
             }
@@ -1028,6 +1024,41 @@ impl From<crate::types::SchemaError> for EtlError {
             ),
         }
     }
+}
+
+/// Builds a readable detail for unknown replicated columns.
+fn unknown_replicated_columns_detail(columns: &[String]) -> String {
+    if columns.is_empty() {
+        return "The replication stream included columns that are not present in the stored \
+                schema snapshot. This may indicate the stored schema state is stale or corrupted."
+            .to_owned();
+    }
+
+    format!(
+        "The replication stream included {} unknown column{}. Unknown columns: {}. This may \
+         indicate the stored schema state is stale or corrupted.",
+        columns.len(),
+        if columns.len() == 1 { "" } else { "s" },
+        summarize_schema_error_columns(columns)
+    )
+}
+
+/// Formats column names for schema error details without overwhelming wide
+/// tables.
+fn summarize_schema_error_columns(columns: &[String]) -> String {
+    let mut summary = columns
+        .iter()
+        .take(MAX_SCHEMA_ERROR_COLUMN_NAMES)
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    if columns.len() > MAX_SCHEMA_ERROR_COLUMN_NAMES {
+        summary
+            .push_str(&format!(", ... ({} more)", columns.len() - MAX_SCHEMA_ERROR_COLUMN_NAMES));
+    }
+
+    summary
 }
 
 #[cfg(test)]
@@ -1055,6 +1086,44 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::SourceQueryFailed);
         assert_eq!(err.detail(), Some("Table 'users' doesn't exist"));
         assert_eq!(err.kinds(), vec![ErrorKind::SourceQueryFailed]);
+    }
+
+    #[test]
+    fn unknown_replicated_columns_error_is_readable() {
+        let err = EtlError::from(crate::types::SchemaError::UnknownReplicatedColumns(vec![
+            "extra_id".to_owned(),
+            "extra_name".to_owned(),
+        ]));
+
+        assert_eq!(err.kind(), ErrorKind::CorruptedTableSchema);
+        assert_eq!(
+            err.description(),
+            Some("Replication stream contains columns missing from the stored table schema")
+        );
+        assert_eq!(
+            err.detail(),
+            Some(
+                "The replication stream included 2 unknown columns. Unknown columns: extra_id, \
+                 extra_name. This may indicate the stored schema state is stale or corrupted."
+            )
+        );
+    }
+
+    #[test]
+    fn unknown_replicated_columns_error_caps_long_column_lists() {
+        let columns = (1..=13).map(|index| format!("column_{index}")).collect();
+
+        let err = EtlError::from(crate::types::SchemaError::UnknownReplicatedColumns(columns));
+
+        assert_eq!(
+            err.detail(),
+            Some(
+                "The replication stream included 13 unknown columns. Unknown columns: column_1, \
+                 column_2, column_3, column_4, column_5, column_6, column_7, column_8, column_9, \
+                 column_10, column_11, column_12, ... (1 more). This may indicate the stored \
+                 schema state is stale or corrupted."
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Improve schema and column-mismatch errors so they describe the observed problem without speculative causes.
- Make schema-change state errors more consistent across BigQuery, ClickHouse, DuckLake, and Snowflake.
- Avoid dumping overly detailed or sensitive provider errors, including BigQuery row messages that may contain source row values.
- Cap long column-name lists in schema errors so wide-table failures stay readable.