### PR TITLE
feat(clickhouse): benchmarks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,15 @@ export BENCH_SNOWFLAKE_DATABASE=$TESTS_SNOWFLAKE_DATABASE
 export BENCH_SNOWFLAKE_SCHEMA=$TESTS_SNOWFLAKE_SCHEMA
 export BENCH_SNOWFLAKE_ROLE=$TESTS_SNOWFLAKE_ROLE
 
+# ClickHouse benchmarks (cargo xtask benchmark --destination clickhouse)
+#
+# Defaults match scripts/docker-compose.yaml's local clickhouse service.
+# Start it with `docker compose -f scripts/docker-compose.yaml up -d clickhouse`.
+export BENCH_CLICKHOUSE_URL=http://localhost:8123
+export BENCH_CLICKHOUSE_USER=etl
+export BENCH_CLICKHOUSE_PASSWORD=etl
+export BENCH_CLICKHOUSE_DATABASE=default
+
 # sccache (optional build cache)
 #
 # Enable per-command instead with: cargo x check --sccache

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,7 @@ on:
         options:
           - "null"
           - bigquery
+          - clickhouse
           - snowflake
         default: "null"
       bq_project_id:
@@ -91,6 +92,10 @@ env:
   POSTGRES_HOST: localhost
   BENCHMARK_SAMPLES: 3
   BENCHMARK_WARMUP_SAMPLES: 1
+  BENCH_CLICKHOUSE_URL: http://localhost:8123
+  BENCH_CLICKHOUSE_USER: etl
+  BENCH_CLICKHOUSE_PASSWORD: etl
+  BENCH_CLICKHOUSE_DATABASE: default
 
 permissions:
   actions: read
@@ -153,6 +158,10 @@ jobs:
             exit 1
           fi
           printf '%s' "${BQ_SA_KEY_JSON}" > "$RUNNER_TEMP/bigquery-key.json"
+
+      - name: Start ClickHouse
+        if: inputs.destination == 'clickhouse'
+        run: docker compose -f scripts/docker-compose.yaml up -d --wait clickhouse
 
       - name: Prepare Snowflake credentials
         if: inputs.destination == 'snowflake'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/etl-benchmarks/Cargo.toml
+++ b/crates/etl-benchmarks/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [features]
 default = []
 bigquery = ["dep:etl-destinations", "etl-destinations/bigquery"]
+clickhouse = ["dep:etl-destinations", "etl-destinations/clickhouse", "dep:url"]
 snowflake = ["dep:etl-destinations", "etl-destinations/snowflake"]
 
 [dependencies]
@@ -31,6 +32,7 @@ serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal"] }
 tracing = { workspace = true, default-features = true }
+url = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/etl-benchmarks/README.md
+++ b/crates/etl-benchmarks/README.md
@@ -23,6 +23,7 @@ Both benchmarks support:
   decoding, batching, and pipeline overhead without destination write cost.
 - `bigquery`: writes to BigQuery. Use this for end-to-end destination throughput.
 - `snowflake`: writes to Snowflake. Use this for end-to-end destination throughput.
+- `clickhouse`: writes to ClickHouse. Use this for end-to-end destination throughput.
 
 Both benchmarks print a human-readable summary. When `--report-path` is set, they
 also persist a pretty JSON report for automation. `xtask` always sets
@@ -238,6 +239,40 @@ Optional:
 
 - `BENCH_SNOWFLAKE_ROLE`: Snowflake role to assume.
 
+## ClickHouse Runs
+
+Start the local ClickHouse server from `scripts/docker-compose.yaml`:
+
+```bash
+docker compose -f scripts/docker-compose.yaml up -d clickhouse
+```
+
+The defaults in `.env.example` (`BENCH_CLICKHOUSE_URL=http://localhost:8123`,
+`BENCH_CLICKHOUSE_USER=etl`, `BENCH_CLICKHOUSE_PASSWORD=etl`,
+`BENCH_CLICKHOUSE_DATABASE=default`) match the compose service. Override them
+to point at any other ClickHouse 23.5 or newer (required by the default
+`ReplacingMergeTree` engine).
+
+Run the benchmark:
+
+```bash
+cargo xtask benchmark \
+  --destination clickhouse \
+  --warehouses 1 \
+  --streaming-duration-seconds 10
+```
+
+Required environment variables (or their `--clickhouse-*` CLI equivalents):
+
+- `BENCH_CLICKHOUSE_URL`: ClickHouse HTTP URL.
+- `BENCH_CLICKHOUSE_USER`: ClickHouse user.
+- `BENCH_CLICKHOUSE_DATABASE`: target database. Must already exist; the
+  destination creates tables but not databases.
+
+Optional:
+
+- `BENCH_CLICKHOUSE_PASSWORD`: ClickHouse password. Omit if the user has none.
+
 ## GitHub Actions
 
 The `Benchmark` workflow is manual and runs through `workflow_dispatch`.
@@ -275,7 +310,7 @@ Important workflow inputs:
   bytes. Defaults to `0.2`.
 - `enable_memory_backpressure`: opt into ETL memory backpressure. Defaults to
   `false` for benchmark runs.
-- `destination`: `null`, `bigquery`, or `snowflake`.
+- `destination`: `null`, `bigquery`, `clickhouse`, or `snowflake`.
 - `force_prepare`: drop and regenerate TPC-C tables before running.
 - `skip_table_copy`: skip table copy.
 - `skip_table_streaming`: skip table streaming.
@@ -288,6 +323,10 @@ For Snowflake workflow runs, set two repository secrets and pass `destination=sn
 
 - `BENCH_SNOWFLAKE_CONNECTION`: colon-separated `account:user:database:schema`.
 - `BENCH_SNOWFLAKE_PRIVATE_KEY`: full PEM contents of the RSA private key.
+
+For ClickHouse workflow runs, pass `destination=clickhouse`. The workflow
+starts the `clickhouse` service from `scripts/docker-compose.yaml` and points
+the benchmark at it (user `etl`, database `default`); no secrets are needed.
 
 The workflow starts only source Postgres, installs pinned `go-tpc`, runs
 `cargo xtask benchmark` with three measured samples plus one warmup sample,

--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "bigquery", feature = "snowflake"))]
+#[cfg(any(feature = "bigquery", feature = "clickhouse", feature = "snowflake"))]
 use std::sync::Once;
 use std::{
     fs,
@@ -30,6 +30,10 @@ use etl_config::{
 };
 #[cfg(feature = "bigquery")]
 use etl_destinations::bigquery::BigQueryDestination;
+#[cfg(feature = "clickhouse")]
+use etl_destinations::clickhouse::{
+    ClickHouseClientConfig, ClickHouseDestination, ClickHouseInserterConfig,
+};
 #[cfg(feature = "snowflake")]
 use etl_destinations::snowflake::{
     AuthManager, Client as SnowflakeClient, Config as SnowflakeConfig,
@@ -43,12 +47,14 @@ use sqlx::{
 };
 use tokio::sync::Notify;
 use tracing::info;
+#[cfg(feature = "clickhouse")]
+use url::Url;
 
 /// Default batch fill time for benchmark runs.
 pub const BENCHMARK_DEFAULT_BATCH_MAX_FILL_MS: u64 = 1_000;
 
 /// Ensures crypto provider is only initialized once.
-#[cfg(any(feature = "bigquery", feature = "snowflake"))]
+#[cfg(any(feature = "bigquery", feature = "clickhouse", feature = "snowflake"))]
 static INIT_CRYPTO: Once = Once::new();
 
 /// Where benchmark logs should be written.
@@ -79,6 +85,9 @@ pub enum DestinationType {
     /// Use BigQuery as the destination.
     #[value(name = "bigquery")]
     BigQuery,
+    /// Use ClickHouse as the destination.
+    #[value(name = "clickhouse")]
+    ClickHouse,
     /// Use Snowflake as the destination.
     #[value(name = "snowflake")]
     Snowflake,
@@ -169,6 +178,18 @@ pub struct DestinationArgs {
     /// BigQuery connection pool size.
     #[arg(long, default_value_t = 32)]
     pub bq_connection_pool_size: usize,
+    /// ClickHouse HTTP URL (for example, `http://localhost:8123`).
+    #[arg(long)]
+    pub clickhouse_url: Option<String>,
+    /// ClickHouse username.
+    #[arg(long)]
+    pub clickhouse_user: Option<String>,
+    /// ClickHouse password.
+    #[arg(long)]
+    pub clickhouse_password: Option<String>,
+    /// ClickHouse database. Must already exist.
+    #[arg(long)]
+    pub clickhouse_database: Option<String>,
     /// Snowflake account identifier.
     #[arg(long)]
     pub sf_account: Option<String>,
@@ -457,7 +478,10 @@ impl Destination for NullDestination {
 }
 
 /// Benchmark destination variants.
-#[cfg_attr(any(feature = "bigquery", feature = "snowflake"), expect(clippy::large_enum_variant))]
+#[cfg_attr(
+    any(feature = "bigquery", feature = "clickhouse", feature = "snowflake"),
+    expect(clippy::large_enum_variant)
+)]
 #[derive(Clone)]
 pub enum BenchDestination {
     /// Null destination variant.
@@ -465,6 +489,9 @@ pub enum BenchDestination {
     /// BigQuery destination variant.
     #[cfg(feature = "bigquery")]
     BigQuery(CountingDestination<BigQueryDestination<NotifyingStore>>),
+    /// ClickHouse destination variant.
+    #[cfg(feature = "clickhouse")]
+    ClickHouse(CountingDestination<ClickHouseDestination<NotifyingStore>>),
     /// Snowflake destination variant.
     #[cfg(feature = "snowflake")]
     Snowflake(CountingDestination<SnowflakeDestination<NotifyingStore>>),
@@ -472,15 +499,19 @@ pub enum BenchDestination {
 
 impl BenchDestination {
     /// Creates a benchmark destination from CLI arguments.
-    #[cfg_attr(not(any(feature = "bigquery", feature = "snowflake")), expect(clippy::unused_async))]
+    #[cfg_attr(
+        not(any(feature = "bigquery", feature = "clickhouse", feature = "snowflake")),
+        expect(clippy::unused_async)
+    )]
+    #[allow(
+        unused_variables,
+        reason = "pipeline_id and store are consumed only by feature-gated arms"
+    )]
     pub async fn new(
         destination_args: &DestinationArgs,
         pipeline_id: u64,
         store: NotifyingStore,
     ) -> Result<Self> {
-        #[cfg(not(any(feature = "bigquery", feature = "snowflake")))]
-        let _ = (pipeline_id, &store);
-
         match destination_args.destination {
             DestinationType::Null => Ok(Self::Null(CountingDestination::new(NullDestination))),
             #[cfg(feature = "bigquery")]
@@ -519,6 +550,46 @@ impl BenchDestination {
             #[cfg(not(feature = "bigquery"))]
             DestinationType::BigQuery => {
                 bail!("BigQuery benchmarks require the etl-benchmarks bigquery feature")
+            }
+            #[cfg(feature = "clickhouse")]
+            DestinationType::ClickHouse => {
+                install_crypto_provider();
+
+                let url = destination_args
+                    .clickhouse_url
+                    .clone()
+                    .filter(|u| !u.trim().is_empty())
+                    .context("ClickHouse URL is required for ClickHouse benchmarks")?;
+                let url = Url::parse(&url).context("invalid ClickHouse URL")?;
+                let user = destination_args
+                    .clickhouse_user
+                    .clone()
+                    .filter(|u| !u.trim().is_empty())
+                    .context("ClickHouse user is required for ClickHouse benchmarks")?;
+                let database = destination_args
+                    .clickhouse_database
+                    .clone()
+                    .filter(|d| !d.trim().is_empty())
+                    .context("ClickHouse database is required for ClickHouse benchmarks")?;
+                let password =
+                    destination_args.clickhouse_password.clone().filter(|p| !p.is_empty());
+
+                let destination = ClickHouseDestination::new(
+                    url,
+                    user,
+                    password,
+                    database,
+                    ClickHouseInserterConfig::default(),
+                    ClickHouseClientConfig::default(),
+                    store,
+                )?;
+                destination.validate_engine_support().await?;
+
+                Ok(Self::ClickHouse(CountingDestination::new(destination)))
+            }
+            #[cfg(not(feature = "clickhouse"))]
+            DestinationType::ClickHouse => {
+                bail!("ClickHouse benchmarks require the etl-benchmarks clickhouse feature")
             }
             #[cfg(feature = "snowflake")]
             DestinationType::Snowflake => {
@@ -576,6 +647,8 @@ impl BenchDestination {
             Self::Null(destination) => destination.stats(),
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => destination.stats(),
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => destination.stats(),
             #[cfg(feature = "snowflake")]
             Self::Snowflake(destination) => destination.stats(),
         }
@@ -587,6 +660,8 @@ impl BenchDestination {
             Self::Null(destination) => destination.reset_cdc_stats(),
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => destination.reset_cdc_stats(),
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => destination.reset_cdc_stats(),
             #[cfg(feature = "snowflake")]
             Self::Snowflake(destination) => destination.reset_cdc_stats(),
         }
@@ -598,6 +673,8 @@ impl BenchDestination {
             Self::Null(destination) => destination.set_cdc_target(target),
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => destination.set_cdc_target(target),
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => destination.set_cdc_target(target),
             #[cfg(feature = "snowflake")]
             Self::Snowflake(destination) => destination.set_cdc_target(target),
         }
@@ -609,6 +686,8 @@ impl BenchDestination {
             Self::Null(destination) => destination.wait_for_cdc_target().await,
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => destination.wait_for_cdc_target().await,
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => destination.wait_for_cdc_target().await,
             #[cfg(feature = "snowflake")]
             Self::Snowflake(destination) => destination.wait_for_cdc_target().await,
         }
@@ -625,6 +704,8 @@ impl Destination for BenchDestination {
             Self::Null(destination) => destination.shutdown().await,
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => destination.shutdown().await,
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => destination.shutdown().await,
             #[cfg(feature = "snowflake")]
             Self::Snowflake(destination) => destination.shutdown().await,
         }
@@ -641,6 +722,10 @@ impl Destination for BenchDestination {
             }
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => {
+                destination.drop_table_for_copy(replicated_table_schema, async_result).await
+            }
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => {
                 destination.drop_table_for_copy(replicated_table_schema, async_result).await
             }
             #[cfg(feature = "snowflake")]
@@ -668,6 +753,12 @@ impl Destination for BenchDestination {
                     .write_table_rows(replicated_table_schema, table_rows, async_result)
                     .await
             }
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => {
+                destination
+                    .write_table_rows(replicated_table_schema, table_rows, async_result)
+                    .await
+            }
             #[cfg(feature = "snowflake")]
             Self::Snowflake(destination) => {
                 destination
@@ -686,6 +777,8 @@ impl Destination for BenchDestination {
             Self::Null(destination) => destination.write_events(events, async_result).await,
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => destination.write_events(events, async_result).await,
+            #[cfg(feature = "clickhouse")]
+            Self::ClickHouse(destination) => destination.write_events(events, async_result).await,
             #[cfg(feature = "snowflake")]
             Self::Snowflake(destination) => destination.write_events(events, async_result).await,
         }
@@ -990,7 +1083,7 @@ async fn drop_replication_slot(pool: &PgPool, slot_name: &str) {
     .await;
 }
 
-#[cfg(any(feature = "bigquery", feature = "snowflake"))]
+#[cfg(any(feature = "bigquery", feature = "clickhouse", feature = "snowflake"))]
 fn install_crypto_provider() {
     INIT_CRYPTO.call_once(|| {
         rustls::crypto::aws_lc_rs::default_provider()

--- a/crates/etl-benchmarks/src/table_copy.rs
+++ b/crates/etl-benchmarks/src/table_copy.rs
@@ -231,6 +231,7 @@ fn destination_label(destination: DestinationType) -> &'static str {
     match destination {
         DestinationType::Null => "null",
         DestinationType::BigQuery => "bigquery",
+        DestinationType::ClickHouse => "clickhouse",
         DestinationType::Snowflake => "snowflake",
     }
 }

--- a/crates/etl-benchmarks/src/table_streaming.rs
+++ b/crates/etl-benchmarks/src/table_streaming.rs
@@ -319,6 +319,7 @@ fn destination_label(destination: DestinationType) -> &'static str {
     match destination {
         DestinationType::Null => "null",
         DestinationType::BigQuery => "bigquery",
+        DestinationType::ClickHouse => "clickhouse",
         DestinationType::Snowflake => "snowflake",
     }
 }

--- a/crates/etl-maintenance/src/ducklake/runner.rs
+++ b/crates/etl-maintenance/src/ducklake/runner.rs
@@ -2509,9 +2509,15 @@ mod tests {
     async fn maintenance_executor_timeout_releases_resources_for_follow_up_queries() {
         let executor = make_maintenance_test_executor();
 
+        // Run a long DuckDB query so the watchdog's interrupt handle aborts it
+        // at the deadline. This avoids racing `thread::sleep` against the
+        // watchdog's scheduler time, which was flaky under CI load.
         let error = executor
-            .run_with_timeout(Duration::from_millis(50), |_conn| -> EtlResult<()> {
-                std::thread::sleep(Duration::from_millis(100));
+            .run_with_timeout(Duration::from_millis(50), |conn| -> EtlResult<()> {
+                let _ =
+                    conn.query_row("SELECT COUNT(*) FROM range(0, 10_000_000_000)", [], |row| {
+                        row.get::<_, i64>(0)
+                    });
                 Ok(())
             })
             .await

--- a/crates/xtask/src/commands/benchmark.rs
+++ b/crates/xtask/src/commands/benchmark.rs
@@ -76,6 +76,18 @@ pub(crate) struct BenchmarkArgs {
     /// BigQuery service account key file.
     #[arg(long, env = "BQ_SA_KEY_FILE")]
     bq_sa_key_file: Option<PathBuf>,
+    /// ClickHouse HTTP URL (for example, `http://localhost:8123`).
+    #[arg(long, env = "BENCH_CLICKHOUSE_URL")]
+    clickhouse_url: Option<String>,
+    /// ClickHouse username.
+    #[arg(long, env = "BENCH_CLICKHOUSE_USER")]
+    clickhouse_user: Option<String>,
+    /// ClickHouse password.
+    #[arg(long, env = "BENCH_CLICKHOUSE_PASSWORD")]
+    clickhouse_password: Option<String>,
+    /// ClickHouse database. Must already exist.
+    #[arg(long, env = "BENCH_CLICKHOUSE_DATABASE")]
+    clickhouse_database: Option<String>,
     /// Snowflake account identifier.
     #[arg(long, env = "BENCH_SNOWFLAKE_ACCOUNT")]
     sf_account: Option<String>,
@@ -134,6 +146,8 @@ enum Destination {
     Null,
     #[value(name = "bigquery")]
     BigQuery,
+    #[value(name = "clickhouse")]
+    ClickHouse,
     #[value(name = "snowflake")]
     Snowflake,
 }
@@ -271,6 +285,20 @@ impl BenchmarkArgs {
                     "BigQuery service account key file does not exist: {}",
                     sa_key_file.display()
                 );
+            }
+        }
+
+        if matches!(self.destination, Destination::ClickHouse) {
+            if self.clickhouse_url.as_deref().is_none_or(|u| u.trim().is_empty()) {
+                bail!("--clickhouse-url is required for --destination clickhouse");
+            }
+
+            if self.clickhouse_user.as_deref().is_none_or(|u| u.trim().is_empty()) {
+                bail!("--clickhouse-user is required for --destination clickhouse");
+            }
+
+            if self.clickhouse_database.as_deref().is_none_or(|d| d.trim().is_empty()) {
+                bail!("--clickhouse-database is required for --destination clickhouse");
             }
         }
 
@@ -711,6 +739,23 @@ impl BenchmarkArgs {
                     args.extend(["--bq-sa-key-file".to_owned(), sa_key_file.display().to_string()]);
                 }
             }
+            Destination::ClickHouse => {
+                if let Some(url) = &self.clickhouse_url {
+                    args.extend(["--clickhouse-url".to_owned(), url.clone()]);
+                }
+
+                if let Some(user) = &self.clickhouse_user {
+                    args.extend(["--clickhouse-user".to_owned(), user.clone()]);
+                }
+
+                if let Some(password) = &self.clickhouse_password {
+                    args.extend(["--clickhouse-password".to_owned(), password.clone()]);
+                }
+
+                if let Some(database) = &self.clickhouse_database {
+                    args.extend(["--clickhouse-database".to_owned(), database.clone()]);
+                }
+            }
             Destination::Snowflake => {
                 if let Some(account) = &self.sf_account {
                     args.extend(["--sf-account".to_owned(), account.clone()]);
@@ -795,6 +840,7 @@ impl Destination {
         match self {
             Self::Null => "null",
             Self::BigQuery => "bigquery",
+            Self::ClickHouse => "clickhouse",
             Self::Snowflake => "snowflake",
         }
     }
@@ -1148,11 +1194,8 @@ fn run_benchmark_binary(
 ) -> Result<Value> {
     let mut command = Command::new("cargo");
     command.args(["run", "--quiet", "-p", "etl-benchmarks", "--release"]);
-    if matches!(destination, Destination::BigQuery) {
-        command.args(["--features", "bigquery"]);
-    }
-    if matches!(destination, Destination::Snowflake) {
-        command.args(["--features", "snowflake"]);
+    if !matches!(destination, Destination::Null) {
+        command.args(["--features", destination.as_arg()]);
     }
     command.args(["--bin", binary_name, "--"]).args(binary_args);
 


### PR DESCRIPTION
Add ClickHouse as a benchmark destination alongside bigquery and snowflake. Mirrors the snowflake wiring: feature flag, DestinationType variant, BenchDestination arm, xtask clap fields with BENCH_CLICKHOUSE_* env fallbacks, and a workflow_dispatch path that boots the local clickhouse compose service before running.