### PR TITLE
refactor(ducklake): remove useless logs

### DIFF
--- a/crates/etl-destinations/src/ducklake/client.rs
+++ b/crates/etl-destinations/src/ducklake/client.rs
@@ -201,11 +201,6 @@ impl RegisteredDuckLakeInterrupt {
         Arc::clone(&self.state)
     }
 
-    /// Returns the currently recorded interrupt reason.
-    fn interrupt_reason(&self) -> DuckLakeInterruptReason {
-        self.state.reason()
-    }
-
     /// Interrupts the connection and records why the interrupt was sent.
     fn interrupt_with_reason(&self, reason: DuckLakeInterruptReason) {
         self.state.record(reason);
@@ -219,15 +214,9 @@ impl DuckDbQueryInterrupt for RegisteredDuckLakeInterrupt {
     }
 }
 
-fn remaining_ms_until(deadline: Instant) -> u64 {
-    deadline.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO).as_millis() as u64
-}
-
 /// Async watchdog that interrupts one timed DuckDB query when its deadline
 /// expires.
 pub(super) struct DuckDbQueryWatchdog {
-    operation_id: u64,
-    timeout: Duration,
     timed_out: Arc<AtomicBool>,
     interrupt_tx: Option<oneshot::Sender<DuckDbQueryInterruptHandle>>,
     done_tx: Option<oneshot::Sender<()>>,
@@ -235,187 +224,51 @@ pub(super) struct DuckDbQueryWatchdog {
 }
 
 impl DuckDbQueryWatchdog {
-    #[cfg(test)]
     fn spawn(deadline: Instant) -> Self {
-        Self::spawn_with_context(deadline, 0, Duration::ZERO)
-    }
-
-    fn spawn_with_context(deadline: Instant, operation_id: u64, timeout: Duration) -> Self {
-        let operation_kind = DUCKDB_BLOCKING_OPERATION_KIND;
         let timed_out = Arc::new(AtomicBool::new(false));
         let timeout_flag = Arc::clone(&timed_out);
         let (interrupt_tx, interrupt_rx) = oneshot::channel::<DuckDbQueryInterruptHandle>();
         let (done_tx, done_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
-            info!(
-                operation_id,
-                operation_kind = operation_kind,
-                timeout_ms = timeout.as_millis() as u64,
-                deadline_remaining_ms = remaining_ms_until(deadline),
-                "ducklake query watchdog task started: operation_id={}, operation_kind={}, \
-                 timeout_ms={}, deadline_remaining_ms={}",
-                operation_id,
-                operation_kind,
-                timeout.as_millis(),
-                remaining_ms_until(deadline)
-            );
             let mut interrupt_rx = Box::pin(interrupt_rx);
             let mut done_rx = Box::pin(done_rx);
             let interrupt_handle = tokio::select! {
                 biased;
-                _ = &mut done_rx => {
-                    info!(
-                        operation_id,
-                        operation_kind = operation_kind,
-                        "ducklake query watchdog finished before interrupt handle: operation_id={}, operation_kind={}",
-                        operation_id,
-                        operation_kind
-                    );
-                    return;
-                },
+                _ = &mut done_rx => return,
                 result = &mut interrupt_rx => match result {
-                    Ok(handle) => {
-                        info!(
-                            operation_id,
-                            operation_kind = operation_kind,
-                            deadline_remaining_ms = remaining_ms_until(deadline),
-                            "ducklake query watchdog received interrupt handle before deadline: \
-                             operation_id={}, operation_kind={}, deadline_remaining_ms={}",
-                            operation_id,
-                            operation_kind,
-                            remaining_ms_until(deadline)
-                        );
-                        handle
-                    },
-                    Err(_) => {
-                        warn!(
-                            operation_id,
-                            operation_kind = operation_kind,
-                            "ducklake query watchdog interrupt sender dropped before deadline: \
-                             operation_id={}, operation_kind={}",
-                            operation_id,
-                            operation_kind
-                        );
-                        return;
-                    },
+                    Ok(handle) => handle,
+                    Err(_) => return,
                 },
                 _ = tokio::time::sleep_until(deadline) => {
                     timeout_flag.store(true, Ordering::Relaxed);
-                    warn!(
-                        operation_id,
-                        operation_kind = operation_kind,
-                        timeout_ms = timeout.as_millis() as u64,
-                        "ducklake query watchdog deadline elapsed before interrupt handle: \
-                         operation_id={}, operation_kind={}, timeout_ms={}",
-                        operation_id,
-                        operation_kind,
-                        timeout.as_millis()
-                    );
                     // If we didn't receive the interrupt_rx yet, make sure to get it to call interrupt() later
                     tokio::select! {
                         biased;
-                        _ = &mut done_rx => {
-                            info!(
-                                operation_id,
-                                operation_kind = operation_kind,
-                                "ducklake query watchdog received done after deadline before interrupt handle: \
-                                 operation_id={}, operation_kind={}",
-                                operation_id,
-                                operation_kind
-                            );
-                            return;
-                        },
+                        _ = &mut done_rx => return,
                         result = &mut interrupt_rx => match result {
-                            Ok(handle) => {
-                                warn!(
-                                    operation_id,
-                                    operation_kind = operation_kind,
-                                    "ducklake query watchdog received interrupt handle after deadline: \
-                                     operation_id={}, operation_kind={}",
-                                    operation_id,
-                                    operation_kind
-                                );
-                                handle
-                            },
-                            Err(_) => {
-                                warn!(
-                                    operation_id,
-                                    operation_kind = operation_kind,
-                                    "ducklake query watchdog interrupt sender dropped after deadline: \
-                                     operation_id={}, operation_kind={}",
-                                    operation_id,
-                                    operation_kind
-                                );
-                                return;
-                            },
+                            Ok(handle) => handle,
+                            Err(_) => return,
                         },
                     }
                 },
             };
 
             if timeout_flag.load(Ordering::Relaxed) {
-                warn!(
-                    operation_id,
-                    operation_kind = operation_kind,
-                    "ducklake query watchdog calling interrupt after timeout: operation_id={}, \
-                     operation_kind={}",
-                    operation_id,
-                    operation_kind
-                );
                 interrupt_handle.interrupt();
-                warn!(
-                    operation_id,
-                    operation_kind = operation_kind,
-                    "ducklake query watchdog interrupt returned after timeout: operation_id={}, \
-                     operation_kind={}",
-                    operation_id,
-                    operation_kind
-                );
                 return;
             }
 
             tokio::select! {
                 biased;
-                _ = &mut done_rx => {
-                    info!(
-                        operation_id,
-                        operation_kind = operation_kind,
-                        deadline_remaining_ms = remaining_ms_until(deadline),
-                        "ducklake query watchdog received done before deadline after interrupt handle: \
-                         operation_id={}, operation_kind={}, deadline_remaining_ms={}",
-                        operation_id,
-                        operation_kind,
-                        remaining_ms_until(deadline)
-                    );
-                }
+                _ = &mut done_rx => {}
                 _ = tokio::time::sleep_until(deadline) => {
                     timeout_flag.store(true, Ordering::Relaxed);
-                    warn!(
-                        operation_id,
-                        operation_kind = operation_kind,
-                        timeout_ms = timeout.as_millis() as u64,
-                        "ducklake query watchdog deadline elapsed after interrupt handle; calling interrupt: \
-                         operation_id={}, operation_kind={}, timeout_ms={}",
-                        operation_id,
-                        operation_kind,
-                        timeout.as_millis()
-                    );
                     interrupt_handle.interrupt();
-                    warn!(
-                        operation_id,
-                        operation_kind = operation_kind,
-                        "ducklake query watchdog interrupt returned after handle/deadline path: \
-                         operation_id={}, operation_kind={}",
-                        operation_id,
-                        operation_kind
-                    );
                 }
             }
         });
 
         Self {
-            operation_id,
-            timeout,
             timed_out,
             interrupt_tx: Some(interrupt_tx),
             done_tx: Some(done_tx),
@@ -429,53 +282,13 @@ impl DuckDbQueryWatchdog {
 
     fn publish_query_interrupt_handle(&mut self, handle: DuckDbQueryInterruptHandle) {
         if let Some(interrupt_tx) = self.interrupt_tx.take() {
-            info!(
-                operation_id = self.operation_id,
-                operation_kind = DUCKDB_BLOCKING_OPERATION_KIND,
-                timeout_ms = self.timeout.as_millis() as u64,
-                "ducklake query watchdog publishing interrupt handle: operation_id={}, \
-                 operation_kind={}, timeout_ms={}",
-                self.operation_id,
-                DUCKDB_BLOCKING_OPERATION_KIND,
-                self.timeout.as_millis()
-            );
             let _ = interrupt_tx.send(handle);
-        } else {
-            warn!(
-                operation_id = self.operation_id,
-                operation_kind = DUCKDB_BLOCKING_OPERATION_KIND,
-                "ducklake query watchdog interrupt handle publish skipped because sender is gone: \
-                 operation_id={}, operation_kind={}",
-                self.operation_id,
-                DUCKDB_BLOCKING_OPERATION_KIND
-            );
         }
     }
 
     fn finish(&mut self) {
         if let Some(done_tx) = self.done_tx.take() {
-            info!(
-                operation_id = self.operation_id,
-                operation_kind = DUCKDB_BLOCKING_OPERATION_KIND,
-                timed_out = self.timed_out(),
-                "ducklake query watchdog finish signal sent: operation_id={}, operation_kind={}, \
-                 timed_out={}",
-                self.operation_id,
-                DUCKDB_BLOCKING_OPERATION_KIND,
-                self.timed_out()
-            );
             let _ = done_tx.send(());
-        } else {
-            warn!(
-                operation_id = self.operation_id,
-                operation_kind = DUCKDB_BLOCKING_OPERATION_KIND,
-                timed_out = self.timed_out(),
-                "ducklake query watchdog finish skipped because sender is gone: operation_id={}, \
-                 operation_kind={}, timed_out={}",
-                self.operation_id,
-                DUCKDB_BLOCKING_OPERATION_KIND,
-                self.timed_out()
-            );
         }
     }
 
@@ -801,22 +614,12 @@ pub(super) fn is_ducklake_shutdown_requested_error(error: &EtlError) -> bool {
         && error.description() == Some(DUCKLAKE_SHUTDOWN_REQUESTED)
 }
 
-fn abort_stuck_duckdb_blocking_operation(
-    operation_id: u64,
-    timeout: Duration,
-    abort_grace: Duration,
-) -> ! {
+fn abort_stuck_duckdb_blocking_operation(timeout: Duration, abort_grace: Duration) -> ! {
     tracing::error!(
-        operation_id,
         operation_kind = DUCKDB_BLOCKING_OPERATION_KIND,
         timeout_ms = timeout.as_millis() as u64,
         abort_grace_ms = abort_grace.as_millis() as u64,
-        "ducklake blocking operation did not return after timeout interrupt; aborting process: \
-         operation_id={}, operation_kind={}, timeout_ms={}, abort_grace_ms={}",
-        operation_id,
-        DUCKDB_BLOCKING_OPERATION_KIND,
-        timeout.as_millis(),
-        abort_grace.as_millis()
+        "ducklake blocking operation did not return after timeout interrupt; aborting process"
     );
     process::abort();
 }
@@ -891,83 +694,15 @@ where
     let operation_kind = DUCKDB_BLOCKING_OPERATION_KIND;
     let operation_id = NEXT_DUCKDB_BLOCKING_OPERATION_ID.fetch_add(1, Ordering::Relaxed);
     let deadline = Instant::now() + timeout;
-    info!(
-        operation_id,
-        operation_kind = operation_kind,
-        timeout_ms = timeout.as_millis() as u64,
-        abort_grace_ms = BLOCKING_ABORT_GRACE.as_millis() as u64,
-        available_permits = blocking_slots.available_permits(),
-        "ducklake blocking operation starting: operation_id={}, operation_kind={}, timeout_ms={}, \
-         abort_grace_ms={}, available_permits={}",
-        operation_id,
-        operation_kind,
-        timeout.as_millis(),
-        BLOCKING_ABORT_GRACE.as_millis(),
-        blocking_slots.available_permits()
-    );
     let slot_wait_started = Instant::now();
-    info!(
-        operation_id,
-        operation_kind = operation_kind,
-        deadline_remaining_ms = remaining_ms_until(deadline),
-        available_permits = blocking_slots.available_permits(),
-        "ducklake blocking operation waiting for semaphore slot: operation_id={}, \
-         operation_kind={}, deadline_remaining_ms={}, available_permits={}",
-        operation_id,
-        operation_kind,
-        remaining_ms_until(deadline),
-        blocking_slots.available_permits()
-    );
-    let permit = match tokio::time::timeout_at(
-        deadline,
-        Arc::clone(&blocking_slots).acquire_owned(),
-    )
-    .await
-    {
-        Ok(Ok(permit)) => permit,
-        Ok(Err(_)) => {
-            tracing::error!(
-                operation_id,
-                operation_kind = operation_kind,
-                "ducklake blocking operation semaphore closed: operation_id={}, operation_kind={}",
-                operation_id,
-                operation_kind
-            );
-            return Err(etl_error!(
-                ErrorKind::ApplyWorkerPanic,
-                "DuckLake blocking slot acquisition failed"
-            ));
-        }
-        Err(_) => {
-            warn!(
-                operation_id,
-                operation_kind = operation_kind,
-                timeout_ms = timeout.as_millis() as u64,
-                slot_wait_ms = slot_wait_started.elapsed().as_millis() as u64,
-                "ducklake blocking operation timed out waiting for semaphore slot: \
-                 operation_id={}, operation_kind={}, timeout_ms={}, slot_wait_ms={}",
-                operation_id,
-                operation_kind,
-                timeout.as_millis(),
-                slot_wait_started.elapsed().as_millis()
-            );
-            return Err(duckdb_blocking_timeout_error(timeout, "slot_wait"));
-        }
-    };
+    let permit = tokio::time::timeout_at(deadline, Arc::clone(&blocking_slots).acquire_owned())
+        .await
+        .map_err(|_| duckdb_blocking_timeout_error(timeout, "slot_wait"))?
+        .map_err(|_| {
+            etl_error!(ErrorKind::ApplyWorkerPanic, "DuckLake blocking slot acquisition failed")
+        })?;
     histogram!(ETL_DUCKLAKE_BLOCKING_SLOT_WAIT_SECONDS)
         .record(slot_wait_started.elapsed().as_secs_f64());
-    info!(
-        operation_id,
-        operation_kind = operation_kind,
-        slot_wait_ms = slot_wait_started.elapsed().as_millis() as u64,
-        deadline_remaining_ms = remaining_ms_until(deadline),
-        "ducklake blocking operation acquired semaphore slot: operation_id={}, operation_kind={}, \
-         slot_wait_ms={}, deadline_remaining_ms={}",
-        operation_id,
-        operation_kind,
-        slot_wait_started.elapsed().as_millis(),
-        remaining_ms_until(deadline)
-    );
     trace!(
         wait_ms = slot_wait_started.elapsed().as_millis() as u64,
         "wait for ducklake blocking slot"
@@ -976,102 +711,33 @@ where
     // This is needed to make sure we properly interrupt the blocking operation if
     // it exceeds the timeout, we don't just cancel the task and leave the
     // connection active.
-    let mut watchdog = DuckDbQueryWatchdog::spawn_with_context(deadline, operation_id, timeout);
+    let mut watchdog = DuckDbQueryWatchdog::spawn(deadline);
     let watchdog_task = watchdog.async_task_handle()?;
-    let watchdog_timed_out = Arc::clone(&watchdog.timed_out);
     let abort_deadline = deadline + BLOCKING_ABORT_GRACE;
 
     let blocking_task = tokio::task::spawn_blocking(move || -> EtlResult<R> {
-        info!(
-            operation_id,
-            operation_kind = operation_kind,
-            deadline_remaining_ms = remaining_ms_until(deadline),
-            "ducklake blocking operation entered spawn_blocking task: operation_id={}, \
-             operation_kind={}, deadline_remaining_ms={}",
-            operation_id,
-            operation_kind,
-            remaining_ms_until(deadline)
-        );
         // Please if you modify the code inside this blocking task do not add any
         // blocking operations that could delay other tasks waiting on this slot.
         let _permit = permit;
         let checkout_timeout =
             deadline.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO);
         if checkout_timeout.is_zero() {
-            warn!(
-                operation_id,
-                operation_kind = operation_kind,
-                "ducklake blocking operation deadline reached before pool checkout: \
-                 operation_id={}, operation_kind={}",
-                operation_id,
-                operation_kind
-            );
             return Err(duckdb_blocking_timeout_error(timeout, "pool_checkout"));
         }
         let checkout_started = Instant::now();
-        info!(
-            operation_id,
-            operation_kind = operation_kind,
-            checkout_timeout_ms = checkout_timeout.as_millis() as u64,
-            "ducklake blocking operation checking out pooled connection: operation_id={}, \
-             operation_kind={}, checkout_timeout_ms={}",
-            operation_id,
-            operation_kind,
-            checkout_timeout.as_millis()
-        );
-        let mut pooled_conn = match pool.get_timeout(checkout_timeout) {
-            Ok(pooled_conn) => pooled_conn,
-            Err(e) if Instant::now() >= deadline => {
-                warn!(
-                    operation_id,
-                    operation_kind = operation_kind,
-                    checkout_wait_ms = checkout_started.elapsed().as_millis() as u64,
-                    timeout_ms = timeout.as_millis() as u64,
-                    error = %e,
-                    "ducklake blocking operation timed out checking out pooled connection: \
-                     operation_id={}, operation_kind={}, checkout_wait_ms={}, timeout_ms={}, error={}",
-                    operation_id,
-                    operation_kind,
-                    checkout_started.elapsed().as_millis(),
-                    timeout.as_millis(),
-                    e
-                );
-                return Err(duckdb_blocking_timeout_error(timeout, "pool_checkout"));
-            }
-            Err(e) => {
-                warn!(
-                    operation_id,
-                    operation_kind = operation_kind,
-                    checkout_wait_ms = checkout_started.elapsed().as_millis() as u64,
-                    error = %e,
-                    "ducklake blocking operation failed checking out pooled connection: operation_id={}, \
-                     operation_kind={}, checkout_wait_ms={}, error={}",
-                    operation_id,
-                    operation_kind,
-                    checkout_started.elapsed().as_millis(),
-                    e
-                );
-                return Err(etl_error!(
+        let mut pooled_conn = pool.get_timeout(checkout_timeout).map_err(|e| {
+            if Instant::now() >= deadline {
+                duckdb_blocking_timeout_error(timeout, "pool_checkout")
+            } else {
+                etl_error!(
                     ErrorKind::DestinationConnectionFailed,
                     "Failed to check out DuckLake connection",
                     source: e
-                ));
+                )
             }
-        };
+        })?;
         histogram!(ETL_DUCKLAKE_POOL_CHECKOUT_WAIT_SECONDS)
             .record(checkout_started.elapsed().as_secs_f64());
-        info!(
-            operation_id,
-            operation_kind = operation_kind,
-            checkout_wait_ms = checkout_started.elapsed().as_millis() as u64,
-            deadline_remaining_ms = remaining_ms_until(deadline),
-            "ducklake blocking operation checked out pooled connection: operation_id={}, \
-             operation_kind={}, checkout_wait_ms={}, deadline_remaining_ms={}",
-            operation_id,
-            operation_kind,
-            checkout_started.elapsed().as_millis(),
-            remaining_ms_until(deadline)
-        );
         trace!(
             wait_ms = checkout_started.elapsed().as_millis() as u64,
             "wait for ducklake pool checkout"
@@ -1080,24 +746,13 @@ where
             warn!(
                 operation_id,
                 operation_kind = operation_kind,
-                "ducklake blocking operation skipped because shutdown was requested: \
-                 operation_id={}, operation_kind={}",
-                operation_id,
-                operation_kind
+                "ducklake blocking operation skipped because shutdown was requested"
             );
             return Err(ducklake_shutdown_requested_error());
         }
         let operation_timeout =
             deadline.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO);
         if operation_timeout.is_zero() {
-            warn!(
-                operation_id,
-                operation_kind = operation_kind,
-                "ducklake blocking operation deadline reached before query execution: \
-                 operation_id={}, operation_kind={}",
-                operation_id,
-                operation_kind
-            );
             return Err(duckdb_blocking_timeout_error(timeout, "query_execution"));
         }
         pooled_conn.interrupt_handle.clear_reason();
@@ -1110,63 +765,13 @@ where
         let interrupt_handle: Arc<RegisteredDuckLakeInterrupt> =
             Arc::clone(&pooled_conn.interrupt_handle);
         let interrupt_handle: DuckDbQueryInterruptHandle = interrupt_handle;
-        info!(
-            operation_id,
-            operation_kind = operation_kind,
-            operation_timeout_ms = operation_timeout.as_millis() as u64,
-            "ducklake blocking operation publishing interrupt handle before query execution: \
-             operation_id={}, operation_kind={}, operation_timeout_ms={}",
-            operation_id,
-            operation_kind,
-            operation_timeout.as_millis()
-        );
         watchdog.publish_interrupt_handle(interrupt_handle);
-        let interrupt_reason = pooled_conn.interrupt_handle.interrupt_reason();
         if watchdog.timed_out() {
-            warn!(
-                operation_id,
-                operation_kind = operation_kind,
-                interrupt_reason = interrupt_reason.as_str(),
-                "ducklake blocking operation timed out before query started; marking pooled \
-                 connection broken: operation_id={}, operation_kind={}, interrupt_reason={}",
-                operation_id,
-                operation_kind,
-                interrupt_reason.as_str()
-            );
             pooled_conn.broken = true;
             return Err(duckdb_blocking_timeout_error(timeout, "query_execution"));
         }
         let operation_started = Instant::now();
-        info!(
-            operation_id,
-            operation_kind = operation_kind,
-            deadline_remaining_ms = remaining_ms_until(deadline),
-            "ducklake blocking operation invoking DuckDB closure: operation_id={}, \
-             operation_kind={}, deadline_remaining_ms={}",
-            operation_id,
-            operation_kind,
-            remaining_ms_until(deadline)
-        );
         let res = operation(&pooled_conn.conn, &operation_context);
-        let operation_duration_ms = operation_started.elapsed().as_millis() as u64;
-        let interrupt_reason = pooled_conn.interrupt_handle.interrupt_reason();
-        info!(
-            operation_id,
-            operation_kind = operation_kind,
-            duration_ms = operation_duration_ms,
-            timed_out = watchdog.timed_out(),
-            interrupt_reason = interrupt_reason.as_str(),
-            result_is_error = res.is_err(),
-            "ducklake blocking operation DuckDB closure returned: operation_id={}, \
-             operation_kind={}, duration_ms={}, timed_out={}, interrupt_reason={}, \
-             result_is_error={}",
-            operation_id,
-            operation_kind,
-            operation_duration_ms,
-            watchdog.timed_out(),
-            interrupt_reason.as_str(),
-            res.is_err()
-        );
         watchdog.finish();
         histogram!(ETL_DUCKLAKE_BLOCKING_OPERATION_DURATION_SECONDS)
             .record(operation_started.elapsed().as_secs_f64());
@@ -1175,61 +780,16 @@ where
             "ducklake blocking operation finished"
         );
         if watchdog.timed_out() {
-            warn!(
-                operation_id,
-                operation_kind = operation_kind,
-                duration_ms = operation_duration_ms,
-                interrupt_reason = interrupt_reason.as_str(),
-                "ducklake blocking operation returned after timeout; marking pooled connection \
-                 broken: operation_id={}, operation_kind={}, duration_ms={}, interrupt_reason={}",
-                operation_id,
-                operation_kind,
-                operation_duration_ms,
-                interrupt_reason.as_str()
-            );
             pooled_conn.broken = true;
             return Err(duckdb_blocking_timeout_error(timeout, "query_execution"));
         }
         if res.is_err() {
-            warn!(
-                operation_id,
-                operation_kind = operation_kind,
-                duration_ms = operation_duration_ms,
-                interrupt_reason = interrupt_reason.as_str(),
-                "ducklake blocking operation returned error; marking pooled connection broken: \
-                 operation_id={}, operation_kind={}, duration_ms={}, interrupt_reason={}",
-                operation_id,
-                operation_kind,
-                operation_duration_ms,
-                interrupt_reason.as_str()
-            );
             pooled_conn.broken = true;
-        } else {
-            info!(
-                operation_id,
-                operation_kind = operation_kind,
-                duration_ms = operation_duration_ms,
-                "ducklake blocking operation returned success; pooled connection remains healthy: \
-                 operation_id={}, operation_kind={}, duration_ms={}",
-                operation_id,
-                operation_kind,
-                operation_duration_ms
-            );
         }
 
         res
     });
 
-    info!(
-        operation_id,
-        operation_kind = operation_kind,
-        abort_deadline_remaining_ms = remaining_ms_until(abort_deadline),
-        "ducklake blocking operation waiting for blocking task or abort deadline: \
-         operation_id={}, operation_kind={}, abort_deadline_remaining_ms={}",
-        operation_id,
-        operation_kind,
-        remaining_ms_until(abort_deadline)
-    );
     let blocking_result = tokio::select! {
         biased;
         result = blocking_task => result,
@@ -1240,89 +800,15 @@ where
             // the stuck native call also keeps holding its semaphore permit and
             // blocking thread, so restarting the process is the recoverable
             // boundary.
-            abort_stuck_duckdb_blocking_operation(operation_id, timeout, BLOCKING_ABORT_GRACE);
+            abort_stuck_duckdb_blocking_operation(timeout, BLOCKING_ABORT_GRACE);
         }
     };
 
-    match &blocking_result {
-        Ok(Ok(_)) => info!(
-            operation_id,
-            operation_kind = operation_kind,
-            timed_out = watchdog_timed_out.load(Ordering::Relaxed),
-            "ducklake blocking operation task joined with success: operation_id={}, \
-             operation_kind={}, timed_out={}",
-            operation_id,
-            operation_kind,
-            watchdog_timed_out.load(Ordering::Relaxed)
-        ),
-        Ok(Err(error)) => warn!(
-            operation_id,
-            operation_kind = operation_kind,
-            timed_out = watchdog_timed_out.load(Ordering::Relaxed),
-            error = ?error,
-            "ducklake blocking operation task joined with error: operation_id={}, operation_kind={}, \
-             timed_out={}, error={:?}",
-            operation_id,
-            operation_kind,
-            watchdog_timed_out.load(Ordering::Relaxed),
-            error
-        ),
-        Err(error) => tracing::error!(
-            operation_id,
-            operation_kind = operation_kind,
-            timed_out = watchdog_timed_out.load(Ordering::Relaxed),
-            error = %error,
-            "ducklake blocking operation task join failed: operation_id={}, operation_kind={}, \
-             timed_out={}, error={}",
-            operation_id,
-            operation_kind,
-            watchdog_timed_out.load(Ordering::Relaxed),
-            error
-        ),
-    }
-
     // Await the watchdog so it cannot outlive the finished blocking task and
     // accidentally interrupt a later operation that reuses the connection.
-    info!(
-        operation_id,
-        operation_kind = operation_kind,
-        timed_out = watchdog_timed_out.load(Ordering::Relaxed),
-        "ducklake blocking operation awaiting watchdog task: operation_id={}, operation_kind={}, \
-         timed_out={}",
-        operation_id,
-        operation_kind,
-        watchdog_timed_out.load(Ordering::Relaxed)
-    );
-    match watchdog_task.await {
-        Ok(()) => info!(
-            operation_id,
-            operation_kind = operation_kind,
-            timed_out = watchdog_timed_out.load(Ordering::Relaxed),
-            "ducklake blocking operation watchdog task joined: operation_id={}, \
-             operation_kind={}, timed_out={}",
-            operation_id,
-            operation_kind,
-            watchdog_timed_out.load(Ordering::Relaxed)
-        ),
-        Err(error) => {
-            tracing::error!(
-                operation_id,
-                operation_kind = operation_kind,
-                timed_out = watchdog_timed_out.load(Ordering::Relaxed),
-                error = %error,
-                "ducklake blocking operation watchdog task panicked: operation_id={}, operation_kind={}, \
-                 timed_out={}, error={}",
-                operation_id,
-                operation_kind,
-                watchdog_timed_out.load(Ordering::Relaxed),
-                error
-            );
-            return Err(etl_error!(
-                ErrorKind::ApplyWorkerPanic,
-                "DuckLake query watchdog task panicked"
-            ));
-        }
-    }
+    watchdog_task.await.map_err(|_| {
+        etl_error!(ErrorKind::ApplyWorkerPanic, "DuckLake query watchdog task panicked")
+    })?;
 
     blocking_result.map_err(|_| {
         etl_error!(ErrorKind::ApplyWorkerPanic, "DuckLake blocking operation task panicked")

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -1,11 +1,9 @@
 #[cfg(feature = "test-utils")]
 use std::sync::atomic::AtomicUsize;
-#[cfg(test)]
-use std::time::Duration;
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, atomic::AtomicBool},
-    time::Instant,
+    time::Duration,
 };
 
 use etl::{
@@ -1795,24 +1793,20 @@ where
                                     &segment.replicated_table_schema,
                                 )
                                 .await?;
-                            let _table_write_permit =
-                                destination.acquire_table_write_slot(&destination_table_name).await?;
+                            let _table_write_permit = destination
+                                .acquire_table_write_slot(&destination_table_name)
+                                .await?;
                             let checkpoint_wait_started = tokio::time::Instant::now();
-                            info!(
-                                table = %destination_table_name,
-                                "ducklake waiting for checkpoint gate before streaming write: table={}",
-                                destination_table_name
-                            );
                             let _checkpoint_guard =
                                 Arc::clone(&destination.checkpoint_gate).read_owned().await;
                             let checkpoint_wait = checkpoint_wait_started.elapsed();
-                            info!(
-                                table = %destination_table_name,
-                                checkpoint_wait_ms = checkpoint_wait.as_millis() as u64,
-                                "ducklake acquired checkpoint gate before streaming write: table={}, checkpoint_wait_ms={}",
-                                destination_table_name,
-                                checkpoint_wait.as_millis()
-                            );
+                            if checkpoint_wait > Duration::from_secs(1) {
+                                info!(
+                                    table = %destination_table_name,
+                                    checkpoint_wait_ms = checkpoint_wait.as_millis() as u64,
+                                    "ducklake waited for checkpoint gate before streaming write"
+                                );
+                            }
                             let last_sequence_key =
                                 read_table_streaming_progress_sequence_key_blocking(
                                     Arc::clone(&destination.pool),
@@ -1827,8 +1821,7 @@ where
                             if pending_mutations.is_empty() {
                                 debug!(
                                     table = %destination_table_name,
-                                    "ducklake streaming mutation replay skipped, no pending events: table={}",
-                                    destination_table_name
+                                    "ducklake streaming mutation replay skipped, no pending events"
                                 );
                                 continue;
                             }
@@ -1837,10 +1830,7 @@ where
                                 table = %destination_table_name,
                                 pending_mutation_count = pending_mutations.len(),
                                 is_first_streaming_batch,
-                                "ducklake applying streaming mutations: table={}, pending_mutation_count={}, is_first_streaming_batch={}",
-                                destination_table_name,
-                                pending_mutations.len(),
-                                is_first_streaming_batch
+                                "ducklake applying streaming mutations"
                             );
 
                             let prepared_batches = prepare_mutation_table_batches(
@@ -1857,9 +1847,7 @@ where
                             info!(
                                 table = %destination_table_name,
                                 is_first_streaming_batch,
-                                "ducklake applied streaming mutations: table={}, is_first_streaming_batch={}",
-                                destination_table_name,
-                                is_first_streaming_batch
+                                "ducklake applied streaming mutations"
                             );
                         }
 
@@ -1918,21 +1906,7 @@ where
                     let blocking_slots = Arc::clone(&self.blocking_slots);
                     join_set.spawn(async move {
                         let _table_write_permit = table_write_permit;
-                        let checkpoint_wait_started = tokio::time::Instant::now();
-                        info!(
-                            table = %table_name,
-                            "ducklake waiting for checkpoint gate before streaming truncate: table={}",
-                            table_name
-                        );
                         let _checkpoint_guard = checkpoint_gate.read_owned().await;
-                        let checkpoint_wait = checkpoint_wait_started.elapsed();
-                        info!(
-                            table = %table_name,
-                            checkpoint_wait_ms = checkpoint_wait.as_millis() as u64,
-                            "ducklake acquired checkpoint gate before streaming truncate: table={}, checkpoint_wait_ms={}",
-                            table_name,
-                            checkpoint_wait.as_millis()
-                        );
                         let last_sequence_key =
                             read_table_streaming_progress_sequence_key_blocking(
                                 Arc::clone(&pool),
@@ -1945,19 +1919,11 @@ where
                         if pending_truncates.is_empty() {
                             debug!(
                                 table = %table_name,
-                                "ducklake streaming truncate replay skipped, no pending events: table={}",
-                                table_name
+                                "ducklake streaming truncate replay skipped, no pending events"
                             );
                             return Ok(());
                         }
 
-                        info!(
-                            table = %table_name,
-                            pending_truncate_count = pending_truncates.len(),
-                            "ducklake applying streaming truncates: table={}, pending_truncate_count={}",
-                            table_name,
-                            pending_truncates.len()
-                        );
                         let prepared_batch =
                             prepare_truncate_table_batch(table_name, pending_truncates);
                         apply_table_batch_with_retry(pool, blocking_slots, prepared_batch).await
@@ -2198,9 +2164,7 @@ where
         info!(
             table_id = %table_id,
             table = %table_name,
-            "ducklake destination table cache miss, ensuring table exists: table_id={}, table={}",
-            table_id,
-            table_name
+            "ducklake destination table cache miss, ensuring table exists"
         );
 
         let _table_creation_permit =
@@ -2309,19 +2273,14 @@ where
             Err(TryAcquireError::NoPermits) => {
                 info!(
                     table = %table_name,
-                    "ducklake waiting for table write slot: table={}",
-                    table_name
+                    "ducklake waiting for table write slot"
                 );
-                let started = Instant::now();
                 let permit = table_slot.acquire_owned().await.map_err(|_| {
                     etl_error!(ErrorKind::InvalidState, "DuckLake table write semaphore closed")
                 })?;
                 info!(
                     table = %table_name,
-                    wait_ms = started.elapsed().as_millis() as u64,
-                    "ducklake acquired table write slot after wait: table={}, wait_ms={}",
-                    table_name,
-                    started.elapsed().as_millis()
+                    "ducklake acquired table write slot after wait"
                 );
                 Ok(permit)
             }
@@ -2334,42 +2293,16 @@ where
     /// Acquires shared mutation access so exclusive background maintenance
     /// cannot start in the middle of a foreground write sequence.
     async fn acquire_mutation_guard(&self) -> OwnedRwLockReadGuard<()> {
-        let started = Instant::now();
-        info!(
-            metadata_schema = %self.metadata_schema,
-            "ducklake waiting for shared mutation guard: metadata_schema={}",
-            self.metadata_schema
-        );
-        let guard = Arc::clone(&self.checkpoint_gate).read_owned().await;
-        info!(
-            metadata_schema = %self.metadata_schema,
-            wait_ms = started.elapsed().as_millis() as u64,
-            "ducklake acquired shared mutation guard: metadata_schema={}, wait_ms={}",
-            self.metadata_schema,
-            started.elapsed().as_millis()
-        );
-        guard
+        Arc::clone(&self.checkpoint_gate).read_owned().await
     }
 
     /// Acquires exclusive DuckLake mutation access for an external maintenance
     /// run. While this guard is held, new foreground writes and in-process
     /// background maintenance operations wait before mutating the catalog.
     pub async fn acquire_external_maintenance_pause(&self) -> DuckLakeExternalMaintenancePause {
-        let started = Instant::now();
-        info!(
-            metadata_schema = %self.metadata_schema,
-            "ducklake waiting for exclusive external maintenance mutation guard: metadata_schema={}",
-            self.metadata_schema
-        );
-        let guard = Arc::clone(&self.checkpoint_gate).write_owned().await;
-        info!(
-            metadata_schema = %self.metadata_schema,
-            wait_ms = started.elapsed().as_millis() as u64,
-            "ducklake acquired exclusive external maintenance mutation guard: metadata_schema={}, wait_ms={}",
-            self.metadata_schema,
-            started.elapsed().as_millis()
-        );
-        DuckLakeExternalMaintenancePause { _guard: guard }
+        DuckLakeExternalMaintenancePause {
+            _guard: Arc::clone(&self.checkpoint_gate).write_owned().await,
+        }
     }
 
     /// Samples catalog state and returns which externally coordinated

--- a/crates/etl-destinations/src/ducklake/external_maintenance.rs
+++ b/crates/etl-destinations/src/ducklake/external_maintenance.rs
@@ -96,10 +96,7 @@ where
         )
         .await?;
 
-    info!(
-        pipeline_id,
-        "ducklake Postgres external maintenance watcher configured: pipeline_id={}", pipeline_id
-    );
+    info!(pipeline_id, "ducklake Postgres external maintenance watcher configured");
 
     run_external_maintenance_watcher(destination, store, config).await
 }
@@ -121,11 +118,7 @@ where
         poll_interval_ms = config.poll_interval.as_millis() as u64,
         request_cooldown_ms = config.request_cooldown.as_millis() as u64,
         store_timeout_ms = config.store_timeout.as_millis() as u64,
-        "ducklake external maintenance watcher started: poll_interval_ms={}, \
-         request_cooldown_ms={}, store_timeout_ms={}",
-        config.poll_interval.as_millis(),
-        config.request_cooldown.as_millis(),
-        config.store_timeout.as_millis()
+        "ducklake external maintenance watcher started"
     );
 
     loop {
@@ -152,17 +145,14 @@ where
                 warn!(
                     error = %error,
                     timeout_ms = config.store_timeout.as_millis() as u64,
-                    "failed to read ducklake external maintenance state: timeout_ms={}, error={}",
-                    config.store_timeout.as_millis(),
-                    error
+                    "failed to read ducklake external maintenance state"
                 );
                 release_expired_pause_if_needed(&store, &config, &mut held_pause).await;
             }
             Err(_) => {
                 warn!(
                     timeout_ms = config.store_timeout.as_millis() as u64,
-                    "timed out reading ducklake external maintenance state: timeout_ms={}",
-                    config.store_timeout.as_millis()
+                    "timed out reading ducklake external maintenance state"
                 );
                 release_expired_pause_if_needed(&store, &config, &mut held_pause).await;
             }
@@ -179,16 +169,13 @@ where
     if let Some(held) = held_pause.take() {
         info!(
             run_id = %held.run_id,
-            "ducklake maintenance state disappeared, resuming foreground mutations: run_id={}",
-            held.run_id
+            "ducklake maintenance state disappeared, resuming foreground mutations"
         );
         release_held_pause(held, "state_missing");
         if let Err(error) = store.clear_replicator_status().await {
             warn!(
                 error = %error,
-                "failed to clear ducklake maintenance replicator status after state disappeared: \
-                 error={}",
-                error
+                "failed to clear ducklake maintenance replicator status after state disappeared"
             );
         }
     }
@@ -209,9 +196,7 @@ async fn reconcile_pause<S, M>(
         if let Some(held) = held_pause.take() {
             info!(
                 run_id = %held.run_id,
-                "ducklake external maintenance pause cleared, resuming foreground mutations: \
-                 run_id={}",
-                held.run_id
+                "ducklake external maintenance pause cleared, resuming foreground mutations"
             );
             release_held_pause(held, "cleared");
             report_running(store, config.store_timeout).await;
@@ -240,10 +225,7 @@ async fn reconcile_pause<S, M>(
         info!(
             previous_run_id = %held.run_id,
             next_run_id = %pause.run_id,
-            "ducklake external maintenance pause replaced, resuming previous run before pausing again: \
-             previous_run_id={}, next_run_id={}",
-            held.run_id,
-            pause.run_id
+            "ducklake external maintenance pause replaced, resuming previous run before pausing again"
         );
         release_held_pause(held, "replaced");
         report_running(store, config.store_timeout).await;
@@ -252,10 +234,7 @@ async fn reconcile_pause<S, M>(
     info!(
         run_id = %pause.run_id,
         expires_at = %pause.expires_at.to_rfc3339(),
-        "ducklake external maintenance pause requested, waiting for foreground mutations to drain: \
-         run_id={}, expires_at={}",
-        pause.run_id,
-        pause.expires_at.to_rfc3339()
+        "ducklake external maintenance pause requested, waiting for foreground mutations to drain"
     );
     report_pausing(store, &pause.run_id, config.store_timeout).await;
     let operations = active_pause_operations(state, &pause);
@@ -267,9 +246,7 @@ async fn reconcile_pause<S, M>(
             run_id = %pause.run_id,
             expires_at = %pause.expires_at.to_rfc3339(),
             "ducklake external maintenance pause expired before quiescence, resuming foreground \
-             mutations: run_id={}, expires_at={}",
-            pause.run_id,
-            pause.expires_at.to_rfc3339()
+             mutations"
         );
         release_held_pause(
             HeldPause {
@@ -292,11 +269,7 @@ async fn reconcile_pause<S, M>(
         run_id = %pause.run_id,
         quiesced_at = %quiesced_at.to_rfc3339(),
         expires_at = %pause.expires_at.to_rfc3339(),
-        "ducklake external maintenance quiesced, foreground mutations are paused: run_id={}, \
-         quiesced_at={}, expires_at={}",
-        pause.run_id,
-        quiesced_at.to_rfc3339(),
-        pause.expires_at.to_rfc3339()
+        "ducklake external maintenance quiesced, foreground mutations are paused"
     );
     let quiesced_reported =
         report_quiesced(store, &pause.run_id, quiesced_at, config.store_timeout).await;
@@ -305,10 +278,7 @@ async fn reconcile_pause<S, M>(
             run_id = %pause.run_id,
             timeout_ms = config.store_timeout.as_millis() as u64,
             "ducklake external maintenance quiesced status was not confirmed; keeping foreground \
-             mutations paused until the status patch succeeds or the pause expires: run_id={}, \
-             timeout_ms={}",
-            pause.run_id,
-            config.store_timeout.as_millis()
+             mutations paused until the status patch succeeds or the pause expires"
         );
     }
 
@@ -338,9 +308,7 @@ async fn release_expired_pause_if_needed<M>(
     };
     warn!(
         run_id = %expired.run_id,
-        "ducklake maintenance pause expired while external maintenance store was unavailable: \
-         run_id={}",
-        expired.run_id
+        "ducklake maintenance pause expired while external maintenance store was unavailable"
     );
     release_held_pause(expired, "expired");
     report_running(store, config.store_timeout).await;
@@ -355,10 +323,7 @@ fn release_held_pause(held: HeldPause, outcome: &'static str) {
         run_id = %held.run_id,
         outcome,
         held_ms,
-        "ducklake external maintenance pause guard released: run_id={}, outcome={}, held_ms={}",
-        held.run_id,
-        outcome,
-        held_ms
+        "ducklake external maintenance pause guard released"
     );
 }
 
@@ -477,10 +442,7 @@ impl ExpireSnapshotsRequestGate {
         debug!(
             completed_at = %completed_at,
             next_request_after = ?self.next_request_after,
-            "ducklake expire-snapshots request gate initialized from maintenance state: \
-             completed_at={}, next_request_after={:?}",
-            completed_at,
-            self.next_request_after
+            "ducklake expire-snapshots request gate initialized from maintenance state"
         );
     }
 
@@ -533,8 +495,7 @@ async fn maybe_request_operations<S, M>(
         Err(error) => {
             warn!(
                 error = %error,
-                "failed to sample ducklake external maintenance operations: error={}",
-                error
+                "failed to sample ducklake external maintenance operations"
             );
             return;
         }
@@ -609,15 +570,13 @@ async fn maybe_request_operations<S, M>(
         Ok(Err(error)) => {
             warn!(
                 error = %error,
-                "failed to request ducklake external maintenance operations: error={}",
-                error
+                "failed to request ducklake external maintenance operations"
             );
         }
         Err(_) => {
             warn!(
                 timeout_ms = config.store_timeout.as_millis() as u64,
-                "timed out requesting ducklake external maintenance operations: timeout_ms={}",
-                config.store_timeout.as_millis()
+                "timed out requesting ducklake external maintenance operations"
             );
         }
     }
@@ -691,9 +650,7 @@ where
             warn!(
                 error = %error,
                 state = ?state,
-                "failed to report ducklake maintenance replicator status: state={:?}, error={}",
-                state,
-                error
+                "failed to report ducklake maintenance replicator status"
             );
             false
         }
@@ -701,10 +658,7 @@ where
             warn!(
                 state = ?state,
                 timeout_ms = timeout.as_millis() as u64,
-                "timed out reporting ducklake maintenance replicator status: state={:?}, \
-                 timeout_ms={}",
-                state,
-                timeout.as_millis()
+                "timed out reporting ducklake maintenance replicator status"
             );
             false
         }


### PR DESCRIPTION
These logs were introduced in https://github.com/supabase/etl/pull/721 to debug and make sure having enough context to debug. It's no longer required.