### PR TITLE
feat(xtask): snowflake test script

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,10 +5,11 @@ test-threads = "num-cpus"
 # All tests that share the source Postgres cluster must run serially. Separate
 # nextest test groups do not serialize against each other, so cluster-wide
 # setting tests, etl replication tests, and PG-backed destination tests all
-# share one group. Local-only destination tests stay parallel.
+# share one group. Destination tests that do not use source Postgres stay
+# parallel.
 [test-groups.shared-pg]
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = "test(exclusive_) | binary_id(etl::main) | (binary_id(etl-destinations::main) & test(/^(bigquery|clickhouse|ducklake|iceberg|snowflake)::/)) | (binary_id(etl-destinations) & test(/ducklake::core::tests::postgres_backed::/))"
+filter = "test(exclusive_) | binary_id(etl::main) | (binary_id(etl-destinations::main) & test(/^(bigquery|clickhouse|ducklake|iceberg)::/)) | (binary_id(etl-destinations) & test(/ducklake::core::tests::postgres_backed::/))"
 test-group = "shared-pg"

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,8 @@ export TESTS_CLICKHOUSE_PASSWORD=
 # Snowflake (required for ignored Snowflake integration tests)
 #
 # These tests are #[ignore]'d by default and require real Snowflake credentials.
-# Run them with: cargo test -p etl-destinations --features snowflake -- --ignored
+# Run the full suite with: cargo x test-snowflake
+# Or run destination tests directly: cargo test -p etl-destinations --features snowflake,test-utils -- --ignored
 #
 # ACCOUNT: Your Snowflake account identifier in ORG-ACCOUNT format.
 #   Find it in the Snowflake UI (bottom-left account selector), or run:

--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,8 @@ export TESTS_CLICKHOUSE_PASSWORD=
 #
 # These tests are #[ignore]'d by default and require real Snowflake credentials.
 # Run the full suite with: cargo x test-snowflake
-# Or run destination tests directly: cargo test -p etl-destinations --features snowflake,test-utils -- --ignored
+# Or run destination tests directly:
+#   cargo test -p etl-destinations --no-default-features --features snowflake,test-utils -- --ignored
 #
 # ACCOUNT: Your Snowflake account identifier in ORG-ACCOUNT format.
 #   Find it in the Snowflake UI (bottom-left account selector), or run:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,6 +56,7 @@ cargo x init             # set up local dev environment
 cargo x migrate          # run database migrations
 cargo x deploy-local     # deploy replicator to local OrbStack k8s
 cargo x test-clickhouse  # run ClickHouse integration tests
+cargo x test-snowflake   # run Snowflake tests
 cargo x vendor-duckdb    # download and vendor DuckDB extensions
 ```
 

--- a/crates/etl-destinations/src/snowflake/README.md
+++ b/crates/etl-destinations/src/snowflake/README.md
@@ -2,27 +2,23 @@
 
 ## Running Integration Tests
 
-Snowflake integration tests are marked `#[ignore]` because they require a real Snowflake account.
-
-To run them:
-
-1. Copy the example env file and fill in your Snowflake credentials (see variables below):
+The easiest way to run the full Snowflake test suite (API tests, validator integration, and
+destination integration) is a single xtask command:
 
 ```bash
-cp .env.example .env
-# edit .env with your values
+cargo x test-snowflake
 ```
 
-2. Source the file and run tests:
+This requires local Postgres to already be running. Run `cargo x init` first if the local
+development stack is not up. The command runs API-level Snowflake tests that do not require
+credentials, then runs the credentialed integration tiers when `TESTS_SNOWFLAKE_ACCOUNT`,
+`TESTS_SNOWFLAKE_USER`, and `TESTS_SNOWFLAKE_PRIVATE_KEY_PATH` are set. See `.env.example` for
+setup instructions. Use `--no-credentials` to run only the non-credentialed tier.
+
+To run a specific destination test directly:
 
 ```bash
 source .env
-cargo test -p etl-destinations --features snowflake,test-utils -- --ignored
-```
-
-To run a specific test:
-
-```bash
 cargo test -p etl-destinations --features snowflake,test-utils -- --ignored authenticate_against_snowflake
 ```
 

--- a/crates/etl-destinations/src/snowflake/README.md
+++ b/crates/etl-destinations/src/snowflake/README.md
@@ -10,8 +10,8 @@ cargo x test-snowflake
 ```
 
 This requires local Postgres to already be running. Run `cargo x init` first if the local
-development stack is not up. The command runs API-level Snowflake tests that do not require
-credentials, then runs the credentialed integration tiers when `TESTS_SNOWFLAKE_ACCOUNT`,
+development stack is not up. The command first runs the non-credentialed Snowflake destination
+preset, then runs the credentialed integration tiers when `TESTS_SNOWFLAKE_ACCOUNT`,
 `TESTS_SNOWFLAKE_USER`, and `TESTS_SNOWFLAKE_PRIVATE_KEY_PATH` are set. See `.env.example` for
 setup instructions. Use `--no-credentials` to run only the non-credentialed tier.
 
@@ -19,7 +19,7 @@ To run a specific destination test directly:
 
 ```bash
 source .env
-cargo test -p etl-destinations --features snowflake,test-utils -- --ignored authenticate_against_snowflake
+cargo test -p etl-destinations --no-default-features --features snowflake,test-utils -- --ignored authenticate_against_snowflake
 ```
 
 ### Environment Variables

--- a/crates/etl-destinations/tests/snowflake/common.rs
+++ b/crates/etl-destinations/tests/snowflake/common.rs
@@ -49,8 +49,11 @@ where
     T: etl_destinations::snowflake::TokenProvider + 'static,
     C: StreamClient,
 {
-    for _ in 0..max_attempts {
-        tokio::time::sleep(interval).await;
+    for attempt in 0..max_attempts {
+        if attempt > 0 {
+            tokio::time::sleep(interval).await;
+        }
+
         if let Ok(Some(offset)) = destination.committed_offset(table_id).await
             && &offset == expected
         {

--- a/crates/etl-destinations/tests/snowflake/destination.rs
+++ b/crates/etl-destinations/tests/snowflake/destination.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use etl::{
     state::destination_table_metadata::DestinationTableMetadata,
@@ -17,6 +17,9 @@ use etl_destinations::snowflake::{
 };
 
 use super::common::{build_auth, poll_destination_offset, with_table_cleanup};
+
+const DESTINATION_OFFSET_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const DESTINATION_OFFSET_MAX_ATTEMPTS: usize = 90;
 
 struct TestHarness {
     destination: Destination<
@@ -60,8 +63,8 @@ async fn poll_and_query_rows(
         &harness.destination,
         table_id,
         expected_offset,
-        std::time::Duration::from_secs(5),
-        18,
+        DESTINATION_OFFSET_POLL_INTERVAL,
+        DESTINATION_OFFSET_MAX_ATTEMPTS,
     )
     .await;
     assert_eq!(
@@ -341,8 +344,8 @@ async fn schema_evolution_add_column() {
             &harness.destination,
             table_id,
             &zero,
-            std::time::Duration::from_secs(5),
-            18,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
         assert!(committed.is_some(), "initial data should commit before DDL");
@@ -386,8 +389,8 @@ async fn schema_evolution_add_column() {
             &harness.destination,
             table_id,
             &expected_offset,
-            std::time::Duration::from_secs(5),
-            18,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
         assert_eq!(committed, Some(expected_offset), "data should commit within 90s");
@@ -464,8 +467,8 @@ async fn schema_evolution_rename_column() {
             &harness.destination,
             table_id,
             &zero,
-            std::time::Duration::from_secs(5),
-            18,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
         assert!(committed.is_some(), "initial data should commit before DDL");
@@ -505,8 +508,8 @@ async fn schema_evolution_rename_column() {
             &harness.destination,
             table_id,
             &expected_offset,
-            std::time::Duration::from_secs(5),
-            18,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
         assert_eq!(committed, Some(expected_offset), "data should commit within 90s");
@@ -596,8 +599,8 @@ async fn schema_evolution_drop_column() {
             &harness.destination,
             table_id,
             &zero,
-            std::time::Duration::from_secs(5),
-            18,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
         assert!(committed.is_some(), "initial data should commit before DDL");
@@ -637,8 +640,8 @@ async fn schema_evolution_drop_column() {
             &harness.destination,
             table_id,
             &expected_offset,
-            std::time::Duration::from_secs(5),
-            18,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
         assert_eq!(committed, Some(expected_offset), "data should commit within 90s");
@@ -735,8 +738,8 @@ async fn schema_evolution_interleaved_ddl_dml() {
                 &harness.destination,
                 table_id,
                 &expected,
-                std::time::Duration::from_secs(5),
-                18,
+                DESTINATION_OFFSET_POLL_INTERVAL,
+                DESTINATION_OFFSET_MAX_ATTEMPTS,
             )
             .await;
             assert_eq!(committed, Some(expected), "data should commit before next DDL");
@@ -760,8 +763,8 @@ async fn schema_evolution_interleaved_ddl_dml() {
             &harness.destination,
             table_id,
             &zero,
-            std::time::Duration::from_secs(5),
-            18,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
         assert!(committed.is_some(), "initial data should commit before DDL");

--- a/crates/xtask/src/commands/mod.rs
+++ b/crates/xtask/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod rotate_encryption_key;
 mod seed;
 mod test;
 mod test_clickhouse;
+mod test_snowflake;
 mod vendor_duckdb;
 
 pub(crate) use benchmark::BenchmarkArgs;
@@ -34,4 +35,5 @@ pub(crate) use rotate_encryption_key::RotateEncryptionKeyArgs;
 pub(crate) use seed::SeedArgs;
 pub(crate) use test::TestArgs;
 pub(crate) use test_clickhouse::TestClickhouseArgs;
+pub(crate) use test_snowflake::TestSnowflakeArgs;
 pub(crate) use vendor_duckdb::VendorDuckdbArgs;

--- a/crates/xtask/src/commands/nextest.rs
+++ b/crates/xtask/src/commands/nextest.rs
@@ -15,7 +15,7 @@ use crate::utils::{DEFAULT_BASE_PORT, DEFAULT_PG_SHARD_COUNT, READ_REPLICA_PORT_
 /// `.config/nextest.toml`.
 const SHARED_PG_FILTER: &str = "\
     test(exclusive_) | binary_id(etl::main) | (binary_id(etl-destinations::main) & \
-                                test(/^(bigquery|clickhouse|ducklake|iceberg|snowflake)::/)) | \
+                                test(/^(bigquery|clickhouse|ducklake|iceberg)::/)) | \
                                 (binary_id(etl-destinations) & \
                                 test(/ducklake::core::tests::postgres_backed::/))";
 

--- a/crates/xtask/src/commands/test_snowflake.rs
+++ b/crates/xtask/src/commands/test_snowflake.rs
@@ -2,9 +2,12 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
-use xshell::{Shell, cmd};
+use xshell::{Cmd, Shell, cmd};
 
-use crate::utils::{DEFAULT_BASE_PORT, maybe_with_sccache};
+use crate::utils::{
+    CargoFeatureSelection, DEFAULT_BASE_PORT, DefaultFeatureBehavior, DestinationPreset,
+    maybe_with_sccache,
+};
 
 const GREEN: &str = "\x1b[32m";
 const YELLOW: &str = "\x1b[33m";
@@ -26,20 +29,17 @@ impl TestSnowflakeArgs {
         let sh = Shell::new()?;
 
         let sccache = self.sccache;
-        let db_host = env_or("TESTS_DATABASE_HOST", "localhost");
-        let db_port = env_or("TESTS_DATABASE_PORT", &DEFAULT_BASE_PORT.to_string());
-        let db_user = env_or("TESTS_DATABASE_USERNAME", "postgres");
-        let db_pass = env_or("TESTS_DATABASE_PASSWORD", "postgres");
+        let pg_env = PgEnv::from_env();
 
-        check_postgres_ready(&db_host, &db_port, &db_user)?;
+        check_postgres_ready(&pg_env.host, &pg_env.port, &pg_env.username)?;
 
-        eprintln!("{GREEN}🧪 running Snowflake API tests (no credentials needed).{RESET}");
-        maybe_with_sccache(cmd!(sh, "cargo test -p etl-api -- snowflake"), sccache)
-            .env("TESTS_DATABASE_HOST", &db_host)
-            .env("TESTS_DATABASE_PORT", &db_port)
-            .env("TESTS_DATABASE_USERNAME", &db_user)
-            .env("TESTS_DATABASE_PASSWORD", &db_pass)
-            .run()?;
+        eprintln!(
+            "{GREEN}🧪 running Snowflake destination preset tests (no credentials needed).{RESET}"
+        );
+        let tests = CargoFeatureSelection::for_destination(Some(DestinationPreset::Snowflake))
+            .apply_to(cmd!(sh, "cargo nextest run --no-fail-fast"), DefaultFeatureBehavior::All)
+            .arg("snowflake");
+        with_pg_env(maybe_with_sccache(tests, sccache), &pg_env).run()?;
 
         if self.no_credentials {
             eprintln!("{YELLOW}⏭ skipping Snowflake credentialed tests (--no-credentials).{RESET}");
@@ -71,35 +71,67 @@ impl TestSnowflakeArgs {
             );
         }
 
-        eprintln!("{GREEN}🔑 running Snowflake API validator integration tests.{RESET}");
-        maybe_with_sccache(
-            cmd!(sh, "cargo test -p etl-api -- snowflake --ignored --nocapture --test-threads=1"),
-            sccache,
+        eprintln!(
+            "{GREEN}🔑 running Snowflake API validator integration tests sequentially.{RESET}"
+        );
+        let tests = CargoFeatureSelection::new(
+            true,
+            vec!["snowflake".to_owned()],
+            vec!["etl-api".to_owned()],
         )
-        .env("TESTS_DATABASE_HOST", &db_host)
-        .env("TESTS_DATABASE_PORT", &db_port)
-        .env("TESTS_DATABASE_USERNAME", &db_user)
-        .env("TESTS_DATABASE_PASSWORD", &db_pass)
-        .run()?;
+        .apply_to(
+            cmd!(sh, "cargo nextest run --no-fail-fast --run-ignored only --test-threads 1"),
+            DefaultFeatureBehavior::CargoDefault,
+        )
+        .arg("snowflake");
+        with_pg_env(maybe_with_sccache(tests, sccache), &pg_env).run()?;
 
-        eprintln!("{GREEN}❄️  running Snowflake destination integration tests.{RESET}");
-        maybe_with_sccache(
-            cmd!(sh, "cargo test -p etl-destinations --features snowflake,test-utils --test main"),
-            sccache,
+        eprintln!(
+            "{GREEN}❄️  running Snowflake destination integration tests sequentially.{RESET}"
+        );
+        let tests = CargoFeatureSelection::new(
+            true,
+            vec!["snowflake".to_owned(), "test-utils".to_owned()],
+            vec!["etl-destinations".to_owned()],
         )
-        .args(["--", "snowflake", "--ignored", "--nocapture", "--test-threads=1"])
-        .env("TESTS_DATABASE_HOST", &db_host)
-        .env("TESTS_DATABASE_PORT", &db_port)
-        .env("TESTS_DATABASE_USERNAME", &db_user)
-        .env("TESTS_DATABASE_PASSWORD", &db_pass)
-        .run()?;
+        .apply_to(
+            cmd!(sh, "cargo nextest run --no-fail-fast --run-ignored only --test-threads 1"),
+            DefaultFeatureBehavior::CargoDefault,
+        )
+        .arg("snowflake");
+        with_pg_env(maybe_with_sccache(tests, sccache), &pg_env).run()?;
 
         Ok(())
     }
 }
 
+struct PgEnv {
+    host: String,
+    port: String,
+    username: String,
+    password: String,
+}
+
+impl PgEnv {
+    fn from_env() -> Self {
+        Self {
+            host: env_or("TESTS_DATABASE_HOST", "localhost"),
+            port: env_or("TESTS_DATABASE_PORT", &DEFAULT_BASE_PORT.to_string()),
+            username: env_or("TESTS_DATABASE_USERNAME", "postgres"),
+            password: env_or("TESTS_DATABASE_PASSWORD", "postgres"),
+        }
+    }
+}
+
 fn env_or(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+fn with_pg_env<'a>(cmd: Cmd<'a>, pg_env: &PgEnv) -> Cmd<'a> {
+    cmd.env("TESTS_DATABASE_HOST", &pg_env.host)
+        .env("TESTS_DATABASE_PORT", &pg_env.port)
+        .env("TESTS_DATABASE_USERNAME", &pg_env.username)
+        .env("TESTS_DATABASE_PASSWORD", &pg_env.password)
 }
 
 fn check_postgres_ready(host: &str, port: &str, user: &str) -> Result<()> {

--- a/crates/xtask/src/commands/test_snowflake.rs
+++ b/crates/xtask/src/commands/test_snowflake.rs
@@ -71,31 +71,27 @@ impl TestSnowflakeArgs {
             );
         }
 
-        eprintln!(
-            "{GREEN}🔑 running Snowflake API validator integration tests sequentially.{RESET}"
-        );
+        eprintln!("{GREEN}🔑 running Snowflake API validator integration tests.{RESET}");
         let tests = CargoFeatureSelection::new(
             true,
             vec!["snowflake".to_owned()],
             vec!["etl-api".to_owned()],
         )
         .apply_to(
-            cmd!(sh, "cargo nextest run --no-fail-fast --run-ignored only --test-threads 1"),
+            cmd!(sh, "cargo nextest run --no-fail-fast --run-ignored only"),
             DefaultFeatureBehavior::CargoDefault,
         )
         .arg("snowflake");
         with_pg_env(maybe_with_sccache(tests, sccache), &pg_env).run()?;
 
-        eprintln!(
-            "{GREEN}❄️  running Snowflake destination integration tests sequentially.{RESET}"
-        );
+        eprintln!("{GREEN}❄️  running Snowflake destination integration tests.{RESET}");
         let tests = CargoFeatureSelection::new(
             true,
             vec!["snowflake".to_owned(), "test-utils".to_owned()],
             vec!["etl-destinations".to_owned()],
         )
         .apply_to(
-            cmd!(sh, "cargo nextest run --no-fail-fast --run-ignored only --test-threads 1"),
+            cmd!(sh, "cargo nextest run --no-fail-fast --run-ignored only"),
             DefaultFeatureBehavior::CargoDefault,
         )
         .arg("snowflake");

--- a/crates/xtask/src/commands/test_snowflake.rs
+++ b/crates/xtask/src/commands/test_snowflake.rs
@@ -1,0 +1,117 @@
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use xshell::{Shell, cmd};
+
+use crate::utils::{DEFAULT_BASE_PORT, maybe_with_sccache};
+
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const RESET: &str = "\x1b[0m";
+
+#[derive(Args)]
+pub(crate) struct TestSnowflakeArgs {
+    /// Run only tests that do not require Snowflake credentials.
+    #[arg(long)]
+    no_credentials: bool,
+
+    /// Enable sccache for cargo builds (also enabled by ETL_SCCACHE=1).
+    #[arg(long)]
+    sccache: bool,
+}
+
+impl TestSnowflakeArgs {
+    pub(crate) fn run(self) -> Result<()> {
+        let sh = Shell::new()?;
+
+        let sccache = self.sccache;
+        let db_host = env_or("TESTS_DATABASE_HOST", "localhost");
+        let db_port = env_or("TESTS_DATABASE_PORT", &DEFAULT_BASE_PORT.to_string());
+        let db_user = env_or("TESTS_DATABASE_USERNAME", "postgres");
+        let db_pass = env_or("TESTS_DATABASE_PASSWORD", "postgres");
+
+        check_postgres_ready(&db_host, &db_port, &db_user)?;
+
+        eprintln!("{GREEN}🧪 running Snowflake API tests (no credentials needed).{RESET}");
+        maybe_with_sccache(cmd!(sh, "cargo test -p etl-api -- snowflake"), sccache)
+            .env("TESTS_DATABASE_HOST", &db_host)
+            .env("TESTS_DATABASE_PORT", &db_port)
+            .env("TESTS_DATABASE_USERNAME", &db_user)
+            .env("TESTS_DATABASE_PASSWORD", &db_pass)
+            .run()?;
+
+        if self.no_credentials {
+            eprintln!("{YELLOW}⏭ skipping Snowflake credentialed tests (--no-credentials).{RESET}");
+            return Ok(());
+        }
+
+        let has_account =
+            std::env::var("TESTS_SNOWFLAKE_ACCOUNT").ok().filter(|s| !s.is_empty()).is_some();
+        let has_user =
+            std::env::var("TESTS_SNOWFLAKE_USER").ok().filter(|s| !s.is_empty()).is_some();
+        let key_path =
+            std::env::var("TESTS_SNOWFLAKE_PRIVATE_KEY_PATH").ok().filter(|s| !s.is_empty());
+
+        if !has_account || !has_user || key_path.is_none() {
+            eprintln!(
+                "{YELLOW}⏭ skipping Snowflake credentialed tests: one or more of \
+                 TESTS_SNOWFLAKE_ACCOUNT, TESTS_SNOWFLAKE_USER, TESTS_SNOWFLAKE_PRIVATE_KEY_PATH \
+                 is missing.\n   See .env.example and \
+                 crates/etl-destinations/src/snowflake/README.md for setup instructions.{RESET}"
+            );
+            return Ok(());
+        }
+
+        let key_path = key_path.unwrap();
+        if std::fs::File::open(&key_path).is_err() {
+            bail!(
+                "TESTS_SNOWFLAKE_PRIVATE_KEY_PATH={key_path} is not readable. Check that the file \
+                 exists and has correct permissions."
+            );
+        }
+
+        eprintln!("{GREEN}🔑 running Snowflake API validator integration tests.{RESET}");
+        maybe_with_sccache(
+            cmd!(sh, "cargo test -p etl-api -- snowflake --ignored --nocapture --test-threads=1"),
+            sccache,
+        )
+        .env("TESTS_DATABASE_HOST", &db_host)
+        .env("TESTS_DATABASE_PORT", &db_port)
+        .env("TESTS_DATABASE_USERNAME", &db_user)
+        .env("TESTS_DATABASE_PASSWORD", &db_pass)
+        .run()?;
+
+        eprintln!("{GREEN}❄️  running Snowflake destination integration tests.{RESET}");
+        maybe_with_sccache(
+            cmd!(sh, "cargo test -p etl-destinations --features snowflake,test-utils --test main"),
+            sccache,
+        )
+        .args(["--", "snowflake", "--ignored", "--nocapture", "--test-threads=1"])
+        .env("TESTS_DATABASE_HOST", &db_host)
+        .env("TESTS_DATABASE_PORT", &db_port)
+        .env("TESTS_DATABASE_USERNAME", &db_user)
+        .env("TESTS_DATABASE_PASSWORD", &db_pass)
+        .run()?;
+
+        Ok(())
+    }
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+fn check_postgres_ready(host: &str, port: &str, user: &str) -> Result<()> {
+    let status = Command::new("pg_isready")
+        .args(["-h", host, "-p", port, "-U", user])
+        .stdout(Stdio::null())
+        .status()
+        .context("failed to run pg_isready -- is it installed?")?;
+
+    if !status.success() {
+        bail!("local Postgres is not ready on {host}:{port}; run \"cargo x init\" first.");
+    }
+
+    Ok(())
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,7 +6,8 @@ use clap::{Parser, Subcommand};
 use commands::{
     BenchmarkArgs, BenchmarkCompareArgs, ChaosArgs, CheckArgs, DeployLocalArgs, ExampleArgs,
     FixArgs, FmtArgs, InitArgs, MigrateArgs, MsrvArgs, NextestArgs, PostgresArgs,
-    RotateEncryptionKeyArgs, SeedArgs, TestArgs, TestClickhouseArgs, VendorDuckdbArgs,
+    RotateEncryptionKeyArgs, SeedArgs, TestArgs, TestClickhouseArgs, TestSnowflakeArgs,
+    VendorDuckdbArgs,
 };
 
 #[derive(Parser)]
@@ -59,6 +60,10 @@ enum Command {
     /// Run ClickHouse integration tests with a local Docker setup.
     #[command(name = "test-clickhouse")]
     TestClickhouse(TestClickhouseArgs),
+    /// Run Snowflake tests, including integration tests (requiring credentials)
+    /// when configured.
+    #[command(name = "test-snowflake")]
+    TestSnowflake(TestSnowflakeArgs),
     /// Download and vendor DuckDB extensions.
     #[command(name = "vendor-duckdb")]
     VendorDuckdb(VendorDuckdbArgs),
@@ -85,6 +90,7 @@ async fn main() -> Result<()> {
         Command::Seed(cmd) => cmd.run(),
         Command::Test(cmd) => cmd.run(),
         Command::TestClickhouse(cmd) => cmd.run(),
+        Command::TestSnowflake(cmd) => cmd.run(),
         Command::VendorDuckdb(cmd) => cmd.run(),
     }
 }


### PR DESCRIPTION
## Summary

Adds `cargo x test-snowflake`, a single entry point for Snowflake-related tests across `etl-api` and `etl-destinations`.

The command:
- requires local Postgres to already be running, usually via `cargo x init`
- always runs API Snowflake tests that do not require Snowflake credentials
- runs credentialed Snowflake validator and destination integration tests only when required Snowflake env vars are present