### PR TITLE
feat(api): gate destination validators by feature

### DIFF
--- a/crates/etl-api/Cargo.toml
+++ b/crates/etl-api/Cargo.toml
@@ -17,6 +17,14 @@ doctest = false
 path = "src/main.rs"
 name = "etl-api"
 
+[features]
+default = ["bigquery", "clickhouse", "ducklake", "iceberg", "snowflake"]
+bigquery = ["etl-destinations/bigquery"]
+clickhouse = ["etl-destinations/clickhouse"]
+ducklake = ["etl-destinations/ducklake"]
+iceberg = ["etl-destinations/iceberg"]
+snowflake = ["etl-destinations/snowflake"]
+
 [dependencies]
 
 anyhow = { workspace = true, features = ["std"] }
@@ -29,22 +37,16 @@ configcat = { workspace = true }
 constant_time_eq = { workspace = true }
 etl = { workspace = true }
 etl-config = { workspace = true, features = ["utoipa", "supabase"] }
-etl-destinations = { workspace = true, features = [
-  "bigquery",
-  "clickhouse",
-  "ducklake",
-  "iceberg",
-  "snowflake",
-] }
+etl-destinations = { workspace = true }
 etl-maintenance = { workspace = true }
 etl-postgres = { workspace = true, features = ["replication"] }
 etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 kube = { workspace = true, features = [
-  "runtime",
-  "derive",
-  "client",
-  "rustls-tls",
+    "runtime",
+    "derive",
+    "client",
+    "rustls-tls",
 ] }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
@@ -56,12 +58,12 @@ sentry = { workspace = true, features = ["tower-http", "tower-axum-matched-path"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 sqlx = { workspace = true, features = [
-  "runtime-tokio",
-  "tls-rustls",
-  "macros",
-  "postgres",
-  "json",
-  "migrate",
+    "runtime-tokio",
+    "tls-rustls",
+    "macros",
+    "postgres",
+    "json",
+    "migrate",
 ] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
@@ -73,14 +75,7 @@ utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 
 [dev-dependencies]
-etl-destinations = { workspace = true, features = [
-  "test-utils",
-  "bigquery",
-  "clickhouse",
-  "ducklake",
-  "iceberg",
-  "snowflake",
-] }
+etl-destinations = { workspace = true, features = ["test-utils"] }
 etl-postgres = { workspace = true, features = ["test-utils", "sqlx"] }
 
 insta = { workspace = true, features = ["json", "redactions"] }

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -146,7 +146,6 @@ mod ducklake {
             s3_url_style,
             s3_use_ssl,
             metadata_schema,
-            duckdb_memory_cache_limit,
             maintenance_target_file_size,
             expire_snapshots_older_than,
             maintenance_mode: _,
@@ -166,7 +165,6 @@ mod ducklake {
             s3_url_style.clone(),
             *s3_use_ssl,
             metadata_schema.clone(),
-            duckdb_memory_cache_limit.clone(),
             maintenance_target_file_size.clone(),
             expire_snapshots_older_than.clone(),
         )

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -1,0 +1,239 @@
+//! Destination validation dispatch.
+
+use async_trait::async_trait;
+
+use super::super::{ValidationContext, ValidationError, ValidationFailure, Validator};
+use crate::configs::destination::FullApiDestinationConfig;
+
+/// Composite validator for destination prerequisites.
+#[derive(Debug)]
+pub(in crate::validation) struct DestinationValidator {
+    config: FullApiDestinationConfig,
+}
+
+impl DestinationValidator {
+    /// Creates a destination validator for the provided configuration.
+    pub(in crate::validation) fn new(config: FullApiDestinationConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl Validator for DestinationValidator {
+    async fn validate(
+        &self,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        match &self.config {
+            FullApiDestinationConfig::BigQuery { .. } => {
+                bigquery::validate(&self.config, ctx).await
+            }
+            FullApiDestinationConfig::ClickHouse { .. } => {
+                clickhouse::validate(&self.config, ctx).await
+            }
+            FullApiDestinationConfig::Iceberg { .. } => iceberg::validate(&self.config, ctx).await,
+            FullApiDestinationConfig::Ducklake { .. } => {
+                ducklake::validate(&self.config, ctx).await
+            }
+            FullApiDestinationConfig::Snowflake { .. } => {
+                snowflake::validate(&self.config, ctx).await
+            }
+        }
+    }
+}
+
+/// Defines a disabled destination validation adapter module.
+macro_rules! disabled_destination {
+    ($module:ident, $feature:literal, $destination:literal) => {
+        /// Disabled destination validation adapter.
+        #[cfg(not(feature = $feature))]
+        mod $module {
+            use super::{
+                FullApiDestinationConfig, ValidationContext, ValidationError, ValidationFailure,
+            };
+
+            /// Returns a validation failure for disabled destination support.
+            pub(super) fn validate(
+                _config: &FullApiDestinationConfig,
+                _ctx: &ValidationContext,
+            ) -> std::future::Ready<Result<Vec<ValidationFailure>, ValidationError>> {
+                std::future::ready(Ok(vec![ValidationFailure::critical(
+                    format!("{} Backend Disabled", $destination),
+                    format!("{} support is not compiled into this API binary.", $destination),
+                )]))
+            }
+        }
+    };
+}
+
+/// BigQuery validation adapter.
+#[cfg(feature = "bigquery")]
+mod bigquery {
+    use secrecy::ExposeSecret;
+
+    use super::{FullApiDestinationConfig, ValidationContext, ValidationError, ValidationFailure};
+    use crate::validation::{Validator, validators::bigquery::BigQueryValidator};
+
+    /// Validates a BigQuery destination configuration.
+    pub(super) async fn validate(
+        config: &FullApiDestinationConfig,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let FullApiDestinationConfig::BigQuery {
+            project_id, dataset_id, service_account_key, ..
+        } = config
+        else {
+            unreachable!("Destination config should match BigQuery.");
+        };
+
+        BigQueryValidator::new(
+            project_id.clone(),
+            dataset_id.clone(),
+            service_account_key.expose_secret().to_owned(),
+        )
+        .validate(ctx)
+        .await
+    }
+}
+
+disabled_destination!(bigquery, "bigquery", "BigQuery");
+
+/// ClickHouse validation adapter.
+#[cfg(feature = "clickhouse")]
+mod clickhouse {
+    use super::{FullApiDestinationConfig, ValidationContext, ValidationError, ValidationFailure};
+    use crate::validation::{Validator, validators::clickhouse::ClickHouseValidator};
+
+    /// Validates a ClickHouse destination configuration.
+    pub(super) async fn validate(
+        config: &FullApiDestinationConfig,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let FullApiDestinationConfig::ClickHouse { url, user, password, database, .. } = config
+        else {
+            unreachable!("Destination config should match ClickHouse.");
+        };
+
+        ClickHouseValidator::new(url.clone(), user.clone(), password.clone(), database.clone())
+            .validate(ctx)
+            .await
+    }
+}
+
+disabled_destination!(clickhouse, "clickhouse", "ClickHouse");
+
+/// DuckLake validation adapter.
+#[cfg(feature = "ducklake")]
+mod ducklake {
+    use secrecy::ExposeSecret;
+
+    use super::{FullApiDestinationConfig, ValidationContext, ValidationError, ValidationFailure};
+    use crate::validation::{Validator, validators::ducklake::DucklakeValidator};
+
+    /// Validates a DuckLake destination configuration.
+    pub(super) async fn validate(
+        config: &FullApiDestinationConfig,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let FullApiDestinationConfig::Ducklake {
+            catalog_url,
+            data_path,
+            pool_size,
+            s3_access_key_id,
+            s3_secret_access_key,
+            s3_region,
+            s3_endpoint,
+            s3_url_style,
+            s3_use_ssl,
+            metadata_schema,
+            duckdb_memory_cache_limit,
+            maintenance_target_file_size,
+            expire_snapshots_older_than,
+            maintenance_mode: _,
+        } = config
+        else {
+            unreachable!("Destination config should match DuckLake.");
+        };
+
+        DucklakeValidator::new(
+            catalog_url.expose_secret().to_owned(),
+            data_path.clone(),
+            pool_size.unwrap_or(etl_config::shared::DestinationConfig::DEFAULT_DUCKLAKE_POOL_SIZE),
+            s3_access_key_id.as_ref().map(|value| value.expose_secret().to_owned()),
+            s3_secret_access_key.as_ref().map(|value| value.expose_secret().to_owned()),
+            s3_region.clone(),
+            s3_endpoint.clone(),
+            s3_url_style.clone(),
+            *s3_use_ssl,
+            metadata_schema.clone(),
+            duckdb_memory_cache_limit.clone(),
+            maintenance_target_file_size.clone(),
+            expire_snapshots_older_than.clone(),
+        )
+        .validate(ctx)
+        .await
+    }
+}
+
+disabled_destination!(ducklake, "ducklake", "DuckLake");
+
+/// Iceberg validation adapter.
+#[cfg(feature = "iceberg")]
+mod iceberg {
+    use super::{FullApiDestinationConfig, ValidationContext, ValidationError, ValidationFailure};
+    use crate::validation::{Validator, validators::iceberg::IcebergValidator};
+
+    /// Validates an Iceberg destination configuration.
+    pub(super) async fn validate(
+        config: &FullApiDestinationConfig,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let FullApiDestinationConfig::Iceberg { config } = config else {
+            unreachable!("Destination config should match Iceberg.");
+        };
+
+        IcebergValidator::new(config.clone()).validate(ctx).await
+    }
+}
+
+disabled_destination!(iceberg, "iceberg", "Iceberg");
+
+/// Snowflake validation adapter.
+#[cfg(feature = "snowflake")]
+mod snowflake {
+    use super::{FullApiDestinationConfig, ValidationContext, ValidationError, ValidationFailure};
+    use crate::validation::{Validator, validators::snowflake::SnowflakeValidator};
+
+    /// Validates a Snowflake destination configuration.
+    pub(super) async fn validate(
+        config: &FullApiDestinationConfig,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let FullApiDestinationConfig::Snowflake {
+            account_id,
+            user,
+            private_key,
+            private_key_passphrase,
+            database,
+            schema,
+            role,
+        } = config
+        else {
+            unreachable!("Destination config should match Snowflake.");
+        };
+
+        SnowflakeValidator::new(
+            account_id.clone(),
+            user.clone(),
+            private_key.clone(),
+            private_key_passphrase.clone(),
+            database.clone(),
+            schema.clone(),
+            role.clone(),
+        )
+        .validate(ctx)
+        .await
+    }
+}
+
+disabled_destination!(snowflake, "snowflake", "Snowflake");

--- a/crates/etl-api/src/validation/validators/mod.rs
+++ b/crates/etl-api/src/validation/validators/mod.rs
@@ -1,27 +1,28 @@
+#[cfg(feature = "bigquery")]
 mod bigquery;
+#[cfg(feature = "clickhouse")]
 mod clickhouse;
+mod destination;
+#[cfg(feature = "ducklake")]
 mod ducklake;
+#[cfg(feature = "iceberg")]
 mod iceberg;
 mod pipeline;
+#[cfg(feature = "snowflake")]
 mod snowflake;
 mod source;
 
 use async_trait::async_trait;
-use bigquery::BigQueryValidator;
-use clickhouse::ClickHouseValidator;
-use ducklake::DucklakeValidator;
-use iceberg::IcebergValidator;
+pub(super) use destination::DestinationValidator;
 use pipeline::{
     GeneratedColumnsValidator, PrimaryKeysValidator, PublicationExcludesEtlTablesValidator,
     PublicationExistsValidator, PublicationHasTablesValidator, ReplicationPermissionsValidator,
     ReplicationSlotsValidator, WalLevelValidator,
 };
-use secrecy::ExposeSecret;
-use snowflake::SnowflakeValidator;
 pub(super) use source::SourceValidator;
 
 use super::{ValidationContext, ValidationError, ValidationFailure, Validator};
-use crate::configs::{destination::FullApiDestinationConfig, pipeline::FullApiPipelineConfig};
+use crate::configs::pipeline::FullApiPipelineConfig;
 
 /// Composite validator for pipeline prerequisites.
 #[derive(Debug)]
@@ -64,107 +65,5 @@ impl Validator for PipelineValidator {
         }
 
         Ok(failures)
-    }
-}
-
-/// Composite validator for destination prerequisites.
-#[derive(Debug)]
-pub(super) struct DestinationValidator {
-    config: FullApiDestinationConfig,
-}
-
-impl DestinationValidator {
-    pub(super) fn new(config: FullApiDestinationConfig) -> Self {
-        Self { config }
-    }
-}
-
-#[async_trait]
-impl Validator for DestinationValidator {
-    async fn validate(
-        &self,
-        ctx: &ValidationContext,
-    ) -> Result<Vec<ValidationFailure>, ValidationError> {
-        match &self.config {
-            FullApiDestinationConfig::BigQuery {
-                project_id,
-                dataset_id,
-                service_account_key,
-                ..
-            } => {
-                let validator = BigQueryValidator::new(
-                    project_id.clone(),
-                    dataset_id.clone(),
-                    service_account_key.expose_secret().to_owned(),
-                );
-                validator.validate(ctx).await
-            }
-            FullApiDestinationConfig::ClickHouse { url, user, password, database, .. } => {
-                let validator = ClickHouseValidator::new(
-                    url.clone(),
-                    user.clone(),
-                    password.clone(),
-                    database.clone(),
-                );
-                validator.validate(ctx).await
-            }
-            FullApiDestinationConfig::Iceberg { config } => {
-                let validator = IcebergValidator::new(config.clone());
-                validator.validate(ctx).await
-            }
-            FullApiDestinationConfig::Ducklake {
-                catalog_url,
-                data_path,
-                pool_size,
-                s3_access_key_id,
-                s3_secret_access_key,
-                s3_region,
-                s3_endpoint,
-                s3_url_style,
-                s3_use_ssl,
-                metadata_schema,
-                maintenance_target_file_size,
-                expire_snapshots_older_than,
-                maintenance_mode: _,
-            } => {
-                let validator = DucklakeValidator::new(
-                    catalog_url.expose_secret().to_owned(),
-                    data_path.clone(),
-                    pool_size.unwrap_or(
-                        etl_config::shared::DestinationConfig::DEFAULT_DUCKLAKE_POOL_SIZE,
-                    ),
-                    s3_access_key_id.as_ref().map(|value| value.expose_secret().to_owned()),
-                    s3_secret_access_key.as_ref().map(|value| value.expose_secret().to_owned()),
-                    s3_region.clone(),
-                    s3_endpoint.clone(),
-                    s3_url_style.clone(),
-                    *s3_use_ssl,
-                    metadata_schema.clone(),
-                    maintenance_target_file_size.clone(),
-                    expire_snapshots_older_than.clone(),
-                );
-                validator.validate(ctx).await
-            }
-            FullApiDestinationConfig::Snowflake {
-                account_id,
-                user,
-                private_key,
-                private_key_passphrase,
-                database,
-                schema,
-                role,
-            } => {
-                let validator = SnowflakeValidator::new(
-                    account_id.clone(),
-                    user.clone(),
-                    private_key.clone(),
-                    private_key_passphrase.clone(),
-                    database.clone(),
-                    schema.clone(),
-                    role.clone(),
-                );
-                validator.validate(ctx).await
-            }
-        }
     }
 }

--- a/crates/etl-api/tests/validators/mod.rs
+++ b/crates/etl-api/tests/validators/mod.rs
@@ -1,6 +1,9 @@
+#[cfg(feature = "bigquery")]
 mod bigquery;
+#[cfg(feature = "iceberg")]
 mod iceberg;
 mod pipeline;
+#[cfg(feature = "snowflake")]
 mod snowflake;
 
 use etl_api::{configs::pipeline::FullApiPipelineConfig, validation::ValidationContext};
@@ -9,6 +12,7 @@ use etl_postgres::sqlx::test_utils::create_pg_database;
 
 use crate::support::database::get_test_db_config;
 
+#[cfg(any(feature = "bigquery", feature = "iceberg", feature = "snowflake"))]
 pub(super) fn create_validation_context() -> ValidationContext {
     let environment = Environment::load().expect("Failed to load environment");
     ValidationContext::builder(environment).build()

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -135,7 +135,6 @@ zstd = { workspace = true, optional = true }
 base64 = { workspace = true }
 
 chrono = { workspace = true }
-duckdb = { workspace = true, features = ["bundled", "json", "parquet"] }
 etl = { workspace = true, features = ["test-utils"] }
 etl-postgres = { workspace = true, features = ["test-utils", "tokio"] }
 etl-telemetry = { workspace = true }


### PR DESCRIPTION
## Problem

`etl-api` always compiled all destination validators, so working on non-DuckLake destinations could still pull `DuckDB/libduckdb-sys` into the build graph.

## Resolution

- Added destination feature flags to `etl-api`, with defaults preserving current all-destination behavior.
- Moved destination validation dispatch into a feature-gated module.
- Return an explicit validation error when a configured destination is not compiled into the API binary.
- Removed the unconditional DuckDB dev-dependency from `etl-destinations`.

The code delta is mostly moving things around and adding feature flags.

## How Other Destinations Benefit

Destination-specific API checks can now avoid DuckLake entirely:

```sh
cargo check -p etl-api --no-default-features --features snowflake --all-targets
```

And I will amend the `cargo x` commands with some pre-sets in follow-up pr, that will make this easier to type.