### PR TITLE
feat(replicator): feature-gate destinations

### DIFF
--- a/crates/etl-destinations/src/lib.rs
+++ b/crates/etl-destinations/src/lib.rs
@@ -4,9 +4,13 @@
 //! warehouses and analytics platforms, enabling data replication from Postgres
 //! to cloud services.
 
-#[cfg(any(feature = "bigquery", feature = "ducklake", feature = "iceberg", feature = "snowflake"))]
+#[cfg(any(
+    feature = "ducklake",
+    feature = "snowflake",
+    all(feature = "bigquery", feature = "test-utils")
+))]
 mod retry;
-#[cfg(any(feature = "clickhouse", feature = "ducklake", feature = "snowflake"))]
+#[cfg(any(feature = "ducklake", feature = "snowflake"))]
 mod sql;
 #[cfg(any(
     feature = "bigquery",

--- a/crates/etl-replicator/Cargo.toml
+++ b/crates/etl-replicator/Cargo.toml
@@ -7,8 +7,19 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[[bin]]
+name = "etl-ducklake-maintenance"
+path = "src/bin/etl-ducklake-maintenance.rs"
+required-features = ["ducklake"]
+
 [features]
-default = []
+default = ["bigquery", "clickhouse", "ducklake", "iceberg", "snowflake"]
+any-destination = []
+bigquery = ["any-destination", "etl-destinations/bigquery"]
+clickhouse = ["any-destination", "etl-destinations/clickhouse"]
+ducklake = ["any-destination", "etl-destinations/ducklake", "etl-maintenance/ducklake"]
+iceberg = ["any-destination", "etl-destinations/iceberg"]
+snowflake = ["any-destination", "etl-destinations/snowflake"]
 egress = ["etl/egress", "etl-destinations/egress"]
 
 [dependencies]
@@ -16,8 +27,8 @@ egress = ["etl/egress", "etl-destinations/egress"]
 configcat = { workspace = true }
 etl = { workspace = true }
 etl-config = { workspace = true, features = ["supabase"] }
-etl-destinations = { workspace = true, features = ["bigquery", "clickhouse", "ducklake", "iceberg", "snowflake"] }
-etl-maintenance = { workspace = true, features = ["ducklake"] }
+etl-destinations = { workspace = true }
+etl-maintenance = { workspace = true }
 etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 metrics = { workspace = true }

--- a/crates/etl-replicator/src/core.rs
+++ b/crates/etl-replicator/src/core.rs
@@ -1,42 +1,32 @@
-use std::collections::HashMap;
+//! Replicator service orchestration.
 
-use etl::{
-    config::IcebergConfig,
-    destination::PipelineDestination,
-    pipeline::Pipeline,
-    store::{PipelineStore, both::postgres::PostgresStore},
-    types::PipelineId,
-};
-use etl_config::{
-    Environment, parse_ducklake_s3_data_path, parse_ducklake_url,
-    shared::{
-        DestinationConfig, DuckLakeMaintenanceMode as ConfigDuckLakeMaintenanceMode,
-        PgConnectionConfig, ReplicatorConfig,
-    },
-};
-use etl_destinations::{
-    bigquery::BigQueryDestination,
-    clickhouse::{ClickHouseClientConfig, ClickHouseDestination, ClickHouseInserterConfig},
-    ducklake::{
-        DuckLakeDestination, DuckLakeExternalMaintenanceConfig, DuckLakeMaintenanceMode,
-        S3Config as DucklakeS3Config,
-    },
-    iceberg::{
-        DestinationNamespace, IcebergClient, IcebergDestination, S3_ACCESS_KEY_ID, S3_ENDPOINT,
-        S3_SECRET_ACCESS_KEY,
-    },
-    snowflake,
-};
-use secrecy::ExposeSecret;
-use tokio::signal::unix::{SignalKind, signal};
-use tracing::{error, info, warn};
+mod destinations;
+#[cfg(feature = "any-destination")]
+mod pipeline;
+
+#[cfg(all(
+    feature = "any-destination",
+    not(any(
+        feature = "bigquery",
+        feature = "clickhouse",
+        feature = "ducklake",
+        feature = "iceberg",
+        feature = "snowflake"
+    ))
+))]
+compile_error!("`any-destination` is internal; enable a concrete destination feature instead.");
+
+use etl::{store::both::postgres::PostgresStore, types::PipelineId};
+use etl_config::shared::{PgConnectionConfig, ReplicatorConfig};
+use tracing::info;
 
 use crate::{
-    error::{ReplicatorError, ReplicatorResult},
-    error_notification::ErrorNotificationClient,
+    error::ReplicatorResult, error_notification::ErrorNotificationClient,
     error_reporting::ErrorReportingStateStore,
-    metrics,
 };
+
+/// Store type used by the replicator runtime.
+type ReplicatorStore = ErrorReportingStateStore<PostgresStore>;
 
 /// Starts the replicator service with the provided configuration.
 ///
@@ -53,212 +43,7 @@ pub(crate) async fn start_replicator_with_config(
     let store_pg_connection_config = replicator_config.pipeline.store_pg_connection().clone();
     let store = init_store(pipeline_id, store_pg_connection_config, notification_client).await?;
 
-    // For each destination, we start the pipeline. This is more verbose due to
-    // static dispatch, but we prefer more performance at the cost of
-    // ergonomics.
-    match &replicator_config.destination {
-        DestinationConfig::BigQuery {
-            project_id,
-            dataset_id,
-            service_account_key,
-            max_staleness_mins,
-            connection_pool_size,
-        } => {
-            let destination = BigQueryDestination::new_with_key(
-                project_id.clone(),
-                dataset_id.clone(),
-                service_account_key.expose_secret(),
-                *max_staleness_mins,
-                *connection_pool_size,
-                pipeline_id,
-                store.clone(),
-            )
-            .await?;
-
-            let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
-            start_pipeline(pipeline).await?;
-        }
-        DestinationConfig::Iceberg {
-            config:
-                IcebergConfig::Supabase {
-                    project_ref,
-                    warehouse_name,
-                    namespace,
-                    catalog_token,
-                    s3_access_key_id,
-                    s3_secret_access_key,
-                    s3_region,
-                },
-        } => {
-            let env = Environment::load().map_err(ReplicatorError::config)?;
-            let client = IcebergClient::new_with_supabase_catalog(
-                project_ref,
-                env.get_supabase_domain(),
-                catalog_token.expose_secret().to_owned(),
-                warehouse_name.clone(),
-                s3_access_key_id.expose_secret().to_owned(),
-                s3_secret_access_key.expose_secret().to_owned(),
-                s3_region.clone(),
-            )
-            .await
-            .map_err(ReplicatorError::config)?;
-            let namespace = match namespace {
-                Some(ns) => DestinationNamespace::Single(ns.clone()),
-                None => DestinationNamespace::OnePerSchema,
-            };
-            let destination = IcebergDestination::new(client, namespace, store.clone());
-
-            let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
-            start_pipeline(pipeline).await?;
-        }
-        DestinationConfig::Iceberg {
-            config:
-                IcebergConfig::Rest {
-                    catalog_uri,
-                    warehouse_name,
-                    namespace,
-                    s3_access_key_id,
-                    s3_secret_access_key,
-                    s3_endpoint,
-                },
-        } => {
-            let client = IcebergClient::new_with_rest_catalog(
-                catalog_uri.clone(),
-                warehouse_name.clone(),
-                create_props(
-                    s3_access_key_id.expose_secret().to_owned(),
-                    s3_secret_access_key.expose_secret().to_owned(),
-                    s3_endpoint.clone(),
-                ),
-            )
-            .await
-            .map_err(ReplicatorError::config)?;
-            let namespace = match namespace {
-                Some(ns) => DestinationNamespace::Single(ns.clone()),
-                None => DestinationNamespace::OnePerSchema,
-            };
-            let destination = IcebergDestination::new(client, namespace, store.clone());
-
-            let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
-            start_pipeline(pipeline).await?;
-        }
-        DestinationConfig::Ducklake {
-            catalog_url,
-            data_path,
-            pool_size,
-            s3_access_key_id,
-            s3_secret_access_key,
-            s3_region,
-            s3_endpoint,
-            s3_url_style,
-            s3_use_ssl,
-            metadata_schema,
-            maintenance_target_file_size,
-            expire_snapshots_older_than,
-            maintenance_mode,
-        } => {
-            let s3_config = match (s3_access_key_id, s3_secret_access_key) {
-                (Some(access_key_id), Some(secret_access_key)) => Some(DucklakeS3Config {
-                    access_key_id: access_key_id.expose_secret().to_owned(),
-                    secret_access_key: secret_access_key.expose_secret().to_owned(),
-                    region: s3_region.clone().unwrap_or_else(|| "us-east-1".to_owned()),
-                    endpoint: s3_endpoint.clone(),
-                    url_style: s3_url_style.clone().unwrap_or_else(|| "path".to_owned()),
-                    use_ssl: s3_use_ssl.unwrap_or(false),
-                }),
-                (None, None) => None,
-                _ => {
-                    return Err(ReplicatorError::config(std::io::Error::other(
-                        "DuckLake S3 credentials must include both access key id and secret \
-                         access key",
-                    )));
-                }
-            };
-
-            let maintenance_mode = match maintenance_mode {
-                ConfigDuckLakeMaintenanceMode::Disabled => DuckLakeMaintenanceMode::Disabled,
-                ConfigDuckLakeMaintenanceMode::Kubernetes => DuckLakeMaintenanceMode::Kubernetes,
-                ConfigDuckLakeMaintenanceMode::Postgres => DuckLakeMaintenanceMode::Postgres,
-            };
-            let external_maintenance =
-                DuckLakeExternalMaintenanceConfig { mode: maintenance_mode, pipeline_id };
-
-            let destination = DuckLakeDestination::new_with_external_maintenance(
-                parse_ducklake_url(catalog_url.expose_secret()).map_err(ReplicatorError::config)?,
-                parse_ducklake_s3_data_path(data_path).map_err(ReplicatorError::config)?,
-                *pool_size,
-                s3_config,
-                metadata_schema.clone(),
-                maintenance_target_file_size.clone(),
-                expire_snapshots_older_than.clone(),
-                external_maintenance,
-                store.clone(),
-            )
-            .await?;
-
-            let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
-            start_pipeline(pipeline).await?;
-        }
-        DestinationConfig::ClickHouse { url, user, password, database, engine } => {
-            let destination = ClickHouseDestination::new(
-                url.clone(),
-                user,
-                password.as_ref().map(|p| p.expose_secret().to_owned()),
-                database,
-                ClickHouseInserterConfig { engine: *engine, ..Default::default() },
-                ClickHouseClientConfig::default(),
-                store.clone(),
-            )?;
-            destination.validate_engine_support().await?;
-
-            let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
-            start_pipeline(pipeline).await?;
-        }
-        DestinationConfig::Snowflake {
-            account_id,
-            user,
-            private_key,
-            private_key_passphrase,
-            database,
-            schema,
-            role,
-        } => {
-            let mut config = snowflake::Config::new(account_id, user, database, schema)
-                .map_err(ReplicatorError::config)?;
-            if let Some(r) = role {
-                config = config.with_role(r);
-            }
-            let auth = std::sync::Arc::new(
-                snowflake::AuthManager::new(
-                    &config,
-                    private_key.expose_secret(),
-                    private_key_passphrase.as_ref(),
-                )
-                .map_err(ReplicatorError::config)?,
-            );
-            let client = snowflake::Client::new(config, auth, pipeline_id);
-            let destination = snowflake::Destination::new(client, store.clone());
-
-            let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
-            start_pipeline(pipeline).await?;
-        }
-    }
-
-    Ok(())
-}
-
-fn create_props(
-    s3_access_key_id: String,
-    s3_secret_access_key: String,
-    s3_endpoint: String,
-) -> HashMap<String, String> {
-    let mut props: HashMap<String, String> = HashMap::new();
-
-    props.insert(S3_ACCESS_KEY_ID.to_owned(), s3_access_key_id);
-    props.insert(S3_SECRET_ACCESS_KEY.to_owned(), s3_secret_access_key);
-    props.insert(S3_ENDPOINT.to_owned(), s3_endpoint);
-
-    props
+    destinations::start(replicator_config, store).await
 }
 
 /// Initializes the store.
@@ -269,80 +54,11 @@ async fn init_store(
     pipeline_id: PipelineId,
     store_pg_connection_config: PgConnectionConfig,
     notification_client: Option<ErrorNotificationClient>,
-) -> ReplicatorResult<impl PipelineStore> {
+) -> ReplicatorResult<ReplicatorStore> {
     info!("initializing postgres store");
 
     Ok(ErrorReportingStateStore::new(
         PostgresStore::new(pipeline_id, store_pg_connection_config).await?,
         notification_client,
     ))
-}
-
-/// Starts a pipeline and handles graceful shutdown signals.
-///
-/// Launches the pipeline, sets up signal handlers for SIGTERM and SIGINT,
-/// and ensures proper cleanup on shutdown. The pipeline will attempt to
-/// finish processing current batches before terminating.
-#[tracing::instrument(skip(pipeline))]
-async fn start_pipeline<S, D>(mut pipeline: Pipeline<S, D>) -> ReplicatorResult<()>
-where
-    S: PipelineStore,
-    D: PipelineDestination,
-{
-    // Start the pipeline.
-    pipeline.start().await?;
-
-    // We spawn metrics collection after the pipeline was started, so that if we
-    // crash before starting we don't keep emitting metrics that make it look as
-    // if the system is running.
-    let metrics_tasks = metrics::spawn_metrics_tasks();
-
-    // Spawn a task to listen for shutdown signals and trigger shutdown.
-    let shutdown_tx = pipeline.shutdown_tx();
-    let shutdown_handle = tokio::spawn(async move {
-        // Listen for SIGTERM, sent by Kubernetes before SIGKILL during pod termination.
-        //
-        // If the process is killed before shutdown completes, the pipeline may become
-        // corrupted, depending on the store and destination
-        // implementations.
-        let Ok(mut sigterm) = signal(SignalKind::terminate()) else {
-            error!("failed to register sigterm handler, shutting down pipeline");
-
-            if let Err(err) = shutdown_tx.shutdown() {
-                warn!(error = %err, "failed to send shutdown signal");
-            }
-
-            return;
-        };
-
-        tokio::select! {
-            _ = tokio::signal::ctrl_c() => {
-                info!("sigint (ctrl+c) received, shutting down pipeline");
-            }
-            _ = sigterm.recv() => {
-                info!("sigterm received, shutting down pipeline");
-            }
-        }
-
-        if let Err(err) = shutdown_tx.shutdown() {
-            warn!(error = %err, "failed to send shutdown signal");
-        }
-    });
-
-    // Wait for the pipeline to finish (either normally or via shutdown).
-    let result = pipeline.wait().await;
-
-    // Ensure the shutdown task is finished before returning.
-    // If the pipeline finished before Ctrl+C, we want to abort the shutdown task.
-    // If Ctrl+C was pressed, the shutdown task will have already triggered
-    // shutdown. We don't care about the result of the shutdown_handle, but we
-    // should abort it if it's still running.
-    shutdown_handle.abort();
-    let _ = shutdown_handle.await;
-    metrics_tasks.abort_and_wait().await;
-
-    // Propagate any pipeline error.
-    result?;
-
-    Ok(())
 }

--- a/crates/etl-replicator/src/core/destinations.rs
+++ b/crates/etl-replicator/src/core/destinations.rs
@@ -1,0 +1,419 @@
+//! Destination startup dispatch.
+
+use etl_config::shared::{DestinationKind, ReplicatorConfig};
+
+use super::ReplicatorStore;
+use crate::error::{ReplicatorError, ReplicatorResult};
+
+/// Starts the configured destination pipeline.
+pub(super) async fn start(
+    replicator_config: ReplicatorConfig,
+    store: ReplicatorStore,
+) -> ReplicatorResult<()> {
+    #[cfg(not(feature = "any-destination"))]
+    let _ = &store;
+
+    match replicator_config.destination.kind() {
+        DestinationKind::BigQuery => {
+            #[cfg(feature = "bigquery")]
+            {
+                bigquery::start(replicator_config, store).await
+            }
+
+            #[cfg(not(feature = "bigquery"))]
+            {
+                Err(disabled_destination_error(DestinationKind::BigQuery))
+            }
+        }
+        DestinationKind::ClickHouse => {
+            #[cfg(feature = "clickhouse")]
+            {
+                clickhouse::start(replicator_config, store).await
+            }
+
+            #[cfg(not(feature = "clickhouse"))]
+            {
+                Err(disabled_destination_error(DestinationKind::ClickHouse))
+            }
+        }
+        DestinationKind::Ducklake => {
+            #[cfg(feature = "ducklake")]
+            {
+                ducklake::start(replicator_config, store).await
+            }
+
+            #[cfg(not(feature = "ducklake"))]
+            {
+                Err(disabled_destination_error(DestinationKind::Ducklake))
+            }
+        }
+        DestinationKind::Iceberg => {
+            #[cfg(feature = "iceberg")]
+            {
+                iceberg::start(replicator_config, store).await
+            }
+
+            #[cfg(not(feature = "iceberg"))]
+            {
+                Err(disabled_destination_error(DestinationKind::Iceberg))
+            }
+        }
+        DestinationKind::Snowflake => {
+            #[cfg(feature = "snowflake")]
+            {
+                snowflake::start(replicator_config, store).await
+            }
+
+            #[cfg(not(feature = "snowflake"))]
+            {
+                Err(disabled_destination_error(DestinationKind::Snowflake))
+            }
+        }
+    }
+}
+
+#[cfg(any(
+    not(feature = "bigquery"),
+    not(feature = "clickhouse"),
+    not(feature = "ducklake"),
+    not(feature = "iceberg"),
+    not(feature = "snowflake")
+))]
+fn disabled_destination_error(kind: DestinationKind) -> ReplicatorError {
+    ReplicatorError::config(std::io::Error::other(format!(
+        "Destination `{}` support is not compiled into this binary.",
+        kind.as_str()
+    )))
+}
+
+/// BigQuery destination startup.
+#[cfg(feature = "bigquery")]
+mod bigquery {
+    use etl::pipeline::Pipeline;
+    use etl_config::shared::{DestinationConfig, ReplicatorConfig};
+    use etl_destinations::bigquery::BigQueryDestination;
+    use secrecy::ExposeSecret;
+
+    use super::super::{ReplicatorStore, pipeline};
+    use crate::error::ReplicatorResult;
+
+    /// Starts the BigQuery destination pipeline.
+    pub(super) async fn start(
+        replicator_config: ReplicatorConfig,
+        store: ReplicatorStore,
+    ) -> ReplicatorResult<()> {
+        let pipeline_id = replicator_config.pipeline.id;
+
+        let DestinationConfig::BigQuery {
+            project_id,
+            dataset_id,
+            service_account_key,
+            max_staleness_mins,
+            connection_pool_size,
+        } = &replicator_config.destination
+        else {
+            unreachable!("Destination kind should match BigQuery config");
+        };
+
+        let destination = BigQueryDestination::new_with_key(
+            project_id.clone(),
+            dataset_id.clone(),
+            service_account_key.expose_secret(),
+            *max_staleness_mins,
+            *connection_pool_size,
+            pipeline_id,
+            store.clone(),
+        )
+        .await?;
+
+        let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
+        pipeline::start(pipeline).await
+    }
+}
+
+/// ClickHouse destination startup.
+#[cfg(feature = "clickhouse")]
+mod clickhouse {
+    use etl::pipeline::Pipeline;
+    use etl_config::shared::{DestinationConfig, ReplicatorConfig};
+    use etl_destinations::clickhouse::{
+        ClickHouseClientConfig, ClickHouseDestination, ClickHouseInserterConfig,
+    };
+    use secrecy::ExposeSecret;
+
+    use super::super::{ReplicatorStore, pipeline};
+    use crate::error::ReplicatorResult;
+
+    /// Starts the ClickHouse destination pipeline.
+    pub(super) async fn start(
+        replicator_config: ReplicatorConfig,
+        store: ReplicatorStore,
+    ) -> ReplicatorResult<()> {
+        let DestinationConfig::ClickHouse { url, user, password, database, engine } =
+            &replicator_config.destination
+        else {
+            unreachable!("Destination kind should match ClickHouse config");
+        };
+
+        let destination = ClickHouseDestination::new(
+            url.clone(),
+            user,
+            password.as_ref().map(|p| p.expose_secret().to_owned()),
+            database,
+            ClickHouseInserterConfig { engine: *engine, ..Default::default() },
+            ClickHouseClientConfig::default(),
+            store.clone(),
+        )?;
+        destination.validate_engine_support().await?;
+
+        let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
+        pipeline::start(pipeline).await
+    }
+}
+
+/// DuckLake destination startup.
+#[cfg(feature = "ducklake")]
+mod ducklake {
+    use etl::pipeline::Pipeline;
+    use etl_config::{
+        parse_ducklake_s3_data_path, parse_ducklake_url,
+        shared::{
+            DestinationConfig, DuckLakeMaintenanceMode as ConfigDuckLakeMaintenanceMode,
+            ReplicatorConfig,
+        },
+    };
+    use etl_destinations::ducklake::{
+        DuckLakeDestination, DuckLakeExternalMaintenanceConfig, DuckLakeMaintenanceMode,
+        S3Config as DucklakeS3Config,
+    };
+    use secrecy::ExposeSecret;
+
+    use super::super::{ReplicatorStore, pipeline};
+    use crate::error::{ReplicatorError, ReplicatorResult};
+
+    /// Starts the DuckLake destination pipeline.
+    pub(super) async fn start(
+        replicator_config: ReplicatorConfig,
+        store: ReplicatorStore,
+    ) -> ReplicatorResult<()> {
+        let pipeline_id = replicator_config.pipeline.id;
+
+        let DestinationConfig::Ducklake {
+            catalog_url,
+            data_path,
+            pool_size,
+            s3_access_key_id,
+            s3_secret_access_key,
+            s3_region,
+            s3_endpoint,
+            s3_url_style,
+            s3_use_ssl,
+            metadata_schema,
+            maintenance_target_file_size,
+            expire_snapshots_older_than,
+            maintenance_mode,
+        } = &replicator_config.destination
+        else {
+            unreachable!("Destination kind should match DuckLake config");
+        };
+
+        let s3_config = match (s3_access_key_id, s3_secret_access_key) {
+            (Some(access_key_id), Some(secret_access_key)) => Some(DucklakeS3Config {
+                access_key_id: access_key_id.expose_secret().to_owned(),
+                secret_access_key: secret_access_key.expose_secret().to_owned(),
+                region: s3_region.clone().unwrap_or_else(|| "us-east-1".to_owned()),
+                endpoint: s3_endpoint.clone(),
+                url_style: s3_url_style.clone().unwrap_or_else(|| "path".to_owned()),
+                use_ssl: s3_use_ssl.unwrap_or(false),
+            }),
+            (None, None) => None,
+            _ => {
+                return Err(ReplicatorError::config(std::io::Error::other(
+                    "DuckLake S3 credentials must include both access key id and secret access key",
+                )));
+            }
+        };
+
+        let maintenance_mode = match maintenance_mode {
+            ConfigDuckLakeMaintenanceMode::Disabled => DuckLakeMaintenanceMode::Disabled,
+            ConfigDuckLakeMaintenanceMode::Kubernetes => DuckLakeMaintenanceMode::Kubernetes,
+            ConfigDuckLakeMaintenanceMode::Postgres => DuckLakeMaintenanceMode::Postgres,
+        };
+        let external_maintenance =
+            DuckLakeExternalMaintenanceConfig { mode: maintenance_mode, pipeline_id };
+
+        let destination = DuckLakeDestination::new_with_external_maintenance(
+            parse_ducklake_url(catalog_url.expose_secret()).map_err(ReplicatorError::config)?,
+            parse_ducklake_s3_data_path(data_path).map_err(ReplicatorError::config)?,
+            *pool_size,
+            s3_config,
+            metadata_schema.clone(),
+            maintenance_target_file_size.clone(),
+            expire_snapshots_older_than.clone(),
+            external_maintenance,
+            store.clone(),
+        )
+        .await?;
+
+        let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
+        pipeline::start(pipeline).await
+    }
+}
+
+/// Iceberg destination startup.
+#[cfg(feature = "iceberg")]
+mod iceberg {
+    use std::collections::HashMap;
+
+    use etl::{config::IcebergConfig, pipeline::Pipeline};
+    use etl_config::{Environment, shared::ReplicatorConfig};
+    use etl_destinations::iceberg::{
+        DestinationNamespace, IcebergClient, IcebergDestination, S3_ACCESS_KEY_ID, S3_ENDPOINT,
+        S3_SECRET_ACCESS_KEY,
+    };
+    use secrecy::ExposeSecret;
+
+    use super::super::{ReplicatorStore, pipeline};
+    use crate::error::{ReplicatorError, ReplicatorResult};
+
+    /// Starts the Iceberg destination pipeline.
+    pub(super) async fn start(
+        replicator_config: ReplicatorConfig,
+        store: ReplicatorStore,
+    ) -> ReplicatorResult<()> {
+        let client = match &replicator_config.destination {
+            etl_config::shared::DestinationConfig::Iceberg {
+                config:
+                    IcebergConfig::Supabase {
+                        project_ref,
+                        warehouse_name,
+                        catalog_token,
+                        s3_access_key_id,
+                        s3_secret_access_key,
+                        s3_region,
+                        ..
+                    },
+            } => {
+                let env = Environment::load().map_err(ReplicatorError::config)?;
+                IcebergClient::new_with_supabase_catalog(
+                    project_ref,
+                    env.get_supabase_domain(),
+                    catalog_token.expose_secret().to_owned(),
+                    warehouse_name.clone(),
+                    s3_access_key_id.expose_secret().to_owned(),
+                    s3_secret_access_key.expose_secret().to_owned(),
+                    s3_region.clone(),
+                )
+                .await
+                .map_err(ReplicatorError::config)?
+            }
+            etl_config::shared::DestinationConfig::Iceberg {
+                config:
+                    IcebergConfig::Rest {
+                        catalog_uri,
+                        warehouse_name,
+                        s3_access_key_id,
+                        s3_secret_access_key,
+                        s3_endpoint,
+                        ..
+                    },
+            } => IcebergClient::new_with_rest_catalog(
+                catalog_uri.clone(),
+                warehouse_name.clone(),
+                create_props(
+                    s3_access_key_id.expose_secret().to_owned(),
+                    s3_secret_access_key.expose_secret().to_owned(),
+                    s3_endpoint.clone(),
+                ),
+            )
+            .await
+            .map_err(ReplicatorError::config)?,
+            _ => unreachable!("Destination kind should match Iceberg config"),
+        };
+
+        let etl_config::shared::DestinationConfig::Iceberg { config } =
+            &replicator_config.destination
+        else {
+            unreachable!("Destination kind should match Iceberg config");
+        };
+        let namespace = match config {
+            IcebergConfig::Supabase { namespace, .. } | IcebergConfig::Rest { namespace, .. } => {
+                match namespace {
+                    Some(ns) => DestinationNamespace::Single(ns.clone()),
+                    None => DestinationNamespace::OnePerSchema,
+                }
+            }
+        };
+        let destination = IcebergDestination::new(client, namespace, store.clone());
+
+        let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
+        pipeline::start(pipeline).await
+    }
+
+    /// Creates Iceberg REST catalog S3 properties.
+    fn create_props(
+        s3_access_key_id: String,
+        s3_secret_access_key: String,
+        s3_endpoint: String,
+    ) -> HashMap<String, String> {
+        let mut props: HashMap<String, String> = HashMap::new();
+
+        props.insert(S3_ACCESS_KEY_ID.to_owned(), s3_access_key_id);
+        props.insert(S3_SECRET_ACCESS_KEY.to_owned(), s3_secret_access_key);
+        props.insert(S3_ENDPOINT.to_owned(), s3_endpoint);
+
+        props
+    }
+}
+
+/// Snowflake destination startup.
+#[cfg(feature = "snowflake")]
+mod snowflake {
+    use etl::pipeline::Pipeline;
+    use etl_config::shared::{DestinationConfig, ReplicatorConfig};
+    use etl_destinations::snowflake as snowflake_destination;
+    use secrecy::ExposeSecret;
+
+    use super::super::{ReplicatorStore, pipeline};
+    use crate::error::{ReplicatorError, ReplicatorResult};
+
+    /// Starts the Snowflake destination pipeline.
+    pub(super) async fn start(
+        replicator_config: ReplicatorConfig,
+        store: ReplicatorStore,
+    ) -> ReplicatorResult<()> {
+        let pipeline_id = replicator_config.pipeline.id;
+
+        let DestinationConfig::Snowflake {
+            account_id,
+            user,
+            private_key,
+            private_key_passphrase,
+            database,
+            schema,
+            role,
+        } = &replicator_config.destination
+        else {
+            unreachable!("Destination kind should match Snowflake config");
+        };
+
+        let mut config = snowflake_destination::Config::new(account_id, user, database, schema)
+            .map_err(ReplicatorError::config)?;
+        if let Some(r) = role {
+            config = config.with_role(r);
+        }
+        let auth = std::sync::Arc::new(
+            snowflake_destination::AuthManager::new(
+                &config,
+                private_key.expose_secret(),
+                private_key_passphrase.as_ref(),
+            )
+            .map_err(ReplicatorError::config)?,
+        );
+        let client = snowflake_destination::Client::new(config, auth, pipeline_id);
+        let destination = snowflake_destination::Destination::new(client, store.clone());
+
+        let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
+        pipeline::start(pipeline).await
+    }
+}

--- a/crates/etl-replicator/src/core/destinations.rs
+++ b/crates/etl-replicator/src/core/destinations.rs
@@ -3,7 +3,7 @@
 use etl_config::shared::{DestinationKind, ReplicatorConfig};
 
 use super::ReplicatorStore;
-use crate::error::{ReplicatorError, ReplicatorResult};
+use crate::error::ReplicatorResult;
 
 /// Starts the configured destination pipeline.
 pub(super) async fn start(

--- a/crates/etl-replicator/src/core/destinations.rs
+++ b/crates/etl-replicator/src/core/destinations.rs
@@ -79,8 +79,8 @@ pub(super) async fn start(
     not(feature = "iceberg"),
     not(feature = "snowflake")
 ))]
-fn disabled_destination_error(kind: DestinationKind) -> ReplicatorError {
-    ReplicatorError::config(std::io::Error::other(format!(
+fn disabled_destination_error(kind: DestinationKind) -> crate::error::ReplicatorError {
+    crate::error::ReplicatorError::config(std::io::Error::other(format!(
         "Destination `{}` support is not compiled into this binary.",
         kind.as_str()
     )))

--- a/crates/etl-replicator/src/core/pipeline.rs
+++ b/crates/etl-replicator/src/core/pipeline.rs
@@ -1,0 +1,76 @@
+//! Pipeline runtime helpers.
+
+use etl::{destination::PipelineDestination, pipeline::Pipeline, store::PipelineStore};
+use tokio::signal::unix::{SignalKind, signal};
+use tracing::{error, info, warn};
+
+use crate::{error::ReplicatorResult, metrics};
+
+/// Starts a pipeline and handles graceful shutdown signals.
+///
+/// Launches the pipeline, sets up signal handlers for SIGTERM and SIGINT,
+/// and ensures proper cleanup on shutdown. The pipeline will attempt to
+/// finish processing current batches before terminating.
+#[tracing::instrument(skip(pipeline))]
+pub(super) async fn start<S, D>(mut pipeline: Pipeline<S, D>) -> ReplicatorResult<()>
+where
+    S: PipelineStore,
+    D: PipelineDestination,
+{
+    // Start the pipeline.
+    pipeline.start().await?;
+
+    // We spawn metrics collection after the pipeline was started, so that if we
+    // crash before starting we don't keep emitting metrics that make it look as
+    // if the system is running.
+    let metrics_tasks = metrics::spawn_metrics_tasks();
+
+    // Spawn a task to listen for shutdown signals and trigger shutdown.
+    let shutdown_tx = pipeline.shutdown_tx();
+    let shutdown_handle = tokio::spawn(async move {
+        // Listen for SIGTERM, sent by Kubernetes before SIGKILL during pod termination.
+        //
+        // If the process is killed before shutdown completes, the pipeline may become
+        // corrupted, depending on the store and destination
+        // implementations.
+        let Ok(mut sigterm) = signal(SignalKind::terminate()) else {
+            error!("failed to register sigterm handler, shutting down pipeline");
+
+            if let Err(err) = shutdown_tx.shutdown() {
+                warn!(error = %err, "failed to send shutdown signal");
+            }
+
+            return;
+        };
+
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                info!("sigint (ctrl+c) received, shutting down pipeline");
+            }
+            _ = sigterm.recv() => {
+                info!("sigterm received, shutting down pipeline");
+            }
+        }
+
+        if let Err(err) = shutdown_tx.shutdown() {
+            warn!(error = %err, "failed to send shutdown signal");
+        }
+    });
+
+    // Wait for the pipeline to finish (either normally or via shutdown).
+    let result = pipeline.wait().await;
+
+    // Ensure the shutdown task is finished before returning.
+    // If the pipeline finished before Ctrl+C, we want to abort the shutdown task.
+    // If Ctrl+C was pressed, the shutdown task will have already triggered
+    // shutdown. We don't care about the result of the shutdown_handle, but we
+    // should abort it if it's still running.
+    shutdown_handle.abort();
+    let _ = shutdown_handle.await;
+    metrics_tasks.abort_and_wait().await;
+
+    // Propagate any pipeline error.
+    result?;
+
+    Ok(())
+}

--- a/crates/etl-replicator/src/main.rs
+++ b/crates/etl-replicator/src/main.rs
@@ -59,6 +59,7 @@ mod error;
 mod error_notification;
 mod error_reporting;
 mod init;
+#[cfg(feature = "any-destination")]
 mod metrics;
 mod sentry;
 


### PR DESCRIPTION
## Problem

`etl-replicator` always compiled every destination runtime, so working on non-DuckLake destinations still pulled `libduckdb-sys` into the build graph.

## Resolution

- Added destination feature flags to `etl-replicator`, with defaults preserving current all-destination behavior.
- Moved destination startup dispatch into feature-gated modules for readability.
- Return an explicit runtime error when config asks for a destination not compiled into the binary.
- Guarded the DuckLake maintenance binary behind the `ducklake` feature.

The implementation is mostly moving things around and adding feature gates.

## Usage and Verification

```sh
cargo check -p etl-replicator --no-default-features --all-targets
cargo check -p etl-replicator --no-default-features --features bigquery --all-targets
cargo check -p etl-replicator --no-default-features --features clickhouse --all-targets
cargo check -p etl-replicator --no-default-features --features snowflake --all-targets
cargo clippy --all-targets -p etl-destinations -p etl-replicator --no-default-features --features snowflake --no-deps -- -D warnings