### PR TITLE
feat(lag): Improve the lag calculation

### DIFF
--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -373,9 +373,46 @@ pub struct TableStatus {
     pub table_sync_lag: Option<SlotLagMetricsResponse>,
 }
 
+/// WAL availability status reported by Postgres for a replication slot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum SlotWalStatusResponse {
+    /// Required WAL is still within normal retention.
+    Reserved,
+    /// Required WAL exceeds `max_wal_size`, but is still retained.
+    Extended,
+    /// Required WAL is no longer fully reserved and can be removed at the next
+    /// checkpoint.
+    Unreserved,
+    /// Required WAL has been removed and the slot is no longer usable.
+    Lost,
+    /// A WAL status value not known by this API version.
+    Unknown,
+}
+
+impl From<lag::SlotWalStatus> for SlotWalStatusResponse {
+    fn from(status: lag::SlotWalStatus) -> Self {
+        match status {
+            lag::SlotWalStatus::Reserved => Self::Reserved,
+            lag::SlotWalStatus::Extended => Self::Extended,
+            lag::SlotWalStatus::Unreserved => Self::Unreserved,
+            lag::SlotWalStatus::Lost => Self::Lost,
+            lag::SlotWalStatus::Unknown => Self::Unknown,
+        }
+    }
+}
+
 /// Lag metrics reported for replication slots.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SlotLagMetricsResponse {
+    /// Whether the slot currently has an active replication connection.
+    pub active: bool,
+    /// The WAL availability status reported by Postgres for the slot. Known
+    /// values are `reserved`, `extended`, `unreserved`, and `lost`; unknown
+    /// future values are returned as `unknown`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = true)]
+    pub wal_status: Option<SlotWalStatusResponse>,
     /// Bytes between the current WAL location and the slot restart LSN.
     #[schema(example = 1024)]
     pub restart_lsn_bytes: i64,
@@ -383,9 +420,10 @@ pub struct SlotLagMetricsResponse {
     #[schema(example = 2048)]
     pub confirmed_flush_lsn_bytes: i64,
     /// How many bytes of WAL are still safe to build up before the limit of the
-    /// slot is reached.
-    #[schema(example = 8192)]
-    pub safe_wal_size_bytes: i64,
+    /// slot is reached. `None` means Postgres reports unlimited slot WAL
+    /// retention.
+    #[schema(example = 8192, nullable = true)]
+    pub safe_wal_size_bytes: Option<i64>,
     /// Write lag expressed in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 1500, nullable = true)]
@@ -394,16 +432,24 @@ pub struct SlotLagMetricsResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 1200, nullable = true)]
     pub flush_lag: Option<i64>,
+    /// Milliseconds elapsed since the walsender last received client feedback.
+    /// This can be present even when write and flush lag are unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 5000, nullable = true)]
+    pub reply_time_lag: Option<i64>,
 }
 
 impl From<lag::SlotLagMetrics> for SlotLagMetricsResponse {
     fn from(metrics: lag::SlotLagMetrics) -> Self {
         Self {
+            active: metrics.active,
+            wal_status: metrics.wal_status.map(Into::into),
             restart_lsn_bytes: metrics.restart_lsn_bytes,
             confirmed_flush_lsn_bytes: metrics.confirmed_flush_lsn_bytes,
             safe_wal_size_bytes: metrics.safe_wal_size_bytes,
             write_lag: metrics.write_lag_ms,
             flush_lag: metrics.flush_lag_ms,
+            reply_time_lag: metrics.reply_time_lag_ms,
         }
     }
 }

--- a/crates/etl-postgres/src/replication/lag.rs
+++ b/crates/etl-postgres/src/replication/lag.rs
@@ -2,11 +2,18 @@ use std::collections::BTreeMap;
 
 use sqlx::{FromRow, PgExecutor};
 
-use crate::{replication::slots::EtlReplicationSlot, types::TableId};
+use crate::{
+    replication::slots::{EtlReplicationSlot, table_sync_like_pattern},
+    types::TableId,
+};
 
 /// Lag metrics associated with a logical replication slot.
 #[derive(Debug)]
 pub struct SlotLagMetrics {
+    /// Whether the slot currently has an active replication connection.
+    pub active: bool,
+    /// The WAL availability status reported by Postgres for the slot.
+    pub wal_status: Option<SlotWalStatus>,
     /// The number of bytes between the current WAL LSN and the slot restart
     /// LSN.
     pub restart_lsn_bytes: i64,
@@ -15,11 +22,41 @@ pub struct SlotLagMetrics {
     pub confirmed_flush_lsn_bytes: i64,
     /// How many bytes of WAL are still safe to build up before the limit of the
     /// slot is reached.
-    pub safe_wal_size_bytes: i64,
+    pub safe_wal_size_bytes: Option<i64>,
     /// Write lag in milliseconds relative to the primary.
     pub write_lag_ms: Option<i64>,
     /// Flush lag in milliseconds relative to the primary.
     pub flush_lag_ms: Option<i64>,
+    /// Milliseconds elapsed since the walsender last received client feedback.
+    pub reply_time_lag_ms: Option<i64>,
+}
+
+/// WAL availability status reported by Postgres for a replication slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlotWalStatus {
+    /// Required WAL is still within normal retention.
+    Reserved,
+    /// Required WAL exceeds `max_wal_size`, but is still retained.
+    Extended,
+    /// Required WAL is no longer fully reserved and can be removed at the next
+    /// checkpoint.
+    Unreserved,
+    /// Required WAL has been removed and the slot is no longer usable.
+    Lost,
+    /// A WAL status value not known by this ETL version.
+    Unknown,
+}
+
+impl From<String> for SlotWalStatus {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "reserved" => Self::Reserved,
+            "extended" => Self::Extended,
+            "unreserved" => Self::Unreserved,
+            "lost" => Self::Lost,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 /// Lag metrics for pipeline apply and table sync workers.
@@ -35,11 +72,14 @@ pub struct PipelineLagMetrics {
 #[derive(Debug, FromRow)]
 struct SlotLagRow {
     slot_name: String,
+    active: bool,
+    wal_status: Option<String>,
     restart_lsn_bytes: i64,
     confirmed_flush_lsn_bytes: i64,
-    safe_wal_size_bytes: i64,
+    safe_wal_size_bytes: Option<i64>,
     write_lag_ms: Option<i64>,
     flush_lag_ms: Option<i64>,
+    reply_time_lag_ms: Option<i64>,
 }
 
 /// Fetches replication lag metrics for the given pipeline by inspecting logical
@@ -47,8 +87,8 @@ struct SlotLagRow {
 ///
 /// Returns aggregated lag metrics for the apply worker slot and each table sync
 /// slot associated with the pipeline. Slots that are not currently active in
-/// `pg_stat_replication` still report their WAL metrics, while the write and
-/// flush lag values remain `None`.
+/// `pg_stat_replication` still report their slot WAL metrics, while the
+/// walsender feedback metrics remain `None`.
 pub async fn get_pipeline_lag_metrics<'c, E>(
     executor: E,
     pipeline_id: u64,
@@ -59,27 +99,35 @@ where
     let Ok(apply_prefix) = EtlReplicationSlot::apply_prefix(pipeline_id) else {
         return Ok(PipelineLagMetrics::default());
     };
-    let Ok(table_sync_prefix) = EtlReplicationSlot::table_sync_prefix(pipeline_id) else {
+    let Ok(table_sync_pattern) = table_sync_like_pattern(pipeline_id) else {
         return Ok(PipelineLagMetrics::default());
     };
 
     let rows: Vec<SlotLagRow> = sqlx::query_as(
         r#"
+        with current_wal as (
+            select pg_current_wal_lsn() as lsn
+        )
         select
             s.slot_name,
-            coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), s.restart_lsn), 0)::bigint as restart_lsn_bytes,
-            coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), s.confirmed_flush_lsn), 0)::bigint as confirmed_flush_lsn_bytes,
-            coalesce(s.safe_wal_size, 0) as safe_wal_size_bytes,
+            s.active,
+            s.wal_status,
+            coalesce(pg_wal_lsn_diff(current_wal.lsn, s.restart_lsn), 0)::bigint as restart_lsn_bytes,
+            coalesce(pg_wal_lsn_diff(current_wal.lsn, s.confirmed_flush_lsn), 0)::bigint as confirmed_flush_lsn_bytes,
+            s.safe_wal_size as safe_wal_size_bytes,
             round(extract(epoch from r.write_lag) * 1000)::bigint as write_lag_ms,
-            round(extract(epoch from r.flush_lag) * 1000)::bigint as flush_lag_ms
+            round(extract(epoch from r.flush_lag) * 1000)::bigint as flush_lag_ms,
+            round(extract(epoch from clock_timestamp() - r.reply_time) * 1000)::bigint as reply_time_lag_ms
         from pg_replication_slots as s
+        cross join current_wal
         left outer join pg_stat_replication as r on s.active_pid = r.pid
         where s.slot_type = 'logical'
-          and (s.slot_name = $1 or s.slot_name like $2)
+          and s.database = current_database()
+          and (s.slot_name = $1 or s.slot_name like $2 escape '\')
         "#,
     )
     .bind(apply_prefix)
-    .bind(format!("{table_sync_prefix}%"))
+    .bind(table_sync_pattern)
     .fetch_all(executor)
     .await?;
 
@@ -87,11 +135,14 @@ where
 
     for row in rows {
         let slot_lag_metrics = SlotLagMetrics {
+            active: row.active,
+            wal_status: row.wal_status.map(Into::into),
             restart_lsn_bytes: row.restart_lsn_bytes,
             confirmed_flush_lsn_bytes: row.confirmed_flush_lsn_bytes,
             safe_wal_size_bytes: row.safe_wal_size_bytes,
             write_lag_ms: row.write_lag_ms,
             flush_lag_ms: row.flush_lag_ms,
+            reply_time_lag_ms: row.reply_time_lag_ms,
         };
 
         match EtlReplicationSlot::try_from(row.slot_name.as_str()) {

--- a/crates/etl-postgres/src/replication/slots.rs
+++ b/crates/etl-postgres/src/replication/slots.rs
@@ -138,10 +138,14 @@ impl TryFrom<EtlReplicationSlot> for String {
 /// Builds a SQL `LIKE` pattern that matches all table-sync replication slots
 /// belonging to the given pipeline.
 ///
+/// Table-sync slots include a table id suffix, so callers use this pattern when
+/// they need all table-sync slots for a pipeline and do not already know the
+/// table ids.
+///
 /// The pattern escapes the literal `_` characters in the slot prefix so that
 /// LIKE does not treat them as single-character wildcards. Must be used with
 /// `LIKE ... ESCAPE '\'`.
-fn table_sync_like_pattern(pipeline_id: u64) -> Result<String, EtlReplicationSlotError> {
+pub(super) fn table_sync_like_pattern(pipeline_id: u64) -> Result<String, EtlReplicationSlotError> {
     let prefix = EtlReplicationSlot::table_sync_prefix(pipeline_id)?;
     Ok(format!("{}%", prefix.replace('_', r"\_")))
 }

--- a/docs/src/content/docs/guides/configure-postgres.md
+++ b/docs/src/content/docs/guides/configure-postgres.md
@@ -142,11 +142,13 @@ If a slot is terminated due to exceeding this limit, ETL will restart the table 
 ### Monitoring WAL Usage
 
 ```sql
--- Check replication slot lag (how far behind each slot is)
+-- Check replication slot WAL usage.
 SELECT slot_name,
-       pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag_bytes,
-       pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS lag_pretty,
-       active
+       active,
+       wal_status,
+       pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS retained_wal_bytes,
+       pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) AS confirmed_flush_lag_bytes,
+       safe_wal_size
 FROM pg_replication_slots;
 
 -- Check total WAL directory size
@@ -154,10 +156,24 @@ SELECT pg_size_pretty(sum(size)) AS wal_size
 FROM pg_ls_waldir();
 ```
 
+`wal_status` reports whether the WAL required by a replication slot is still
+available:
+
+- `reserved`: required WAL is within normal retention.
+- `extended`: required WAL exceeds `max_wal_size`, but Postgres is still retaining it.
+- `unreserved`: required WAL is no longer fully reserved and may be removed at the next checkpoint.
+- `lost`: required WAL was removed and the slot is no longer usable.
+- `NULL`: the slot has not reserved WAL yet, usually because `restart_lsn` is `NULL`.
+
+ETL API responses return unknown future Postgres `wal_status` values as `unknown`.
+
 ### Recommendations
 
 - Set `max_slot_wal_keep_size` to a reasonable limit based on available disk space
-- Monitor replication slot lag and alert when it exceeds acceptable thresholds
+- Monitor `confirmed_flush_lag_bytes` for logical replication lag
+- Monitor `retained_wal_bytes`, `safe_wal_size`, and `wal_status` for WAL retention risk
+- Treat `safe_wal_size IS NULL` as unlimited slot WAL retention, and `safe_wal_size = 0` as no remaining headroom
+- Alert when slots fall behind acceptable thresholds
 - Address errored tables promptly to prevent indefinite WAL accumulation
 - Size initial sync workers appropriately (`max_table_sync_workers`) to balance parallelism with resource usage
 


### PR DESCRIPTION
This PR improves the way we calculate the lag metrics in ETL. It now exposes more metrics and doesn't `coalesce` which will show no max wal size as `0`. In addition, it uses a CTE to get the current wal, so that we don't call it multiple times in the same querying, causing inconsistent results.