### PR TITLE
ref(etl): Validate that etl tables are not replicated and rework partitioned tables implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ETL officially supports and tests against **PostgreSQL 14, 15, 16, 17, and
 - **PostgreSQL 15+** is recommended for advanced publication features:
   - Column-level filtering
   - Row-level filtering with `WHERE` clauses
-  - `FOR ALL TABLES IN SCHEMA` syntax
+  - `FOR TABLES IN SCHEMA` syntax
 - **PostgreSQL 16+** is required when the ETL replication connection points at
   a physical read replica. Earlier versions support logical decoding only on
   the primary.

--- a/crates/etl-api/src/data/publications.rs
+++ b/crates/etl-api/src/data/publications.rs
@@ -44,8 +44,7 @@ pub async fn create_publication(
         }
     }
 
-    // Ensure partitioned tables publish via ancestor/root schema for logical
-    // replication
+    // Default API-created publications to logical partition root semantics.
     query.push_str(" with (publish_via_partition_root = true)");
 
     sqlx::query(AssertSqlSafe(query)).execute(pool).await?;

--- a/crates/etl-api/src/validation/validators/mod.rs
+++ b/crates/etl-api/src/validation/validators/mod.rs
@@ -12,9 +12,9 @@ use clickhouse::ClickHouseValidator;
 use ducklake::DucklakeValidator;
 use iceberg::IcebergValidator;
 use pipeline::{
-    GeneratedColumnsValidator, PrimaryKeysValidator, PublicationExistsValidator,
-    PublicationHasTablesValidator, ReplicationPermissionsValidator, ReplicationSlotsValidator,
-    WalLevelValidator,
+    GeneratedColumnsValidator, PrimaryKeysValidator, PublicationExcludesEtlTablesValidator,
+    PublicationExistsValidator, PublicationHasTablesValidator, ReplicationPermissionsValidator,
+    ReplicationSlotsValidator, WalLevelValidator,
 };
 use secrecy::ExposeSecret;
 use snowflake::SnowflakeValidator;
@@ -43,6 +43,7 @@ impl PipelineValidator {
             Box::new(ReplicationPermissionsValidator),
             Box::new(PublicationExistsValidator::new(publication_name.clone())),
             Box::new(PublicationHasTablesValidator::new(publication_name.clone())),
+            Box::new(PublicationExcludesEtlTablesValidator::new(publication_name.clone())),
             Box::new(PrimaryKeysValidator::new(publication_name.clone())),
             Box::new(GeneratedColumnsValidator::new(publication_name)),
             Box::new(ReplicationSlotsValidator::new(max_table_sync_workers)),

--- a/crates/etl-api/src/validation/validators/pipeline.rs
+++ b/crates/etl-api/src/validation/validators/pipeline.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use etl_postgres::replication::catalog::ETL_SCHEMA_NAME;
 
 use super::super::{ValidationContext, ValidationError, ValidationFailure, Validator};
 
@@ -219,6 +220,121 @@ impl Validator for PublicationHasTablesValidator {
                 ),
             )])
         }
+    }
+}
+
+/// Validates that a publication does not include ETL-owned tables.
+#[derive(Debug)]
+pub(super) struct PublicationExcludesEtlTablesValidator {
+    publication_name: String,
+}
+
+impl PublicationExcludesEtlTablesValidator {
+    pub(super) fn new(publication_name: String) -> Self {
+        Self { publication_name }
+    }
+}
+
+#[async_trait]
+impl Validator for PublicationExcludesEtlTablesValidator {
+    async fn validate(
+        &self,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let source_pool =
+            ctx.source_pool.as_ref().expect("source pool required for publication validation");
+
+        let Some(puballtables) = sqlx::query_scalar::<_, bool>(
+            "select puballtables from pg_publication where pubname = $1",
+        )
+        .bind(&self.publication_name)
+        .fetch_optional(source_pool)
+        .await?
+        else {
+            // If publication doesn't exist, skip this check. The existence
+            // validator reports the actionable failure.
+            return Ok(vec![]);
+        };
+
+        if puballtables {
+            return Ok(vec![ValidationFailure::critical(
+                "Publication Includes ETL Tables",
+                format!(
+                    "Publication '{}' is defined FOR ALL TABLES, which also publishes ETL's \
+                     internal schema tables when they exist. Use an explicit table list or FOR \
+                     TABLES IN SCHEMA for customer-owned schemas, excluding the \
+                     '{ETL_SCHEMA_NAME}' schema.",
+                    self.publication_name
+                ),
+            )]);
+        }
+
+        let published_etl_tables: Vec<String> = sqlx::query_scalar(
+            r#"
+            select pt.schemaname || '.' || pt.tablename
+            from pg_publication_tables pt
+            where pt.pubname = $1
+              and pt.schemaname = $2
+            order by pt.tablename
+            limit 100
+            "#,
+        )
+        .bind(&self.publication_name)
+        .bind(ETL_SCHEMA_NAME)
+        .fetch_all(source_pool)
+        .await?;
+
+        if !published_etl_tables.is_empty() {
+            return Ok(vec![ValidationFailure::critical(
+                "Publication Includes ETL Tables",
+                format!(
+                    "Publication '{}' includes ETL internal tables: {}.\n\nRemove the \
+                     '{ETL_SCHEMA_NAME}' schema from the publication before starting this \
+                     pipeline. ETL state tables are implementation details and must not be \
+                     replicated.",
+                    self.publication_name,
+                    published_etl_tables.join(", ")
+                ),
+            )]);
+        }
+
+        let server_version_num: i32 =
+            sqlx::query_scalar("select current_setting('server_version_num')::int")
+                .fetch_one(source_pool)
+                .await?;
+
+        if server_version_num >= 15_00_00 {
+            let publishes_etl_schema: bool = sqlx::query_scalar(
+                r#"
+                select exists (
+                    select 1
+                    from pg_publication_namespace pn
+                    join pg_publication p on p.oid = pn.pnpubid
+                    join pg_namespace n on n.oid = pn.pnnspid
+                    where p.pubname = $1
+                      and n.nspname = $2
+                )
+                "#,
+            )
+            .bind(&self.publication_name)
+            .bind(ETL_SCHEMA_NAME)
+            .fetch_one(source_pool)
+            .await?;
+
+            if publishes_etl_schema {
+                return Ok(vec![ValidationFailure::critical(
+                    "Publication Includes ETL Tables",
+                    format!(
+                        "Publication '{}' includes the '{ETL_SCHEMA_NAME}' schema. Remove that \
+                         schema from the publication and publish only customer-owned schemas or \
+                         explicit customer tables.",
+                        self.publication_name
+                    ),
+                )]);
+            }
+        }
+
+        Ok(vec![])
     }
 }
 

--- a/crates/etl-api/src/validation/validators/pipeline.rs
+++ b/crates/etl-api/src/validation/validators/pipeline.rs
@@ -244,12 +244,34 @@ impl Validator for PublicationExcludesEtlTablesValidator {
         let source_pool =
             ctx.source_pool.as_ref().expect("source pool required for publication validation");
 
-        let Some(puballtables) = sqlx::query_scalar::<_, bool>(
-            "select puballtables from pg_publication where pubname = $1",
-        )
-        .bind(&self.publication_name)
-        .fetch_optional(source_pool)
-        .await?
+        let Some((puballtables, server_version_num, published_etl_tables)) =
+            sqlx::query_as::<_, (bool, i32, Vec<String>)>(
+                r#"
+                select
+                    p.puballtables,
+                    current_setting('server_version_num')::int,
+                    coalesce(
+                        (
+                            select array_agg(t.table_name order by t.table_name)
+                            from (
+                                select pt.schemaname || '.' || pt.tablename as table_name
+                                from pg_publication_tables pt
+                                where pt.pubname = p.pubname
+                                  and pt.schemaname = $2
+                                order by pt.tablename
+                                limit 100
+                            ) t
+                        ),
+                        array[]::text[]
+                    )
+                from pg_publication p
+                where p.pubname = $1
+                "#,
+            )
+            .bind(&self.publication_name)
+            .bind(ETL_SCHEMA_NAME)
+            .fetch_optional(source_pool)
+            .await?
         else {
             // If publication doesn't exist, skip this check. The existence
             // validator reports the actionable failure.
@@ -269,21 +291,6 @@ impl Validator for PublicationExcludesEtlTablesValidator {
             )]);
         }
 
-        let published_etl_tables: Vec<String> = sqlx::query_scalar(
-            r#"
-            select pt.schemaname || '.' || pt.tablename
-            from pg_publication_tables pt
-            where pt.pubname = $1
-              and pt.schemaname = $2
-            order by pt.tablename
-            limit 100
-            "#,
-        )
-        .bind(&self.publication_name)
-        .bind(ETL_SCHEMA_NAME)
-        .fetch_all(source_pool)
-        .await?;
-
         if !published_etl_tables.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "Publication Includes ETL Tables",
@@ -297,11 +304,6 @@ impl Validator for PublicationExcludesEtlTablesValidator {
                 ),
             )]);
         }
-
-        let server_version_num: i32 =
-            sqlx::query_scalar("select current_setting('server_version_num')::int")
-                .fetch_one(source_pool)
-                .await?;
 
         if server_version_num >= 15_00_00 {
             let publishes_etl_schema: bool = sqlx::query_scalar(

--- a/crates/etl-api/src/validation/validators/source.rs
+++ b/crates/etl-api/src/validation/validators/source.rs
@@ -1,9 +1,8 @@
 use async_trait::async_trait;
+use etl_postgres::replication::catalog::ETL_SCHEMA_NAME;
 use sqlx::FromRow;
 
 use super::super::{ValidationContext, ValidationError, ValidationFailure, Validator};
-
-const ETL_SCHEMA_NAME: &str = "etl";
 
 /// Validates the connected source role profile for ETL.
 #[derive(Debug)]

--- a/crates/etl-api/tests/validators/pipeline.rs
+++ b/crates/etl-api/tests/validators/pipeline.rs
@@ -72,6 +72,77 @@ async fn validate_pipeline_publication_empty() {
 }
 
 #[tokio::test]
+async fn validate_pipeline_rejects_explicit_etl_tables() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute("create schema etl").await.unwrap();
+    pool.execute(
+        "create table etl.table_columns (
+            id serial primary key,
+            ordinal_position integer not null
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute("create publication etl_table_pub for table etl.table_columns").await.unwrap();
+
+    let pipeline_config = create_pipeline_config("etl_table_pub");
+    let failures = validate_pipeline(&ctx, &pipeline_config).await.unwrap();
+
+    let etl_failure = failures.iter().find(|f| f.name == "Publication Includes ETL Tables");
+    assert!(etl_failure.is_some(), "Should reject publications containing ETL tables");
+    assert_eq!(etl_failure.unwrap().failure_type, FailureType::Critical);
+    assert!(
+        etl_failure.unwrap().reason.contains("etl.table_columns"),
+        "Failure reason should mention the ETL table"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_pipeline_rejects_all_tables_publication() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute("create table customer_table (id serial primary key)").await.unwrap();
+    pool.execute("create publication all_tables_pub for all tables").await.unwrap();
+
+    let pipeline_config = create_pipeline_config("all_tables_pub");
+    let failures = validate_pipeline(&ctx, &pipeline_config).await.unwrap();
+
+    let etl_failure = failures.iter().find(|f| f.name == "Publication Includes ETL Tables");
+    assert!(etl_failure.is_some(), "Should reject FOR ALL TABLES publications");
+    assert_eq!(etl_failure.unwrap().failure_type, FailureType::Critical);
+    assert!(
+        etl_failure.unwrap().reason.contains("FOR ALL TABLES"),
+        "Failure reason should explain the publication mode"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_pipeline_rejects_etl_schema_publication() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute("create schema etl").await.unwrap();
+    pool.execute("create publication etl_schema_pub for tables in schema etl").await.unwrap();
+
+    let pipeline_config = create_pipeline_config("etl_schema_pub");
+    let failures = validate_pipeline(&ctx, &pipeline_config).await.unwrap();
+
+    let etl_failure = failures.iter().find(|f| f.name == "Publication Includes ETL Tables");
+    assert!(etl_failure.is_some(), "Should reject publications containing the ETL schema");
+    assert_eq!(etl_failure.unwrap().failure_type, FailureType::Critical);
+    assert!(
+        etl_failure.unwrap().reason.contains("'etl' schema"),
+        "Failure reason should mention the ETL schema"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
 async fn validate_pipeline_tables_without_primary_keys() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 

--- a/crates/etl-api/tests/validators/pipeline.rs
+++ b/crates/etl-api/tests/validators/pipeline.rs
@@ -1,6 +1,9 @@
 use etl_api::validation::{FailureType, ValidationContext, validate_pipeline, validate_source};
 use etl_config::Environment;
-use etl_postgres::sqlx::test_utils::drop_pg_database;
+use etl_postgres::{
+    below_version, replication::extract_server_version, sqlx::test_utils::drop_pg_database,
+    version::POSTGRES_15,
+};
 use sqlx::Executor;
 
 use super::{create_pipeline_config, create_validation_context_with_source};
@@ -124,6 +127,13 @@ async fn validate_pipeline_rejects_all_tables_publication() {
 #[tokio::test]
 async fn validate_pipeline_rejects_etl_schema_publication() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    let server_version =
+        sqlx::query_scalar::<_, String>("show server_version").fetch_one(&pool).await.unwrap();
+    if below_version!(extract_server_version(server_version), POSTGRES_15) {
+        drop_pg_database(&config).await;
+        return;
+    }
 
     pool.execute("create schema etl").await.unwrap();
     pool.execute("create publication etl_schema_pub for tables in schema etl").await.unwrap();

--- a/crates/etl-postgres/src/replication/catalog.rs
+++ b/crates/etl-postgres/src/replication/catalog.rs
@@ -1,0 +1,67 @@
+//! Catalog definitions for ETL-owned source objects.
+
+/// The schema reserved for ETL source helpers and state tables.
+pub const ETL_SCHEMA_NAME: &str = "etl";
+
+/// A table owned and managed by ETL in the source database.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct EtlTable {
+    schema: &'static str,
+    name: &'static str,
+}
+
+impl EtlTable {
+    /// Creates a new ETL-owned table definition.
+    pub const fn new(schema: &'static str, name: &'static str) -> Self {
+        Self { schema, name }
+    }
+
+    /// Returns the table schema name.
+    pub const fn schema(&self) -> &'static str {
+        self.schema
+    }
+
+    /// Returns the unqualified table name.
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns the fully-qualified table name.
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", self.schema, self.name)
+    }
+}
+
+/// The table storing per-table replication state history.
+pub const REPLICATION_STATE_TABLE: EtlTable = EtlTable::new(ETL_SCHEMA_NAME, "replication_state");
+
+/// The table storing destination table metadata.
+pub const DESTINATION_TABLES_METADATA_TABLE: EtlTable =
+    EtlTable::new(ETL_SCHEMA_NAME, "destination_tables_metadata");
+
+/// The table storing versioned source table schemas.
+pub const TABLE_SCHEMAS_TABLE: EtlTable = EtlTable::new(ETL_SCHEMA_NAME, "table_schemas");
+
+/// The table storing columns for versioned source table schemas.
+pub const TABLE_COLUMNS_TABLE: EtlTable = EtlTable::new(ETL_SCHEMA_NAME, "table_columns");
+
+/// The table storing durable per-worker replication progress.
+pub const REPLICATION_PROGRESS_TABLE: EtlTable =
+    EtlTable::new(ETL_SCHEMA_NAME, "replication_progress");
+
+/// Current source tables owned and managed by ETL.
+pub const ETL_TABLES: [EtlTable; 5] = [
+    REPLICATION_STATE_TABLE,
+    DESTINATION_TABLES_METADATA_TABLE,
+    TABLE_SCHEMAS_TABLE,
+    TABLE_COLUMNS_TABLE,
+    REPLICATION_PROGRESS_TABLE,
+];
+
+/// Core state tables needed for API state inspection and cleanup.
+pub const ETL_CORE_STATE_TABLES: [EtlTable; 4] = [
+    REPLICATION_STATE_TABLE,
+    DESTINATION_TABLES_METADATA_TABLE,
+    TABLE_SCHEMAS_TABLE,
+    TABLE_COLUMNS_TABLE,
+];

--- a/crates/etl-postgres/src/replication/health.rs
+++ b/crates/etl-postgres/src/replication/health.rs
@@ -1,12 +1,6 @@
 use sqlx::PgExecutor;
 
-/// Fully-qualified table names required by ETL.
-pub const ETL_TABLE_NAMES: [&str; 4] = [
-    "etl.replication_state",
-    "etl.destination_tables_metadata",
-    "etl.table_schemas",
-    "etl.table_columns",
-];
+use super::catalog::{ETL_CORE_STATE_TABLES, EtlTable};
 
 /// Returns true if all required ETL tables exist in the source database.
 ///
@@ -20,7 +14,8 @@ where
     E: PgExecutor<'c>,
 {
     // Perform a single query checking all required relations via unnest
-    let table_names: Vec<String> = ETL_TABLE_NAMES.iter().map(ToString::to_string).collect();
+    let table_names: Vec<String> =
+        ETL_CORE_STATE_TABLES.iter().map(EtlTable::qualified_name).collect();
     let present: bool = sqlx::query_scalar(
         r#"
         select coalesce(bool_and(to_regclass(t) is not null), false)

--- a/crates/etl-postgres/src/replication/mod.rs
+++ b/crates/etl-postgres/src/replication/mod.rs
@@ -1,3 +1,4 @@
+pub mod catalog;
 mod db;
 pub mod destination_table_metadata;
 pub mod health;

--- a/crates/etl-postgres/src/tokio/test_utils.rs
+++ b/crates/etl-postgres/src/tokio/test_utils.rs
@@ -124,7 +124,7 @@ impl<G: GenericClient> PgDatabase<G> {
         let quoted_publication_name = quote_identifier(publication_name);
 
         if requires_version!(self.server_version, POSTGRES_15) {
-            // PostgreSQL 15+ supports FOR ALL TABLES IN SCHEMA syntax
+            // PostgreSQL 15+ supports FOR TABLES IN SCHEMA syntax.
             let create_publication_query = match schema {
                 Some(schema_name) => format!(
                     "create publication {quoted_publication_name} for tables in schema {} with \

--- a/crates/etl/src/pipeline.rs
+++ b/crates/etl/src/pipeline.rs
@@ -351,38 +351,6 @@ where
             "publication tables loaded"
         );
 
-        // Validate that the publication is configured correctly for partitioned tables.
-        //
-        // When `publish_via_partition_root = false`, logical replication messages
-        // contain child partition OIDs instead of parent table OIDs. Since our
-        // schema cache only contains parent table IDs (from
-        // `get_publication_table_ids`), relation messages with child OIDs would
-        // cause pipeline failures.
-        let publish_via_partition_root = replication_client
-            .get_publish_via_partition_root(&self.config.publication_name)
-            .await?;
-
-        if !publish_via_partition_root {
-            let has_partitioned_tables =
-                replication_client.has_partitioned_tables(&publication_table_ids).await?;
-
-            if has_partitioned_tables {
-                bail!(
-                    ErrorKind::ConfigError,
-                    "Invalid publication configuration for partitioned tables",
-                    format!(
-                        "The publication '{}' contains partitioned tables but has \
-                         publish_via_partition_root=false. This configuration causes replication \
-                         messages to use child partition OIDs, which are not tracked by the \
-                         pipeline and will cause failures. Please recreate the publication with \
-                         publish_via_partition_root=true or use: ALTER PUBLICATION {} SET \
-                         (publish_via_partition_root = true);",
-                        self.config.publication_name, self.config.publication_name
-                    )
-                );
-            }
-        }
-
         // We load the current table states.
         self.store.load_table_states().await?;
         let table_states = self.store.get_table_states().await?;

--- a/crates/etl/src/replication/client/raw.rs
+++ b/crates/etl/src/replication/client/raw.rs
@@ -513,7 +513,7 @@ impl PgReplicationClient {
 
     /// Retrieves the OIDs of all tables included in a publication.
     ///
-    /// This follows [`pg_publication_tables`], which applies PostgreSQL's
+    /// This follows `pg_publication_tables`, which applies PostgreSQL's
     /// logical replication identity rules for partitioned tables. With
     /// `publish_via_partition_root=true`, PostgreSQL returns the topmost
     /// published ancestor used for relation messages. With

--- a/crates/etl/src/replication/client/raw.rs
+++ b/crates/etl/src/replication/client/raw.rs
@@ -515,8 +515,8 @@ impl PgReplicationClient {
     ///
     /// This follows `pg_publication_tables`, which applies PostgreSQL's
     /// logical replication identity rules for partitioned tables. With
-    /// `publish_via_partition_root=true`, PostgreSQL returns the topmost
-    /// published ancestor used for relation messages. With
+    /// `publish_via_partition_root=true`, PostgreSQL returns the published
+    /// partition root or subtree root used for relation messages. With
     /// `publish_via_partition_root=false`, it returns the leaf relations whose
     /// schemas are used for replication.
     ///

--- a/crates/etl/src/replication/client/raw.rs
+++ b/crates/etl/src/replication/client/raw.rs
@@ -488,39 +488,6 @@ impl PgReplicationClient {
         Ok(false)
     }
 
-    /// Retrieves the `publish_via_partition_root` setting for a publication.
-    ///
-    /// Returns `true` if the publication is configured to send replication
-    /// messages using the parent table OID, or `false` if it sends them
-    /// using child partition OIDs.
-    pub async fn get_publish_via_partition_root(&self, publication_name: &str) -> EtlResult<bool> {
-        let query = format!(
-            "select pubviaroot from pg_publication where pubname = {};",
-            quote_literal(publication_name)
-        );
-
-        for msg in self.client.simple_query(&query).await? {
-            if let SimpleQueryMessage::Row(row) = msg {
-                let pubviaroot = get_row_value::<String>(&row, "pubviaroot", "pg_publication")?;
-                return Ok(pubviaroot == "t");
-            }
-        }
-
-        bail!(
-            ErrorKind::ConfigError,
-            "Publication not found",
-            format!("Publication '{}' not found in database", publication_name)
-        );
-    }
-
-    /// Checks if any of the provided table IDs are partitioned tables.
-    ///
-    /// A partitioned table is one where `relkind = 'p'` in `pg_class`.
-    /// Returns `true` if at least one table is partitioned, `false` otherwise.
-    pub(crate) async fn has_partitioned_tables(&self, table_ids: &[TableId]) -> EtlResult<bool> {
-        self.target().has_partitioned_tables(table_ids).await
-    }
-
     /// Retrieves the names of all tables included in a publication.
     pub async fn get_publication_table_names(
         &self,
@@ -546,10 +513,12 @@ impl PgReplicationClient {
 
     /// Retrieves the OIDs of all tables included in a publication.
     ///
-    /// For partitioned tables with `publish_via_partition_root=true`, this
-    /// returns only the parent table OID. The query uses a recursive CTE to
-    /// walk up the partition inheritance hierarchy and identify root tables
-    /// that have no parent themselves.
+    /// This follows [`pg_publication_tables`], which applies PostgreSQL's
+    /// logical replication identity rules for partitioned tables. With
+    /// `publish_via_partition_root=true`, PostgreSQL returns the topmost
+    /// published ancestor used for relation messages. With
+    /// `publish_via_partition_root=false`, it returns the leaf relations whose
+    /// schemas are used for replication.
     ///
     /// # Errors
     ///
@@ -562,45 +531,26 @@ impl PgReplicationClient {
     ) -> EtlResult<Vec<TableId>> {
         let query = format!(
             r#"
-            with recursive pub_tables as (
-                -- Get all tables from publication (pg_publication_tables includes explicit tables,
-                -- ALL TABLES publications, and FOR TABLES IN SCHEMA publications)
-                select c.oid
-                from pg_publication_tables pt
-                join pg_class c on c.relname = pt.tablename
-                join pg_namespace n on n.oid = c.relnamespace and n.nspname = pt.schemaname
-                where pt.pubname = {pub}
-            ),
-            hierarchy(relid) as (
-                -- Start with published tables
-                select oid from pub_tables
-
-                union
-
-                -- Recursively find parent tables in inheritance hierarchy
-                select i.inhparent
-                from pg_inherits i
-                join hierarchy h on h.relid = i.inhrelid
-            )
-            -- Return only root tables (those without a parent)
-            select distinct relid as oid
-            from hierarchy
-            where not exists (
-                select 1 from pg_inherits i where i.inhrelid = hierarchy.relid
-            );
+            select distinct c.oid
+            from pg_publication_tables pt
+            join pg_class c on c.relname = pt.tablename
+            join pg_namespace n on n.oid = c.relnamespace
+             and n.nspname = pt.schemaname
+            where pt.pubname = {pub}
+            order by c.oid;
             "#,
             pub = quote_literal(publication_name)
         );
 
-        let mut root_tables = vec![];
+        let mut table_ids = vec![];
         for row in self.client.simple_query(&query).await? {
             if let SimpleQueryMessage::Row(row) = row {
                 let table_id = get_row_value::<TableId>(&row, "oid", "pg_class")?;
-                root_tables.push(table_id);
+                table_ids.push(table_id);
             }
         }
 
-        if root_tables.is_empty() {
+        if table_ids.is_empty() {
             bail!(
                 ErrorKind::ConfigError,
                 "Publication has no tables",
@@ -613,7 +563,7 @@ impl PgReplicationClient {
             );
         }
 
-        Ok(root_tables)
+        Ok(table_ids)
     }
 
     /// Starts a logical replication stream from the specified publication and

--- a/crates/etl/src/replication/client/transaction.rs
+++ b/crates/etl/src/replication/client/transaction.rs
@@ -205,8 +205,12 @@ impl<'a> PgReplicationTransactionCore<'a> {
         .await
     }
 
-    /// Creates a COPY stream for reading data from the specified table, using
-    /// another table to resolve publication row filters.
+    /// Creates a COPY stream for reading data from `table_id`, using
+    /// `filter_table_id` to resolve publication row filters.
+    ///
+    /// Serial copy passes the same table ID for both values. Parallel copy of a
+    /// partitioned table can pass a leaf partition as the physical copy source
+    /// while resolving row filters from the tracked published root or subtree.
     async fn get_table_copy_stream_with_filter_table(
         &self,
         table_id: TableId,
@@ -755,8 +759,12 @@ impl<'a> PgChildReplicationTransaction<'a> {
         Self { core }
     }
 
-    /// Creates a COPY stream for reading data from the specified table, using
-    /// another table to resolve publication row filters.
+    /// Creates a COPY stream for reading data from `table_id`, using
+    /// `filter_table_id` to resolve publication row filters.
+    ///
+    /// This is used when parallel partition copy reads a leaf partition while
+    /// applying the row filter attached to the tracked published root or
+    /// subtree.
     pub(crate) async fn get_table_copy_stream_with_filter_table(
         &self,
         table_id: TableId,

--- a/crates/etl/src/replication/client/transaction.rs
+++ b/crates/etl/src/replication/client/transaction.rs
@@ -196,6 +196,24 @@ impl<'a> PgReplicationTransactionCore<'a> {
         column_schemas: &[ColumnSchema],
         publication_name: Option<&str>,
     ) -> EtlResult<CopyOutStream> {
+        self.get_table_copy_stream_with_filter_table(
+            table_id,
+            table_id,
+            column_schemas,
+            publication_name,
+        )
+        .await
+    }
+
+    /// Creates a COPY stream for reading data from the specified table, using
+    /// another table to resolve publication row filters.
+    async fn get_table_copy_stream_with_filter_table(
+        &self,
+        table_id: TableId,
+        filter_table_id: TableId,
+        column_schemas: &[ColumnSchema],
+        publication_name: Option<&str>,
+    ) -> EtlResult<CopyOutStream> {
         let column_list = column_schemas
             .iter()
             .map(|col| quote_identifier(&col.name))
@@ -203,7 +221,7 @@ impl<'a> PgReplicationTransactionCore<'a> {
             .join(", ");
 
         let table_name = self.get_table_name(table_id).await?;
-        let row_filter = self.get_row_filter(table_id, publication_name).await?;
+        let row_filter = self.get_row_filter(filter_table_id, publication_name).await?;
 
         let copy_query = if let Some(row_filter) = row_filter {
             format!(
@@ -737,17 +755,23 @@ impl<'a> PgChildReplicationTransaction<'a> {
         Self { core }
     }
 
-    /// Creates a COPY stream for reading all data from the specified table.
-    ///
-    /// Resolves the table name and row filter internally. Used for copying leaf
-    /// partitions of a partitioned table.
-    pub(crate) async fn get_table_copy_stream(
+    /// Creates a COPY stream for reading data from the specified table, using
+    /// another table to resolve publication row filters.
+    pub(crate) async fn get_table_copy_stream_with_filter_table(
         &self,
         table_id: TableId,
+        filter_table_id: TableId,
         column_schemas: &[ColumnSchema],
         publication_name: Option<&str>,
     ) -> EtlResult<CopyOutStream> {
-        self.core.get_table_copy_stream(table_id, column_schemas, publication_name).await
+        self.core
+            .get_table_copy_stream_with_filter_table(
+                table_id,
+                filter_table_id,
+                column_schemas,
+                publication_name,
+            )
+            .await
     }
 
     /// Creates a COPY stream for a ctid partition range of the specified table.

--- a/crates/etl/src/workers/table_sync_copy.rs
+++ b/crates/etl/src/workers/table_sync_copy.rs
@@ -561,8 +561,9 @@ where
         }
         CopyPartition::LeafPartition { leaf_table_id } => {
             child_replication_transaction
-                .get_table_copy_stream(
+                .get_table_copy_stream_with_filter_table(
                     *leaf_table_id,
+                    table_id,
                     &replicated_column_schemas,
                     publication_name.as_ref().map(Arc::as_ref),
                 )

--- a/crates/etl/src/workers/table_sync_copy.rs
+++ b/crates/etl/src/workers/table_sync_copy.rs
@@ -238,6 +238,9 @@ pub(crate) async fn table_copy<D: Destination + Clone + Send + 'static>(
 
 /// Copies a table serially using a single COPY stream from the slot
 /// transaction.
+///
+/// The tracked table is both the physical copy source and the publication
+/// row-filter lookup table.
 #[expect(clippy::too_many_arguments)]
 async fn serial_table_copy<D: Destination + Clone + Send + 'static>(
     replication_transaction: &PgReplicationTransaction<'_>,
@@ -493,7 +496,8 @@ async fn parallel_table_copy<D: Destination + Clone + Send + 'static>(
 ///
 /// The child transaction is already pinned to the exported snapshot. Depending
 /// on the [`CopyPartition`] variant, streams rows from either a ctid range or
-/// an entire leaf partition. All rows are written under the parent `table_id`.
+/// an entire leaf partition. All rows are written under the tracked
+/// `table_id`.
 #[expect(clippy::too_many_arguments)]
 async fn copy_partition<D>(
     child_replication_transaction: PgChildReplicationTransaction<'_>,

--- a/crates/etl/tests/main.rs
+++ b/crates/etl/tests/main.rs
@@ -10,3 +10,4 @@ mod pipeline_with_partitioned_table;
 mod pipelines_with_schema_changes;
 mod postgres_store;
 mod replication;
+mod support;

--- a/crates/etl/tests/pipeline_with_partitioned_table.rs
+++ b/crates/etl/tests/pipeline_with_partitioned_table.rs
@@ -1,5 +1,4 @@
 use etl::{
-    error::ErrorKind,
     state::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
@@ -15,10 +14,259 @@ use etl::{
 use etl_postgres::{below_version, types::TableName, version::POSTGRES_15};
 use etl_telemetry::tracing::init_test_tracing;
 use rand::random;
-use tokio_postgres::types::Type;
+use tokio_postgres::{Client, types::Type};
 
 fn quoted_qualified_table_name(schema: &str, table: &str) -> String {
     TableName::new(schema.to_owned(), table.to_owned()).as_quoted_identifier()
+}
+
+#[derive(Debug)]
+struct NestedPartitionHierarchy {
+    root_table_name: TableName,
+    p_2026_table_name: TableName,
+    root_table_id: TableId,
+    p_2025_01_table_id: TableId,
+    p_2025_02_table_id: TableId,
+    p_2026_table_id: TableId,
+    p_2026_01_table_id: TableId,
+    p_2026_02_table_id: TableId,
+}
+
+async fn get_table_id(
+    database: &etl_postgres::tokio::test_utils::PgDatabase<Client>,
+    table_name: &TableName,
+) -> TableId {
+    let row = database
+        .client
+        .as_ref()
+        .unwrap()
+        .query_one(
+            "select c.oid from pg_class c join pg_namespace n on n.oid = c.relnamespace
+             where n.nspname = $1 and c.relname = $2",
+            &[&table_name.schema, &table_name.name],
+        )
+        .await
+        .unwrap();
+
+    row.get(0)
+}
+
+async fn create_nested_partition_hierarchy(
+    database: &etl_postgres::tokio::test_utils::PgDatabase<Client>,
+    table_name: TableName,
+) -> NestedPartitionHierarchy {
+    database
+        .run_sql(&format!(
+            "create table {} (
+                id bigserial,
+                data text not null,
+                partition_year integer not null,
+                partition_month integer not null,
+                primary key (id, partition_year, partition_month)
+            ) partition by range (partition_year)",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_2025", table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2025) to (2026)
+             partition by range (partition_month)",
+            p_2025_table_name.as_quoted_identifier(),
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_01_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_01", p_2025_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (1) to (2)",
+            p_2025_01_table_name.as_quoted_identifier(),
+            p_2025_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_02_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_02", p_2025_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2) to (3)",
+            p_2025_02_table_name.as_quoted_identifier(),
+            p_2025_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_2026", table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2026) to (2027)
+             partition by range (partition_month)",
+            p_2026_table_name.as_quoted_identifier(),
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_01_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_01", p_2026_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (1) to (2)",
+            p_2026_01_table_name.as_quoted_identifier(),
+            p_2026_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_02_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_02", p_2026_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2) to (3)",
+            p_2026_02_table_name.as_quoted_identifier(),
+            p_2026_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    NestedPartitionHierarchy {
+        root_table_id: get_table_id(database, &table_name).await,
+        p_2025_01_table_id: get_table_id(database, &p_2025_01_table_name).await,
+        p_2025_02_table_id: get_table_id(database, &p_2025_02_table_name).await,
+        p_2026_table_id: get_table_id(database, &p_2026_table_name).await,
+        p_2026_01_table_id: get_table_id(database, &p_2026_01_table_name).await,
+        p_2026_02_table_id: get_table_id(database, &p_2026_02_table_name).await,
+        root_table_name: table_name,
+        p_2026_table_name,
+    }
+}
+
+async fn assert_nested_partition_pipeline_case(
+    test_name: &str,
+    publish_middle_root: bool,
+    publish_via_partition_root: bool,
+) {
+    init_test_tracing();
+    let database = spawn_source_database().await;
+
+    let hierarchy = create_nested_partition_hierarchy(&database, test_table_name(test_name)).await;
+
+    database
+        .run_sql(&format!(
+            "insert into {} (data, partition_year, partition_month) values
+             ('initial_2025_01', 2025, 1),
+             ('initial_2025_02', 2025, 2),
+             ('initial_2026_01', 2026, 1),
+             ('initial_2026_02', 2026, 2)",
+            hierarchy.root_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let publication_table_name = if publish_middle_root {
+        hierarchy.p_2026_table_name.clone()
+    } else {
+        hierarchy.root_table_name.clone()
+    };
+    let publication_name = format!("pub_{test_name}");
+    database
+        .create_publication_with_config(
+            &publication_name,
+            std::slice::from_ref(&publication_table_name),
+            publish_via_partition_root,
+        )
+        .await
+        .unwrap();
+
+    let expected_copy_counts = match (publish_middle_root, publish_via_partition_root) {
+        (false, true) => vec![(hierarchy.root_table_id, 4)],
+        (false, false) => vec![
+            (hierarchy.p_2025_01_table_id, 1),
+            (hierarchy.p_2025_02_table_id, 1),
+            (hierarchy.p_2026_01_table_id, 1),
+            (hierarchy.p_2026_02_table_id, 1),
+        ],
+        (true, true) => vec![(hierarchy.p_2026_table_id, 2)],
+        (true, false) => {
+            vec![(hierarchy.p_2026_01_table_id, 1), (hierarchy.p_2026_02_table_id, 1)]
+        }
+    };
+    let expected_cdc_counts = expected_copy_counts.clone();
+    let expected_cdc_total = expected_cdc_counts.iter().map(|(_, count)| count).sum::<usize>();
+
+    let state_store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(state_store.clone()));
+
+    let mut ready_notifies = Vec::new();
+    for (table_id, _) in &expected_copy_counts {
+        ready_notifies
+            .push(state_store.notify_on_table_state_type(*table_id, TableStateType::Ready).await);
+    }
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name,
+        state_store.clone(),
+        destination.clone(),
+    );
+
+    pipeline.start().await.unwrap();
+    for notify in &ready_notifies {
+        notify.notified().await;
+    }
+
+    let table_states = state_store.get_table_states().await;
+    assert_eq!(table_states.len(), expected_copy_counts.len());
+    for (table_id, _) in &expected_copy_counts {
+        assert!(table_states.contains_key(table_id));
+    }
+
+    let table_rows = destination.get_table_rows().await;
+    assert_eq!(table_rows.len(), expected_copy_counts.len());
+    for (table_id, expected_count) in &expected_copy_counts {
+        assert_eq!(table_rows.get(table_id).map_or(0, Vec::len), *expected_count);
+    }
+
+    let inserts_notify = destination
+        .wait_for_events_count(vec![(EventType::Insert, expected_cdc_total as u64)])
+        .await;
+
+    let cdc_insert_values = if publish_middle_root {
+        "('new_2026_01', 2026, 1), ('new_2026_02', 2026, 2)"
+    } else {
+        "('new_2025_01', 2025, 1),
+         ('new_2025_02', 2025, 2),
+         ('new_2026_01', 2026, 1),
+         ('new_2026_02', 2026, 2)"
+    };
+    database
+        .run_sql(&format!(
+            "insert into {} (data, partition_year, partition_month) values {cdc_insert_values}",
+            hierarchy.root_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    inserts_notify.notified().await;
+
+    let _ = pipeline.shutdown_and_wait().await;
+
+    let events = destination.get_events().await;
+    let grouped = group_events_by_type_and_table_id(&events);
+    for (table_id, expected_count) in expected_cdc_counts {
+        let inserts = grouped.get(&(EventType::Insert, table_id)).cloned().unwrap_or_default();
+        assert_eq!(inserts.len(), expected_count);
+    }
 }
 
 /// Tests that initial COPY replicates all rows from a partitioned table.
@@ -1040,363 +1288,22 @@ async fn partition_detach_with_schema_publication_does_replicate_detached_insert
     assert_eq!(detached_rows, 2);
 }
 
-/// Tests that nested partitions (sub-partitioned tables) work correctly.
-/// Creates a two-level partition hierarchy where one partition is itself
-/// partitioned, and verifies that both initial COPY and CDC streaming work
-/// correctly. Only the top-level parent table should be tracked in the pipeline
-/// state.
 #[tokio::test(flavor = "multi_thread")]
-async fn nested_partitioned_table_copy_and_cdc() {
-    init_test_tracing();
-    let database = spawn_source_database().await;
-
-    let table_name = test_table_name("nested_partitioned_events");
-
-    // Create the parent partitioned table (Level 1).
-    // Primary key must include all partitioning columns used at any level.
-    database
-        .run_sql(&format!(
-            "create table {} (
-                id bigserial,
-                data text NOT NULL,
-                partition_key integer NOT NULL,
-                sub_partition_key integer NOT NULL,
-                primary key (id, partition_key, sub_partition_key)
-            ) partition by range (partition_key)",
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    // Get parent table ID.
-    let parent_row = database
-        .client
-        .as_ref()
-        .unwrap()
-        .query_one(
-            "select c.oid from pg_class c join pg_namespace n on n.oid = c.relnamespace
-             where n.nspname = $1 and c.relname = $2",
-            &[&table_name.schema, &table_name.name],
-        )
-        .await
-        .unwrap();
-    let parent_table_id: TableId = parent_row.get(0);
-
-    // Create first partition (simple leaf partition) (Level 2a).
-    let p1_name = format!("{}_{}", table_name.name, "p1");
-    let p1_qualified = quoted_qualified_table_name(&table_name.schema, &p1_name);
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (1) to (100)",
-            p1_qualified,
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    // Create second partition that is itself partitioned (Level 2b).
-    let p2_name = format!("{}_{}", table_name.name, "p2");
-    let p2_qualified = quoted_qualified_table_name(&table_name.schema, &p2_name);
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (100) to (200) partition by range \
-             (sub_partition_key)",
-            p2_qualified,
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    // Create sub-partitions of p2 (Level 3).
-    let p2_sub1_name = format!("{}_{}", p2_name, "sub1");
-    let p2_sub1_qualified = quoted_qualified_table_name(&table_name.schema, &p2_sub1_name);
-    database
-        .run_sql(&format!(
-            "create table {p2_sub1_qualified} partition of {p2_qualified} for values from (1) to \
-             (50)"
-        ))
-        .await
-        .unwrap();
-
-    let p2_sub2_name = format!("{}_{}", p2_name, "sub2");
-    let p2_sub2_qualified = quoted_qualified_table_name(&table_name.schema, &p2_sub2_name);
-    database
-        .run_sql(&format!(
-            "create table {p2_sub2_qualified} partition of {p2_qualified} for values from (50) to \
-             (100)"
-        ))
-        .await
-        .unwrap();
-
-    // Create third partition that is itself partitioned (Level 2c).
-    let p3_name = format!("{}_{}", table_name.name, "p3");
-    let p3_qualified = quoted_qualified_table_name(&table_name.schema, &p3_name);
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (200) to (300) partition by range \
-             (sub_partition_key)",
-            p3_qualified,
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    // Create sub-partitions of p3 (Level 3).
-    let p3_sub1_name = format!("{}_{}", p3_name, "sub1");
-    let p3_sub1_qualified = quoted_qualified_table_name(&table_name.schema, &p3_sub1_name);
-    database
-        .run_sql(&format!(
-            "create table {p3_sub1_qualified} partition of {p3_qualified} for values from (1) to \
-             (50)"
-        ))
-        .await
-        .unwrap();
-
-    let p3_sub2_name = format!("{}_{}", p3_name, "sub2");
-    let p3_sub2_qualified = quoted_qualified_table_name(&table_name.schema, &p3_sub2_name);
-    database
-        .run_sql(&format!(
-            "create table {p3_sub2_qualified} partition of {p3_qualified} for values from (50) to \
-             (100)"
-        ))
-        .await
-        .unwrap();
-
-    // Create fourth partition (simple leaf partition) (Level 2d).
-    let p4_name = format!("{}_{}", table_name.name, "p4");
-    let p4_qualified = quoted_qualified_table_name(&table_name.schema, &p4_name);
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (300) to (400)",
-            p4_qualified,
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    // Insert initial data into all 6 leaf partitions:
-    // - p1: partition_key=50
-    // - p2_sub1: partition_key=150, sub_partition_key=25
-    // - p2_sub2: partition_key=150, sub_partition_key=75
-    // - p3_sub1: partition_key=250, sub_partition_key=25
-    // - p3_sub2: partition_key=250, sub_partition_key=75
-    // - p4: partition_key=350
-    database
-        .run_sql(&format!(
-            "insert into {} (data, partition_key, sub_partition_key) values
-             ('event_p1', 50, 25),
-             ('event_p2_sub1', 150, 25),
-             ('event_p2_sub2', 150, 75),
-             ('event_p3_sub1', 250, 25),
-             ('event_p3_sub2', 250, 75),
-             ('event_p4', 350, 25)",
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let publication_name = "test_nested_partitioned_pub".to_owned();
-    database
-        .create_publication(&publication_name, std::slice::from_ref(&table_name))
-        .await
-        .unwrap();
-
-    let state_store = NotifyingStore::new();
-    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(state_store.clone()));
-
-    // Register notification for initial copy completion.
-    let parent_ready_notify =
-        state_store.notify_on_table_state_type(parent_table_id, TableStateType::Ready).await;
-
-    let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name,
-        state_store.clone(),
-        destination.clone(),
-    );
-
-    pipeline.start().await.unwrap();
-
-    parent_ready_notify.notified().await;
-
-    // Verify table schema was discovered correctly for nested partitioned table.
-    let table_schemas = state_store.get_latest_table_schemas().await;
-    assert!(table_schemas.contains_key(&parent_table_id));
-
-    let parent_schema = &table_schemas[&parent_table_id];
-    assert_eq!(parent_schema.id, parent_table_id);
-    assert_eq!(parent_schema.name, table_name);
-
-    // Verify columns are correctly discovered (includes sub_partition_key).
-    assert_eq!(parent_schema.column_schemas.len(), 4);
-
-    // Check id column (added by default).
-    let id_column = &parent_schema.column_schemas[0];
-    assert_eq!(id_column.name, "id");
-    assert_eq!(id_column.typ, Type::INT8);
-    assert!(!id_column.nullable);
-    assert!(id_column.primary_key());
-
-    // Check data column.
-    let data_column = &parent_schema.column_schemas[1];
-    assert_eq!(data_column.name, "data");
-    assert_eq!(data_column.typ, Type::TEXT);
-    assert!(!data_column.nullable);
-    assert!(!data_column.primary_key());
-
-    // Check partition_key column (part of primary key).
-    let partition_key_column = &parent_schema.column_schemas[2];
-    assert_eq!(partition_key_column.name, "partition_key");
-    assert_eq!(partition_key_column.typ, Type::INT4);
-    assert!(!partition_key_column.nullable);
-    assert!(partition_key_column.primary_key());
-
-    // Check sub_partition_key column (part of primary key for nested partitioning).
-    let sub_partition_key_column = &parent_schema.column_schemas[3];
-    assert_eq!(sub_partition_key_column.name, "sub_partition_key");
-    assert_eq!(sub_partition_key_column.typ, Type::INT4);
-    assert!(!sub_partition_key_column.nullable);
-    assert!(sub_partition_key_column.primary_key());
-
-    // Verify initial COPY replicated all 6 rows (one per leaf partition).
-    let table_rows = destination.get_table_rows().await;
-    let total_rows: usize = table_rows.values().map(Vec::len).sum();
-    assert_eq!(total_rows, 6);
-
-    // Verify only the parent table is tracked (not intermediate or leaf
-    // partitions).
-    let table_states = state_store.get_table_states().await;
-    assert!(table_states.contains_key(&parent_table_id));
-    assert_eq!(table_states.len(), 1);
-
-    // Verify all rows are attributed to the parent table.
-    let parent_table_rows = table_rows
-        .iter()
-        .filter(|(table_id, _)| **table_id == parent_table_id)
-        .map(|(_, rows)| rows.len())
-        .sum::<usize>();
-    assert_eq!(parent_table_rows, 6);
-
-    // Insert new rows into all 6 leaf partitions via CDC.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 6)]).await;
-
-    database
-        .run_sql(&format!(
-            "insert into {} (data, partition_key, sub_partition_key) values
-             ('new_event_p1', 75, 30),
-             ('new_event_p2_sub1', 125, 40),
-             ('new_event_p2_sub2', 175, 60),
-             ('new_event_p3_sub1', 225, 40),
-             ('new_event_p3_sub2', 275, 60),
-             ('new_event_p4', 350, 30)",
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    inserts_notify.notified().await;
-
-    let _ = pipeline.shutdown_and_wait().await;
-
-    // Verify that CDC events were captured for all 6 leaf partitions.
-    let events = destination.get_events().await;
-    let grouped = group_events_by_type_and_table_id(&events);
-    let parent_inserts =
-        grouped.get(&(EventType::Insert, parent_table_id)).cloned().unwrap_or_default();
-    assert_eq!(parent_inserts.len(), 6);
+async fn nested_pipeline_top_root_with_partition_root() {
+    assert_nested_partition_pipeline_case("nested_pipeline_top_root_true", false, true).await;
 }
 
-/// Tests that the pipeline throws an error during startup when
-/// `publish_via_partition_root` is set to `false` and the publication contains
-/// partitioned tables.
-///
-/// When `publish_via_partition_root = false`, logical replication messages
-/// contain child partition OIDs instead of parent table OIDs. Since the
-/// pipeline's schema cache only tracks parent table IDs, this configuration
-/// would cause pipeline failures when relation messages arrive with unknown
-/// child OIDs.
-///
-/// The pipeline validates this configuration at startup and rejects it with a
-/// clear error message instructing the user to enable
-/// `publish_via_partition_root`.
 #[tokio::test(flavor = "multi_thread")]
-async fn partitioned_table_with_publish_via_partition_root_false_and_partitioned_tables() {
-    init_test_tracing();
-    let database = spawn_source_database().await;
-
-    let table_name = test_table_name("partitioned_events");
-    let partition_specs = [("p1", "from (1) to (100)"), ("p2", "from (100) to (200)")];
-
-    let (_parent_table_id, _partition_table_ids) =
-        create_partitioned_table(&database, table_name.clone(), &partition_specs).await.unwrap();
-
-    database
-        .run_sql(&format!(
-            "insert into {} (data, partition_key) values ('event1', 50), ('event2', 150)",
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let publication_name = "test_partitioned_pub".to_owned();
-    database
-        .create_publication_with_config(&publication_name, std::slice::from_ref(&table_name), false)
-        .await
-        .unwrap();
-
-    let state_store = NotifyingStore::new();
-    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(state_store.clone()));
-
-    let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name.clone(),
-        state_store.clone(),
-        destination.clone(),
-    );
-
-    // The pipeline should fail to start due to invalid configuration.
-    let err = pipeline.start().await.err().unwrap();
-    assert_eq!(err.kind(), ErrorKind::ConfigError);
+async fn nested_pipeline_top_root_without_partition_root() {
+    assert_nested_partition_pipeline_case("nested_pipeline_top_root_false", false, false).await;
 }
 
-/// Tests that the pipeline doesn't throw an error when
-/// `publish_via_partition_root=false` and there are no partitioned tables in
-/// the tables of the publication.
 #[tokio::test(flavor = "multi_thread")]
-async fn partitioned_table_with_publish_via_partition_root_false_and_no_partitioned_tables() {
-    init_test_tracing();
-    let database = spawn_source_database().await;
+async fn nested_pipeline_middle_root_with_partition_root() {
+    assert_nested_partition_pipeline_case("nested_pipeline_middle_root_true", true, true).await;
+}
 
-    let table_name = test_table_name("non_partitioned_events");
-    database
-        .create_table(table_name.clone(), true, &[("description", "text not null")])
-        .await
-        .unwrap();
-
-    let publication_name = "test_non_partitioned_pub".to_owned();
-    database
-        .create_publication_with_config(&publication_name, std::slice::from_ref(&table_name), false)
-        .await
-        .unwrap();
-
-    let state_store = NotifyingStore::new();
-    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(state_store.clone()));
-
-    let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name.clone(),
-        state_store.clone(),
-        destination.clone(),
-    );
-
-    // The pipeline should start and stop successfully.
-    pipeline.start().await.unwrap();
-    let result = pipeline.shutdown_and_wait().await;
-    assert!(result.is_ok());
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_middle_root_without_partition_root() {
+    assert_nested_partition_pipeline_case("nested_pipeline_middle_root_false", true, false).await;
 }

--- a/crates/etl/tests/pipeline_with_partitioned_table.rs
+++ b/crates/etl/tests/pipeline_with_partitioned_table.rs
@@ -7,7 +7,7 @@ use etl::{
         event::group_events_by_type_and_table_id,
         memory_destination::MemoryDestination,
         notifying_store::NotifyingStore,
-        pipeline::create_pipeline,
+        pipeline::{PipelineBuilder, create_pipeline},
         test_destination_wrapper::TestDestinationWrapper,
         test_schema::create_partitioned_table,
     },
@@ -30,6 +30,21 @@ enum PublishedPartitionTarget {
     Top,
     Middle,
     Leaf,
+}
+
+#[derive(Clone, Copy)]
+enum TableCopyMode {
+    Serial,
+    Parallel,
+}
+
+impl TableCopyMode {
+    fn max_copy_connections_per_table(self) -> u16 {
+        match self {
+            TableCopyMode::Serial => 1,
+            TableCopyMode::Parallel => 2,
+        }
+    }
 }
 
 fn assert_table_row_counts(
@@ -170,6 +185,7 @@ async fn assert_nested_partition_pipeline_case(
 async fn assert_nested_partition_pipeline_row_filter_case(
     test_name: &str,
     published_partition_target: PublishedPartitionTarget,
+    table_copy_mode: TableCopyMode,
 ) {
     init_test_tracing();
     let database = spawn_source_database().await;
@@ -225,13 +241,15 @@ async fn assert_nested_partition_pipeline_row_filter_case(
     }
 
     let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
+    let mut pipeline = PipelineBuilder::new(
+        database.config.clone(),
         pipeline_id,
         publication_name,
         state_store,
         destination.clone(),
-    );
+    )
+    .with_max_copy_connections_per_table(table_copy_mode.max_copy_connections_per_table())
+    .build();
 
     pipeline.start().await.unwrap();
     for notify in &ready_notifies {
@@ -1324,28 +1342,62 @@ async fn nested_pipeline_leaf_without_partition_root() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn nested_pipeline_top_root_with_partition_root_respects_row_filter_during_copy() {
+async fn nested_pipeline_top_root_with_partition_root_respects_row_filter_during_parallel_copy() {
     assert_nested_partition_pipeline_row_filter_case(
-        "nested_pipeline_top_root_row_filter",
+        "nested_pipeline_top_root_row_filter_parallel",
         PublishedPartitionTarget::Top,
+        TableCopyMode::Parallel,
     )
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn nested_pipeline_middle_root_with_partition_root_respects_row_filter_during_copy() {
+async fn nested_pipeline_top_root_with_partition_root_respects_row_filter_during_serial_copy() {
     assert_nested_partition_pipeline_row_filter_case(
-        "nested_pipeline_middle_root_row_filter",
+        "nested_pipeline_top_root_row_filter_serial",
+        PublishedPartitionTarget::Top,
+        TableCopyMode::Serial,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_middle_root_with_partition_root_respects_row_filter_during_parallel_copy()
+{
+    assert_nested_partition_pipeline_row_filter_case(
+        "nested_pipeline_middle_root_row_filter_parallel",
         PublishedPartitionTarget::Middle,
+        TableCopyMode::Parallel,
     )
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn nested_pipeline_leaf_with_partition_root_respects_row_filter_during_copy() {
+async fn nested_pipeline_middle_root_with_partition_root_respects_row_filter_during_serial_copy() {
     assert_nested_partition_pipeline_row_filter_case(
-        "nested_pipeline_leaf_row_filter",
+        "nested_pipeline_middle_root_row_filter_serial",
+        PublishedPartitionTarget::Middle,
+        TableCopyMode::Serial,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_leaf_with_partition_root_respects_row_filter_during_parallel_copy() {
+    assert_nested_partition_pipeline_row_filter_case(
+        "nested_pipeline_leaf_row_filter_parallel",
         PublishedPartitionTarget::Leaf,
+        TableCopyMode::Parallel,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_leaf_with_partition_root_respects_row_filter_during_serial_copy() {
+    assert_nested_partition_pipeline_row_filter_case(
+        "nested_pipeline_leaf_row_filter_serial",
+        PublishedPartitionTarget::Leaf,
+        TableCopyMode::Serial,
     )
     .await;
 }

--- a/crates/etl/tests/pipeline_with_partitioned_table.rs
+++ b/crates/etl/tests/pipeline_with_partitioned_table.rs
@@ -15,6 +15,7 @@ use etl::{
 };
 use etl_postgres::{below_version, types::TableName, version::POSTGRES_15};
 use etl_telemetry::tracing::init_test_tracing;
+use pg_escape::quote_identifier;
 use rand::random;
 use tokio_postgres::types::Type;
 
@@ -162,6 +163,83 @@ async fn assert_nested_partition_pipeline_case(
     }
 
     // We check the table rows again just to validate that no new ones were added.
+    let table_rows = destination.get_table_rows().await;
+    assert_table_row_counts(&table_rows, &expected_copy_counts);
+}
+
+async fn assert_nested_partition_pipeline_row_filter_case(
+    test_name: &str,
+    published_partition_target: PublishedPartitionTarget,
+) {
+    init_test_tracing();
+    let database = spawn_source_database().await;
+
+    if below_version!(database.server_version(), POSTGRES_15) {
+        return;
+    }
+
+    let hierarchy = create_nested_partition_hierarchy(&database, test_table_name(test_name)).await;
+
+    database
+        .run_sql(&format!(
+            "insert into {} (data, partition_year, partition_month) values
+             ('initial_2025_01', 2025, 1),
+             ('initial_2025_02', 2025, 2),
+             ('initial_2026_01', 2026, 1),
+             ('initial_2026_02', 2026, 2)",
+            hierarchy.root_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let (publication_table_name, expected_copy_counts) = match published_partition_target {
+        PublishedPartitionTarget::Top => {
+            (hierarchy.root_table_name.clone(), vec![(hierarchy.root_table_id, 2)])
+        }
+        PublishedPartitionTarget::Middle => {
+            (hierarchy.p_2026_table_name.clone(), vec![(hierarchy.p_2026_table_id, 1)])
+        }
+        PublishedPartitionTarget::Leaf => (
+            partition_table_name(&hierarchy.p_2026_table_name, "01"),
+            vec![(hierarchy.p_2026_01_table_id, 1)],
+        ),
+    };
+    let publication_name = format!("pub_{test_name}");
+    database
+        .run_sql(&format!(
+            "create publication {} for table {} where (partition_month = 1) with \
+             (publish_via_partition_root = true)",
+            quote_identifier(&publication_name),
+            publication_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let state_store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(state_store.clone()));
+
+    let mut ready_notifies = Vec::new();
+    for (table_id, _) in &expected_copy_counts {
+        ready_notifies
+            .push(state_store.notify_on_table_state_type(*table_id, TableStateType::Ready).await);
+    }
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name,
+        state_store,
+        destination.clone(),
+    );
+
+    pipeline.start().await.unwrap();
+    for notify in &ready_notifies {
+        notify.notified().await;
+    }
+
+    let _ = pipeline.shutdown_and_wait().await;
+
     let table_rows = destination.get_table_rows().await;
     assert_table_row_counts(&table_rows, &expected_copy_counts);
 }
@@ -1241,6 +1319,33 @@ async fn nested_pipeline_leaf_without_partition_root() {
         "nested_pipeline_leaf_false",
         PublishedPartitionTarget::Leaf,
         false,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_top_root_with_partition_root_respects_row_filter_during_copy() {
+    assert_nested_partition_pipeline_row_filter_case(
+        "nested_pipeline_top_root_row_filter",
+        PublishedPartitionTarget::Top,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_middle_root_with_partition_root_respects_row_filter_during_copy() {
+    assert_nested_partition_pipeline_row_filter_case(
+        "nested_pipeline_middle_root_row_filter",
+        PublishedPartitionTarget::Middle,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_leaf_with_partition_root_respects_row_filter_during_copy() {
+    assert_nested_partition_pipeline_row_filter_case(
+        "nested_pipeline_leaf_row_filter",
+        PublishedPartitionTarget::Leaf,
     )
     .await;
 }

--- a/crates/etl/tests/pipeline_with_partitioned_table.rs
+++ b/crates/etl/tests/pipeline_with_partitioned_table.rs
@@ -9,149 +9,28 @@ use etl::{
         test_destination_wrapper::TestDestinationWrapper,
         test_schema::create_partitioned_table,
     },
-    types::{EventType, PipelineId, TableId},
+    types::{EventType, PipelineId},
 };
 use etl_postgres::{below_version, types::TableName, version::POSTGRES_15};
 use etl_telemetry::tracing::init_test_tracing;
 use rand::random;
-use tokio_postgres::{Client, types::Type};
+use tokio_postgres::types::Type;
+
+use crate::support::partition::create_nested_partition_hierarchy;
 
 fn quoted_qualified_table_name(schema: &str, table: &str) -> String {
     TableName::new(schema.to_owned(), table.to_owned()).as_quoted_identifier()
 }
 
-#[derive(Debug)]
-struct NestedPartitionHierarchy {
-    root_table_name: TableName,
-    p_2026_table_name: TableName,
-    root_table_id: TableId,
-    p_2025_01_table_id: TableId,
-    p_2025_02_table_id: TableId,
-    p_2026_table_id: TableId,
-    p_2026_01_table_id: TableId,
-    p_2026_02_table_id: TableId,
-}
-
-async fn get_table_id(
-    database: &etl_postgres::tokio::test_utils::PgDatabase<Client>,
-    table_name: &TableName,
-) -> TableId {
-    let row = database
-        .client
-        .as_ref()
-        .unwrap()
-        .query_one(
-            "select c.oid from pg_class c join pg_namespace n on n.oid = c.relnamespace
-             where n.nspname = $1 and c.relname = $2",
-            &[&table_name.schema, &table_name.name],
-        )
-        .await
-        .unwrap();
-
-    row.get(0)
-}
-
-async fn create_nested_partition_hierarchy(
-    database: &etl_postgres::tokio::test_utils::PgDatabase<Client>,
-    table_name: TableName,
-) -> NestedPartitionHierarchy {
-    database
-        .run_sql(&format!(
-            "create table {} (
-                id bigserial,
-                data text not null,
-                partition_year integer not null,
-                partition_month integer not null,
-                primary key (id, partition_year, partition_month)
-            ) partition by range (partition_year)",
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2025_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_2025", table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2025) to (2026)
-             partition by range (partition_month)",
-            p_2025_table_name.as_quoted_identifier(),
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2025_01_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_01", p_2025_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (1) to (2)",
-            p_2025_01_table_name.as_quoted_identifier(),
-            p_2025_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2025_02_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_02", p_2025_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2) to (3)",
-            p_2025_02_table_name.as_quoted_identifier(),
-            p_2025_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2026_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_2026", table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2026) to (2027)
-             partition by range (partition_month)",
-            p_2026_table_name.as_quoted_identifier(),
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2026_01_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_01", p_2026_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (1) to (2)",
-            p_2026_01_table_name.as_quoted_identifier(),
-            p_2026_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2026_02_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_02", p_2026_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2) to (3)",
-            p_2026_02_table_name.as_quoted_identifier(),
-            p_2026_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    NestedPartitionHierarchy {
-        root_table_id: get_table_id(database, &table_name).await,
-        p_2025_01_table_id: get_table_id(database, &p_2025_01_table_name).await,
-        p_2025_02_table_id: get_table_id(database, &p_2025_02_table_name).await,
-        p_2026_table_id: get_table_id(database, &p_2026_table_name).await,
-        p_2026_01_table_id: get_table_id(database, &p_2026_01_table_name).await,
-        p_2026_02_table_id: get_table_id(database, &p_2026_02_table_name).await,
-        root_table_name: table_name,
-        p_2026_table_name,
-    }
+#[derive(Clone, Copy)]
+enum PublishedPartitionTarget {
+    Top,
+    Middle,
 }
 
 async fn assert_nested_partition_pipeline_case(
     test_name: &str,
-    publish_middle_root: bool,
+    published_partition_target: PublishedPartitionTarget,
     publish_via_partition_root: bool,
 ) {
     init_test_tracing();
@@ -171,10 +50,9 @@ async fn assert_nested_partition_pipeline_case(
         .await
         .unwrap();
 
-    let publication_table_name = if publish_middle_root {
-        hierarchy.p_2026_table_name.clone()
-    } else {
-        hierarchy.root_table_name.clone()
+    let publication_table_name = match published_partition_target {
+        PublishedPartitionTarget::Top => hierarchy.root_table_name.clone(),
+        PublishedPartitionTarget::Middle => hierarchy.p_2026_table_name.clone(),
     };
     let publication_name = format!("pub_{test_name}");
     database
@@ -186,16 +64,16 @@ async fn assert_nested_partition_pipeline_case(
         .await
         .unwrap();
 
-    let expected_copy_counts = match (publish_middle_root, publish_via_partition_root) {
-        (false, true) => vec![(hierarchy.root_table_id, 4)],
-        (false, false) => vec![
+    let expected_copy_counts = match (published_partition_target, publish_via_partition_root) {
+        (PublishedPartitionTarget::Top, true) => vec![(hierarchy.root_table_id, 4)],
+        (PublishedPartitionTarget::Top, false) => vec![
             (hierarchy.p_2025_01_table_id, 1),
             (hierarchy.p_2025_02_table_id, 1),
             (hierarchy.p_2026_01_table_id, 1),
             (hierarchy.p_2026_02_table_id, 1),
         ],
-        (true, true) => vec![(hierarchy.p_2026_table_id, 2)],
-        (true, false) => {
+        (PublishedPartitionTarget::Middle, true) => vec![(hierarchy.p_2026_table_id, 2)],
+        (PublishedPartitionTarget::Middle, false) => {
             vec![(hierarchy.p_2026_01_table_id, 1), (hierarchy.p_2026_02_table_id, 1)]
         }
     };
@@ -241,13 +119,14 @@ async fn assert_nested_partition_pipeline_case(
         .wait_for_events_count(vec![(EventType::Insert, expected_cdc_total as u64)])
         .await;
 
-    let cdc_insert_values = if publish_middle_root {
-        "('new_2026_01', 2026, 1), ('new_2026_02', 2026, 2)"
-    } else {
-        "('new_2025_01', 2025, 1),
-         ('new_2025_02', 2025, 2),
-         ('new_2026_01', 2026, 1),
-         ('new_2026_02', 2026, 2)"
+    let cdc_insert_values = match published_partition_target {
+        PublishedPartitionTarget::Top => {
+            "('new_2025_01', 2025, 1),
+             ('new_2025_02', 2025, 2),
+             ('new_2026_01', 2026, 1),
+             ('new_2026_02', 2026, 2)"
+        }
+        PublishedPartitionTarget::Middle => "('new_2026_01', 2026, 1), ('new_2026_02', 2026, 2)",
     };
     database
         .run_sql(&format!(
@@ -1290,20 +1169,40 @@ async fn partition_detach_with_schema_publication_does_replicate_detached_insert
 
 #[tokio::test(flavor = "multi_thread")]
 async fn nested_pipeline_top_root_with_partition_root() {
-    assert_nested_partition_pipeline_case("nested_pipeline_top_root_true", false, true).await;
+    assert_nested_partition_pipeline_case(
+        "nested_pipeline_top_root_true",
+        PublishedPartitionTarget::Top,
+        true,
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn nested_pipeline_top_root_without_partition_root() {
-    assert_nested_partition_pipeline_case("nested_pipeline_top_root_false", false, false).await;
+    assert_nested_partition_pipeline_case(
+        "nested_pipeline_top_root_false",
+        PublishedPartitionTarget::Top,
+        false,
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn nested_pipeline_middle_root_with_partition_root() {
-    assert_nested_partition_pipeline_case("nested_pipeline_middle_root_true", true, true).await;
+    assert_nested_partition_pipeline_case(
+        "nested_pipeline_middle_root_true",
+        PublishedPartitionTarget::Middle,
+        true,
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn nested_pipeline_middle_root_without_partition_root() {
-    assert_nested_partition_pipeline_case("nested_pipeline_middle_root_false", true, false).await;
+    assert_nested_partition_pipeline_case(
+        "nested_pipeline_middle_root_false",
+        PublishedPartitionTarget::Middle,
+        false,
+    )
+    .await;
 }

--- a/crates/etl/tests/pipeline_with_partitioned_table.rs
+++ b/crates/etl/tests/pipeline_with_partitioned_table.rs
@@ -26,6 +26,7 @@ fn quoted_qualified_table_name(schema: &str, table: &str) -> String {
 enum PublishedPartitionTarget {
     Top,
     Middle,
+    Leaf,
 }
 
 async fn assert_nested_partition_pipeline_case(
@@ -53,6 +54,9 @@ async fn assert_nested_partition_pipeline_case(
     let publication_table_name = match published_partition_target {
         PublishedPartitionTarget::Top => hierarchy.root_table_name.clone(),
         PublishedPartitionTarget::Middle => hierarchy.p_2026_table_name.clone(),
+        PublishedPartitionTarget::Leaf => {
+            crate::support::partition::partition_table_name(&hierarchy.p_2026_table_name, "01")
+        }
     };
     let publication_name = format!("pub_{test_name}");
     database
@@ -76,6 +80,7 @@ async fn assert_nested_partition_pipeline_case(
         (PublishedPartitionTarget::Middle, false) => {
             vec![(hierarchy.p_2026_01_table_id, 1), (hierarchy.p_2026_02_table_id, 1)]
         }
+        (PublishedPartitionTarget::Leaf, _) => vec![(hierarchy.p_2026_01_table_id, 1)],
     };
     let expected_cdc_counts = expected_copy_counts.clone();
     let expected_cdc_total = expected_cdc_counts.iter().map(|(_, count)| count).sum::<usize>();
@@ -127,6 +132,7 @@ async fn assert_nested_partition_pipeline_case(
              ('new_2026_02', 2026, 2)"
         }
         PublishedPartitionTarget::Middle => "('new_2026_01', 2026, 1), ('new_2026_02', 2026, 2)",
+        PublishedPartitionTarget::Leaf => "('new_2026_01', 2026, 1)",
     };
     database
         .run_sql(&format!(
@@ -1202,6 +1208,26 @@ async fn nested_pipeline_middle_root_without_partition_root() {
     assert_nested_partition_pipeline_case(
         "nested_pipeline_middle_root_false",
         PublishedPartitionTarget::Middle,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_leaf_with_partition_root() {
+    assert_nested_partition_pipeline_case(
+        "nested_pipeline_leaf_true",
+        PublishedPartitionTarget::Leaf,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nested_pipeline_leaf_without_partition_root() {
+    assert_nested_partition_pipeline_case(
+        "nested_pipeline_leaf_false",
+        PublishedPartitionTarget::Leaf,
         false,
     )
     .await;

--- a/crates/etl/tests/pipeline_with_partitioned_table.rs
+++ b/crates/etl/tests/pipeline_with_partitioned_table.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use etl::{
     state::TableStateType,
     test_utils::{
@@ -9,14 +11,14 @@ use etl::{
         test_destination_wrapper::TestDestinationWrapper,
         test_schema::create_partitioned_table,
     },
-    types::{EventType, PipelineId},
+    types::{EventType, PipelineId, TableId, TableRow},
 };
 use etl_postgres::{below_version, types::TableName, version::POSTGRES_15};
 use etl_telemetry::tracing::init_test_tracing;
 use rand::random;
 use tokio_postgres::types::Type;
 
-use crate::support::partition::create_nested_partition_hierarchy;
+use crate::support::partition::{create_nested_partition_hierarchy, partition_table_name};
 
 fn quoted_qualified_table_name(schema: &str, table: &str) -> String {
     TableName::new(schema.to_owned(), table.to_owned()).as_quoted_identifier()
@@ -27,6 +29,16 @@ enum PublishedPartitionTarget {
     Top,
     Middle,
     Leaf,
+}
+
+fn assert_table_row_counts(
+    table_rows: &HashMap<TableId, Vec<TableRow>>,
+    expected_counts: &[(TableId, usize)],
+) {
+    assert_eq!(table_rows.len(), expected_counts.len());
+    for (table_id, expected_count) in expected_counts {
+        assert_eq!(table_rows.get(table_id).map_or(0, Vec::len), *expected_count);
+    }
 }
 
 async fn assert_nested_partition_pipeline_case(
@@ -54,9 +66,7 @@ async fn assert_nested_partition_pipeline_case(
     let publication_table_name = match published_partition_target {
         PublishedPartitionTarget::Top => hierarchy.root_table_name.clone(),
         PublishedPartitionTarget::Middle => hierarchy.p_2026_table_name.clone(),
-        PublishedPartitionTarget::Leaf => {
-            crate::support::partition::partition_table_name(&hierarchy.p_2026_table_name, "01")
-        }
+        PublishedPartitionTarget::Leaf => partition_table_name(&hierarchy.p_2026_table_name, "01"),
     };
     let publication_name = format!("pub_{test_name}");
     database
@@ -104,6 +114,7 @@ async fn assert_nested_partition_pipeline_case(
     );
 
     pipeline.start().await.unwrap();
+
     for notify in &ready_notifies {
         notify.notified().await;
     }
@@ -115,10 +126,7 @@ async fn assert_nested_partition_pipeline_case(
     }
 
     let table_rows = destination.get_table_rows().await;
-    assert_eq!(table_rows.len(), expected_copy_counts.len());
-    for (table_id, expected_count) in &expected_copy_counts {
-        assert_eq!(table_rows.get(table_id).map_or(0, Vec::len), *expected_count);
-    }
+    assert_table_row_counts(&table_rows, &expected_copy_counts);
 
     let inserts_notify = destination
         .wait_for_events_count(vec![(EventType::Insert, expected_cdc_total as u64)])
@@ -152,6 +160,10 @@ async fn assert_nested_partition_pipeline_case(
         let inserts = grouped.get(&(EventType::Insert, table_id)).cloned().unwrap_or_default();
         assert_eq!(inserts.len(), expected_count);
     }
+
+    // We check the table rows again just to validate that no new ones were added.
+    let table_rows = destination.get_table_rows().await;
+    assert_table_row_counts(&table_rows, &expected_copy_counts);
 }
 
 /// Tests that initial COPY replicates all rows from a partitioned table.

--- a/crates/etl/tests/replication.rs
+++ b/crates/etl/tests/replication.rs
@@ -9,12 +9,11 @@ use etl::{
         schema::assert_table_schema_columns,
         test_schema::create_partitioned_table,
     },
-    types::TableId,
 };
 use etl_postgres::{
     below_version,
-    tokio::test_utils::{PgDatabase, TableModification, id_column_schema},
-    types::{ColumnSchema, TableName, convert_type_oid_to_type},
+    tokio::test_utils::{TableModification, id_column_schema},
+    types::{ColumnSchema, convert_type_oid_to_type},
     version::POSTGRES_15,
 };
 use etl_telemetry::tracing::init_test_tracing;
@@ -30,6 +29,8 @@ use tokio_postgres::{
     CopyOutStream,
     types::{ToSql, Type},
 };
+
+use crate::support::partition::{create_nested_partition_hierarchy, partition_table_name};
 
 /// Creates a test column schema with sensible defaults.
 fn test_column(
@@ -79,35 +80,11 @@ fn column_schemas_from_ddl_message(message: &JsonValue) -> Vec<ColumnSchema> {
     columns
 }
 
-async fn get_table_id(
-    database: &PgDatabase<tokio_postgres::Client>,
-    table_name: &TableName,
-) -> TableId {
-    let row = database
-        .client
-        .as_ref()
-        .unwrap()
-        .query_one(
-            "select c.oid
-             from pg_class c
-             join pg_namespace n on n.oid = c.relnamespace
-             where n.nspname = $1 and c.relname = $2",
-            &[&table_name.schema, &table_name.name],
-        )
-        .await
-        .unwrap();
-
-    TableId::new(row.get(0))
-}
-
-fn partition_table_name(table_name: &TableName, partition_name: &str) -> TableName {
-    TableName::new(table_name.schema.clone(), format!("{}_{}", table_name.name, partition_name))
-}
-
 #[derive(Clone, Copy)]
-enum PublishedPartitionRoot {
+enum PublishedPartitionTarget {
     Top,
     Middle,
+    Leaf,
 }
 
 #[derive(Clone, Copy)]
@@ -116,128 +93,20 @@ enum PublicationExpansion {
     Schema,
 }
 
-struct NestedPublicationHierarchy {
-    root_table_name: TableName,
-    p_2026_table_name: TableName,
-    root_table_id: TableId,
-    p_2025_01_table_id: TableId,
-    p_2025_02_table_id: TableId,
-    p_2026_table_id: TableId,
-    p_2026_01_table_id: TableId,
-    p_2026_02_table_id: TableId,
-}
-
-async fn create_nested_publication_hierarchy(
-    database: &PgDatabase<tokio_postgres::Client>,
-    table_name: TableName,
-) -> NestedPublicationHierarchy {
-    database
-        .run_sql(&format!(
-            "create table {} (
-                id integer not null,
-                partition_year integer not null,
-                partition_month integer not null,
-                primary key (id, partition_year, partition_month)
-            ) partition by range (partition_year)",
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2025_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_2025", table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2025) to (2026)
-             partition by range (partition_month)",
-            p_2025_table_name.as_quoted_identifier(),
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2025_01_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_01", p_2025_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (1) to (2)",
-            p_2025_01_table_name.as_quoted_identifier(),
-            p_2025_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2025_02_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_02", p_2025_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2) to (3)",
-            p_2025_02_table_name.as_quoted_identifier(),
-            p_2025_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2026_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_2026", table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2026) to (2027)
-             partition by range (partition_month)",
-            p_2026_table_name.as_quoted_identifier(),
-            table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2026_01_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_01", p_2026_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (1) to (2)",
-            p_2026_01_table_name.as_quoted_identifier(),
-            p_2026_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    let p_2026_02_table_name =
-        TableName::new(table_name.schema.clone(), format!("{}_02", p_2026_table_name.name));
-    database
-        .run_sql(&format!(
-            "create table {} partition of {} for values from (2) to (3)",
-            p_2026_02_table_name.as_quoted_identifier(),
-            p_2026_table_name.as_quoted_identifier()
-        ))
-        .await
-        .unwrap();
-
-    NestedPublicationHierarchy {
-        root_table_id: get_table_id(database, &table_name).await,
-        p_2025_01_table_id: get_table_id(database, &p_2025_01_table_name).await,
-        p_2025_02_table_id: get_table_id(database, &p_2025_02_table_name).await,
-        p_2026_table_id: get_table_id(database, &p_2026_table_name).await,
-        p_2026_01_table_id: get_table_id(database, &p_2026_01_table_name).await,
-        p_2026_02_table_id: get_table_id(database, &p_2026_02_table_name).await,
-        root_table_name: table_name,
-        p_2026_table_name,
-    }
-}
-
 async fn assert_publication_table_ids_for_partition_hierarchy(
     test_name: &str,
-    published_partition_root: PublishedPartitionRoot,
+    published_partition_target: PublishedPartitionTarget,
     publish_via_partition_root: bool,
 ) {
     init_test_tracing();
     let database = spawn_source_database().await;
     let client = PgReplicationClient::connect(database.config.clone()).await.unwrap();
-    let hierarchy =
-        create_nested_publication_hierarchy(&database, test_table_name(test_name)).await;
+    let hierarchy = create_nested_partition_hierarchy(&database, test_table_name(test_name)).await;
 
-    let publication_table_name = match published_partition_root {
-        PublishedPartitionRoot::Top => hierarchy.root_table_name.clone(),
-        PublishedPartitionRoot::Middle => hierarchy.p_2026_table_name.clone(),
+    let publication_table_name = match published_partition_target {
+        PublishedPartitionTarget::Top => hierarchy.root_table_name.clone(),
+        PublishedPartitionTarget::Middle => hierarchy.p_2026_table_name.clone(),
+        PublishedPartitionTarget::Leaf => partition_table_name(&hierarchy.p_2026_table_name, "01"),
     };
     let publication_name = format!("pub_{test_name}");
     database
@@ -249,18 +118,19 @@ async fn assert_publication_table_ids_for_partition_hierarchy(
         .await
         .unwrap();
 
-    let expected_table_ids = match (published_partition_root, publish_via_partition_root) {
-        (PublishedPartitionRoot::Top, true) => HashSet::from([hierarchy.root_table_id]),
-        (PublishedPartitionRoot::Top, false) => HashSet::from([
+    let expected_table_ids = match (published_partition_target, publish_via_partition_root) {
+        (PublishedPartitionTarget::Top, true) => HashSet::from([hierarchy.root_table_id]),
+        (PublishedPartitionTarget::Top, false) => HashSet::from([
             hierarchy.p_2025_01_table_id,
             hierarchy.p_2025_02_table_id,
             hierarchy.p_2026_01_table_id,
             hierarchy.p_2026_02_table_id,
         ]),
-        (PublishedPartitionRoot::Middle, true) => HashSet::from([hierarchy.p_2026_table_id]),
-        (PublishedPartitionRoot::Middle, false) => {
+        (PublishedPartitionTarget::Middle, true) => HashSet::from([hierarchy.p_2026_table_id]),
+        (PublishedPartitionTarget::Middle, false) => {
             HashSet::from([hierarchy.p_2026_01_table_id, hierarchy.p_2026_02_table_id])
         }
+        (PublishedPartitionTarget::Leaf, _) => HashSet::from([hierarchy.p_2026_01_table_id]),
     };
     let table_ids = client
         .get_publication_table_ids(&publication_name)
@@ -1630,7 +1500,7 @@ async fn publication_creation_and_check() {
 async fn publication_table_ids_collapse_partitioned_root() {
     assert_publication_table_ids_for_partition_hierarchy(
         "part_parent",
-        PublishedPartitionRoot::Top,
+        PublishedPartitionTarget::Top,
         true,
     )
     .await;
@@ -1640,60 +1510,37 @@ async fn publication_table_ids_collapse_partitioned_root() {
 async fn publication_table_ids_use_leaf_partitions_without_partition_root() {
     assert_publication_table_ids_for_partition_hierarchy(
         "part_parent_without_root",
-        PublishedPartitionRoot::Top,
+        PublishedPartitionTarget::Top,
         false,
     )
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn publication_table_ids_use_explicit_leaf_for_both_partition_root_settings() {
-    init_test_tracing();
-    let database = spawn_source_database().await;
-
-    let client = PgReplicationClient::connect(database.config.clone()).await.unwrap();
-
-    let table_name = test_table_name("explicit_leaf_parent");
-    let (_parent_table_id, partition_table_ids) = create_partitioned_table(
-        &database,
-        table_name.clone(),
-        &[("p1", "from (1) to (100)"), ("p2", "from (100) to (200)")],
+async fn publication_table_ids_use_explicit_leaf_with_partition_root() {
+    assert_publication_table_ids_for_partition_hierarchy(
+        "explicit_leaf_root",
+        PublishedPartitionTarget::Leaf,
+        true,
     )
-    .await
-    .unwrap();
-    let leaf_table_name = partition_table_name(&table_name, "p1");
-    let leaf_table_id = partition_table_ids[0];
+    .await;
+}
 
-    let publication_name = "pub_explicit_leaf_root";
-    database
-        .create_publication_with_config(
-            publication_name,
-            std::slice::from_ref(&leaf_table_name),
-            true,
-        )
-        .await
-        .unwrap();
-    let table_ids = client.get_publication_table_ids(publication_name).await.unwrap();
-    assert_eq!(table_ids, vec![leaf_table_id]);
-
-    let publication_name = "pub_explicit_leaf_no_root";
-    database
-        .create_publication_with_config(
-            publication_name,
-            std::slice::from_ref(&leaf_table_name),
-            false,
-        )
-        .await
-        .unwrap();
-    let table_ids = client.get_publication_table_ids(publication_name).await.unwrap();
-    assert_eq!(table_ids, vec![leaf_table_id]);
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_use_explicit_leaf_without_partition_root() {
+    assert_publication_table_ids_for_partition_hierarchy(
+        "explicit_leaf_no_root",
+        PublishedPartitionTarget::Leaf,
+        false,
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publication_table_ids_use_published_partition_ancestor() {
     assert_publication_table_ids_for_partition_hierarchy(
         "nested_part_root",
-        PublishedPartitionRoot::Middle,
+        PublishedPartitionTarget::Middle,
         true,
     )
     .await;
@@ -1703,7 +1550,7 @@ async fn publication_table_ids_use_published_partition_ancestor() {
 async fn publication_table_ids_use_leaf_partitions_for_published_subtree_without_partition_root() {
     assert_publication_table_ids_for_partition_hierarchy(
         "nested_leaf_root",
-        PublishedPartitionRoot::Middle,
+        PublishedPartitionTarget::Middle,
         false,
     )
     .await;

--- a/crates/etl/tests/replication.rs
+++ b/crates/etl/tests/replication.rs
@@ -1497,7 +1497,7 @@ async fn publication_creation_and_check() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn publication_table_ids_collapse_partitioned_root() {
+async fn publication_table_ids_use_published_partition_root() {
     assert_publication_table_ids_for_partition_hierarchy(
         "part_parent",
         PublishedPartitionTarget::Top,

--- a/crates/etl/tests/replication.rs
+++ b/crates/etl/tests/replication.rs
@@ -9,11 +9,12 @@ use etl::{
         schema::assert_table_schema_columns,
         test_schema::create_partitioned_table,
     },
+    types::TableId,
 };
 use etl_postgres::{
     below_version,
-    tokio::test_utils::{TableModification, id_column_schema},
-    types::{ColumnSchema, convert_type_oid_to_type},
+    tokio::test_utils::{PgDatabase, TableModification, id_column_schema},
+    types::{ColumnSchema, TableName, convert_type_oid_to_type},
     version::POSTGRES_15,
 };
 use etl_telemetry::tracing::init_test_tracing;
@@ -76,6 +77,283 @@ fn column_schemas_from_ddl_message(message: &JsonValue) -> Vec<ColumnSchema> {
     columns.sort_by_key(|column| column.ordinal_position);
 
     columns
+}
+
+async fn get_table_id(
+    database: &PgDatabase<tokio_postgres::Client>,
+    table_name: &TableName,
+) -> TableId {
+    let row = database
+        .client
+        .as_ref()
+        .unwrap()
+        .query_one(
+            "select c.oid
+             from pg_class c
+             join pg_namespace n on n.oid = c.relnamespace
+             where n.nspname = $1 and c.relname = $2",
+            &[&table_name.schema, &table_name.name],
+        )
+        .await
+        .unwrap();
+
+    TableId::new(row.get(0))
+}
+
+fn partition_table_name(table_name: &TableName, partition_name: &str) -> TableName {
+    TableName::new(table_name.schema.clone(), format!("{}_{}", table_name.name, partition_name))
+}
+
+#[derive(Clone, Copy)]
+enum PublishedPartitionRoot {
+    Top,
+    Middle,
+}
+
+#[derive(Clone, Copy)]
+enum PublicationExpansion {
+    AllTables,
+    Schema,
+}
+
+struct NestedPublicationHierarchy {
+    root_table_name: TableName,
+    p_2026_table_name: TableName,
+    root_table_id: TableId,
+    p_2025_01_table_id: TableId,
+    p_2025_02_table_id: TableId,
+    p_2026_table_id: TableId,
+    p_2026_01_table_id: TableId,
+    p_2026_02_table_id: TableId,
+}
+
+async fn create_nested_publication_hierarchy(
+    database: &PgDatabase<tokio_postgres::Client>,
+    table_name: TableName,
+) -> NestedPublicationHierarchy {
+    database
+        .run_sql(&format!(
+            "create table {} (
+                id integer not null,
+                partition_year integer not null,
+                partition_month integer not null,
+                primary key (id, partition_year, partition_month)
+            ) partition by range (partition_year)",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_2025", table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2025) to (2026)
+             partition by range (partition_month)",
+            p_2025_table_name.as_quoted_identifier(),
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_01_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_01", p_2025_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (1) to (2)",
+            p_2025_01_table_name.as_quoted_identifier(),
+            p_2025_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_02_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_02", p_2025_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2) to (3)",
+            p_2025_02_table_name.as_quoted_identifier(),
+            p_2025_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_2026", table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2026) to (2027)
+             partition by range (partition_month)",
+            p_2026_table_name.as_quoted_identifier(),
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_01_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_01", p_2026_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (1) to (2)",
+            p_2026_01_table_name.as_quoted_identifier(),
+            p_2026_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_02_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_02", p_2026_table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2) to (3)",
+            p_2026_02_table_name.as_quoted_identifier(),
+            p_2026_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    NestedPublicationHierarchy {
+        root_table_id: get_table_id(database, &table_name).await,
+        p_2025_01_table_id: get_table_id(database, &p_2025_01_table_name).await,
+        p_2025_02_table_id: get_table_id(database, &p_2025_02_table_name).await,
+        p_2026_table_id: get_table_id(database, &p_2026_table_name).await,
+        p_2026_01_table_id: get_table_id(database, &p_2026_01_table_name).await,
+        p_2026_02_table_id: get_table_id(database, &p_2026_02_table_name).await,
+        root_table_name: table_name,
+        p_2026_table_name,
+    }
+}
+
+async fn assert_publication_table_ids_for_partition_hierarchy(
+    test_name: &str,
+    published_partition_root: PublishedPartitionRoot,
+    publish_via_partition_root: bool,
+) {
+    init_test_tracing();
+    let database = spawn_source_database().await;
+    let client = PgReplicationClient::connect(database.config.clone()).await.unwrap();
+    let hierarchy =
+        create_nested_publication_hierarchy(&database, test_table_name(test_name)).await;
+
+    let publication_table_name = match published_partition_root {
+        PublishedPartitionRoot::Top => hierarchy.root_table_name.clone(),
+        PublishedPartitionRoot::Middle => hierarchy.p_2026_table_name.clone(),
+    };
+    let publication_name = format!("pub_{test_name}");
+    database
+        .create_publication_with_config(
+            &publication_name,
+            std::slice::from_ref(&publication_table_name),
+            publish_via_partition_root,
+        )
+        .await
+        .unwrap();
+
+    let expected_table_ids = match (published_partition_root, publish_via_partition_root) {
+        (PublishedPartitionRoot::Top, true) => HashSet::from([hierarchy.root_table_id]),
+        (PublishedPartitionRoot::Top, false) => HashSet::from([
+            hierarchy.p_2025_01_table_id,
+            hierarchy.p_2025_02_table_id,
+            hierarchy.p_2026_01_table_id,
+            hierarchy.p_2026_02_table_id,
+        ]),
+        (PublishedPartitionRoot::Middle, true) => HashSet::from([hierarchy.p_2026_table_id]),
+        (PublishedPartitionRoot::Middle, false) => {
+            HashSet::from([hierarchy.p_2026_01_table_id, hierarchy.p_2026_02_table_id])
+        }
+    };
+    let table_ids = client
+        .get_publication_table_ids(&publication_name)
+        .await
+        .unwrap()
+        .into_iter()
+        .collect::<HashSet<_>>();
+
+    assert_eq!(table_ids, expected_table_ids);
+}
+
+async fn assert_publication_table_ids_for_expanded_publication(
+    test_name: &str,
+    expansion: PublicationExpansion,
+    publish_via_partition_root: bool,
+) {
+    init_test_tracing();
+    let database = spawn_source_database().await;
+
+    if matches!(expansion, PublicationExpansion::Schema)
+        && below_version!(database.server_version(), POSTGRES_15)
+    {
+        return;
+    }
+
+    let client = PgReplicationClient::connect(database.config.clone()).await.unwrap();
+    let table_name = test_table_name(test_name);
+    let (parent_table_id, partition_table_ids) = create_partitioned_table(
+        &database,
+        table_name.clone(),
+        &[("p1", "from (1) to (100)"), ("p2", "from (100) to (200)")],
+    )
+    .await
+    .unwrap();
+    let regular_table_id = database
+        .create_table(test_table_name(&format!("{test_name}_regular")), true, &[("age", "integer")])
+        .await
+        .unwrap();
+
+    let publication_name = format!("pub_{test_name}");
+    match expansion {
+        PublicationExpansion::AllTables => {
+            database
+                .run_sql(&format!(
+                    "create publication {} for all tables with (publish_via_partition_root = {})",
+                    quote_identifier(&publication_name),
+                    publish_via_partition_root
+                ))
+                .await
+                .unwrap();
+        }
+        PublicationExpansion::Schema => {
+            database
+                .run_sql(&format!(
+                    "create publication {} for tables in schema {} with \
+                     (publish_via_partition_root = {})",
+                    quote_identifier(&publication_name),
+                    quote_identifier(&table_name.schema),
+                    publish_via_partition_root
+                ))
+                .await
+                .unwrap();
+        }
+    }
+
+    let table_ids = client
+        .get_publication_table_ids(&publication_name)
+        .await
+        .unwrap()
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let expected_table_ids = if publish_via_partition_root {
+        HashSet::from([parent_table_id, regular_table_id])
+    } else {
+        let mut expected_table_ids = partition_table_ids.iter().copied().collect::<HashSet<_>>();
+        expected_table_ids.insert(regular_table_id);
+        expected_table_ids
+    };
+
+    match expansion {
+        PublicationExpansion::AllTables => {
+            assert!(expected_table_ids.iter().all(|table_id| table_ids.contains(table_id)));
+        }
+        PublicationExpansion::Schema => {
+            assert_eq!(table_ids, expected_table_ids);
+        }
+    }
+
+    if publish_via_partition_root {
+        assert!(partition_table_ids.iter().all(|table_id| !table_ids.contains(table_id)));
+    } else {
+        assert!(!table_ids.contains(&parent_table_id));
+    }
 }
 
 async fn count_stream_rows(stream: CopyOutStream) -> u64 {
@@ -1350,28 +1628,125 @@ async fn publication_creation_and_check() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publication_table_ids_collapse_partitioned_root() {
+    assert_publication_table_ids_for_partition_hierarchy(
+        "part_parent",
+        PublishedPartitionRoot::Top,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_use_leaf_partitions_without_partition_root() {
+    assert_publication_table_ids_for_partition_hierarchy(
+        "part_parent_without_root",
+        PublishedPartitionRoot::Top,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_use_explicit_leaf_for_both_partition_root_settings() {
     init_test_tracing();
     let database = spawn_source_database().await;
 
     let client = PgReplicationClient::connect(database.config.clone()).await.unwrap();
 
-    // We create a partitioned parent with two child partitions.
-    let table_name = test_table_name("part_parent");
-    let (parent_table_id, _children) = create_partitioned_table(
+    let table_name = test_table_name("explicit_leaf_parent");
+    let (_parent_table_id, partition_table_ids) = create_partitioned_table(
         &database,
         table_name.clone(),
         &[("p1", "from (1) to (100)"), ("p2", "from (100) to (200)")],
     )
     .await
     .unwrap();
+    let leaf_table_name = partition_table_name(&table_name, "p1");
+    let leaf_table_id = partition_table_ids[0];
 
-    let publication_name = "pub_part_root";
-    database.create_publication(publication_name, std::slice::from_ref(&table_name)).await.unwrap();
+    let publication_name = "pub_explicit_leaf_root";
+    database
+        .create_publication_with_config(
+            publication_name,
+            std::slice::from_ref(&leaf_table_name),
+            true,
+        )
+        .await
+        .unwrap();
+    let table_ids = client.get_publication_table_ids(publication_name).await.unwrap();
+    assert_eq!(table_ids, vec![leaf_table_id]);
 
-    let id = client.get_publication_table_ids(publication_name).await.unwrap();
+    let publication_name = "pub_explicit_leaf_no_root";
+    database
+        .create_publication_with_config(
+            publication_name,
+            std::slice::from_ref(&leaf_table_name),
+            false,
+        )
+        .await
+        .unwrap();
+    let table_ids = client.get_publication_table_ids(publication_name).await.unwrap();
+    assert_eq!(table_ids, vec![leaf_table_id]);
+}
 
-    // We expect to get only the parent table id.
-    assert_eq!(id, vec![parent_table_id]);
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_use_published_partition_ancestor() {
+    assert_publication_table_ids_for_partition_hierarchy(
+        "nested_part_root",
+        PublishedPartitionRoot::Middle,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_use_leaf_partitions_for_published_subtree_without_partition_root() {
+    assert_publication_table_ids_for_partition_hierarchy(
+        "nested_leaf_root",
+        PublishedPartitionRoot::Middle,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_for_all_tables_use_partition_roots() {
+    assert_publication_table_ids_for_expanded_publication(
+        "all_tables_part_parent",
+        PublicationExpansion::AllTables,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_for_all_tables_use_leaf_partitions_without_partition_root() {
+    assert_publication_table_ids_for_expanded_publication(
+        "all_tables_leaf_parent",
+        PublicationExpansion::AllTables,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_for_schema_use_partition_roots() {
+    assert_publication_table_ids_for_expanded_publication(
+        "schema_part_parent",
+        PublicationExpansion::Schema,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_table_ids_for_schema_use_leaf_partitions_without_partition_root() {
+    assert_publication_table_ids_for_expanded_publication(
+        "schema_leaf_parent",
+        PublicationExpansion::Schema,
+        false,
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/support/mod.rs
+++ b/crates/etl/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod partition;

--- a/crates/etl/tests/support/partition.rs
+++ b/crates/etl/tests/support/partition.rs
@@ -1,0 +1,131 @@
+use etl::types::TableId;
+use etl_postgres::{tokio::test_utils::PgDatabase, types::TableName};
+use tokio_postgres::Client;
+
+#[derive(Debug)]
+pub(crate) struct NestedPartitionHierarchy {
+    pub(crate) root_table_name: TableName,
+    pub(crate) p_2026_table_name: TableName,
+    pub(crate) root_table_id: TableId,
+    pub(crate) p_2025_01_table_id: TableId,
+    pub(crate) p_2025_02_table_id: TableId,
+    pub(crate) p_2026_table_id: TableId,
+    pub(crate) p_2026_01_table_id: TableId,
+    pub(crate) p_2026_02_table_id: TableId,
+}
+
+pub(crate) fn partition_table_name(table_name: &TableName, partition_name: &str) -> TableName {
+    TableName::new(table_name.schema.clone(), format!("{}_{}", table_name.name, partition_name))
+}
+
+pub(crate) async fn create_nested_partition_hierarchy(
+    database: &PgDatabase<Client>,
+    table_name: TableName,
+) -> NestedPartitionHierarchy {
+    database
+        .run_sql(&format!(
+            "create table {} (
+                id bigserial,
+                data text not null,
+                partition_year integer not null,
+                partition_month integer not null,
+                primary key (id, partition_year, partition_month)
+            ) partition by range (partition_year)",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_2025", table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2025) to (2026)
+             partition by range (partition_month)",
+            p_2025_table_name.as_quoted_identifier(),
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_01_table_name = partition_table_name(&p_2025_table_name, "01");
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (1) to (2)",
+            p_2025_01_table_name.as_quoted_identifier(),
+            p_2025_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2025_02_table_name = partition_table_name(&p_2025_table_name, "02");
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2) to (3)",
+            p_2025_02_table_name.as_quoted_identifier(),
+            p_2025_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_table_name =
+        TableName::new(table_name.schema.clone(), format!("{}_2026", table_name.name));
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2026) to (2027)
+             partition by range (partition_month)",
+            p_2026_table_name.as_quoted_identifier(),
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_01_table_name = partition_table_name(&p_2026_table_name, "01");
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (1) to (2)",
+            p_2026_01_table_name.as_quoted_identifier(),
+            p_2026_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    let p_2026_02_table_name = partition_table_name(&p_2026_table_name, "02");
+    database
+        .run_sql(&format!(
+            "create table {} partition of {} for values from (2) to (3)",
+            p_2026_02_table_name.as_quoted_identifier(),
+            p_2026_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    NestedPartitionHierarchy {
+        root_table_id: get_table_id(database, &table_name).await,
+        p_2025_01_table_id: get_table_id(database, &p_2025_01_table_name).await,
+        p_2025_02_table_id: get_table_id(database, &p_2025_02_table_name).await,
+        p_2026_table_id: get_table_id(database, &p_2026_table_name).await,
+        p_2026_01_table_id: get_table_id(database, &p_2026_01_table_name).await,
+        p_2026_02_table_id: get_table_id(database, &p_2026_02_table_name).await,
+        root_table_name: table_name,
+        p_2026_table_name,
+    }
+}
+
+async fn get_table_id(database: &PgDatabase<Client>, table_name: &TableName) -> TableId {
+    let row = database
+        .client
+        .as_ref()
+        .unwrap()
+        .query_one(
+            "select c.oid
+             from pg_class c
+             join pg_namespace n on n.oid = c.relnamespace
+             where n.nspname = $1 and c.relname = $2",
+            &[&table_name.schema, &table_name.name],
+        )
+        .await
+        .unwrap();
+
+    row.get(0)
+}

--- a/docs/src/content/docs/guides/configure-postgres.md
+++ b/docs/src/content/docs/guides/configure-postgres.md
@@ -288,14 +288,20 @@ orders
 (publish_via_partition_root = false)` replicates `orders_2026_01` and
 `orders_2026_02` as separate leaf tables.
 
-**Limitation:** With `publish_via_partition_root = true`, `TRUNCATE` operations on individual partitions are not replicated. Execute truncates on the published partition root table instead:
+On PostgreSQL 15+, row filters on partition publications are applied during
+both the initial copy and CDC. ETL uses the row filter attached to the effective
+publication table entry: the published root or subtree when
+`publish_via_partition_root = true`, and the published leaf relation when
+`publish_via_partition_root = false`.
+
+**Limitation:** With `publish_via_partition_root = true`, `TRUNCATE` operations on individual partitions are not replicated. Execute truncates on the published partition table instead. For a top-level publication, that is the top root; for a subtree publication, that is the published subtree root.
 
 ```sql
 -- This will NOT be replicated
-TRUNCATE TABLE orders_2024_q1;
+TRUNCATE TABLE orders_2026_01;
 
 -- This WILL be replicated
-TRUNCATE TABLE orders;
+TRUNCATE TABLE orders_2026;
 ```
 
 ### Managing Publications

--- a/docs/src/content/docs/guides/configure-postgres.md
+++ b/docs/src/content/docs/guides/configure-postgres.md
@@ -12,7 +12,7 @@ This guide covers the essential **Postgres settings, slots, publications, and ve
 ## Prerequisites
 
 - **PostgreSQL 14, 15, 16, 17, or 18** (officially supported and tested versions)
-  - PostgreSQL 15+ recommended for advanced publication filtering (column-level, row-level, `FOR ALL TABLES IN SCHEMA`)
+  - PostgreSQL 15+ recommended for advanced publication filtering (column-level, row-level, `FOR TABLES IN SCHEMA`)
   - PostgreSQL 16+ required when logical replication is read from a physical read replica
   - PostgreSQL 14 supported with table-level filtering only
 - Superuser access to the Postgres server
@@ -252,24 +252,6 @@ ETL reads the effective table list from `pg_publication_tables`, so it tracks
 the same relation identities and schemas PostgreSQL uses for logical
 replication messages.
 
-For the easiest destination shape, prefer `publish_via_partition_root = true`.
-This tells PostgreSQL to publish changes using the schema and identity of the
-[topmost partitioned table included in the publication](https://www.postgresql.org/docs/current/sql-createpublication.html#SQL-CREATEPUBLICATION-PARAMS-WITH-PUBLISH-VIA-PARTITION-ROOT).
-If you publish a subtree such as `orders_2026`, changes under that subtree are
-published as `orders_2026`, not as the absolute root table:
-
-```sql
--- Publish the selected partitioned tables as logical root tables
-CREATE PUBLICATION my_publication FOR TABLE users, orders WITH (publish_via_partition_root = true);
-
--- For all tables including partitioned tables
-CREATE PUBLICATION all_tables FOR ALL TABLES WITH (publish_via_partition_root = true);
-```
-
-When publications are created through the ETL API, ETL uses
-`publish_via_partition_root = true` by default. Manually-created publications
-can use either setting.
-
 | Publication shape | `publish_via_partition_root` | PostgreSQL publishes as | ETL tracks |
 | --- | --- | --- | --- |
 | `FOR TABLE orders` where `orders` is the top partitioned table | `true` | `orders` | `orders` |
@@ -356,7 +338,7 @@ CREATE PUBLICATION active_users FOR TABLE users WHERE (status = 'active');
 
 ```sql
 -- Replicate all tables in a schema
-CREATE PUBLICATION schema_pub FOR ALL TABLES IN SCHEMA public;
+CREATE PUBLICATION schema_pub FOR TABLES IN SCHEMA public;
 ```
 
 ### PostgreSQL 14 Limitations
@@ -370,7 +352,7 @@ PostgreSQL 14 supports table-level publication filtering only. Column-level and 
 | Table-level publication | Yes | Yes | Yes |
 | Column-level filtering | No | Yes | Yes |
 | Row-level filtering | No | Yes | Yes |
-| `FOR ALL TABLES IN SCHEMA` | No | Yes | Yes |
+| `FOR TABLES IN SCHEMA` | No | Yes | Yes |
 | Partitioned table support | Yes | Yes | Yes |
 | Logical decoding on physical read replicas | No | No | Yes |
 

--- a/docs/src/content/docs/guides/configure-postgres.md
+++ b/docs/src/content/docs/guides/configure-postgres.md
@@ -240,6 +240,9 @@ CREATE PUBLICATION my_publication FOR TABLE users, orders;
 -- Create publication for all tables (use with caution)
 CREATE PUBLICATION all_tables FOR ALL TABLES;
 
+-- Create publication for all tables in selected schemas
+CREATE PUBLICATION schema_tables FOR TABLES IN SCHEMA public, analytics;
+
 -- Include only specific operations
 CREATE PUBLICATION inserts_only FOR TABLE users WITH (publish = 'insert');
 ```
@@ -259,8 +262,8 @@ replication messages.
 | `FOR TABLE orders_2026` where `orders_2026` is a partitioned subtree | `true` | `orders_2026` | `orders_2026` |
 | `FOR TABLE orders_2026` where `orders_2026` is a partitioned subtree | `false` | Leaf partitions under `orders_2026` | The leaf partitions under `orders_2026` |
 | `FOR TABLE orders_2026_01` where `orders_2026_01` is a leaf partition | Either | `orders_2026_01` | `orders_2026_01` |
-| `FOR ALL TABLES` or `FOR TABLES IN SCHEMA ...` | `true` | Partition roots plus regular tables | Partition roots plus regular tables |
-| `FOR ALL TABLES` or `FOR TABLES IN SCHEMA ...` | `false` | Leaf partitions plus regular tables | Leaf partitions plus regular tables |
+| `FOR ALL TABLES` for the whole database, or `FOR TABLES IN SCHEMA ...` for selected schemas | `true` | Partition roots plus regular tables | Partition roots plus regular tables |
+| `FOR ALL TABLES` for the whole database, or `FOR TABLES IN SCHEMA ...` for selected schemas | `false` | Leaf partitions plus regular tables | Leaf partitions plus regular tables |
 
 For example, with this hierarchy:
 

--- a/docs/src/content/docs/guides/configure-postgres.md
+++ b/docs/src/content/docs/guides/configure-postgres.md
@@ -247,6 +247,12 @@ CREATE PUBLICATION schema_tables FOR TABLES IN SCHEMA public, analytics;
 CREATE PUBLICATION inserts_only FOR TABLE users WITH (publish = 'insert');
 ```
 
+Avoid publishing ETL-owned tables. If the source database is also used as the
+ETL state store, the `etl` schema contains ETL internal tables. Do not include
+that schema in the publication. In that setup, `FOR ALL TABLES` also includes
+ETL-owned tables, so use explicit table lists or `FOR TABLES IN SCHEMA ...` for
+customer-owned schemas instead.
+
 #### Partitioned Tables
 
 ETL supports PostgreSQL partition publications with either
@@ -262,8 +268,8 @@ replication messages.
 | `FOR TABLE orders_2026` where `orders_2026` is a partitioned subtree | `true` | `orders_2026` | `orders_2026` |
 | `FOR TABLE orders_2026` where `orders_2026` is a partitioned subtree | `false` | Leaf partitions under `orders_2026` | The leaf partitions under `orders_2026` |
 | `FOR TABLE orders_2026_01` where `orders_2026_01` is a leaf partition | Either | `orders_2026_01` | `orders_2026_01` |
-| `FOR ALL TABLES` for the whole database, or `FOR TABLES IN SCHEMA ...` for selected schemas | `true` | Partition roots plus regular tables | Partition roots plus regular tables |
-| `FOR ALL TABLES` for the whole database, or `FOR TABLES IN SCHEMA ...` for selected schemas | `false` | Leaf partitions plus regular tables | Leaf partitions plus regular tables |
+| `FOR ALL TABLES` for the whole database, or `FOR TABLES IN SCHEMA ...` for selected schemas. Do not include ETL-owned tables. | `true` | Partition roots plus regular tables | Partition roots plus regular tables |
+| `FOR ALL TABLES` for the whole database, or `FOR TABLES IN SCHEMA ...` for selected schemas. Do not include ETL-owned tables. | `false` | Leaf partitions plus regular tables | Leaf partitions plus regular tables |
 
 For example, with this hierarchy:
 

--- a/docs/src/content/docs/guides/configure-postgres.md
+++ b/docs/src/content/docs/guides/configure-postgres.md
@@ -246,17 +246,58 @@ CREATE PUBLICATION inserts_only FOR TABLE users WITH (publish = 'insert');
 
 #### Partitioned Tables
 
-To replicate partitioned tables, use `publish_via_partition_root = true`. This tells Postgres to treat the [partitioned table as a single table](https://www.postgresql.org/docs/current/sql-createpublication.html#SQL-CREATEPUBLICATION-PARAMS-WITH-PUBLISH-VIA-PARTITION-ROOT) for replication purposes. **All changes to any partition are published as changes to the parent table**:
+ETL supports PostgreSQL partition publications with either
+`publish_via_partition_root = true` or `publish_via_partition_root = false`.
+ETL reads the effective table list from `pg_publication_tables`, so it tracks
+the same relation identities and schemas PostgreSQL uses for logical
+replication messages.
+
+For the easiest destination shape, prefer `publish_via_partition_root = true`.
+This tells PostgreSQL to publish changes using the schema and identity of the
+[topmost partitioned table included in the publication](https://www.postgresql.org/docs/current/sql-createpublication.html#SQL-CREATEPUBLICATION-PARAMS-WITH-PUBLISH-VIA-PARTITION-ROOT).
+If you publish a subtree such as `orders_2026`, changes under that subtree are
+published as `orders_2026`, not as the absolute root table:
 
 ```sql
--- Create publication with partitioned table support
+-- Publish the selected partitioned tables as logical root tables
 CREATE PUBLICATION my_publication FOR TABLE users, orders WITH (publish_via_partition_root = true);
 
 -- For all tables including partitioned tables
 CREATE PUBLICATION all_tables FOR ALL TABLES WITH (publish_via_partition_root = true);
 ```
 
-**Limitation:** With this option enabled, `TRUNCATE` operations on individual partitions are not replicated. Execute truncates on the parent table instead:
+When publications are created through the ETL API, ETL uses
+`publish_via_partition_root = true` by default. Manually-created publications
+can use either setting.
+
+| Publication shape | `publish_via_partition_root` | PostgreSQL publishes as | ETL tracks |
+| --- | --- | --- | --- |
+| `FOR TABLE orders` where `orders` is the top partitioned table | `true` | `orders` | `orders` |
+| `FOR TABLE orders` where `orders` is the top partitioned table | `false` | Leaf partitions under `orders` | The leaf partitions |
+| `FOR TABLE orders_2026` where `orders_2026` is a partitioned subtree | `true` | `orders_2026` | `orders_2026` |
+| `FOR TABLE orders_2026` where `orders_2026` is a partitioned subtree | `false` | Leaf partitions under `orders_2026` | The leaf partitions under `orders_2026` |
+| `FOR TABLE orders_2026_01` where `orders_2026_01` is a leaf partition | Either | `orders_2026_01` | `orders_2026_01` |
+| `FOR ALL TABLES` or `FOR TABLES IN SCHEMA ...` | `true` | Partition roots plus regular tables | Partition roots plus regular tables |
+| `FOR ALL TABLES` or `FOR TABLES IN SCHEMA ...` | `false` | Leaf partitions plus regular tables | Leaf partitions plus regular tables |
+
+For example, with this hierarchy:
+
+```text
+orders
+  ├── orders_2025
+  │   ├── orders_2025_01
+  │   └── orders_2025_02
+  └── orders_2026
+      ├── orders_2026_01
+      └── orders_2026_02
+```
+
+`FOR TABLE orders_2026 WITH (publish_via_partition_root = true)` replicates the
+2026 subtree as `orders_2026`. `FOR TABLE orders_2026 WITH
+(publish_via_partition_root = false)` replicates `orders_2026_01` and
+`orders_2026_02` as separate leaf tables.
+
+**Limitation:** With `publish_via_partition_root = true`, `TRUNCATE` operations on individual partitions are not replicated. Execute truncates on the published partition root table instead:
 
 ```sql
 -- This will NOT be replicated


### PR DESCRIPTION
## Summary

This PR hardens ETL publication handling in three related areas:

- Prevents ETL-owned source tables from being replicated by customer publications.
- Aligns partitioned-table publication handling with PostgreSQL's effective logical replication semantics from `pg_publication_tables`.
- Fixes a pre-existing row-filter bug in partitioned-table parallel copy when `publish_via_partition_root = true`.

## Changes

### ETL-owned table catalog and validation

- Adds a central ETL source catalog in `etl-postgres` for the `etl` schema and ETL-managed tables.
- Reuses the shared ETL schema/table definitions from source validation and health checks so table names do not drift across crates.
- Adds an ETL API pipeline validator that rejects publications which would include ETL-owned tables:
  - `FOR ALL TABLES` publications.
  - Explicitly published `etl.*` tables.
  - `FOR TABLES IN SCHEMA etl` publications on PostgreSQL 15+.
- Keeps the schema-publication test version-gated because `FOR TABLES IN SCHEMA` is only available on PostgreSQL 15+.

### Publication table identity semantics

- Changes `PgReplicationClient::get_publication_table_ids` to read the effective publication table identities from `pg_publication_tables` directly.
- Removes the old recursive walk to the absolute partition root, which did not match PostgreSQL semantics for subtree publications.
- Removes the ETL startup validation that rejected partitioned publications with `publish_via_partition_root = false`; ETL now supports both settings by tracking the same relation identities PostgreSQL publishes.
- Removes the unused `get_publish_via_partition_root` path from the raw replication client.
- Keeps ETL API-created publications defaulting to `publish_via_partition_root = true` for the simpler destination shape.

### Row filters during partitioned copy

- Fixes a pre-existing bug for row-filtered partitioned publications with `publish_via_partition_root = true` and parallel copy.
- Parallel copy physically copies leaf partitions, but for `publish_via_partition_root = true`, the row filter is attached to the published root/subtree entry in `pg_publication_tables`.
- Separates the physical COPY table ID from the publication row-filter lookup table ID:
  - Copy source table: the leaf partition being copied.
  - Row-filter lookup table: the tracked/published root or subtree table.
- Keeps single-copy behavior explicit: serial COPY uses the tracked table as both the copy source and the row-filter lookup table.
- Leaves `publish_via_partition_root = false` behavior natural: ETL tracks leaf tables directly, so the copy table and row-filter lookup table are the same leaf ID.

### Test coverage

- Adds raw publication table ID tests for:
  - Top-level partition root with `publish_via_partition_root = true` and `false`.
  - Middle/subtree partition root with `publish_via_partition_root = true` and `false`.
  - Explicit leaf partitions under both settings.
  - `FOR ALL TABLES` with both partition-root settings.
  - `FOR TABLES IN SCHEMA` with both partition-root settings on PostgreSQL 15+.
- Adds end-to-end pipeline tests for nested partition hierarchies covering top-root, middle-root, and leaf publications under both partition-root settings.
- Adds row-filtered partition-copy regression tests for top-root, middle-root, and leaf publications with `publish_via_partition_root = true`, across both serial and parallel copy paths.
- Reuses shared nested partition test helpers across raw replication and pipeline tests.
- Asserts initial copied table rows as well as CDC events in the nested pipeline matrix.
- Removes the old narrow schema-mismatch reproduction test in favor of the broader publication/partition behavior coverage.
- Deduplicates older partition tests where the new matrix covers the behavior more directly.

### Documentation

- Updates the Postgres configuration guide to explain that ETL supports both `publish_via_partition_root = true` and `false`.
- Documents the behavior matrix for top roots, subtree roots, leaf partitions, `FOR ALL TABLES`, and `FOR TABLES IN SCHEMA`.
- Clarifies valid PostgreSQL publication syntax:
  - `FOR ALL TABLES` publishes all tables in the database.
  - `FOR TABLES IN SCHEMA ...` publishes all tables in selected schemas.
- Warns users not to include ETL-owned tables in publications, especially when the source database is also used as the ETL state store.
- Removes ETL API-specific wording from public docs.
