### PR TITLE
feat(api): Add replica identity and primary key validation

### DIFF
--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -288,7 +288,7 @@ pub trait K8sClient: Send + Sync {
     /// Does nothing if the config map does not exist.
     async fn delete_replicator_config_map(&self, prefix: &str) -> Result<(), K8sError>;
 
-    /// Creates or updates the replicator [`StatefulSet`].
+    /// Creates or updates the replicator `StatefulSet`.
     ///
     /// The stateful set references secrets and config maps created by other
     /// methods. Changing the configuration may trigger a rolling restart of
@@ -298,12 +298,12 @@ pub trait K8sClient: Send + Sync {
         config: ReplicatorStatefulSetConfig,
     ) -> Result<(), K8sError>;
 
-    /// Deletes the replicator [`StatefulSet`].
+    /// Deletes the replicator `StatefulSet`.
     ///
     /// Does nothing if the stateful set does not exist.
     async fn delete_replicator_stateful_set(&self, prefix: &str) -> Result<(), K8sError>;
 
-    /// Returns whether the replicator [`StatefulSet`] exists.
+    /// Returns whether the replicator `StatefulSet` exists.
     async fn replicator_stateful_set_exists(&self, prefix: &str) -> Result<bool, K8sError>;
 
     /// Creates or updates the DuckLake maintenance CR.

--- a/crates/etl-api/src/k8s/mod.rs
+++ b/crates/etl-api/src/k8s/mod.rs
@@ -7,10 +7,10 @@
 //!
 //! The default client, [`http::HttpK8sClient`], is backed by the [`kube`]
 //! crate and talks to the cluster using the ambient configuration (in-cluster
-//! or local `~/.kube/config`). Keeping the abstraction in [`base`] lets us
+//! or local `~/.kube/config`). Keeping the abstraction in `base` lets us
 //! swap implementations in tests and non-Kubernetes environments.
 //!
-//! See [`base`] for errors, pod phase mapping, and the client trait.
+//! See `base` for errors, pod phase mapping, and the client trait.
 
 mod base;
 pub mod cache;

--- a/crates/etl-api/src/routes/destinations.rs
+++ b/crates/etl-api/src/routes/destinations.rs
@@ -159,10 +159,14 @@ pub struct ReadDestinationsResponse {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ValidateDestinationRequest {
+    /// Source identifier used for source-aware destination validation.
     #[schema(example = 1)]
     pub source_id: Option<i64>,
+    /// Destination configuration to validate.
     #[schema(required = true)]
     pub config: FullApiDestinationConfig,
+    /// Pipeline configuration used to cross-reference source publication
+    /// details.
     pub pipeline_config: Option<FullApiPipelineConfig>,
 }
 
@@ -184,6 +188,7 @@ impl From<ValidationFailure> for ValidationFailureResponse {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ValidateDestinationResponse {
+    /// Validation failures found for the destination configuration.
     pub validation_failures: Vec<ValidationFailureResponse>,
 }
 

--- a/crates/etl-api/src/routes/destinations.rs
+++ b/crates/etl-api/src/routes/destinations.rs
@@ -13,14 +13,19 @@ use thiserror::Error;
 use utoipa::ToSchema;
 
 use crate::{
-    configs::{destination::FullApiDestinationConfig, encryption::EncryptionKeyring},
+    config::ApiConfig,
+    configs::{
+        destination::FullApiDestinationConfig, encryption::EncryptionKeyring,
+        pipeline::FullApiPipelineConfig,
+    },
     data,
     data::{
         destinations::{DestinationsDbError, destination_exists},
         pipelines::{PipelinesDbError, read_pipelines_for_destination_for_deletion},
+        sources::SourcesDbError,
     },
     k8s::{
-        K8sClient,
+        K8sClient, TrustedRootCertsCache,
         core::{K8sCoreError, first_active_pipeline_id},
     },
     routes::{
@@ -46,6 +51,9 @@ pub enum DestinationError {
     PipelinesDb(#[from] PipelinesDbError),
 
     #[error(transparent)]
+    SourcesDb(#[from] SourcesDbError),
+
+    #[error(transparent)]
     Validation(#[from] ValidationError),
 
     #[error("Failed to load environment: {0}")]
@@ -59,6 +67,12 @@ pub enum DestinationError {
 
     #[error("The destination with id {0} is still used by pipelines; delete those pipelines first")]
     DestinationInUse(i64),
+
+    #[error("The source with id {0} was not found")]
+    SourceNotFound(i64),
+
+    #[error("Invalid destination validation request: {0}")]
+    InvalidValidationRequest(String),
 }
 
 impl DestinationError {
@@ -67,6 +81,7 @@ impl DestinationError {
             // Do not expose internal details in error messages.
             DestinationError::DestinationsDb(DestinationsDbError::Database(_))
             | DestinationError::PipelinesDb(PipelinesDbError::Database(_))
+            | DestinationError::SourcesDb(SourcesDbError::Database(_))
             | DestinationError::Environment(_)
             | DestinationError::K8sCore(_) => "Internal server error".to_owned(),
             DestinationError::Validation(error) => {
@@ -83,14 +98,19 @@ impl IntoResponse for DestinationError {
         let status_code = match &self {
             DestinationError::DestinationsDb(_)
             | DestinationError::PipelinesDb(_)
+            | DestinationError::SourcesDb(_)
             | DestinationError::Environment(_)
             | DestinationError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DestinationError::Validation(error) => utils::validation_error_status_code(error),
-            DestinationError::DestinationNotFound(_) => StatusCode::NOT_FOUND,
+            DestinationError::DestinationNotFound(_) | DestinationError::SourceNotFound(_) => {
+                StatusCode::NOT_FOUND
+            }
             DestinationError::ActivePipeline(_) | DestinationError::DestinationInUse(_) => {
                 StatusCode::CONFLICT
             }
-            DestinationError::TenantId(_) => StatusCode::BAD_REQUEST,
+            DestinationError::TenantId(_) | DestinationError::InvalidValidationRequest(_) => {
+                StatusCode::BAD_REQUEST
+            }
         };
 
         error_response_with_internal_error(status_code, self.to_message(), &self)
@@ -139,8 +159,11 @@ pub struct ReadDestinationsResponse {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ValidateDestinationRequest {
+    #[schema(example = 1)]
+    pub source_id: Option<i64>,
     #[schema(required = true)]
     pub config: FullApiDestinationConfig,
+    pub pipeline_config: Option<FullApiPipelineConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -395,15 +418,46 @@ pub(crate) async fn read_all_destinations(
 )]
 pub(crate) async fn validate_destination(
     headers: HeaderMap,
+    Extension(pool): Extension<PgPool>,
+    Extension(api_config): Extension<Arc<ApiConfig>>,
+    Extension(trusted_root_certs_cache): Extension<Arc<TrustedRootCertsCache>>,
+    Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     request: Json<ValidateDestinationRequest>,
 ) -> Result<impl IntoResponse, DestinationError> {
-    let _tenant_id = extract_tenant_id(&headers)?;
+    let tenant_id = extract_tenant_id(&headers)?;
     let request = request.into_inner();
+    if let Some(pipeline_config) = &request.pipeline_config {
+        pipeline_config.validate().map_err(DestinationError::InvalidValidationRequest)?;
+    }
+    let pipeline_config = request.pipeline_config.as_ref();
+    let publication_name =
+        pipeline_config.map(|pipeline_config| pipeline_config.publication_name.as_str());
 
-    let environment = Environment::load()?;
-    let ctx = ValidationContext::builder(environment).build();
+    let ctx = match (request.source_id, publication_name) {
+        (Some(source_id), Some(_)) => {
+            let source = data::sources::read_source(&pool, tenant_id, source_id, &encryption_key)
+                .await?
+                .ok_or(DestinationError::SourceNotFound(source_id))?;
 
-    let failures = validation::validate_destination(&ctx, &request.config).await?;
+            ValidationContext::build_from_source(
+                source.config,
+                api_config.as_ref(),
+                trusted_root_certs_cache.as_ref(),
+            )
+            .await?
+        }
+        (None, None) => {
+            let environment = Environment::load()?;
+            ValidationContext::builder(environment).build()
+        }
+        _ => {
+            return Err(DestinationError::InvalidValidationRequest(
+                "`source_id` and `pipeline_config` must be provided together.".to_owned(),
+            ));
+        }
+    };
+
+    let failures = validation::validate_destination(&ctx, &request.config, pipeline_config).await?;
     let response = ValidateDestinationResponse {
         validation_failures: failures.into_iter().map(Into::into).collect(),
     };

--- a/crates/etl-api/src/validation/mod.rs
+++ b/crates/etl-api/src/validation/mod.rs
@@ -192,6 +192,9 @@ pub async fn validate_source(
 /// Checks that the destination is accessible and properly configured:
 /// - **BigQuery**: Validates dataset exists and is accessible.
 /// - **Iceberg**: Validates catalog connectivity.
+///
+/// If a pipeline configuration is provided, validates that the publication
+/// tables use replica identities supported by the destination.
 pub async fn validate_destination(
     ctx: &ValidationContext,
     destination_config: &FullApiDestinationConfig,

--- a/crates/etl-api/src/validation/mod.rs
+++ b/crates/etl-api/src/validation/mod.rs
@@ -181,6 +181,7 @@ pub async fn validate_source(
     ctx: &ValidationContext,
 ) -> Result<Vec<ValidationFailure>, ValidationError> {
     let validator = SourceValidator;
+
     validator.validate(ctx).await
 }
 
@@ -193,17 +194,19 @@ pub async fn validate_source(
 /// - **BigQuery**: Validates dataset exists and is accessible.
 /// - **Iceberg**: Validates catalog connectivity.
 ///
-/// If a pipeline configuration is provided, validates that the publication
-/// tables use replica identities supported by the destination.
+/// If a pipeline configuration is provided, validates source compatibility for
+/// the publication tables, including destination-specific primary-key and
+/// replica-identity requirements.
 pub async fn validate_destination(
     ctx: &ValidationContext,
     destination_config: &FullApiDestinationConfig,
     pipeline_config: Option<&FullApiPipelineConfig>,
 ) -> Result<Vec<ValidationFailure>, ValidationError> {
-    let replica_identity_publication_name =
+    let publication_name =
         pipeline_config.map(|pipeline_config| pipeline_config.publication_name.clone());
-    let validator =
-        DestinationValidator::new(destination_config.clone(), replica_identity_publication_name);
+
+    let validator = DestinationValidator::new(destination_config.clone(), publication_name);
+
     validator.validate(ctx).await
 }
 
@@ -222,6 +225,7 @@ pub async fn validate_pipeline(
     let mut failures = validate_source(ctx).await?;
 
     let validator = PipelineValidator::new(pipeline_config.clone());
+
     failures.extend(validator.validate(ctx).await?);
 
     Ok(failures)

--- a/crates/etl-api/src/validation/mod.rs
+++ b/crates/etl-api/src/validation/mod.rs
@@ -195,8 +195,13 @@ pub async fn validate_source(
 pub async fn validate_destination(
     ctx: &ValidationContext,
     destination_config: &FullApiDestinationConfig,
+    pipeline_config: Option<&FullApiPipelineConfig>,
 ) -> Result<Vec<ValidationFailure>, ValidationError> {
-    validate_destination_internal(ctx, destination_config, true).await
+    let replica_identity_publication_name =
+        pipeline_config.map(|pipeline_config| pipeline_config.publication_name.clone());
+    let validator =
+        DestinationValidator::new(destination_config.clone(), replica_identity_publication_name);
+    validator.validate(ctx).await
 }
 
 /// Validates pipeline configuration against the source database.
@@ -211,36 +216,7 @@ pub async fn validate_pipeline(
     ctx: &ValidationContext,
     pipeline_config: &FullApiPipelineConfig,
 ) -> Result<Vec<ValidationFailure>, ValidationError> {
-    validate_pipeline_internal(ctx, pipeline_config, true).await
-}
-
-async fn validate_destination_internal(
-    ctx: &ValidationContext,
-    destination_config: &FullApiDestinationConfig,
-    validate_source_profile: bool,
-) -> Result<Vec<ValidationFailure>, ValidationError> {
-    let mut failures = Vec::new();
-
-    if validate_source_profile {
-        failures.extend(validate_source(ctx).await?);
-    }
-
-    let validator = DestinationValidator::new(destination_config.clone());
-    failures.extend(validator.validate(ctx).await?);
-
-    Ok(failures)
-}
-
-async fn validate_pipeline_internal(
-    ctx: &ValidationContext,
-    pipeline_config: &FullApiPipelineConfig,
-    validate_source_profile: bool,
-) -> Result<Vec<ValidationFailure>, ValidationError> {
-    let mut failures = Vec::new();
-
-    if validate_source_profile {
-        failures.extend(validate_source(ctx).await?);
-    }
+    let mut failures = validate_source(ctx).await?;
 
     let validator = PipelineValidator::new(pipeline_config.clone());
     failures.extend(validator.validate(ctx).await?);

--- a/crates/etl-api/src/validation/validators/bigquery.rs
+++ b/crates/etl-api/src/validation/validators/bigquery.rs
@@ -32,7 +32,7 @@ impl Validator for BigQueryValidator {
                 format!(
                     "We couldn't authenticate with BigQuery using the service account \
                      key.\n\nCheck that the key is valid JSON, has not been revoked, and belongs \
-                     to a service account with access to project '{}'.",
+                     to a service account with access to project `{}`.",
                     self.project_id
                 ),
             )]);
@@ -43,7 +43,7 @@ impl Validator for BigQueryValidator {
             Ok(false) => Ok(vec![ValidationFailure::critical(
                 "BigQuery Dataset Not Found",
                 format!(
-                    "BigQuery dataset '{}' was not found in project '{}'.\n\nCheck the dataset \
+                    "BigQuery dataset `{}` was not found in project `{}`.\n\nCheck the dataset \
                      name and make sure the service account can access it.",
                     self.dataset_id, self.project_id
                 ),
@@ -52,7 +52,7 @@ impl Validator for BigQueryValidator {
                 "BigQuery Connection Failed",
                 "We couldn't reach BigQuery or confirm that the dataset exists.\n\nCheck network \
                  access to Google Cloud, that the BigQuery API is enabled, and that the service \
-                 account has BigQuery Data Editor and BigQuery Job User permissions.",
+                 account has `BigQuery Data Editor` and `BigQuery Job User` permissions.",
             )]),
         }
     }

--- a/crates/etl-api/src/validation/validators/bigquery.rs
+++ b/crates/etl-api/src/validation/validators/bigquery.rs
@@ -29,9 +29,12 @@ impl Validator for BigQueryValidator {
         else {
             return Ok(vec![ValidationFailure::critical(
                 "BigQuery Authentication Failed",
-                "Unable to authenticate with BigQuery.\n\nPlease verify:\n(1) The service account \
-                 key is valid JSON\n(2) The key has not expired or been revoked\n(3) The project \
-                 ID is correct",
+                format!(
+                    "We couldn't authenticate with BigQuery using the service account \
+                     key.\n\nCheck that the key is valid JSON, has not been revoked, and belongs \
+                     to a service account with access to project '{}'.",
+                    self.project_id
+                ),
             )]);
         };
 
@@ -40,17 +43,16 @@ impl Validator for BigQueryValidator {
             Ok(false) => Ok(vec![ValidationFailure::critical(
                 "BigQuery Dataset Not Found",
                 format!(
-                    "Dataset '{}' does not exist in project '{}'.\n\nPlease verify:\n(1) The \
-                     dataset name is correct\n(2) The dataset exists in the specified \
-                     project\n(3) The service account has permission to access it",
+                    "BigQuery dataset '{}' was not found in project '{}'.\n\nCheck the dataset \
+                     name and make sure the service account can access it.",
                     self.dataset_id, self.project_id
                 ),
             )]),
             Err(_) => Ok(vec![ValidationFailure::critical(
                 "BigQuery Connection Failed",
-                "Unable to connect to BigQuery.\n\nPlease verify:\n(1) Network connectivity to \
-                 Google Cloud\n(2) The service account has the required permissions (BigQuery \
-                 Data Editor, BigQuery Job User)\n(3) BigQuery API is enabled for your project",
+                "We couldn't reach BigQuery or confirm that the dataset exists.\n\nCheck network \
+                 access to Google Cloud, that the BigQuery API is enabled, and that the service \
+                 account has BigQuery Data Editor and BigQuery Job User permissions.",
             )]),
         }
     }

--- a/crates/etl-api/src/validation/validators/clickhouse.rs
+++ b/crates/etl-api/src/validation/validators/clickhouse.rs
@@ -39,9 +39,8 @@ impl Validator for ClickHouseValidator {
             return Ok(vec![ValidationFailure::critical(
                 "ClickHouse URL Invalid",
                 format!(
-                    "ClickHouse URL must use 'https'. Got '{scheme}'. ETL requires TLS for all \
-                     ClickHouse destinations to keep credentials and replicated rows off the wire \
-                     in cleartext."
+                    "ClickHouse URL must use https, but this URL uses '{scheme}'.\n\nETL requires \
+                     TLS to protect credentials and replicated rows."
                 ),
             )]);
         }
@@ -49,14 +48,14 @@ impl Validator for ClickHouseValidator {
         if self.user.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "ClickHouse User Required",
-                "ClickHouse user must not be empty.",
+                "Enter the ClickHouse user that ETL should connect with.",
             )]);
         }
 
         if self.database.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "ClickHouse Database Required",
-                "ClickHouse database must not be empty.",
+                "Choose the ClickHouse database where replicated tables should be written.",
             )]);
         }
 
@@ -72,8 +71,8 @@ impl Validator for ClickHouseValidator {
         if client.validate_connectivity().await.is_err() {
             return Ok(vec![ValidationFailure::critical(
                 "ClickHouse Connection Failed",
-                "Cannot connect to ClickHouse.\n\nPlease verify:\n(1) The URL is correct and \
-                 reachable\n(2) The user name is correct\n(3) The password is correct",
+                "We couldn't connect to ClickHouse with this URL and user.\n\nCheck that the host \
+                 is reachable and that the username and password are correct.",
             )]);
         }
 
@@ -82,17 +81,15 @@ impl Validator for ClickHouseValidator {
             Ok(false) => Ok(vec![ValidationFailure::critical(
                 "ClickHouse Database Not Found",
                 format!(
-                    "ClickHouse database '{}' does not exist.\n\nPlease verify:\n(1) The database \
-                     name is correct\n(2) The database has been created on the server\n(3) The \
-                     user has permission to use it",
+                    "ClickHouse database '{}' was not found.\n\nCreate the database, or choose an \
+                     existing database this user can access.",
                     self.database
                 ),
             )]),
             Err(_) => Ok(vec![ValidationFailure::critical(
                 "ClickHouse Connection Failed",
-                "Cannot query ClickHouse to confirm the target database exists.\n\nPlease \
-                 verify:\n(1) The user has permission to read system.databases\n(2) The server is \
-                 healthy and reachable",
+                "We connected to ClickHouse, but couldn't confirm whether the target database \
+                 exists.\n\nGrant this user permission to read system.databases and try again.",
             )]),
         }
     }

--- a/crates/etl-api/src/validation/validators/clickhouse.rs
+++ b/crates/etl-api/src/validation/validators/clickhouse.rs
@@ -39,8 +39,8 @@ impl Validator for ClickHouseValidator {
             return Ok(vec![ValidationFailure::critical(
                 "ClickHouse URL Invalid",
                 format!(
-                    "ClickHouse URL must use https, but this URL uses '{scheme}'.\n\nETL requires \
-                     TLS to protect credentials and replicated rows."
+                    "ClickHouse URL must use `https`, but this URL uses `{scheme}`.\n\nETL \
+                     requires TLS to protect credentials and replicated rows."
                 ),
             )]);
         }
@@ -81,7 +81,7 @@ impl Validator for ClickHouseValidator {
             Ok(false) => Ok(vec![ValidationFailure::critical(
                 "ClickHouse Database Not Found",
                 format!(
-                    "ClickHouse database '{}' was not found.\n\nCreate the database, or choose an \
+                    "ClickHouse database `{}` was not found.\n\nCreate the database, or choose an \
                      existing database this user can access.",
                     self.database
                 ),
@@ -89,7 +89,7 @@ impl Validator for ClickHouseValidator {
             Err(_) => Ok(vec![ValidationFailure::critical(
                 "ClickHouse Connection Failed",
                 "We connected to ClickHouse, but couldn't confirm whether the target database \
-                 exists.\n\nGrant this user permission to read system.databases and try again.",
+                 exists.\n\nGrant this user permission to read `system.databases` and try again.",
             )]),
         }
     }

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -6,6 +6,7 @@ use etl_postgres::types::IdentityType;
 
 use super::{
     super::{ValidationContext, ValidationError, ValidationFailure, Validator},
+    pipeline::PublicationExistsValidator,
     primary_key::PrimaryKeyValidator,
     replica_identity::ReplicaIdentityValidator,
 };
@@ -26,6 +27,14 @@ impl DestinationValidator {
         Self { config, publication_name }
     }
 
+    /// Builds the publication existence validator when publication-aware
+    /// destination checks are enabled.
+    fn publication_exists_validator(&self) -> Option<PublicationExistsValidator> {
+        let publication_name = self.publication_name.clone()?;
+
+        Some(PublicationExistsValidator::new(publication_name))
+    }
+
     /// Builds the replica identity validator for the configured destination.
     fn replica_identity_validator(&self) -> Option<ReplicaIdentityValidator> {
         let publication_name = self.publication_name.clone()?;
@@ -35,23 +44,32 @@ impl DestinationValidator {
                 publication_name,
                 "BigQuery",
                 &[IdentityType::PrimaryKey, IdentityType::Full],
+                &[IdentityType::PrimaryKey, IdentityType::Full],
             ),
             FullApiDestinationConfig::ClickHouse { .. } => ReplicaIdentityValidator::new(
                 publication_name,
                 "ClickHouse",
                 &[IdentityType::PrimaryKey, IdentityType::Full],
+                &[IdentityType::PrimaryKey, IdentityType::Full],
             ),
-            FullApiDestinationConfig::Iceberg { .. } => {
-                ReplicaIdentityValidator::new(publication_name, "Iceberg", &[IdentityType::Full])
-            }
+            FullApiDestinationConfig::Iceberg { .. } => ReplicaIdentityValidator::new(
+                publication_name,
+                "Iceberg",
+                &[IdentityType::Full],
+                &[IdentityType::Full],
+            ),
             FullApiDestinationConfig::Ducklake { .. } => ReplicaIdentityValidator::new(
                 publication_name,
                 "DuckLake",
                 &[IdentityType::PrimaryKey, IdentityType::AlternativeKey, IdentityType::Full],
+                &[IdentityType::PrimaryKey, IdentityType::AlternativeKey, IdentityType::Full],
             ),
-            FullApiDestinationConfig::Snowflake { .. } => {
-                ReplicaIdentityValidator::new(publication_name, "Snowflake", &[IdentityType::Full])
-            }
+            FullApiDestinationConfig::Snowflake { .. } => ReplicaIdentityValidator::new(
+                publication_name,
+                "Snowflake",
+                &[IdentityType::Full],
+                &[IdentityType::PrimaryKey, IdentityType::AlternativeKey, IdentityType::Full],
+            ),
         })
     }
 
@@ -113,6 +131,10 @@ impl Validator for DestinationValidator {
                 snowflake::validate(&self.config, ctx).await
             }
         }?;
+
+        if let Some(validator) = self.publication_exists_validator() {
+            failures.extend(validator.validate(ctx).await?);
+        }
 
         if let Some(validator) = self.replica_identity_validator() {
             failures.extend(validator.validate(ctx).await?);

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -16,22 +16,19 @@ use crate::configs::destination::FullApiDestinationConfig;
 pub(crate) struct DestinationValidator {
     /// Destination configuration to validate.
     config: FullApiDestinationConfig,
-    /// Publication name used for source-aware replica identity checks.
-    replica_identity_publication_name: Option<String>,
+    /// Publication name of the pipeline that will be used for table checks.
+    publication_name: Option<String>,
 }
 
 impl DestinationValidator {
     /// Creates a destination validator for the provided configuration.
-    pub(crate) fn new(
-        config: FullApiDestinationConfig,
-        replica_identity_publication_name: Option<String>,
-    ) -> Self {
-        Self { config, replica_identity_publication_name }
+    pub(crate) fn new(config: FullApiDestinationConfig, publication_name: Option<String>) -> Self {
+        Self { config, publication_name }
     }
 
     /// Builds the replica identity validator for the configured destination.
     fn replica_identity_validator(&self) -> Option<ReplicaIdentityValidator> {
-        let publication_name = self.replica_identity_publication_name.clone()?;
+        let publication_name = self.publication_name.clone()?;
 
         Some(match &self.config {
             FullApiDestinationConfig::BigQuery { .. } => ReplicaIdentityValidator::new(
@@ -71,14 +68,14 @@ impl DestinationValidator {
     ///   identity requirements, handled by [`Self::replica_identity_validator`]
     ///   and destination runtime checks.
     fn primary_key_validator(&self) -> Option<PrimaryKeyValidator> {
-        let publication_name = self.replica_identity_publication_name.clone()?;
+        let publication_name = self.publication_name.clone()?;
 
         match &self.config {
             FullApiDestinationConfig::BigQuery { .. } => Some(PrimaryKeyValidator::new(
                 publication_name,
                 "BigQuery",
-                "BigQuery tables are keyed by the source primary key for initial loads, upserts, \
-                 deletes, and primary-key-changing updates.",
+                "BigQuery uses the source primary key to match rows during initial loads, \
+                 upserts, deletes, and updates that change primary-key values.",
             )),
             FullApiDestinationConfig::ClickHouse {
                 engine: ClickHouseEngine::ReplacingMergeTree,
@@ -145,7 +142,10 @@ macro_rules! disabled_destination {
             ) -> std::future::Ready<Result<Vec<ValidationFailure>, ValidationError>> {
                 std::future::ready(Ok(vec![ValidationFailure::critical(
                     format!("{} Backend Disabled", $destination),
-                    format!("{} support is not compiled into this API binary.", $destination),
+                    format!(
+                        "This API server was built without {} destination support.",
+                        $destination
+                    ),
                 )]))
             }
         }

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -12,7 +12,9 @@ use crate::configs::destination::FullApiDestinationConfig;
 /// Composite validator for destination prerequisites.
 #[derive(Debug)]
 pub(crate) struct DestinationValidator {
+    /// Destination configuration to validate.
     config: FullApiDestinationConfig,
+    /// Publication name used for source-aware replica identity checks.
     replica_identity_publication_name: Option<String>,
 }
 
@@ -25,6 +27,7 @@ impl DestinationValidator {
         Self { config, replica_identity_publication_name }
     }
 
+    /// Builds the replica identity validator for the configured destination.
     fn replica_identity_validator(&self) -> Option<ReplicaIdentityValidator> {
         let publication_name = self.replica_identity_publication_name.clone()?;
 

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -61,12 +61,13 @@ impl DestinationValidator {
     /// Keep this aligned with destination runtime checks:
     /// - BigQuery always requires source primary keys because destination rows
     ///   are keyed by the source primary key for initial loads and CDC.
-    /// - ClickHouse `ReplacingMergeTree` requires source primary keys because
-    ///   it uses them as the `ORDER BY` and deduplication key.
-    /// - ClickHouse `MergeTree`, Iceberg, DuckLake, and Snowflake do not
-    ///   require source primary keys. They still have their own replica
-    ///   identity requirements, handled by [`Self::replica_identity_validator`]
-    ///   and destination runtime checks.
+    /// - ClickHouse requires all source primary-key columns to be replicated
+    ///   when a source primary key exists, and `ReplacingMergeTree` also
+    ///   requires source primary keys because it uses them as the `ORDER BY`
+    ///   and deduplication key.
+    /// - Iceberg, DuckLake, and Snowflake do not require source primary keys.
+    ///   They still have their own replica identity requirements, handled by
+    ///   [`Self::replica_identity_validator`] and destination runtime checks.
     fn primary_key_validator(&self) -> Option<PrimaryKeyValidator> {
         let publication_name = self.publication_name.clone()?;
 
@@ -76,6 +77,7 @@ impl DestinationValidator {
                 "BigQuery",
                 "BigQuery uses the source primary key to match rows during initial loads, \
                  upserts, deletes, and updates that change primary-key values.",
+                true,
             )),
             FullApiDestinationConfig::ClickHouse {
                 engine: ClickHouseEngine::ReplacingMergeTree,
@@ -85,6 +87,16 @@ impl DestinationValidator {
                 "ClickHouse ReplacingMergeTree",
                 "ClickHouse ReplacingMergeTree uses the source primary key as the ORDER BY and \
                  deduplication key.",
+                true,
+            )),
+            FullApiDestinationConfig::ClickHouse {
+                engine: ClickHouseEngine::MergeTree, ..
+            } => Some(PrimaryKeyValidator::new(
+                publication_name,
+                "ClickHouse MergeTree",
+                "ClickHouse uses replicated source primary-key columns to apply row-level updates \
+                 and deletes when a source primary key exists.",
+                false,
             )),
             _ => None,
         }

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -1,20 +1,56 @@
 //! Destination validation dispatch.
 
 use async_trait::async_trait;
+use etl_postgres::types::IdentityType;
 
-use super::super::{ValidationContext, ValidationError, ValidationFailure, Validator};
+use super::{
+    super::{ValidationContext, ValidationError, ValidationFailure, Validator},
+    replica_identity::ReplicaIdentityValidator,
+};
 use crate::configs::destination::FullApiDestinationConfig;
 
 /// Composite validator for destination prerequisites.
 #[derive(Debug)]
-pub(in crate::validation) struct DestinationValidator {
+pub(crate) struct DestinationValidator {
     config: FullApiDestinationConfig,
+    replica_identity_publication_name: Option<String>,
 }
 
 impl DestinationValidator {
     /// Creates a destination validator for the provided configuration.
-    pub(in crate::validation) fn new(config: FullApiDestinationConfig) -> Self {
-        Self { config }
+    pub(crate) fn new(
+        config: FullApiDestinationConfig,
+        replica_identity_publication_name: Option<String>,
+    ) -> Self {
+        Self { config, replica_identity_publication_name }
+    }
+
+    fn replica_identity_validator(&self) -> Option<ReplicaIdentityValidator> {
+        let publication_name = self.replica_identity_publication_name.clone()?;
+
+        Some(match &self.config {
+            FullApiDestinationConfig::BigQuery { .. } => ReplicaIdentityValidator::new(
+                publication_name,
+                "BigQuery",
+                &[IdentityType::PrimaryKey, IdentityType::Full],
+            ),
+            FullApiDestinationConfig::ClickHouse { .. } => ReplicaIdentityValidator::new(
+                publication_name,
+                "ClickHouse",
+                &[IdentityType::PrimaryKey, IdentityType::Full],
+            ),
+            FullApiDestinationConfig::Iceberg { .. } => {
+                ReplicaIdentityValidator::new(publication_name, "Iceberg", &[IdentityType::Full])
+            }
+            FullApiDestinationConfig::Ducklake { .. } => ReplicaIdentityValidator::new(
+                publication_name,
+                "DuckLake",
+                &[IdentityType::PrimaryKey, IdentityType::AlternativeKey, IdentityType::Full],
+            ),
+            FullApiDestinationConfig::Snowflake { .. } => {
+                ReplicaIdentityValidator::new(publication_name, "Snowflake", &[IdentityType::Full])
+            }
+        })
     }
 }
 
@@ -24,7 +60,7 @@ impl Validator for DestinationValidator {
         &self,
         ctx: &ValidationContext,
     ) -> Result<Vec<ValidationFailure>, ValidationError> {
-        match &self.config {
+        let mut failures = match &self.config {
             FullApiDestinationConfig::BigQuery { .. } => {
                 bigquery::validate(&self.config, ctx).await
             }
@@ -38,7 +74,13 @@ impl Validator for DestinationValidator {
             FullApiDestinationConfig::Snowflake { .. } => {
                 snowflake::validate(&self.config, ctx).await
             }
+        }?;
+
+        if let Some(validator) = self.replica_identity_validator() {
+            failures.extend(validator.validate(ctx).await?);
         }
+
+        Ok(failures)
     }
 }
 

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -57,17 +57,6 @@ impl DestinationValidator {
 
     /// Builds the primary-key validator for destinations that require source
     /// primary keys.
-    ///
-    /// Keep this aligned with destination runtime checks:
-    /// - BigQuery always requires source primary keys because destination rows
-    ///   are keyed by the source primary key for initial loads and CDC.
-    /// - ClickHouse requires all source primary-key columns to be replicated
-    ///   when a source primary key exists, and `ReplacingMergeTree` also
-    ///   requires source primary keys because it uses them as the `ORDER BY`
-    ///   and deduplication key.
-    /// - Iceberg, DuckLake, and Snowflake do not require source primary keys.
-    ///   They still have their own replica identity requirements, handled by
-    ///   [`Self::replica_identity_validator`] and destination runtime checks.
     fn primary_key_validator(&self) -> Option<PrimaryKeyValidator> {
         let publication_name = self.publication_name.clone()?;
 

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -74,7 +74,7 @@ impl DestinationValidator {
             } => Some(PrimaryKeyValidator::new(
                 publication_name,
                 "ClickHouse ReplacingMergeTree",
-                "ClickHouse ReplacingMergeTree uses the source primary key as the ORDER BY and \
+                "ClickHouse ReplacingMergeTree uses the source primary key as the `ORDER BY` and \
                  deduplication key.",
                 true,
             )),

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -6,7 +6,6 @@ use etl_postgres::types::IdentityType;
 
 use super::{
     super::{ValidationContext, ValidationError, ValidationFailure, Validator},
-    pipeline::PublicationExistsValidator,
     primary_key::PrimaryKeyValidator,
     replica_identity::ReplicaIdentityValidator,
 };
@@ -25,14 +24,6 @@ impl DestinationValidator {
     /// Creates a destination validator for the provided configuration.
     pub(crate) fn new(config: FullApiDestinationConfig, publication_name: Option<String>) -> Self {
         Self { config, publication_name }
-    }
-
-    /// Builds the publication existence validator when publication-aware
-    /// destination checks are enabled.
-    fn publication_exists_validator(&self) -> Option<PublicationExistsValidator> {
-        let publication_name = self.publication_name.clone()?;
-
-        Some(PublicationExistsValidator::new(publication_name))
     }
 
     /// Builds the replica identity validator for the configured destination.
@@ -131,10 +122,6 @@ impl Validator for DestinationValidator {
                 snowflake::validate(&self.config, ctx).await
             }
         }?;
-
-        if let Some(validator) = self.publication_exists_validator() {
-            failures.extend(validator.validate(ctx).await?);
-        }
 
         if let Some(validator) = self.replica_identity_validator() {
             failures.extend(validator.validate(ctx).await?);

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -1,10 +1,12 @@
 //! Destination validation dispatch.
 
 use async_trait::async_trait;
+use etl_config::shared::ClickHouseEngine;
 use etl_postgres::types::IdentityType;
 
 use super::{
     super::{ValidationContext, ValidationError, ValidationFailure, Validator},
+    primary_key::PrimaryKeyValidator,
     replica_identity::ReplicaIdentityValidator,
 };
 use crate::configs::destination::FullApiDestinationConfig;
@@ -55,6 +57,41 @@ impl DestinationValidator {
             }
         })
     }
+
+    /// Builds the primary-key validator for destinations that require source
+    /// primary keys.
+    ///
+    /// Keep this aligned with destination runtime checks:
+    /// - BigQuery always requires source primary keys because destination rows
+    ///   are keyed by the source primary key for initial loads and CDC.
+    /// - ClickHouse `ReplacingMergeTree` requires source primary keys because
+    ///   it uses them as the `ORDER BY` and deduplication key.
+    /// - ClickHouse `MergeTree`, Iceberg, DuckLake, and Snowflake do not
+    ///   require source primary keys. They still have their own replica
+    ///   identity requirements, handled by [`Self::replica_identity_validator`]
+    ///   and destination runtime checks.
+    fn primary_key_validator(&self) -> Option<PrimaryKeyValidator> {
+        let publication_name = self.replica_identity_publication_name.clone()?;
+
+        match &self.config {
+            FullApiDestinationConfig::BigQuery { .. } => Some(PrimaryKeyValidator::new(
+                publication_name,
+                "BigQuery",
+                "BigQuery tables are keyed by the source primary key for initial loads, upserts, \
+                 deletes, and primary-key-changing updates.",
+            )),
+            FullApiDestinationConfig::ClickHouse {
+                engine: ClickHouseEngine::ReplacingMergeTree,
+                ..
+            } => Some(PrimaryKeyValidator::new(
+                publication_name,
+                "ClickHouse ReplacingMergeTree",
+                "ClickHouse ReplacingMergeTree uses the source primary key as the ORDER BY and \
+                 deduplication key.",
+            )),
+            _ => None,
+        }
+    }
 }
 
 #[async_trait]
@@ -80,6 +117,10 @@ impl Validator for DestinationValidator {
         }?;
 
         if let Some(validator) = self.replica_identity_validator() {
+            failures.extend(validator.validate(ctx).await?);
+        }
+
+        if let Some(validator) = self.primary_key_validator() {
             failures.extend(validator.validate(ctx).await?);
         }
 

--- a/crates/etl-api/src/validation/validators/ducklake.rs
+++ b/crates/etl-api/src/validation/validators/ducklake.rs
@@ -69,8 +69,8 @@ impl Validator for DucklakeValidator {
                 _ => {
                     return Ok(vec![ValidationFailure::critical(
                         "DuckLake S3 Configuration Invalid",
-                        "DuckLake needs both an S3 access key ID and secret access key to read \
-                         and write the data path.",
+                        "DuckLake needs both an `S3 access key ID` and `S3 secret access key` to \
+                         read and write the data path.",
                     )]);
                 }
             };
@@ -78,8 +78,8 @@ impl Validator for DucklakeValidator {
         if s3_access_key_id.is_empty() || s3_secret_access_key.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "DuckLake S3 Configuration Invalid",
-                "DuckLake needs both an S3 access key ID and secret access key to read and write \
-                 the data path.",
+                "DuckLake needs both an `S3 access key ID` and `S3 secret access key` to read and \
+                 write the data path.",
             )]);
         }
 
@@ -129,7 +129,7 @@ impl Validator for DucklakeValidator {
                 "DuckLake Connection Failed",
                 "We couldn't connect to DuckLake with this catalog and data path.\n\nCheck that \
                  the catalog URL is reachable, catalog credentials are present in the URL, and \
-                 the S3-compatible endpoint and credentials are correct.",
+                 the `S3-compatible endpoint` and credentials are correct.",
             )]),
         }
     }

--- a/crates/etl-api/src/validation/validators/ducklake.rs
+++ b/crates/etl-api/src/validation/validators/ducklake.rs
@@ -68,16 +68,18 @@ impl Validator for DucklakeValidator {
                 }
                 _ => {
                     return Ok(vec![ValidationFailure::critical(
-                        "Ducklake S3 Configuration Invalid",
-                        "DuckLake S3 credentials are required.",
+                        "DuckLake S3 Configuration Invalid",
+                        "DuckLake needs both an S3 access key ID and secret access key to read \
+                         and write the data path.",
                     )]);
                 }
             };
 
         if s3_access_key_id.is_empty() || s3_secret_access_key.is_empty() {
             return Ok(vec![ValidationFailure::critical(
-                "Ducklake S3 Configuration Invalid",
-                "DuckLake S3 credentials are required.",
+                "DuckLake S3 Configuration Invalid",
+                "DuckLake needs both an S3 access key ID and secret access key to read and write \
+                 the data path.",
             )]);
         }
 
@@ -85,7 +87,7 @@ impl Validator for DucklakeValidator {
             Ok(url) => url,
             Err(error) => {
                 return Ok(vec![ValidationFailure::critical(
-                    "Ducklake Catalog Url Invalid",
+                    "DuckLake Catalog URL Invalid",
                     error.to_string(),
                 )]);
             }
@@ -95,7 +97,7 @@ impl Validator for DucklakeValidator {
             Ok(url) => url,
             Err(error) => {
                 return Ok(vec![ValidationFailure::critical(
-                    "Ducklake Data Path Invalid",
+                    "DuckLake Data Path Invalid",
                     error.to_string(),
                 )]);
             }
@@ -124,11 +126,10 @@ impl Validator for DucklakeValidator {
         {
             Ok(_) => Ok(vec![]),
             Err(_) => Ok(vec![ValidationFailure::critical(
-                "Ducklake Connection Failed",
-                "Unable to connect to DuckLake.\n\nPlease verify:\n(1) The catalog URL and data \
-                 path are valid and reachable\n(2) DuckLake catalog credentials are embedded \
-                 correctly in the catalog URL\n(3) The S3-compatible credentials and endpoint are \
-                 correct when using object storage",
+                "DuckLake Connection Failed",
+                "We couldn't connect to DuckLake with this catalog and data path.\n\nCheck that \
+                 the catalog URL is reachable, catalog credentials are present in the URL, and \
+                 the S3-compatible endpoint and credentials are correct.",
             )]),
         }
     }
@@ -166,7 +167,7 @@ mod tests {
         let failures = validator.validate(&ctx).await.unwrap();
 
         assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].name, "Ducklake Data Path Invalid");
+        assert_eq!(failures[0].name, "DuckLake Data Path Invalid");
         assert_eq!(failures[0].reason, "DuckLake data path must use the s3:// scheme, got file://");
     }
 }

--- a/crates/etl-api/src/validation/validators/iceberg.rs
+++ b/crates/etl-api/src/validation/validators/iceberg.rs
@@ -79,8 +79,8 @@ impl Validator for IcebergValidator {
             return Ok(vec![ValidationFailure::critical(
                 "Iceberg Authentication Failed",
                 "We couldn't authenticate with the Iceberg catalog.\n\nCheck that the catalog \
-                 token is valid, the catalog URI is correct, and the S3 access key and secret key \
-                 are correct.",
+                 token is valid, the catalog URI is correct, and the `S3 access key` and `S3 \
+                 secret key` are correct.",
             )]);
         };
 
@@ -89,8 +89,8 @@ impl Validator for IcebergValidator {
             Err(_) => Ok(vec![ValidationFailure::critical(
                 "Iceberg Connection Failed",
                 "We couldn't connect to the Iceberg catalog or warehouse.\n\nCheck that the \
-                 catalog and S3 endpoint are reachable, the warehouse exists, and the configured \
-                 credentials can access it.",
+                 catalog and `S3 endpoint` are reachable, the warehouse exists, and the \
+                 configured credentials can access it.",
             )]),
         }
     }

--- a/crates/etl-api/src/validation/validators/iceberg.rs
+++ b/crates/etl-api/src/validation/validators/iceberg.rs
@@ -78,9 +78,9 @@ impl Validator for IcebergValidator {
         let Ok(client) = client else {
             return Ok(vec![ValidationFailure::critical(
                 "Iceberg Authentication Failed",
-                "Unable to authenticate with Iceberg.\n\nPlease verify:\n(1) The catalog token is \
-                 valid and has not expired\n(2) The S3 access key and secret key are correct\n(3) \
-                 The catalog URI is properly formatted",
+                "We couldn't authenticate with the Iceberg catalog.\n\nCheck that the catalog \
+                 token is valid, the catalog URI is correct, and the S3 access key and secret key \
+                 are correct.",
             )]);
         };
 
@@ -88,10 +88,9 @@ impl Validator for IcebergValidator {
             Ok(()) => Ok(vec![]),
             Err(_) => Ok(vec![ValidationFailure::critical(
                 "Iceberg Connection Failed",
-                "Unable to connect to Iceberg catalog.\n\nPlease verify:\n(1) Network \
-                 connectivity to the catalog and S3\n(2) The warehouse name exists in the \
-                 catalog\n(3) You have the required permissions to access the warehouse\n(4) The \
-                 S3 endpoint is reachable",
+                "We couldn't connect to the Iceberg catalog or warehouse.\n\nCheck that the \
+                 catalog and S3 endpoint are reachable, the warehouse exists, and the configured \
+                 credentials can access it.",
             )]),
         }
     }

--- a/crates/etl-api/src/validation/validators/mod.rs
+++ b/crates/etl-api/src/validation/validators/mod.rs
@@ -8,6 +8,7 @@ mod ducklake;
 #[cfg(feature = "iceberg")]
 mod iceberg;
 mod pipeline;
+mod primary_key;
 mod replica_identity;
 #[cfg(feature = "snowflake")]
 mod snowflake;
@@ -16,9 +17,9 @@ mod source;
 use async_trait::async_trait;
 pub(super) use destination::DestinationValidator;
 use pipeline::{
-    GeneratedColumnsValidator, PrimaryKeysValidator, PublicationExcludesEtlTablesValidator,
-    PublicationExistsValidator, PublicationHasTablesValidator, ReplicationPermissionsValidator,
-    ReplicationSlotsValidator, WalLevelValidator,
+    GeneratedColumnsValidator, PublicationExcludesEtlTablesValidator, PublicationExistsValidator,
+    PublicationHasTablesValidator, ReplicationPermissionsValidator, ReplicationSlotsValidator,
+    WalLevelValidator,
 };
 pub(super) use source::SourceValidator;
 
@@ -46,7 +47,6 @@ impl PipelineValidator {
             Box::new(PublicationExistsValidator::new(publication_name.clone())),
             Box::new(PublicationHasTablesValidator::new(publication_name.clone())),
             Box::new(PublicationExcludesEtlTablesValidator::new(publication_name.clone())),
-            Box::new(PrimaryKeysValidator::new(publication_name.clone())),
             Box::new(GeneratedColumnsValidator::new(publication_name)),
             Box::new(ReplicationSlotsValidator::new(max_table_sync_workers)),
         ]

--- a/crates/etl-api/src/validation/validators/mod.rs
+++ b/crates/etl-api/src/validation/validators/mod.rs
@@ -8,6 +8,7 @@ mod ducklake;
 #[cfg(feature = "iceberg")]
 mod iceberg;
 mod pipeline;
+mod replica_identity;
 #[cfg(feature = "snowflake")]
 mod snowflake;
 mod source;

--- a/crates/etl-api/src/validation/validators/pipeline.rs
+++ b/crates/etl-api/src/validation/validators/pipeline.rs
@@ -340,66 +340,6 @@ impl Validator for PublicationExcludesEtlTablesValidator {
     }
 }
 
-/// Validates that all tables in a publication have primary keys.
-#[derive(Debug)]
-pub(super) struct PrimaryKeysValidator {
-    publication_name: String,
-}
-
-impl PrimaryKeysValidator {
-    pub(super) fn new(publication_name: String) -> Self {
-        Self { publication_name }
-    }
-}
-
-#[async_trait]
-impl Validator for PrimaryKeysValidator {
-    async fn validate(
-        &self,
-        ctx: &ValidationContext,
-    ) -> Result<Vec<ValidationFailure>, ValidationError> {
-        let source_pool =
-            ctx.source_pool.as_ref().expect("source pool required for primary keys validation");
-
-        // Find tables without primary keys using pg_publication_rel for direct OID
-        // access
-        let tables_without_pk: Vec<String> = sqlx::query_scalar(
-            r#"
-            select n.nspname || '.' || c.relname
-            from pg_publication_rel pr
-            join pg_publication p on p.oid = pr.prpubid
-            join pg_class c on c.oid = pr.prrelid
-            join pg_namespace n on n.oid = c.relnamespace
-            where p.pubname = $1
-              and not exists (
-                select 1
-                from pg_constraint con
-                where con.conrelid = pr.prrelid
-                  and con.contype = 'p'
-              )
-            order by n.nspname, c.relname
-            limit 100
-            "#,
-        )
-        .bind(&self.publication_name)
-        .fetch_all(source_pool)
-        .await?;
-
-        if tables_without_pk.is_empty() {
-            Ok(vec![])
-        } else {
-            Ok(vec![ValidationFailure::warning(
-                "Tables Missing Primary Keys",
-                format!(
-                    "Tables without primary keys: {}\n\nPrimary keys are required for UPDATE and \
-                     DELETE replication.",
-                    tables_without_pk.join(", ")
-                ),
-            )])
-        }
-    }
-}
-
 /// Validates that tables in a publication don't have generated columns.
 #[derive(Debug)]
 pub(super) struct GeneratedColumnsValidator {

--- a/crates/etl-api/src/validation/validators/pipeline.rs
+++ b/crates/etl-api/src/validation/validators/pipeline.rs
@@ -36,9 +36,9 @@ impl Validator for PublicationExistsValidator {
             Ok(vec![ValidationFailure::critical(
                 "Publication Not Found",
                 format!(
-                    "Publication '{}' does not exist in the source database.\n\nCreate the \
+                    "Publication `{}` does not exist in the source database.\n\nCreate the \
                      publication, or choose an existing publication for this pipeline. For \
-                     example: CREATE PUBLICATION {} FOR TABLE <table_name>, ...",
+                     example: `CREATE PUBLICATION {} FOR TABLE <table_name>, ...`.",
                     self.publication_name, self.publication_name
                 ),
             )])
@@ -93,8 +93,8 @@ impl Validator for ReplicationSlotsValidator {
                     "The source database has {free_slots} free replication slots, but this \
                      pipeline can need up to {required_slots} during the initial table copy \
                      ({used_slots}/{max_slots} slots are currently in use).\n\nIncrease \
-                     max_replication_slots, remove unused replication slots, or reduce \
-                     max_table_sync_workers. After the initial copy, this pipeline only uses 1 \
+                     `max_replication_slots`, remove unused replication slots, or reduce \
+                     `max_table_sync_workers`. After the initial copy, this pipeline only uses 1 \
                      slot.",
                 ),
             )])
@@ -125,8 +125,8 @@ impl Validator for WalLevelValidator {
             Ok(vec![ValidationFailure::critical(
                 "Invalid WAL Level",
                 format!(
-                    "The source database WAL level is '{wal_level}', but logical replication \
-                     requires 'logical'.\n\nSet wal_level = 'logical' in postgresql.conf and \
+                    "The source database WAL level is `{wal_level}`, but logical replication \
+                     requires `logical`.\n\nSet `wal_level = 'logical'` in `postgresql.conf` and \
                      restart PostgreSQL."
                 ),
             )])
@@ -162,7 +162,7 @@ impl Validator for ReplicationPermissionsValidator {
             Ok(vec![ValidationFailure::critical(
                 "Missing Replication Permission",
                 "The source database user does not have replication privileges.\n\nGrant the user \
-                 the REPLICATION attribute or connect with a role that already has it.",
+                 the `REPLICATION` attribute or connect with a role that already has it.",
             )])
         }
     }
@@ -217,9 +217,9 @@ impl Validator for PublicationHasTablesValidator {
             Ok(vec![ValidationFailure::critical(
                 "Publication Empty",
                 format!(
-                    "Publication '{}' exists, but it does not publish any tables.\n\nAdd tables \
-                     to the publication before starting the pipeline. For example: ALTER \
-                     PUBLICATION {} ADD TABLE <table_name>.",
+                    "Publication `{}` exists, but it does not publish any tables.\n\nAdd tables \
+                     to the publication before starting the pipeline. For example: `ALTER \
+                     PUBLICATION {} ADD TABLE <table_name>`.",
                     self.publication_name, self.publication_name
                 ),
             )])
@@ -286,10 +286,10 @@ impl Validator for PublicationExcludesEtlTablesValidator {
             return Ok(vec![ValidationFailure::critical(
                 "Publication Includes ETL Tables",
                 format!(
-                    "Publication '{}' is defined FOR ALL TABLES, which also publishes ETL's \
+                    "Publication `{}` is defined `FOR ALL TABLES`, which also publishes ETL's \
                      internal schema tables when they exist.\n\nUse an explicit table list, or \
-                     FOR TABLES IN SCHEMA with only customer-owned schemas. Exclude the \
-                     '{ETL_SCHEMA_NAME}' schema.",
+                     `FOR TABLES IN SCHEMA` with only customer-owned schemas. Exclude the \
+                     `{ETL_SCHEMA_NAME}` schema.",
                     self.publication_name
                 ),
             )]);
@@ -299,12 +299,12 @@ impl Validator for PublicationExcludesEtlTablesValidator {
             return Ok(vec![ValidationFailure::critical(
                 "Publication Includes ETL Tables",
                 format!(
-                    "Publication '{}' includes ETL internal tables: {}.\n\nRemove the \
-                     '{ETL_SCHEMA_NAME}' schema from the publication before starting the \
+                    "Publication `{}` includes ETL internal tables: {}.\n\nRemove the \
+                     `{ETL_SCHEMA_NAME}` schema from the publication before starting the \
                      pipeline. ETL state tables are implementation details and must not be \
                      replicated.",
                     self.publication_name,
-                    published_etl_tables.join(", ")
+                    format_code_list(&published_etl_tables)
                 ),
             )]);
         }
@@ -331,7 +331,7 @@ impl Validator for PublicationExcludesEtlTablesValidator {
                 return Ok(vec![ValidationFailure::critical(
                     "Publication Includes ETL Tables",
                     format!(
-                        "Publication '{}' includes the '{ETL_SCHEMA_NAME}' schema.\n\nRemove that \
+                        "Publication `{}` includes the `{ETL_SCHEMA_NAME}` schema.\n\nRemove that \
                          schema from the publication and publish only customer-owned schemas or \
                          explicit customer tables.",
                         self.publication_name
@@ -402,9 +402,14 @@ impl Validator for GeneratedColumnsValidator {
                     "These publication tables have generated columns: {}.\n\nThe pipeline can \
                      start, but generated columns are not replicated and will be omitted from the \
                      destination.",
-                    tables_with_generated.join(", ")
+                    format_code_list(&tables_with_generated)
                 ),
             )])
         }
     }
+}
+
+/// Formats validation values as inline code for UI rendering.
+fn format_code_list(values: &[String]) -> String {
+    values.iter().map(|value| format!("`{value}`")).collect::<Vec<_>>().join(", ")
 }

--- a/crates/etl-api/src/validation/validators/pipeline.rs
+++ b/crates/etl-api/src/validation/validators/pipeline.rs
@@ -36,8 +36,9 @@ impl Validator for PublicationExistsValidator {
             Ok(vec![ValidationFailure::critical(
                 "Publication Not Found",
                 format!(
-                    "Publication '{}' does not exist in the source database. Create it with: \
-                     CREATE PUBLICATION {} FOR TABLE <table_name>, ...",
+                    "Publication '{}' does not exist in the source database.\n\nCreate the \
+                     publication, or choose an existing publication for this pipeline. For \
+                     example: CREATE PUBLICATION {} FOR TABLE <table_name>, ...",
                     self.publication_name, self.publication_name
                 ),
             )])
@@ -89,12 +90,12 @@ impl Validator for ReplicationSlotsValidator {
             Ok(vec![ValidationFailure::critical(
                 "Insufficient Replication Slots",
                 format!(
-                    "Not enough replication slots available.\nFound {free_slots} free slots, but \
-                     {required_slots} are required at most during initial table copy \
-                     ({used_slots}/{max_slots} currently in use).\nOnce all tables are copied, \
-                     only 1 slot will be used.\n\nPlease verify:\n(1) max_replication_slots in \
-                     postgresql.conf is sufficient\n(2) Unused replication slots can be \
-                     removed\n(3) max_table_sync_workers can be reduced if needed",
+                    "The source database has {free_slots} free replication slots, but this \
+                     pipeline can need up to {required_slots} during the initial table copy \
+                     ({used_slots}/{max_slots} slots are currently in use).\n\nIncrease \
+                     max_replication_slots, remove unused replication slots, or reduce \
+                     max_table_sync_workers. After the initial copy, this pipeline only uses 1 \
+                     slot.",
                 ),
             )])
         }
@@ -124,8 +125,9 @@ impl Validator for WalLevelValidator {
             Ok(vec![ValidationFailure::critical(
                 "Invalid WAL Level",
                 format!(
-                    "WAL level is set to '{wal_level}', but must be 'logical' for replication. \
-                     Update postgresql.conf with: wal_level = 'logical' and restart PostgreSQL"
+                    "The source database WAL level is '{wal_level}', but logical replication \
+                     requires 'logical'.\n\nSet wal_level = 'logical' in postgresql.conf and \
+                     restart PostgreSQL."
                 ),
             )])
         }
@@ -159,7 +161,8 @@ impl Validator for ReplicationPermissionsValidator {
         } else {
             Ok(vec![ValidationFailure::critical(
                 "Missing Replication Permission",
-                "The database user does not have replication privileges",
+                "The source database user does not have replication privileges.\n\nGrant the user \
+                 the REPLICATION attribute or connect with a role that already has it.",
             )])
         }
     }
@@ -214,8 +217,9 @@ impl Validator for PublicationHasTablesValidator {
             Ok(vec![ValidationFailure::critical(
                 "Publication Empty",
                 format!(
-                    "Publication '{}' exists but contains no tables.\n\nAdd tables with: ALTER \
-                     PUBLICATION {} ADD TABLE <table_name>",
+                    "Publication '{}' exists, but it does not publish any tables.\n\nAdd tables \
+                     to the publication before starting the pipeline. For example: ALTER \
+                     PUBLICATION {} ADD TABLE <table_name>.",
                     self.publication_name, self.publication_name
                 ),
             )])
@@ -283,8 +287,8 @@ impl Validator for PublicationExcludesEtlTablesValidator {
                 "Publication Includes ETL Tables",
                 format!(
                     "Publication '{}' is defined FOR ALL TABLES, which also publishes ETL's \
-                     internal schema tables when they exist. Use an explicit table list or FOR \
-                     TABLES IN SCHEMA for customer-owned schemas, excluding the \
+                     internal schema tables when they exist.\n\nUse an explicit table list, or \
+                     FOR TABLES IN SCHEMA with only customer-owned schemas. Exclude the \
                      '{ETL_SCHEMA_NAME}' schema.",
                     self.publication_name
                 ),
@@ -296,7 +300,7 @@ impl Validator for PublicationExcludesEtlTablesValidator {
                 "Publication Includes ETL Tables",
                 format!(
                     "Publication '{}' includes ETL internal tables: {}.\n\nRemove the \
-                     '{ETL_SCHEMA_NAME}' schema from the publication before starting this \
+                     '{ETL_SCHEMA_NAME}' schema from the publication before starting the \
                      pipeline. ETL state tables are implementation details and must not be \
                      replicated.",
                     self.publication_name,
@@ -327,7 +331,7 @@ impl Validator for PublicationExcludesEtlTablesValidator {
                 return Ok(vec![ValidationFailure::critical(
                     "Publication Includes ETL Tables",
                     format!(
-                        "Publication '{}' includes the '{ETL_SCHEMA_NAME}' schema. Remove that \
+                        "Publication '{}' includes the '{ETL_SCHEMA_NAME}' schema.\n\nRemove that \
                          schema from the publication and publish only customer-owned schemas or \
                          explicit customer tables.",
                         self.publication_name
@@ -395,8 +399,9 @@ impl Validator for GeneratedColumnsValidator {
             Ok(vec![ValidationFailure::warning(
                 "Tables With Generated Columns",
                 format!(
-                    "Tables with generated columns: {}\n\nGenerated columns cannot be replicated \
-                     and will be excluded from the destination.",
+                    "These publication tables have generated columns: {}.\n\nThe pipeline can \
+                     start, but generated columns are not replicated and will be omitted from the \
+                     destination.",
                     tables_with_generated.join(", ")
                 ),
             )])

--- a/crates/etl-api/src/validation/validators/primary_key.rs
+++ b/crates/etl-api/src/validation/validators/primary_key.rs
@@ -1,6 +1,7 @@
 //! Source primary-key validation for destination compatibility.
 
 use async_trait::async_trait;
+use etl_postgres::version::POSTGRES_15;
 
 use crate::validation::{ValidationContext, ValidationError, ValidationFailure, Validator};
 
@@ -13,6 +14,8 @@ pub(super) struct PrimaryKeyValidator {
     destination_name: &'static str,
     /// Explanation of why the destination needs source primary keys.
     reason: &'static str,
+    /// Whether every publication table must have a primary key.
+    require_primary_key: bool,
 }
 
 impl PrimaryKeyValidator {
@@ -21,8 +24,9 @@ impl PrimaryKeyValidator {
         publication_name: String,
         destination_name: &'static str,
         reason: &'static str,
+        require_primary_key: bool,
     ) -> Self {
-        Self { publication_name, destination_name, reason }
+        Self { publication_name, destination_name, reason, require_primary_key }
     }
 }
 
@@ -109,10 +113,94 @@ impl Validator for PrimaryKeyValidator {
         .fetch_all(source_pool)
         .await?;
 
-        if tables_without_pk.is_empty() {
-            Ok(vec![])
+        let server_version_num: i32 =
+            sqlx::query_scalar("select current_setting('server_version_num')::int")
+                .fetch_one(source_pool)
+                .await?;
+        let tables_with_omitted_pk_columns = if server_version_num >= POSTGRES_15 {
+            sqlx::query_as::<_, (String, String)>(
+                r#"
+                with publication_tables as (
+                    select
+                        n.nspname || '.' || c.relname as table_name,
+                        c.oid as table_oid,
+                        coalesce(pt.attnames, array[]::name[]) as replicated_column_names
+                    from pg_publication p
+                    cross join lateral pg_get_publication_tables(p.pubname) gpt
+                    join pg_class c on c.oid = gpt.relid
+                    join pg_namespace n on n.oid = c.relnamespace
+                    left join pg_publication_tables pt
+                      on pt.pubname = p.pubname
+                     and pt.schemaname = n.nspname
+                     and pt.tablename = c.relname
+                    where p.pubname = $1
+                ),
+                primary_key_cols as (
+                    select
+                        pt.table_name,
+                        pt.table_oid,
+                        pt.replicated_column_names,
+                        epkc.attnum,
+                        epkc.position
+                    from publication_tables pt
+                    cross join lateral (
+                        with direct_parent as (
+                            select i.inhparent as parent_oid
+                            from pg_inherits i
+                            where i.inhrelid = pt.table_oid
+                            order by i.inhseqno
+                            limit 1
+                        ),
+                        table_primary_key_cols as (
+                            select x.attnum::int4 as attnum, x.n::int4 as position
+                            from pg_constraint con
+                            cross join lateral unnest(con.conkey) with ordinality as x(attnum, n)
+                            where con.conrelid = pt.table_oid
+                              and con.contype = 'p'
+                        ),
+                        parent_primary_key_cols as (
+                            select x.attnum::int4 as attnum, x.n::int4 as position
+                            from direct_parent dp
+                            join pg_constraint con
+                              on con.conrelid = dp.parent_oid
+                             and con.contype = 'p'
+                            cross join lateral unnest(con.conkey) with ordinality as x(attnum, n)
+                        )
+                        select tpkc.attnum, tpkc.position
+                        from table_primary_key_cols tpkc
+                        union all
+                        select ppkc.attnum, ppkc.position
+                        from parent_primary_key_cols ppkc
+                        where not exists (
+                            select 1
+                            from table_primary_key_cols tpkc
+                        )
+                    ) epkc
+                )
+                select
+                    pk.table_name,
+                    string_agg(a.attname::text, ', ' order by pk.position) as omitted_columns
+                from primary_key_cols pk
+                join pg_attribute a
+                  on a.attrelid = pk.table_oid
+                 and a.attnum = pk.attnum
+                where cardinality(pk.replicated_column_names) > 0
+                  and a.attname <> all(pk.replicated_column_names)
+                group by pk.table_name
+                order by pk.table_name
+                limit 100
+                "#,
+            )
+            .bind(&self.publication_name)
+            .fetch_all(source_pool)
+            .await?
         } else {
-            Ok(vec![ValidationFailure::critical(
+            Vec::new()
+        };
+
+        let mut failures = Vec::new();
+        if self.require_primary_key && !tables_without_pk.is_empty() {
+            failures.push(ValidationFailure::critical(
                 "Source Primary Keys Required",
                 format!(
                     "{} can only replicate these publication tables when they have a primary key: \
@@ -122,7 +210,28 @@ impl Validator for PrimaryKeyValidator {
                     tables_without_pk.join(", "),
                     self.reason
                 ),
-            )])
+            ));
         }
+
+        if !tables_with_omitted_pk_columns.is_empty() {
+            let formatted_tables = tables_with_omitted_pk_columns
+                .iter()
+                .map(|(table_name, omitted_columns)| format!("{table_name} ({omitted_columns})"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            failures.push(ValidationFailure::critical(
+                "Source Primary Key Columns Required",
+                format!(
+                    "{} can only replicate publication tables when every source primary-key \
+                     column is included in the publication column list. These tables omit \
+                     primary-key columns: {}.\n\nAdd the listed columns to the publication column \
+                     list, remove the column list so all columns are replicated, or remove the \
+                     table from the publication before starting the pipeline. {}",
+                    self.destination_name, formatted_tables, self.reason
+                ),
+            ));
+        }
+
+        Ok(failures)
     }
 }

--- a/crates/etl-api/src/validation/validators/primary_key.rs
+++ b/crates/etl-api/src/validation/validators/primary_key.rs
@@ -1,0 +1,127 @@
+//! Source primary-key validation for destination compatibility.
+
+use async_trait::async_trait;
+
+use crate::validation::{ValidationContext, ValidationError, ValidationFailure, Validator};
+
+/// Validates source primary keys for destinations that require them.
+#[derive(Debug)]
+pub(super) struct PrimaryKeyValidator {
+    /// Name of the publication whose tables should be checked.
+    publication_name: String,
+    /// User-facing destination name included in validation messages.
+    destination_name: &'static str,
+    /// Explanation of why the destination needs source primary keys.
+    reason: &'static str,
+}
+
+impl PrimaryKeyValidator {
+    /// Creates a destination-specific primary-key validator.
+    pub(super) fn new(
+        publication_name: String,
+        destination_name: &'static str,
+        reason: &'static str,
+    ) -> Self {
+        Self { publication_name, destination_name, reason }
+    }
+}
+
+#[async_trait]
+impl Validator for PrimaryKeyValidator {
+    async fn validate(
+        &self,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let Some(source_pool) = ctx.source_pool.as_ref() else {
+            return Ok(vec![]);
+        };
+
+        let publication_exists: bool = sqlx::query_scalar(
+            r#"
+            select exists(
+                select 1
+                from pg_publication
+                where pubname = $1
+            )
+            "#,
+        )
+        .bind(&self.publication_name)
+        .fetch_one(source_pool)
+        .await?;
+
+        if !publication_exists {
+            // If the publication doesn't exist, skip this check. Pipeline
+            // validation reports the actionable publication failure.
+            return Ok(vec![]);
+        }
+
+        let tables_without_pk: Vec<String> = sqlx::query_scalar(
+            r#"
+            select n.nspname || '.' || c.relname
+            from pg_publication p
+            cross join lateral pg_get_publication_tables(p.pubname) gpt
+            join pg_class c on c.oid = gpt.relid
+            join pg_namespace n on n.oid = c.relnamespace
+            left join lateral (
+                with direct_parent as (
+                    select i.inhparent as parent_oid
+                    from pg_inherits i
+                    where i.inhrelid = c.oid
+                    order by i.inhseqno
+                    limit 1
+                ),
+                primary_key_cols as (
+                    select x.attnum::int4 as attnum, x.n::int4 as position
+                    from pg_constraint con
+                    cross join lateral unnest(con.conkey) with ordinality as x(attnum, n)
+                    where con.conrelid = c.oid
+                      and con.contype = 'p'
+                ),
+                parent_primary_key_cols as (
+                    select x.attnum::int4 as attnum, x.n::int4 as position
+                    from direct_parent dp
+                    join pg_constraint con
+                      on con.conrelid = dp.parent_oid
+                     and con.contype = 'p'
+                    cross join lateral unnest(con.conkey) with ordinality as x(attnum, n)
+                ),
+                effective_primary_key_cols as (
+                    select pkc.attnum, pkc.position
+                    from primary_key_cols pkc
+                    union all
+                    select ppkc.attnum, ppkc.position
+                    from parent_primary_key_cols ppkc
+                    where not exists (
+                        select 1
+                        from primary_key_cols pkc
+                    )
+                )
+                select array_agg(epkc.attnum order by epkc.position) as primary_key_attnums
+                from effective_primary_key_cols epkc
+            ) pk on true
+            where p.pubname = $1
+              and cardinality(coalesce(pk.primary_key_attnums, array[]::int4[])) = 0
+            order by n.nspname, c.relname
+            limit 100
+            "#,
+        )
+        .bind(&self.publication_name)
+        .fetch_all(source_pool)
+        .await?;
+
+        if tables_without_pk.is_empty() {
+            Ok(vec![])
+        } else {
+            Ok(vec![ValidationFailure::warning(
+                "Source Primary Keys Required",
+                format!(
+                    "{} requires source primary keys for the following publication tables: \
+                     {}.\n\n{}",
+                    self.destination_name,
+                    tables_without_pk.join(", "),
+                    self.reason
+                ),
+            )])
+        }
+    }
+}

--- a/crates/etl-api/src/validation/validators/primary_key.rs
+++ b/crates/etl-api/src/validation/validators/primary_key.rs
@@ -207,7 +207,7 @@ impl Validator for PrimaryKeyValidator {
                      {}.\n\nAdd a primary key to each listed table, or remove the table from the \
                      publication before starting the pipeline. {}",
                     self.destination_name,
-                    tables_without_pk.join(", "),
+                    format_code_list(&tables_without_pk),
                     self.reason
                 ),
             ));
@@ -216,7 +216,9 @@ impl Validator for PrimaryKeyValidator {
         if !tables_with_omitted_pk_columns.is_empty() {
             let formatted_tables = tables_with_omitted_pk_columns
                 .iter()
-                .map(|(table_name, omitted_columns)| format!("{table_name} ({omitted_columns})"))
+                .map(|(table_name, omitted_columns)| {
+                    format!("`{table_name}` (`{omitted_columns}`)")
+                })
                 .collect::<Vec<_>>()
                 .join(", ");
             failures.push(ValidationFailure::critical(
@@ -234,4 +236,9 @@ impl Validator for PrimaryKeyValidator {
 
         Ok(failures)
     }
+}
+
+/// Formats validation values as inline code for UI rendering.
+fn format_code_list(values: &[String]) -> String {
+    values.iter().map(|value| format!("`{value}`")).collect::<Vec<_>>().join(", ")
 }

--- a/crates/etl-api/src/validation/validators/primary_key.rs
+++ b/crates/etl-api/src/validation/validators/primary_key.rs
@@ -112,11 +112,12 @@ impl Validator for PrimaryKeyValidator {
         if tables_without_pk.is_empty() {
             Ok(vec![])
         } else {
-            Ok(vec![ValidationFailure::warning(
+            Ok(vec![ValidationFailure::critical(
                 "Source Primary Keys Required",
                 format!(
-                    "{} requires source primary keys for the following publication tables: \
-                     {}.\n\n{}",
+                    "{} can only replicate these publication tables when they have a primary key: \
+                     {}.\n\nAdd a primary key to each listed table, or remove the table from the \
+                     publication before starting the pipeline. {}",
                     self.destination_name,
                     tables_without_pk.join(", "),
                     self.reason

--- a/crates/etl-api/src/validation/validators/replica_identity.rs
+++ b/crates/etl-api/src/validation/validators/replica_identity.rs
@@ -149,7 +149,7 @@ impl Validator for ReplicaIdentityValidator {
                 if self.supported_identity_types.contains(&identity_type) {
                     None
                 } else {
-                    Some(format!("{} ({})", table_identity.table_name, identity_type))
+                    Some(format!("`{} ({})`", table_identity.table_name, identity_type))
                 }
             })
             .collect::<Vec<_>>();
@@ -162,8 +162,8 @@ impl Validator for ReplicaIdentityValidator {
                 format!(
                     "{} cannot safely replicate UPDATE or DELETE changes for these publication \
                      tables because their replica identity is unsupported: {}.\n\nSet each table \
-                     to {} before starting the pipeline. If a table has large TOAST-backed \
-                     columns, `REPLICA IDENTITY FULL` is recommended.",
+                     to {} before starting the pipeline. If a table has columns with large values \
+                     (TOAST columns), `REPLICA IDENTITY FULL` is recommended.",
                     self.destination_name,
                     format_unsupported_tables(&unsupported_tables),
                     format_supported_identity_types(self.supported_identity_types),
@@ -176,8 +176,8 @@ impl Validator for ReplicaIdentityValidator {
                     "{} can start because this publication only replicates INSERT changes, but \
                      these tables use replica identities that would not support UPDATE or DELETE \
                      replication: {}.\n\nSet each table to {} before enabling UPDATE or DELETE on \
-                     the publication. If a table has large TOAST-backed columns, `REPLICA \
-                     IDENTITY FULL` is recommended.",
+                     the publication. If a table has columns with large values (TOAST columns), \
+                     `REPLICA IDENTITY FULL` is recommended.",
                     self.destination_name,
                     format_unsupported_tables(&unsupported_tables),
                     format_supported_identity_types(self.supported_identity_types),

--- a/crates/etl-api/src/validation/validators/replica_identity.rs
+++ b/crates/etl-api/src/validation/validators/replica_identity.rs
@@ -17,8 +17,10 @@ pub(super) struct ReplicaIdentityValidator {
     publication_name: String,
     /// User-facing destination name included in validation messages.
     destination_name: &'static str,
-    /// Semantic replica identity types accepted by the destination.
-    supported_identity_types: &'static [IdentityType],
+    /// Semantic replica identity types accepted for update events.
+    update_identity_types: &'static [IdentityType],
+    /// Semantic replica identity types accepted for delete events.
+    delete_identity_types: &'static [IdentityType],
 }
 
 impl ReplicaIdentityValidator {
@@ -26,9 +28,10 @@ impl ReplicaIdentityValidator {
     pub(super) fn new(
         publication_name: String,
         destination_name: &'static str,
-        supported_identity_types: &'static [IdentityType],
+        update_identity_types: &'static [IdentityType],
+        delete_identity_types: &'static [IdentityType],
     ) -> Self {
-        Self { publication_name, destination_name, supported_identity_types }
+        Self { publication_name, destination_name, update_identity_types, delete_identity_types }
     }
 }
 
@@ -45,6 +48,15 @@ struct TableReplicaIdentityAudit {
     replica_identity_index_attnums: Vec<i32>,
 }
 
+/// Unsupported replica identity details for one publication table.
+#[derive(Debug)]
+struct UnsupportedTableIdentity {
+    /// Formatted table and identity, without operation details.
+    table_identity: String,
+    /// Operations this identity cannot support.
+    unsupported_operations: Vec<&'static str>,
+}
+
 #[async_trait]
 impl Validator for ReplicaIdentityValidator {
     async fn validate(
@@ -55,16 +67,17 @@ impl Validator for ReplicaIdentityValidator {
             return Ok(vec![]);
         };
 
-        let Some(publication_publishes_updates_or_deletes): Option<bool> = sqlx::query_scalar(
-            r#"
-            select pubupdate or pubdelete
+        let Some((publication_publishes_updates, publication_publishes_deletes)) =
+            sqlx::query_as::<_, (bool, bool)>(
+                r#"
+            select pubupdate, pubdelete
             from pg_publication
             where pubname = $1
             "#,
-        )
-        .bind(&self.publication_name)
-        .fetch_optional(source_pool)
-        .await?
+            )
+            .bind(&self.publication_name)
+            .fetch_optional(source_pool)
+            .await?
         else {
             // If the publication doesn't exist, skip this check. Pipeline
             // validation reports the actionable publication failure.
@@ -137,68 +150,198 @@ impl Validator for ReplicaIdentityValidator {
         .fetch_all(source_pool)
         .await?;
 
-        let unsupported_tables = table_identities
-            .into_iter()
-            .filter_map(|table_identity| {
-                let identity_type = identity_type_for_table(
-                    &table_identity.relreplident,
-                    &table_identity.primary_key_attnums,
-                    &table_identity.replica_identity_index_attnums,
-                );
+        let mut critical_tables = Vec::new();
+        let mut warning_tables = Vec::new();
+        for table_identity in table_identities {
+            let identity_type = identity_type_for_table(
+                &table_identity.relreplident,
+                &table_identity.primary_key_attnums,
+                &table_identity.replica_identity_index_attnums,
+            );
 
-                if self.supported_identity_types.contains(&identity_type) {
-                    None
-                } else {
-                    Some(format!("`{} ({})`", table_identity.table_name, identity_type))
-                }
-            })
-            .collect::<Vec<_>>();
+            let unsupported_current_operations = self.unsupported_operations(
+                identity_type,
+                publication_publishes_updates,
+                publication_publishes_deletes,
+            );
+            if !unsupported_current_operations.is_empty() {
+                critical_tables.push(UnsupportedTableIdentity {
+                    table_identity: format!("`{} ({})`", table_identity.table_name, identity_type),
+                    unsupported_operations: unsupported_current_operations,
+                });
+                continue;
+            }
 
-        if unsupported_tables.is_empty() {
-            Ok(vec![])
-        } else if publication_publishes_updates_or_deletes {
-            Ok(vec![ValidationFailure::critical(
-                "Unsupported Replica Identity",
-                format!(
-                    "{} cannot safely replicate UPDATE or DELETE changes for these publication \
-                     tables because their replica identity is unsupported: {}.\n\nSet each table \
-                     to {} before starting the pipeline. If a table has columns with large values \
-                     (TOAST columns), `REPLICA IDENTITY FULL` is recommended.",
-                    self.destination_name,
-                    format_unsupported_tables(&unsupported_tables),
-                    format_supported_identity_types(self.supported_identity_types),
-                ),
-            )])
-        } else {
-            Ok(vec![ValidationFailure::warning(
-                "Unsupported Replica Identity",
-                format!(
-                    "{} can start because this publication only replicates INSERT changes, but \
-                     these tables use replica identities that would not support UPDATE or DELETE \
-                     replication: {}.\n\nSet each table to {} before enabling UPDATE or DELETE on \
-                     the publication. If a table has columns with large values (TOAST columns), \
-                     `REPLICA IDENTITY FULL` is recommended.",
-                    self.destination_name,
-                    format_unsupported_tables(&unsupported_tables),
-                    format_supported_identity_types(self.supported_identity_types),
-                ),
-            )])
+            let unsupported_future_operations =
+                self.unsupported_operations(identity_type, true, true);
+            if !unsupported_future_operations.is_empty() {
+                warning_tables.push(UnsupportedTableIdentity {
+                    table_identity: format!("`{} ({})`", table_identity.table_name, identity_type),
+                    unsupported_operations: unsupported_future_operations,
+                });
+            }
         }
+
+        let mut failures = Vec::new();
+        if !critical_tables.is_empty() {
+            failures.push(ValidationFailure::critical(
+                "Unsupported Replica Identity",
+                format!(
+                    "{} cannot safely replicate {} changes for these publication tables because \
+                     their replica identity is unsupported: {}.\n\nSet each table to {} before \
+                     starting the pipeline. If a table has columns with large values (TOAST \
+                     columns), `REPLICA IDENTITY FULL` is recommended.",
+                    self.destination_name,
+                    format_operations(&published_operations(
+                        publication_publishes_updates,
+                        publication_publishes_deletes,
+                    )),
+                    format_unsupported_tables(&critical_tables),
+                    format_supported_identity_types(&self.supported_identity_types_for_operations(
+                        publication_publishes_updates,
+                        publication_publishes_deletes,
+                    )),
+                ),
+            ));
+        }
+
+        if !warning_tables.is_empty() {
+            let warning_prefix = if !publication_publishes_updates && !publication_publishes_deletes
+            {
+                format!(
+                    "{} can start because this publication does not replicate UPDATE or DELETE \
+                     changes, but these tables use replica identities that would not support \
+                     future mutation replication",
+                    self.destination_name
+                )
+            } else {
+                format!(
+                    "{} can start with the current publication operations, but these tables use \
+                     replica identities that would not support future mutation replication",
+                    self.destination_name
+                )
+            };
+
+            failures.push(ValidationFailure::warning(
+                "Unsupported Replica Identity",
+                format!(
+                    "{}: {}.\n\nSet each table to {} before enabling those operations on the \
+                     publication. If a table has columns with large values (TOAST columns), \
+                     `REPLICA IDENTITY FULL` is recommended.",
+                    warning_prefix,
+                    format_unsupported_tables(&warning_tables),
+                    format_supported_identity_types(
+                        &self.supported_identity_types_for_operations(true, true),
+                    ),
+                ),
+            ));
+        }
+
+        Ok(failures)
+    }
+}
+
+impl ReplicaIdentityValidator {
+    /// Returns the operations not supported by `identity_type`.
+    fn unsupported_operations(
+        &self,
+        identity_type: IdentityType,
+        check_update: bool,
+        check_delete: bool,
+    ) -> Vec<&'static str> {
+        let mut operations = Vec::new();
+
+        if check_update && !self.update_identity_types.contains(&identity_type) {
+            operations.push("UPDATE");
+        }
+
+        if check_delete && !self.delete_identity_types.contains(&identity_type) {
+            operations.push("DELETE");
+        }
+
+        operations
+    }
+
+    /// Returns the identity types supported by all selected operations.
+    fn supported_identity_types_for_operations(
+        &self,
+        include_update: bool,
+        include_delete: bool,
+    ) -> Vec<IdentityType> {
+        let mut supported = Vec::new();
+
+        for identity_type in [
+            IdentityType::PrimaryKey,
+            IdentityType::AlternativeKey,
+            IdentityType::Full,
+            IdentityType::Missing,
+        ] {
+            let update_supported =
+                !include_update || self.update_identity_types.contains(&identity_type);
+            let delete_supported =
+                !include_delete || self.delete_identity_types.contains(&identity_type);
+
+            if update_supported && delete_supported {
+                supported.push(identity_type);
+            }
+        }
+
+        supported
     }
 }
 
 /// Formats unsupported table identities for a compact warning message.
-fn format_unsupported_tables(tables: &[String]) -> String {
+fn format_unsupported_tables(tables: &[UnsupportedTableIdentity]) -> String {
     const MAX_DISPLAYED_TABLES: usize = 20;
 
     let displayed_tables =
-        tables.iter().take(MAX_DISPLAYED_TABLES).map(String::as_str).collect::<Vec<_>>().join(", ");
+        tables.iter().take(MAX_DISPLAYED_TABLES).map(format_unsupported_table).collect::<Vec<_>>();
     let remaining_count = tables.len().saturating_sub(MAX_DISPLAYED_TABLES);
 
+    let displayed_tables = displayed_tables.join(", ");
     if remaining_count == 0 {
         displayed_tables
     } else {
         format!("{displayed_tables}, and {remaining_count} more")
+    }
+}
+
+/// Formats one unsupported table identity.
+fn format_unsupported_table(table: &UnsupportedTableIdentity) -> String {
+    format!(
+        "{} (unsupported for {})",
+        table.table_identity,
+        format_operations(&table.unsupported_operations)
+    )
+}
+
+/// Returns publication operations as labels.
+fn published_operations(publishes_updates: bool, publishes_deletes: bool) -> Vec<&'static str> {
+    let mut operations = Vec::new();
+
+    if publishes_updates {
+        operations.push("UPDATE");
+    }
+
+    if publishes_deletes {
+        operations.push("DELETE");
+    }
+
+    operations
+}
+
+/// Formats operation labels for user-facing messages.
+fn format_operations(operations: &[&str]) -> String {
+    match operations {
+        [] => "mutation".to_owned(),
+        [operation] => (*operation).to_owned(),
+        [first, second] => format!("{first} or {second}"),
+        [first, middle @ .., last] => {
+            let mut formatted = Vec::with_capacity(operations.len());
+            formatted.push((*first).to_owned());
+            formatted.extend(middle.iter().map(|operation| (*operation).to_owned()));
+            format!("{}, or {}", formatted.join(", "), last)
+        }
     }
 }
 

--- a/crates/etl-api/src/validation/validators/replica_identity.rs
+++ b/crates/etl-api/src/validation/validators/replica_identity.rs
@@ -71,10 +71,6 @@ impl Validator for ReplicaIdentityValidator {
             return Ok(vec![]);
         };
 
-        if !publication_publishes_updates_or_deletes {
-            return Ok(vec![]);
-        }
-
         let table_identities = sqlx::query_as::<_, TableReplicaIdentityAudit>(
             r#"
             select
@@ -160,14 +156,26 @@ impl Validator for ReplicaIdentityValidator {
 
         if unsupported_tables.is_empty() {
             Ok(vec![])
+        } else if publication_publishes_updates_or_deletes {
+            Ok(vec![ValidationFailure::critical(
+                "Unsupported Replica Identity",
+                format!(
+                    "{} cannot safely replicate UPDATE or DELETE changes for these publication \
+                     tables because their replica identity is unsupported: {}.\n\nSet each table \
+                     to {} before starting the pipeline.",
+                    self.destination_name,
+                    format_unsupported_tables(&unsupported_tables),
+                    format_supported_identity_types(self.supported_identity_types),
+                ),
+            )])
         } else {
             Ok(vec![ValidationFailure::warning(
                 "Unsupported Replica Identity",
                 format!(
-                    "The following publication tables use replica identities that {} does not \
-                     support: {}.\n\nUse {} as the replica identity for reliable UPDATE and \
-                     DELETE replication to this destination. Otherwise, the destination may fail \
-                     to apply UPDATE or DELETE operations for those tables.",
+                    "{} can start because this publication only replicates INSERT changes, but \
+                     these tables use replica identities that would not support UPDATE or DELETE \
+                     replication: {}.\n\nSet each table to {} before enabling UPDATE or DELETE on \
+                     the publication.",
                     self.destination_name,
                     format_unsupported_tables(&unsupported_tables),
                     format_supported_identity_types(self.supported_identity_types),
@@ -259,8 +267,8 @@ fn format_identity_type_suggestion(identity_type: IdentityType) -> &'static str 
              `REPLICA IDENTITY USING INDEX` with the primary-key index)"
         }
         IdentityType::AlternativeKey => {
-            "an alternative-key identity (`REPLICA IDENTITY USING INDEX` with a non-primary-key \
-             unique index)"
+            "an alternative-key identity (`REPLICA IDENTITY USING INDEX` with a unique, \
+             non-primary-key index)"
         }
         IdentityType::Full => "`REPLICA IDENTITY FULL`",
         IdentityType::Missing => "no replica identity",

--- a/crates/etl-api/src/validation/validators/replica_identity.rs
+++ b/crates/etl-api/src/validation/validators/replica_identity.rs
@@ -1,3 +1,8 @@
+//! Replica identity validation for destination compatibility.
+//!
+//! The validator classifies each publication table into semantic identity
+//! types so destinations can declare the row identities they can safely apply.
+
 use async_trait::async_trait;
 use etl_postgres::types::IdentityType;
 use sqlx::FromRow;
@@ -8,8 +13,11 @@ use crate::validation::{ValidationContext, ValidationError, ValidationFailure, V
 /// identities.
 #[derive(Debug)]
 pub(super) struct ReplicaIdentityValidator {
+    /// Name of the publication whose tables should be checked.
     publication_name: String,
+    /// User-facing destination name included in validation messages.
     destination_name: &'static str,
+    /// Semantic replica identity types accepted by the destination.
     supported_identity_types: &'static [IdentityType],
 }
 
@@ -24,11 +32,16 @@ impl ReplicaIdentityValidator {
     }
 }
 
+/// Replica identity catalog data for one publication table.
 #[derive(Debug, FromRow)]
 struct TableReplicaIdentityAudit {
+    /// Schema-qualified table name for warning output.
     table_name: String,
+    /// Raw `pg_class.relreplident` value for the table.
     relreplident: String,
+    /// Table primary-key column numbers from `pg_constraint.conkey`.
     primary_key_attnums: Vec<i32>,
+    /// Key column numbers from the index marked by `pg_index.indisreplident`.
     replica_identity_index_attnums: Vec<i32>,
 }
 
@@ -164,6 +177,7 @@ impl Validator for ReplicaIdentityValidator {
     }
 }
 
+/// Formats unsupported table identities for a compact warning message.
 fn format_unsupported_tables(tables: &[String]) -> String {
     const MAX_DISPLAYED_TABLES: usize = 20;
 
@@ -178,6 +192,7 @@ fn format_unsupported_tables(tables: &[String]) -> String {
     }
 }
 
+/// Converts raw Postgres replica identity metadata into a semantic identity.
 fn identity_type_for_table(
     relreplident: &str,
     primary_key_attnums: &[i32],
@@ -197,6 +212,7 @@ fn identity_type_for_table(
     }
 }
 
+/// Returns whether two attnum lists refer to the same table columns.
 fn attnums_match(left: &[i32], right: &[i32]) -> bool {
     if left.len() != right.len() {
         return false;
@@ -210,6 +226,7 @@ fn attnums_match(left: &[i32], right: &[i32]) -> bool {
     left == right
 }
 
+/// Formats supported identity types as user-facing suggestions.
 fn format_supported_identity_types(identity_types: &[IdentityType]) -> String {
     match identity_types {
         [] => "no".to_owned(),
@@ -234,6 +251,7 @@ fn format_supported_identity_types(identity_types: &[IdentityType]) -> String {
     }
 }
 
+/// Formats a single identity type as a user-facing suggestion.
 fn format_identity_type_suggestion(identity_type: IdentityType) -> &'static str {
     match identity_type {
         IdentityType::PrimaryKey => {

--- a/crates/etl-api/src/validation/validators/replica_identity.rs
+++ b/crates/etl-api/src/validation/validators/replica_identity.rs
@@ -162,7 +162,8 @@ impl Validator for ReplicaIdentityValidator {
                 format!(
                     "{} cannot safely replicate UPDATE or DELETE changes for these publication \
                      tables because their replica identity is unsupported: {}.\n\nSet each table \
-                     to {} before starting the pipeline.",
+                     to {} before starting the pipeline. If a table has large TOAST-backed \
+                     columns, `REPLICA IDENTITY FULL` is recommended.",
                     self.destination_name,
                     format_unsupported_tables(&unsupported_tables),
                     format_supported_identity_types(self.supported_identity_types),
@@ -175,7 +176,8 @@ impl Validator for ReplicaIdentityValidator {
                     "{} can start because this publication only replicates INSERT changes, but \
                      these tables use replica identities that would not support UPDATE or DELETE \
                      replication: {}.\n\nSet each table to {} before enabling UPDATE or DELETE on \
-                     the publication.",
+                     the publication. If a table has large TOAST-backed columns, `REPLICA \
+                     IDENTITY FULL` is recommended.",
                     self.destination_name,
                     format_unsupported_tables(&unsupported_tables),
                     format_supported_identity_types(self.supported_identity_types),

--- a/crates/etl-api/src/validation/validators/replica_identity.rs
+++ b/crates/etl-api/src/validation/validators/replica_identity.rs
@@ -1,0 +1,250 @@
+use async_trait::async_trait;
+use etl_postgres::types::IdentityType;
+use sqlx::FromRow;
+
+use crate::validation::{ValidationContext, ValidationError, ValidationFailure, Validator};
+
+/// Validates that publication tables use destination-supported replica
+/// identities.
+#[derive(Debug)]
+pub(super) struct ReplicaIdentityValidator {
+    publication_name: String,
+    destination_name: &'static str,
+    supported_identity_types: &'static [IdentityType],
+}
+
+impl ReplicaIdentityValidator {
+    /// Creates a replica identity validator for a destination.
+    pub(super) fn new(
+        publication_name: String,
+        destination_name: &'static str,
+        supported_identity_types: &'static [IdentityType],
+    ) -> Self {
+        Self { publication_name, destination_name, supported_identity_types }
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct TableReplicaIdentityAudit {
+    table_name: String,
+    relreplident: String,
+    primary_key_attnums: Vec<i32>,
+    replica_identity_index_attnums: Vec<i32>,
+}
+
+#[async_trait]
+impl Validator for ReplicaIdentityValidator {
+    async fn validate(
+        &self,
+        ctx: &ValidationContext,
+    ) -> Result<Vec<ValidationFailure>, ValidationError> {
+        let Some(source_pool) = ctx.source_pool.as_ref() else {
+            return Ok(vec![]);
+        };
+
+        let Some(publication_publishes_updates_or_deletes): Option<bool> = sqlx::query_scalar(
+            r#"
+            select pubupdate or pubdelete
+            from pg_publication
+            where pubname = $1
+            "#,
+        )
+        .bind(&self.publication_name)
+        .fetch_optional(source_pool)
+        .await?
+        else {
+            // If the publication doesn't exist, skip this check. Pipeline
+            // validation reports the actionable publication failure.
+            return Ok(vec![]);
+        };
+
+        if !publication_publishes_updates_or_deletes {
+            return Ok(vec![]);
+        }
+
+        let table_identities = sqlx::query_as::<_, TableReplicaIdentityAudit>(
+            r#"
+            select
+                n.nspname || '.' || c.relname as table_name,
+                c.relreplident::text as relreplident,
+                coalesce(pk.primary_key_attnums, array[]::int4[]) as primary_key_attnums,
+                coalesce(ri.replica_identity_index_attnums, array[]::int4[])
+                    as replica_identity_index_attnums
+            from pg_publication p
+            cross join lateral pg_get_publication_tables(p.pubname) gpt
+            join pg_class c on c.oid = gpt.relid
+            join pg_namespace n on n.oid = c.relnamespace
+            left join lateral (
+                with direct_parent as (
+                    select i.inhparent as parent_oid
+                    from pg_inherits i
+                    where i.inhrelid = c.oid
+                    order by i.inhseqno
+                    limit 1
+                ),
+                primary_key_cols as (
+                    select x.attnum::int4 as attnum, x.n::int4 as position
+                    from pg_constraint con
+                    cross join lateral unnest(con.conkey) with ordinality as x(attnum, n)
+                    where con.conrelid = c.oid
+                      and con.contype = 'p'
+                ),
+                parent_primary_key_cols as (
+                    select x.attnum::int4 as attnum, x.n::int4 as position
+                    from direct_parent dp
+                    join pg_constraint con
+                      on con.conrelid = dp.parent_oid
+                     and con.contype = 'p'
+                    cross join lateral unnest(con.conkey) with ordinality as x(attnum, n)
+                ),
+                effective_primary_key_cols as (
+                    select pkc.attnum, pkc.position
+                    from primary_key_cols pkc
+                    union all
+                    select ppkc.attnum, ppkc.position
+                    from parent_primary_key_cols ppkc
+                    where not exists (
+                        select 1
+                        from primary_key_cols pkc
+                    )
+                )
+                select array_agg(epkc.attnum order by epkc.position) as primary_key_attnums
+                from effective_primary_key_cols epkc
+            ) pk on true
+            left join lateral (
+                select array_agg(x.attnum::int4 order by x.n) as replica_identity_index_attnums
+                from pg_index i
+                cross join lateral unnest(i.indkey) with ordinality as x(attnum, n)
+                where i.indrelid = c.oid
+                  and i.indisreplident
+                  and x.n <= i.indnkeyatts
+                  and x.attnum > 0
+            ) ri on true
+            where p.pubname = $1
+            order by n.nspname, c.relname
+            "#,
+        )
+        .bind(&self.publication_name)
+        .fetch_all(source_pool)
+        .await?;
+
+        let unsupported_tables = table_identities
+            .into_iter()
+            .filter_map(|table_identity| {
+                let identity_type = identity_type_for_table(
+                    &table_identity.relreplident,
+                    &table_identity.primary_key_attnums,
+                    &table_identity.replica_identity_index_attnums,
+                );
+
+                if self.supported_identity_types.contains(&identity_type) {
+                    None
+                } else {
+                    Some(format!("{} ({})", table_identity.table_name, identity_type))
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if unsupported_tables.is_empty() {
+            Ok(vec![])
+        } else {
+            Ok(vec![ValidationFailure::warning(
+                "Unsupported Replica Identity",
+                format!(
+                    "The following publication tables use replica identities that {} does not \
+                     support: {}.\n\nUse {} as the replica identity for reliable UPDATE and \
+                     DELETE replication to this destination. Otherwise, the destination may fail \
+                     to apply UPDATE or DELETE operations for those tables.",
+                    self.destination_name,
+                    format_unsupported_tables(&unsupported_tables),
+                    format_supported_identity_types(self.supported_identity_types),
+                ),
+            )])
+        }
+    }
+}
+
+fn format_unsupported_tables(tables: &[String]) -> String {
+    const MAX_DISPLAYED_TABLES: usize = 20;
+
+    let displayed_tables =
+        tables.iter().take(MAX_DISPLAYED_TABLES).map(String::as_str).collect::<Vec<_>>().join(", ");
+    let remaining_count = tables.len().saturating_sub(MAX_DISPLAYED_TABLES);
+
+    if remaining_count == 0 {
+        displayed_tables
+    } else {
+        format!("{displayed_tables}, and {remaining_count} more")
+    }
+}
+
+fn identity_type_for_table(
+    relreplident: &str,
+    primary_key_attnums: &[i32],
+    replica_identity_index_attnums: &[i32],
+) -> IdentityType {
+    match relreplident {
+        "f" => IdentityType::Full,
+        "d" if primary_key_attnums.is_empty() => IdentityType::Missing,
+        "d" => IdentityType::PrimaryKey,
+        "i" if replica_identity_index_attnums.is_empty() => IdentityType::Missing,
+        "i" if attnums_match(replica_identity_index_attnums, primary_key_attnums) => {
+            IdentityType::PrimaryKey
+        }
+        "i" => IdentityType::AlternativeKey,
+        "n" => IdentityType::Missing,
+        _ => IdentityType::Missing,
+    }
+}
+
+fn attnums_match(left: &[i32], right: &[i32]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+
+    let mut left = left.to_vec();
+    let mut right = right.to_vec();
+    left.sort_unstable();
+    right.sort_unstable();
+
+    left == right
+}
+
+fn format_supported_identity_types(identity_types: &[IdentityType]) -> String {
+    match identity_types {
+        [] => "no".to_owned(),
+        [identity_type] => format_identity_type_suggestion(*identity_type).to_owned(),
+        [first, second] => {
+            format!(
+                "{} or {}",
+                format_identity_type_suggestion(*first),
+                format_identity_type_suggestion(*second)
+            )
+        }
+        [first, middle @ .., last] => {
+            let mut formatted = Vec::with_capacity(identity_types.len());
+            formatted.push(format_identity_type_suggestion(*first).to_owned());
+            formatted.extend(
+                middle.iter().map(|identity_type| {
+                    format_identity_type_suggestion(*identity_type).to_owned()
+                }),
+            );
+            format!("{}, or {}", formatted.join(", "), format_identity_type_suggestion(*last))
+        }
+    }
+}
+
+fn format_identity_type_suggestion(identity_type: IdentityType) -> &'static str {
+    match identity_type {
+        IdentityType::PrimaryKey => {
+            "a primary-key identity (`REPLICA IDENTITY DEFAULT` on a table with a primary key, or \
+             `REPLICA IDENTITY USING INDEX` with the primary-key index)"
+        }
+        IdentityType::AlternativeKey => {
+            "an alternative-key identity (`REPLICA IDENTITY USING INDEX` with a non-primary-key \
+             unique index)"
+        }
+        IdentityType::Full => "`REPLICA IDENTITY FULL`",
+        IdentityType::Missing => "no replica identity",
+    }
+}

--- a/crates/etl-api/src/validation/validators/snowflake.rs
+++ b/crates/etl-api/src/validation/validators/snowflake.rs
@@ -100,7 +100,7 @@ impl Validator for SnowflakeValidator {
                 "Snowflake Authentication Failed",
                 format!(
                     "We couldn't authenticate with Snowflake using this user and private \
-                     key.\n\nCheck that the private key is a valid PEM-encoded RSA key, the \
+                     key.\n\nCheck that the private key is a valid `PEM`-encoded `RSA` key, the \
                      passphrase is correct if the key is encrypted, and the public key is \
                      registered for this Snowflake user. Snowflake returned: {msg}"
                 ),
@@ -108,17 +108,17 @@ impl Validator for SnowflakeValidator {
             Err(snowflake::Error::DatabaseNotFound(db)) => Ok(vec![ValidationFailure::critical(
                 "Snowflake Database Not Found",
                 format!(
-                    "Snowflake database '{db}' was not found.\n\nCreate the database, choose an \
-                     existing database, or grant this user USAGE on it."
+                    "Snowflake database `{db}` was not found.\n\nCreate the database, choose an \
+                     existing database, or grant this user `USAGE` on it."
                 ),
             )]),
             Err(snowflake::Error::SchemaNotFound { database, schema }) => {
                 Ok(vec![ValidationFailure::critical(
                     "Snowflake Schema Not Found",
                     format!(
-                        "Snowflake schema '{schema}' was not found in database \
-                         '{database}'.\n\nCreate the schema, choose an existing schema, or grant \
-                         this user USAGE on it."
+                        "Snowflake schema `{schema}` was not found in database \
+                         `{database}`.\n\nCreate the schema, choose an existing schema, or grant \
+                         this user `USAGE` on it."
                     ),
                 )])
             }

--- a/crates/etl-api/src/validation/validators/snowflake.rs
+++ b/crates/etl-api/src/validation/validators/snowflake.rs
@@ -40,28 +40,29 @@ impl Validator for SnowflakeValidator {
         if self.account_id.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "Snowflake Account ID Required",
-                "Snowflake account identifier must not be empty.",
+                "Enter the Snowflake account identifier from your account URL or connection \
+                 settings.",
             )]);
         }
 
         if self.user.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "Snowflake User Required",
-                "Snowflake user must not be empty.",
+                "Enter the Snowflake user that ETL should connect with.",
             )]);
         }
 
         if self.database.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "Snowflake Database Required",
-                "Snowflake database must not be empty.",
+                "Choose the Snowflake database where replicated tables should be written.",
             )]);
         }
 
         if self.schema.is_empty() {
             return Ok(vec![ValidationFailure::critical(
                 "Snowflake Schema Required",
-                "Snowflake schema must not be empty.",
+                "Choose the Snowflake schema where replicated tables should be written.",
             )]);
         }
 
@@ -75,7 +76,11 @@ impl Validator for SnowflakeValidator {
             Err(err) => {
                 return Ok(vec![ValidationFailure::critical(
                     "Invalid Snowflake Account ID",
-                    format!("The Snowflake account identifier is not valid.\n\nError: {err}"),
+                    format!(
+                        "The Snowflake account identifier is not valid.\n\nUse the account \
+                         identifier from your Snowflake account URL or connection settings. \
+                         Snowflake returned: {err}"
+                    ),
                 )]);
             }
         };
@@ -94,33 +99,35 @@ impl Validator for SnowflakeValidator {
             Err(snowflake::Error::Auth(msg)) => Ok(vec![ValidationFailure::critical(
                 "Snowflake Authentication Failed",
                 format!(
-                    "Failed to authenticate with Snowflake.\n\nPlease verify:\n(1) The private \
-                     key is a valid PEM-encoded RSA key\n(2) The passphrase is correct (if the \
-                     key is encrypted)\n(3) The key is registered for this user\n\nError: {msg}"
+                    "We couldn't authenticate with Snowflake using this user and private \
+                     key.\n\nCheck that the private key is a valid PEM-encoded RSA key, the \
+                     passphrase is correct if the key is encrypted, and the public key is \
+                     registered for this Snowflake user. Snowflake returned: {msg}"
                 ),
             )]),
             Err(snowflake::Error::DatabaseNotFound(db)) => Ok(vec![ValidationFailure::critical(
                 "Snowflake Database Not Found",
                 format!(
-                    "Database '{db}' does not exist.\n\nPlease verify:\n(1) The database name is \
-                     correct\n(2) The user has USAGE privilege on the database"
+                    "Snowflake database '{db}' was not found.\n\nCreate the database, choose an \
+                     existing database, or grant this user USAGE on it."
                 ),
             )]),
             Err(snowflake::Error::SchemaNotFound { database, schema }) => {
                 Ok(vec![ValidationFailure::critical(
                     "Snowflake Schema Not Found",
                     format!(
-                        "Schema '{schema}' not found in database '{database}'.\n\nPlease \
-                         verify:\n(1) The schema name is correct\n(2) The user has USAGE \
-                         privilege on the schema"
+                        "Snowflake schema '{schema}' was not found in database \
+                         '{database}'.\n\nCreate the schema, choose an existing schema, or grant \
+                         this user USAGE on it."
                     ),
                 )])
             }
             Err(err) => Ok(vec![ValidationFailure::critical(
                 "Snowflake Connection Failed",
                 format!(
-                    "Cannot connect to Snowflake.\n\nPlease verify:\n(1) The account identifier \
-                     is correct\n(2) Network connectivity to Snowflake\n\nError: {err}"
+                    "We couldn't connect to Snowflake with this account identifier and \
+                     user.\n\nCheck the account identifier, role, network access, and \
+                     warehouse/database permissions. Snowflake returned: {err}"
                 ),
             )]),
         }

--- a/crates/etl-api/src/validation/validators/source.rs
+++ b/crates/etl-api/src/validation/validators/source.rs
@@ -42,8 +42,12 @@ impl Validator for SourceValidator {
 
         if current_user != *expected_username {
             return Ok(vec![ValidationFailure::critical(
-                "Invalid source username",
-                format!("Connected as '{current_user}' but expected '{expected_username}'"),
+                "Invalid Source Username",
+                format!(
+                    "The source connection authenticated as '{current_user}', but this API server \
+                     expects '{expected_username}'.\n\nUpdate the source credentials to use the \
+                     trusted ETL role."
+                ),
             )]);
         }
 
@@ -129,8 +133,12 @@ impl Validator for SourceValidator {
 
         let Some(audit) = audit else {
             return Ok(vec![ValidationFailure::critical(
-                "Invalid source role attributes",
-                "Role not found",
+                "Invalid Source Role Attributes",
+                format!(
+                    "The trusted ETL role '{expected_username}' was not found in the source \
+                     database.\n\nCreate the role or update the source credentials to use the \
+                     configured trusted role."
+                ),
             )]);
         };
 
@@ -145,9 +153,10 @@ impl Validator for SourceValidator {
         let mut failures = Vec::new();
         if !has_required_role_attributes {
             failures.push(ValidationFailure::critical(
-                "Invalid source role attributes",
-                "The source database does not grant the trusted username role all permissions ETL \
-                 needs to work properly.",
+                "Invalid Source Role Attributes",
+                "The trusted ETL role does not have the required source database \
+                 attributes.\n\nIt must be able to log in, use replication, bypass RLS, inherit \
+                 privileges, and avoid superuser-style role or database creation permissions.",
             ));
         }
 
@@ -161,10 +170,12 @@ impl Validator for SourceValidator {
 
         if !has_required_etl_schema_permissions {
             failures.push(ValidationFailure::critical(
-                "Invalid source etl schema permissions",
+                "Invalid Source ETL Schema Permissions",
                 format!(
-                    "The source database does not grant the trusted username role all permissions \
-                     ETL needs to manage schema {ETL_SCHEMA_NAME} properly."
+                    "The trusted ETL role cannot manage the '{ETL_SCHEMA_NAME}' schema in the \
+                     source database.\n\nGrant it permission to create the schema if it does not \
+                     exist, or USAGE and CREATE on the schema plus ownership access to existing \
+                     ETL tables."
                 ),
             ));
         }

--- a/crates/etl-api/src/validation/validators/source.rs
+++ b/crates/etl-api/src/validation/validators/source.rs
@@ -6,7 +6,7 @@ use super::super::{ValidationContext, ValidationError, ValidationFailure, Valida
 
 /// Validates the connected source role profile for ETL.
 #[derive(Debug)]
-pub(in crate::validation) struct SourceValidator;
+pub(crate) struct SourceValidator;
 
 #[derive(Debug, FromRow)]
 struct SourceRoleAudit {

--- a/crates/etl-api/src/validation/validators/source.rs
+++ b/crates/etl-api/src/validation/validators/source.rs
@@ -44,8 +44,8 @@ impl Validator for SourceValidator {
             return Ok(vec![ValidationFailure::critical(
                 "Invalid Source Username",
                 format!(
-                    "The source connection authenticated as '{current_user}', but this API server \
-                     expects '{expected_username}'.\n\nUpdate the source credentials to use the \
+                    "The source connection authenticated as `{current_user}`, but this API server \
+                     expects `{expected_username}`.\n\nUpdate the source credentials to use the \
                      trusted ETL role."
                 ),
             )]);
@@ -135,7 +135,7 @@ impl Validator for SourceValidator {
             return Ok(vec![ValidationFailure::critical(
                 "Invalid Source Role Attributes",
                 format!(
-                    "The trusted ETL role '{expected_username}' was not found in the source \
+                    "The trusted ETL role `{expected_username}` was not found in the source \
                      database.\n\nCreate the role or update the source credentials to use the \
                      configured trusted role."
                 ),
@@ -155,8 +155,9 @@ impl Validator for SourceValidator {
             failures.push(ValidationFailure::critical(
                 "Invalid Source Role Attributes",
                 "The trusted ETL role does not have the required source database \
-                 attributes.\n\nIt must be able to log in, use replication, bypass RLS, inherit \
-                 privileges, and avoid superuser-style role or database creation permissions.",
+                 attributes.\n\nIt must be able to `LOGIN`, use `REPLICATION`, `BYPASSRLS`, and \
+                 `INHERIT` privileges, and avoid superuser-style `CREATEROLE` or `CREATEDB` \
+                 permissions.",
             ));
         }
 
@@ -172,10 +173,10 @@ impl Validator for SourceValidator {
             failures.push(ValidationFailure::critical(
                 "Invalid Source ETL Schema Permissions",
                 format!(
-                    "The trusted ETL role cannot manage the '{ETL_SCHEMA_NAME}' schema in the \
+                    "The trusted ETL role cannot manage the `{ETL_SCHEMA_NAME}` schema in the \
                      source database.\n\nGrant it permission to create the schema if it does not \
-                     exist, or USAGE and CREATE on the schema plus ownership access to existing \
-                     ETL tables."
+                     exist, or `USAGE` and `CREATE` on the schema plus ownership access to \
+                     existing ETL tables."
                 ),
             ));
         }

--- a/crates/etl-api/tests/sources.rs
+++ b/crates/etl-api/tests/sources.rs
@@ -482,7 +482,7 @@ async fn source_creation_with_matching_trusted_username_but_invalid_role_profile
     let body = response.text().await.expect("failed to read response body");
 
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-    assert!(body.contains("ETL needs to work properly"));
+    assert!(body.contains("required source database attributes"));
 
     drop_pg_database(&source_db_config).await;
 }

--- a/crates/etl-api/tests/tenants_sources.rs
+++ b/crates/etl-api/tests/tenants_sources.rs
@@ -170,7 +170,7 @@ async fn tenant_and_source_creation_with_invalid_trusted_role_profile_fails() {
     let body = response.text().await.expect("failed to read response body");
 
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-    assert!(body.contains("ETL needs to work properly"));
+    assert!(body.contains("required source database attributes"));
 
     drop_pg_database(&source_db_config).await;
 }

--- a/crates/etl-api/tests/validators/bigquery.rs
+++ b/crates/etl-api/tests/validators/bigquery.rs
@@ -85,7 +85,7 @@ async fn validate_pipeline_includes_source_validation() {
 
     let failures = validate_pipeline(&ctx, &create_pipeline_config("test_pub")).await.unwrap();
 
-    let source_failure = failures.iter().find(|failure| failure.name == "Invalid source username");
+    let source_failure = failures.iter().find(|failure| failure.name == "Invalid Source Username");
     assert!(source_failure.is_some(), "Expected source validation failure");
 
     drop_pg_database(&config).await;

--- a/crates/etl-api/tests/validators/bigquery.rs
+++ b/crates/etl-api/tests/validators/bigquery.rs
@@ -37,7 +37,7 @@ async fn validate_bigquery_connection_success() {
 
     let ctx = create_validation_context();
     let config = create_bigquery_config(db.project_id(), db.dataset_id(), &db.sa_key());
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(failures.is_empty(), "Expected no failures: {failures:?}");
 }
@@ -52,7 +52,7 @@ async fn validate_bigquery_dataset_not_found() {
 
     let ctx = create_validation_context();
     let config = create_bigquery_config(db.project_id(), db.dataset_id(), &db.sa_key());
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "BigQuery Dataset Not Found");
@@ -67,31 +67,11 @@ async fn validate_bigquery_invalid_credentials() {
 
     let ctx = create_validation_context();
     let config = create_bigquery_config("fake-project", "fake-dataset", "{}");
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "BigQuery Authentication Failed");
     assert_eq!(failures[0].failure_type, FailureType::Critical);
-}
-
-#[tokio::test]
-async fn validate_destination_includes_source_validation() {
-    let (ctx, _pool, config) = create_validation_context_with_source().await;
-    let environment = Environment::load().expect("Failed to load environment");
-    let ctx = ValidationContext::builder(environment)
-        .source_pool(ctx.source_pool.expect("source pool should be present for validation"))
-        .trusted_username(Some("different_user".to_owned()))
-        .build();
-
-    let failures =
-        validate_destination(&ctx, &create_bigquery_config("fake-project", "fake-dataset", "{}"))
-            .await
-            .unwrap();
-
-    let source_failure = failures.iter().find(|failure| failure.name == "Invalid source username");
-    assert!(source_failure.is_some(), "Expected source validation failure");
-
-    drop_pg_database(&config).await;
 }
 
 #[tokio::test]

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -3,7 +3,7 @@ use etl_api::{
     validation::{FailureType, validate_destination},
 };
 use etl_config::{SerializableSecretString, shared::ClickHouseEngine};
-use etl_postgres::sqlx::test_utils::drop_pg_database;
+use etl_postgres::{sqlx::test_utils::drop_pg_database, version::POSTGRES_15};
 use sqlx::Executor;
 use url::Url;
 
@@ -181,6 +181,110 @@ async fn validate_destination_allows_clickhouse_merge_tree_table_without_primary
     assert!(
         primary_key_failure.is_none(),
         "ClickHouse MergeTree should allow source tables without primary keys"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_fails_when_bigquery_column_list_omits_primary_key_column() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    let server_version_num: i32 =
+        sqlx::query_scalar("select current_setting('server_version_num')::int")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    if server_version_num < POSTGRES_15 {
+        drop_pg_database(&config).await;
+        return;
+    }
+
+    pool.execute(
+        "create table omitted_pk_column_bigquery_table (
+            id integer not null,
+            account_id integer not null,
+            name text,
+            primary key (id, account_id)
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create publication omitted_pk_column_bigquery_pub
+         for table omitted_pk_column_bigquery_table (id, name)
+         with (publish = 'insert')",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("omitted_pk_column_bigquery_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let primary_key_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Source Primary Key Columns Required")
+        .expect("Should fail when BigQuery source primary-key columns are omitted");
+    assert_eq!(primary_key_failure.failure_type, FailureType::Critical);
+    assert!(
+        primary_key_failure.reason.contains("omitted_pk_column_bigquery_table (account_id)"),
+        "Failure reason should mention the table and omitted primary-key column"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_fails_when_clickhouse_merge_tree_omits_primary_key_column() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    let server_version_num: i32 =
+        sqlx::query_scalar("select current_setting('server_version_num')::int")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    if server_version_num < POSTGRES_15 {
+        drop_pg_database(&config).await;
+        return;
+    }
+
+    pool.execute(
+        "create table omitted_pk_column_clickhouse_table (
+            id integer not null,
+            account_id integer not null,
+            name text,
+            primary key (id, account_id)
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create publication omitted_pk_column_clickhouse_pub
+         for table omitted_pk_column_clickhouse_table (id, name)
+         with (publish = 'insert')",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("omitted_pk_column_clickhouse_pub");
+    let failures = validate_destination(
+        &ctx,
+        &create_clickhouse_config(ClickHouseEngine::MergeTree),
+        Some(&pipeline_config),
+    )
+    .await
+    .unwrap();
+
+    let primary_key_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Source Primary Key Columns Required")
+        .expect("Should fail when ClickHouse source primary-key columns are omitted");
+    assert_eq!(primary_key_failure.failure_type, FailureType::Critical);
+    assert!(
+        primary_key_failure.reason.contains("omitted_pk_column_clickhouse_table (account_id)"),
+        "Failure reason should mention the table and omitted primary-key column"
     );
 
     drop_pg_database(&config).await;

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -29,6 +29,20 @@ fn create_clickhouse_config(engine: ClickHouseEngine) -> FullApiDestinationConfi
     }
 }
 
+fn create_snowflake_config() -> FullApiDestinationConfig {
+    FullApiDestinationConfig::Snowflake {
+        account_id: String::new(),
+        user: "etl".to_owned(),
+        private_key: SerializableSecretString::from(
+            "-----BEGIN PRIVATE KEY-----\ninvalid\n-----END PRIVATE KEY-----".to_owned(),
+        ),
+        private_key_passphrase: None,
+        database: "analytics".to_owned(),
+        schema: "public".to_owned(),
+        role: None,
+    }
+}
+
 async fn create_nested_partitioned_table_with_primary_key(pool: &sqlx::PgPool) {
     pool.execute(
         "create table nested_partitioned_events (
@@ -181,6 +195,28 @@ async fn validate_destination_allows_clickhouse_merge_tree_table_without_primary
     assert!(
         primary_key_failure.is_none(),
         "ClickHouse MergeTree should allow source tables without primary keys"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_fails_when_pipeline_publication_does_not_exist() {
+    let (ctx, _pool, config) = create_validation_context_with_source().await;
+
+    let pipeline_config = create_pipeline_config("missing_destination_validation_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let publication_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Publication Not Found")
+        .expect("Should fail when destination validation receives a missing publication");
+    assert_eq!(publication_failure.failure_type, FailureType::Critical);
+    assert!(
+        publication_failure.reason.contains("missing_destination_validation_pub"),
+        "Failure reason should mention the missing publication"
     );
 
     drop_pg_database(&config).await;
@@ -472,7 +508,7 @@ async fn validate_destination_warns_for_insert_only_unsupported_replica_identity
         "Failure reason should mention the table and identity type"
     );
     assert!(
-        replica_identity_failure.reason.contains("only replicates INSERT"),
+        replica_identity_failure.reason.contains("does not replicate UPDATE or DELETE"),
         "Failure reason should explain this does not block pipeline start"
     );
     assert!(
@@ -482,6 +518,124 @@ async fn validate_destination_warns_for_insert_only_unsupported_replica_identity
     assert!(
         replica_identity_failure.reason.contains("columns with large values (TOAST columns)"),
         "Failure reason should recommend full replica identity for columns with large values"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_fails_when_snowflake_update_uses_alternative_replica_identity() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute(
+        "create table snowflake_update_alt_identity_table (
+            id serial primary key,
+            email text not null,
+            name text
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create unique index snowflake_update_alt_identity_table_email_idx
+         on snowflake_update_alt_identity_table (email)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "alter table snowflake_update_alt_identity_table replica identity using index \
+         snowflake_update_alt_identity_table_email_idx",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create publication snowflake_update_alt_identity_pub
+         for table snowflake_update_alt_identity_table
+         with (publish = 'update')",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("snowflake_update_alt_identity_pub");
+    let failures = validate_destination(&ctx, &create_snowflake_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let replica_identity_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Unsupported Replica Identity")
+        .expect("Should fail when Snowflake UPDATE replication does not have full identity");
+    assert_eq!(replica_identity_failure.failure_type, FailureType::Critical);
+    assert!(
+        replica_identity_failure
+            .reason
+            .contains("snowflake_update_alt_identity_table (alternative_key)"),
+        "Failure reason should mention the table and identity type"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("UPDATE changes"),
+        "Failure reason should explain the published operation"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("`REPLICA IDENTITY FULL`"),
+        "Failure reason should suggest full identity"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_warns_when_snowflake_delete_identity_would_not_support_updates() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute(
+        "create table snowflake_delete_alt_identity_table (
+            id serial primary key,
+            email text not null,
+            name text
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create unique index snowflake_delete_alt_identity_table_email_idx
+         on snowflake_delete_alt_identity_table (email)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "alter table snowflake_delete_alt_identity_table replica identity using index \
+         snowflake_delete_alt_identity_table_email_idx",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create publication snowflake_delete_alt_identity_pub
+         for table snowflake_delete_alt_identity_table
+         with (publish = 'delete')",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("snowflake_delete_alt_identity_pub");
+    let failures = validate_destination(&ctx, &create_snowflake_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let replica_identity_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Unsupported Replica Identity")
+        .expect("Should warn because this identity would not support future updates");
+    assert_eq!(replica_identity_failure.failure_type, FailureType::Warning);
+    assert!(
+        replica_identity_failure
+            .reason
+            .contains("snowflake_delete_alt_identity_table (alternative_key)"),
+        "Failure reason should mention the table and identity type"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("unsupported for UPDATE"),
+        "Failure reason should explain that DELETE is supported but UPDATE is not"
     );
 
     drop_pg_database(&config).await;

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -229,8 +229,11 @@ async fn validate_destination_fails_when_bigquery_column_list_omits_primary_key_
         .expect("Should fail when BigQuery source primary-key columns are omitted");
     assert_eq!(primary_key_failure.failure_type, FailureType::Critical);
     assert!(
-        primary_key_failure.reason.contains("omitted_pk_column_bigquery_table (account_id)"),
-        "Failure reason should mention the table and omitted primary-key column"
+        primary_key_failure
+            .reason
+            .contains("`public.omitted_pk_column_bigquery_table` (`account_id`)"),
+        "Failure reason should mention the table and omitted primary-key column: {}",
+        primary_key_failure.reason
     );
 
     drop_pg_database(&config).await;
@@ -283,8 +286,11 @@ async fn validate_destination_fails_when_clickhouse_merge_tree_omits_primary_key
         .expect("Should fail when ClickHouse source primary-key columns are omitted");
     assert_eq!(primary_key_failure.failure_type, FailureType::Critical);
     assert!(
-        primary_key_failure.reason.contains("omitted_pk_column_clickhouse_table (account_id)"),
-        "Failure reason should mention the table and omitted primary-key column"
+        primary_key_failure
+            .reason
+            .contains("`public.omitted_pk_column_clickhouse_table` (`account_id`)"),
+        "Failure reason should mention the table and omitted primary-key column: {}",
+        primary_key_failure.reason
     );
 
     drop_pg_database(&config).await;
@@ -409,8 +415,8 @@ async fn validate_destination_fails_for_blocking_unsupported_replica_identity() 
         "Failure reason should explain the operation risk"
     );
     assert!(
-        replica_identity_failure.reason.contains("large TOAST-backed columns"),
-        "Failure reason should recommend full replica identity for TOAST-backed columns"
+        replica_identity_failure.reason.contains("columns with large values (TOAST columns)"),
+        "Failure reason should recommend full replica identity for columns with large values"
     );
 
     drop_pg_database(&config).await;
@@ -474,8 +480,8 @@ async fn validate_destination_warns_for_insert_only_unsupported_replica_identity
         "Failure reason should explain the mutation risk"
     );
     assert!(
-        replica_identity_failure.reason.contains("large TOAST-backed columns"),
-        "Failure reason should recommend full replica identity for TOAST-backed columns"
+        replica_identity_failure.reason.contains("columns with large values (TOAST columns)"),
+        "Failure reason should recommend full replica identity for columns with large values"
     );
 
     drop_pg_database(&config).await;

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -1,0 +1,159 @@
+use etl_api::{
+    configs::destination::FullApiDestinationConfig,
+    validation::{FailureType, validate_destination},
+};
+use etl_config::SerializableSecretString;
+use etl_postgres::sqlx::test_utils::drop_pg_database;
+use sqlx::Executor;
+
+use super::{create_pipeline_config, create_validation_context_with_source};
+
+fn create_bigquery_config() -> FullApiDestinationConfig {
+    FullApiDestinationConfig::BigQuery {
+        project_id: "project-id".to_owned(),
+        dataset_id: "dataset-id".to_owned(),
+        service_account_key: SerializableSecretString::from("service-account-key".to_owned()),
+        max_staleness_mins: None,
+        connection_pool_size: Some(1),
+    }
+}
+
+#[tokio::test]
+async fn validate_destination_warns_for_unsupported_replica_identity() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute(
+        "create table alt_identity_table (
+            id serial primary key,
+            email text not null,
+            name text
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute("create unique index alt_identity_table_email_idx on alt_identity_table (email)")
+        .await
+        .unwrap();
+    pool.execute(
+        "alter table alt_identity_table replica identity using index alt_identity_table_email_idx",
+    )
+    .await
+    .unwrap();
+    pool.execute("create publication alt_identity_pub for table alt_identity_table").await.unwrap();
+
+    let pipeline_config = create_pipeline_config("alt_identity_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let replica_identity_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Unsupported Replica Identity")
+        .expect("Should warn for alternative replica identity");
+    assert_eq!(replica_identity_failure.failure_type, FailureType::Warning);
+    assert!(
+        replica_identity_failure.reason.contains("alt_identity_table (alternative_key)"),
+        "Failure reason should mention the table and identity type"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("REPLICA IDENTITY DEFAULT"),
+        "Failure reason should suggest primary-key identity"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("REPLICA IDENTITY FULL"),
+        "Failure reason should suggest full identity"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("UPDATE or DELETE"),
+        "Failure reason should explain the operation risk"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_accepts_primary_key_replica_identity_index() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute(
+        "create table primary_key_identity_table (
+            id serial primary key,
+            name text
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "alter table primary_key_identity_table replica identity using index \
+         primary_key_identity_table_pkey",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create publication primary_key_identity_pub for table primary_key_identity_table",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("primary_key_identity_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let replica_identity_failure =
+        failures.iter().find(|failure| failure.name == "Unsupported Replica Identity");
+    assert!(
+        replica_identity_failure.is_none(),
+        "Should accept USING INDEX when it points at the primary-key index"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_accepts_identity_index_matching_primary_key_columns() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute(
+        "create table primary_key_columns_identity_table (
+            account_id integer not null,
+            id integer not null,
+            name text,
+            primary key (account_id, id)
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create unique index primary_key_columns_identity_idx
+         on primary_key_columns_identity_table (id, account_id)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "alter table primary_key_columns_identity_table replica identity using index \
+         primary_key_columns_identity_idx",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create publication primary_key_columns_identity_pub
+         for table primary_key_columns_identity_table",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("primary_key_columns_identity_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let replica_identity_failure =
+        failures.iter().find(|failure| failure.name == "Unsupported Replica Identity");
+    assert!(
+        replica_identity_failure.is_none(),
+        "Should accept USING INDEX when it covers the same columns as the primary key"
+    );
+
+    drop_pg_database(&config).await;
+}

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -201,28 +201,6 @@ async fn validate_destination_allows_clickhouse_merge_tree_table_without_primary
 }
 
 #[tokio::test]
-async fn validate_destination_fails_when_pipeline_publication_does_not_exist() {
-    let (ctx, _pool, config) = create_validation_context_with_source().await;
-
-    let pipeline_config = create_pipeline_config("missing_destination_validation_pub");
-    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
-        .await
-        .unwrap();
-
-    let publication_failure = failures
-        .iter()
-        .find(|failure| failure.name == "Publication Not Found")
-        .expect("Should fail when destination validation receives a missing publication");
-    assert_eq!(publication_failure.failure_type, FailureType::Critical);
-    assert!(
-        publication_failure.reason.contains("missing_destination_validation_pub"),
-        "Failure reason should mention the missing publication"
-    );
-
-    drop_pg_database(&config).await;
-}
-
-#[tokio::test]
 async fn validate_destination_fails_when_bigquery_column_list_omits_primary_key_column() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -304,6 +304,10 @@ async fn validate_destination_fails_for_blocking_unsupported_replica_identity() 
         replica_identity_failure.reason.contains("UPDATE or DELETE"),
         "Failure reason should explain the operation risk"
     );
+    assert!(
+        replica_identity_failure.reason.contains("large TOAST-backed columns"),
+        "Failure reason should recommend full replica identity for TOAST-backed columns"
+    );
 
     drop_pg_database(&config).await;
 }
@@ -364,6 +368,10 @@ async fn validate_destination_warns_for_insert_only_unsupported_replica_identity
     assert!(
         replica_identity_failure.reason.contains("UPDATE or DELETE"),
         "Failure reason should explain the mutation risk"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("large TOAST-backed columns"),
+        "Failure reason should recommend full replica identity for TOAST-backed columns"
     );
 
     drop_pg_database(&config).await;

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -2,9 +2,10 @@ use etl_api::{
     configs::destination::FullApiDestinationConfig,
     validation::{FailureType, validate_destination},
 };
-use etl_config::SerializableSecretString;
+use etl_config::{SerializableSecretString, shared::ClickHouseEngine};
 use etl_postgres::sqlx::test_utils::drop_pg_database;
 use sqlx::Executor;
+use url::Url;
 
 use super::{create_pipeline_config, create_validation_context_with_source};
 
@@ -16,6 +17,238 @@ fn create_bigquery_config() -> FullApiDestinationConfig {
         max_staleness_mins: None,
         connection_pool_size: Some(1),
     }
+}
+
+fn create_clickhouse_config(engine: ClickHouseEngine) -> FullApiDestinationConfig {
+    FullApiDestinationConfig::ClickHouse {
+        url: Url::parse("http://clickhouse.example.com:8123").unwrap(),
+        user: "etl".to_owned(),
+        password: None,
+        database: "default".to_owned(),
+        engine,
+    }
+}
+
+async fn create_nested_partitioned_table_with_primary_key(pool: &sqlx::PgPool) {
+    pool.execute(
+        "create table nested_partitioned_events (
+            id bigint not null,
+            partition_year integer not null,
+            partition_month integer not null,
+            data text,
+            primary key (id, partition_year, partition_month)
+        ) partition by range (partition_year)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create table nested_partitioned_events_2026
+         partition of nested_partitioned_events
+         for values from (2026) to (2027)
+         partition by range (partition_month)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create table nested_partitioned_events_2026_01
+         partition of nested_partitioned_events_2026
+         for values from (1) to (2)",
+    )
+    .await
+    .unwrap();
+}
+
+async fn create_nested_partitioned_table_without_primary_key(pool: &sqlx::PgPool) {
+    pool.execute(
+        "create table nested_partitioned_events_no_pk (
+            id bigint not null,
+            partition_year integer not null,
+            partition_month integer not null,
+            data text
+        ) partition by range (partition_year)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create table nested_partitioned_events_no_pk_2026
+         partition of nested_partitioned_events_no_pk
+         for values from (2026) to (2027)
+         partition by range (partition_month)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create table nested_partitioned_events_no_pk_2026_01
+         partition of nested_partitioned_events_no_pk_2026
+         for values from (1) to (2)",
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn validate_destination_warns_when_bigquery_source_table_has_no_primary_key() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute("create table no_pk_bigquery_table (id int, name text)").await.unwrap();
+    pool.execute("create publication no_pk_bigquery_pub for table no_pk_bigquery_table")
+        .await
+        .unwrap();
+
+    let pipeline_config = create_pipeline_config("no_pk_bigquery_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let primary_key_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Source Primary Keys Required")
+        .expect("Should warn when BigQuery source tables do not have primary keys");
+    assert_eq!(primary_key_failure.failure_type, FailureType::Warning);
+    assert!(
+        primary_key_failure.reason.contains("no_pk_bigquery_table"),
+        "Failure reason should mention the table name"
+    );
+    assert!(
+        primary_key_failure.reason.contains("initial loads"),
+        "Failure reason should explain why BigQuery requires primary keys"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_warns_when_clickhouse_replacing_merge_tree_table_has_no_primary_key()
+{
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute("create table no_pk_clickhouse_table (id int, name text)").await.unwrap();
+    pool.execute("create publication no_pk_clickhouse_pub for table no_pk_clickhouse_table")
+        .await
+        .unwrap();
+
+    let pipeline_config = create_pipeline_config("no_pk_clickhouse_pub");
+    let failures = validate_destination(
+        &ctx,
+        &create_clickhouse_config(ClickHouseEngine::ReplacingMergeTree),
+        Some(&pipeline_config),
+    )
+    .await
+    .unwrap();
+
+    let primary_key_failure =
+        failures.iter().find(|failure| failure.name == "Source Primary Keys Required").expect(
+            "Should warn when ClickHouse ReplacingMergeTree source tables have no primary keys",
+        );
+    assert_eq!(primary_key_failure.failure_type, FailureType::Warning);
+    assert!(
+        primary_key_failure.reason.contains("no_pk_clickhouse_table"),
+        "Failure reason should mention the table name"
+    );
+    assert!(
+        primary_key_failure.reason.contains("ORDER BY"),
+        "Failure reason should explain why ReplacingMergeTree requires primary keys"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_allows_clickhouse_merge_tree_table_without_primary_key() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute("create table no_pk_clickhouse_merge_tree_table (id int, name text)")
+        .await
+        .unwrap();
+    pool.execute(
+        "create publication no_pk_clickhouse_merge_tree_pub for table \
+         no_pk_clickhouse_merge_tree_table",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("no_pk_clickhouse_merge_tree_pub");
+    let failures = validate_destination(
+        &ctx,
+        &create_clickhouse_config(ClickHouseEngine::MergeTree),
+        Some(&pipeline_config),
+    )
+    .await
+    .unwrap();
+
+    let primary_key_failure =
+        failures.iter().find(|failure| failure.name == "Source Primary Keys Required");
+    assert!(
+        primary_key_failure.is_none(),
+        "ClickHouse MergeTree should allow source tables without primary keys"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_accepts_nested_partition_leaf_with_parent_primary_key() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    create_nested_partitioned_table_with_primary_key(&pool).await;
+    pool.execute(
+        "create publication nested_partitioned_leaf_pub
+         for table nested_partitioned_events_2026_01",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("nested_partitioned_leaf_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let primary_key_failure =
+        failures.iter().find(|failure| failure.name == "Source Primary Keys Required");
+    assert!(
+        primary_key_failure.is_none(),
+        "Primary-key validation should use partition parent key metadata"
+    );
+
+    let replica_identity_failure =
+        failures.iter().find(|failure| failure.name == "Unsupported Replica Identity");
+    assert!(
+        replica_identity_failure.is_none(),
+        "Replica-identity validation should classify default partition identity as primary-key \
+         identity when the partition inherits the parent key"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_warns_for_nested_partition_leaf_without_parent_primary_key() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    create_nested_partitioned_table_without_primary_key(&pool).await;
+    pool.execute(
+        "create publication nested_partitioned_leaf_no_pk_pub
+         for table nested_partitioned_events_no_pk_2026_01",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("nested_partitioned_leaf_no_pk_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let primary_key_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Source Primary Keys Required")
+        .expect("Should warn for nested partition leaves without parent primary keys");
+    assert_eq!(primary_key_failure.failure_type, FailureType::Warning);
+    assert!(
+        primary_key_failure.reason.contains("nested_partitioned_events_no_pk_2026_01"),
+        "Failure reason should mention the published leaf partition"
+    );
+
+    drop_pg_database(&config).await;
 }
 
 #[tokio::test]

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -87,7 +87,7 @@ async fn create_nested_partitioned_table_without_primary_key(pool: &sqlx::PgPool
 }
 
 #[tokio::test]
-async fn validate_destination_warns_when_bigquery_source_table_has_no_primary_key() {
+async fn validate_destination_fails_when_bigquery_source_table_has_no_primary_key() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 
     pool.execute("create table no_pk_bigquery_table (id int, name text)").await.unwrap();
@@ -103,8 +103,8 @@ async fn validate_destination_warns_when_bigquery_source_table_has_no_primary_ke
     let primary_key_failure = failures
         .iter()
         .find(|failure| failure.name == "Source Primary Keys Required")
-        .expect("Should warn when BigQuery source tables do not have primary keys");
-    assert_eq!(primary_key_failure.failure_type, FailureType::Warning);
+        .expect("Should fail when BigQuery source tables do not have primary keys");
+    assert_eq!(primary_key_failure.failure_type, FailureType::Critical);
     assert!(
         primary_key_failure.reason.contains("no_pk_bigquery_table"),
         "Failure reason should mention the table name"
@@ -118,7 +118,7 @@ async fn validate_destination_warns_when_bigquery_source_table_has_no_primary_ke
 }
 
 #[tokio::test]
-async fn validate_destination_warns_when_clickhouse_replacing_merge_tree_table_has_no_primary_key()
+async fn validate_destination_fails_when_clickhouse_replacing_merge_tree_table_has_no_primary_key()
 {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 
@@ -138,9 +138,9 @@ async fn validate_destination_warns_when_clickhouse_replacing_merge_tree_table_h
 
     let primary_key_failure =
         failures.iter().find(|failure| failure.name == "Source Primary Keys Required").expect(
-            "Should warn when ClickHouse ReplacingMergeTree source tables have no primary keys",
+            "Should fail when ClickHouse ReplacingMergeTree source tables have no primary keys",
         );
-    assert_eq!(primary_key_failure.failure_type, FailureType::Warning);
+    assert_eq!(primary_key_failure.failure_type, FailureType::Critical);
     assert!(
         primary_key_failure.reason.contains("no_pk_clickhouse_table"),
         "Failure reason should mention the table name"
@@ -222,7 +222,7 @@ async fn validate_destination_accepts_nested_partition_leaf_with_parent_primary_
 }
 
 #[tokio::test]
-async fn validate_destination_warns_for_nested_partition_leaf_without_parent_primary_key() {
+async fn validate_destination_fails_for_nested_partition_leaf_without_parent_primary_key() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 
     create_nested_partitioned_table_without_primary_key(&pool).await;
@@ -241,8 +241,8 @@ async fn validate_destination_warns_for_nested_partition_leaf_without_parent_pri
     let primary_key_failure = failures
         .iter()
         .find(|failure| failure.name == "Source Primary Keys Required")
-        .expect("Should warn for nested partition leaves without parent primary keys");
-    assert_eq!(primary_key_failure.failure_type, FailureType::Warning);
+        .expect("Should fail for nested partition leaves without parent primary keys");
+    assert_eq!(primary_key_failure.failure_type, FailureType::Critical);
     assert!(
         primary_key_failure.reason.contains("nested_partitioned_events_no_pk_2026_01"),
         "Failure reason should mention the published leaf partition"
@@ -252,7 +252,7 @@ async fn validate_destination_warns_for_nested_partition_leaf_without_parent_pri
 }
 
 #[tokio::test]
-async fn validate_destination_warns_for_unsupported_replica_identity() {
+async fn validate_destination_fails_for_blocking_unsupported_replica_identity() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 
     pool.execute(
@@ -282,11 +282,15 @@ async fn validate_destination_warns_for_unsupported_replica_identity() {
     let replica_identity_failure = failures
         .iter()
         .find(|failure| failure.name == "Unsupported Replica Identity")
-        .expect("Should warn for alternative replica identity");
-    assert_eq!(replica_identity_failure.failure_type, FailureType::Warning);
+        .expect("Should fail for alternative replica identity");
+    assert_eq!(replica_identity_failure.failure_type, FailureType::Critical);
     assert!(
         replica_identity_failure.reason.contains("alt_identity_table (alternative_key)"),
         "Failure reason should mention the table and identity type"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("cannot safely replicate UPDATE or DELETE"),
+        "Failure reason should explain this blocks pipeline start"
     );
     assert!(
         replica_identity_failure.reason.contains("REPLICA IDENTITY DEFAULT"),
@@ -299,6 +303,67 @@ async fn validate_destination_warns_for_unsupported_replica_identity() {
     assert!(
         replica_identity_failure.reason.contains("UPDATE or DELETE"),
         "Failure reason should explain the operation risk"
+    );
+
+    drop_pg_database(&config).await;
+}
+
+#[tokio::test]
+async fn validate_destination_warns_for_insert_only_unsupported_replica_identity() {
+    let (ctx, pool, config) = create_validation_context_with_source().await;
+
+    pool.execute(
+        "create table insert_only_alt_identity_table (
+            id serial primary key,
+            email text not null,
+            name text
+        )",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create unique index insert_only_alt_identity_table_email_idx
+         on insert_only_alt_identity_table (email)",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "alter table insert_only_alt_identity_table replica identity using index \
+         insert_only_alt_identity_table_email_idx",
+    )
+    .await
+    .unwrap();
+    pool.execute(
+        "create publication insert_only_alt_identity_pub
+         for table insert_only_alt_identity_table
+         with (publish = 'insert')",
+    )
+    .await
+    .unwrap();
+
+    let pipeline_config = create_pipeline_config("insert_only_alt_identity_pub");
+    let failures = validate_destination(&ctx, &create_bigquery_config(), Some(&pipeline_config))
+        .await
+        .unwrap();
+
+    let replica_identity_failure = failures
+        .iter()
+        .find(|failure| failure.name == "Unsupported Replica Identity")
+        .expect("Should warn for insert-only alternative replica identity");
+    assert_eq!(replica_identity_failure.failure_type, FailureType::Warning);
+    assert!(
+        replica_identity_failure
+            .reason
+            .contains("insert_only_alt_identity_table (alternative_key)"),
+        "Failure reason should mention the table and identity type"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("only replicates INSERT"),
+        "Failure reason should explain this does not block pipeline start"
+    );
+    assert!(
+        replica_identity_failure.reason.contains("UPDATE or DELETE"),
+        "Failure reason should explain the mutation risk"
     );
 
     drop_pg_database(&config).await;

--- a/crates/etl-api/tests/validators/iceberg.rs
+++ b/crates/etl-api/tests/validators/iceberg.rs
@@ -34,7 +34,7 @@ async fn validate_iceberg_connection_success() {
 
     let ctx = create_validation_context();
     let config = create_iceberg_config(&warehouse_name);
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     let _ = lakekeeper.drop_warehouse(warehouse_id).await;
 
@@ -48,7 +48,7 @@ async fn validate_iceberg_connection_failure() {
     }
     let ctx = create_validation_context();
     let config = create_iceberg_config("nonexistent-warehouse");
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "Iceberg Connection Failed");

--- a/crates/etl-api/tests/validators/mod.rs
+++ b/crates/etl-api/tests/validators/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "bigquery")]
 mod bigquery;
+mod destination;
 #[cfg(feature = "iceberg")]
 mod iceberg;
 mod pipeline;

--- a/crates/etl-api/tests/validators/pipeline.rs
+++ b/crates/etl-api/tests/validators/pipeline.rs
@@ -38,7 +38,7 @@ async fn validate_source_with_trusted_username_mismatch() {
     let failures = validate_source(&ctx).await.unwrap();
 
     assert_eq!(failures.len(), 1);
-    assert_eq!(failures[0].name, "Invalid source username");
+    assert_eq!(failures[0].name, "Invalid Source Username");
     assert_eq!(failures[0].failure_type, FailureType::Critical);
 
     drop_pg_database(&config).await;

--- a/crates/etl-api/tests/validators/pipeline.rs
+++ b/crates/etl-api/tests/validators/pipeline.rs
@@ -145,7 +145,7 @@ async fn validate_pipeline_rejects_etl_schema_publication() {
     assert!(etl_failure.is_some(), "Should reject publications containing the ETL schema");
     assert_eq!(etl_failure.unwrap().failure_type, FailureType::Critical);
     assert!(
-        etl_failure.unwrap().reason.contains("'etl' schema"),
+        etl_failure.unwrap().reason.contains("`etl` schema"),
         "Failure reason should mention the ETL schema"
     );
 

--- a/crates/etl-api/tests/validators/pipeline.rs
+++ b/crates/etl-api/tests/validators/pipeline.rs
@@ -153,7 +153,7 @@ async fn validate_pipeline_rejects_etl_schema_publication() {
 }
 
 #[tokio::test]
-async fn validate_pipeline_tables_without_primary_keys() {
+async fn validate_pipeline_allows_tables_without_primary_keys() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 
     pool.execute("create table no_pk_table (id int, name text)").await.unwrap();
@@ -162,19 +162,17 @@ async fn validate_pipeline_tables_without_primary_keys() {
     let pipeline_config = create_pipeline_config("pk_test_pub");
     let failures = validate_pipeline(&ctx, &pipeline_config).await.unwrap();
 
-    let pk_failure = failures.iter().find(|f| f.name == "Tables Missing Primary Keys");
-    assert!(pk_failure.is_some(), "Should warn for table without primary key");
-    assert_eq!(pk_failure.unwrap().failure_type, FailureType::Warning);
+    let pk_failure = failures.iter().find(|f| f.name == "Source Primary Keys Required");
     assert!(
-        pk_failure.unwrap().reason.contains("no_pk_table"),
-        "Failure reason should mention the table name"
+        pk_failure.is_none(),
+        "Pipeline validation should leave primary-key requirements to destination validation"
     );
 
     drop_pg_database(&config).await;
 }
 
 #[tokio::test]
-async fn validate_pipeline_tables_with_primary_keys_passes() {
+async fn validate_pipeline_tables_with_primary_keys_does_not_emit_destination_pk_warning() {
     let (ctx, pool, config) = create_validation_context_with_source().await;
 
     pool.execute("create table pk_table (id serial primary key, name text)").await.unwrap();
@@ -183,8 +181,11 @@ async fn validate_pipeline_tables_with_primary_keys_passes() {
     let pipeline_config = create_pipeline_config("pk_pass_pub");
     let failures = validate_pipeline(&ctx, &pipeline_config).await.unwrap();
 
-    let pk_failure = failures.iter().find(|f| f.name == "Tables Missing Primary Keys");
-    assert!(pk_failure.is_none(), "Should pass for table with primary key");
+    let pk_failure = failures.iter().find(|f| f.name == "Source Primary Keys Required");
+    assert!(
+        pk_failure.is_none(),
+        "Pipeline validation should not emit destination primary-key warnings"
+    );
 
     drop_pg_database(&config).await;
 }

--- a/crates/etl-api/tests/validators/snowflake.rs
+++ b/crates/etl-api/tests/validators/snowflake.rs
@@ -76,7 +76,7 @@ fn create_snowflake_config(
 async fn validate_snowflake_empty_account_id() {
     let ctx = create_validation_context();
     let config = create_snowflake_config("", "ETL_USER", "fake-key", None, "DB", "PUBLIC", None);
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "Snowflake Account ID Required");
@@ -87,7 +87,7 @@ async fn validate_snowflake_empty_account_id() {
 async fn validate_snowflake_empty_user() {
     let ctx = create_validation_context();
     let config = create_snowflake_config("ORG-ACCT", "", "fake-key", None, "DB", "PUBLIC", None);
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "Snowflake User Required");
@@ -106,7 +106,7 @@ async fn validate_snowflake_invalid_private_key() {
         "PUBLIC",
         None,
     );
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "Snowflake Authentication Failed");
@@ -122,7 +122,7 @@ async fn validate_snowflake_connection_success() {
     let env = SnowflakeTestEnv::load();
     let ctx = create_validation_context();
     let config = env.config(&env.database, &env.schema);
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(failures.is_empty(), "Expected no validation failures, got: {failures:?}");
 }
@@ -136,7 +136,7 @@ async fn validate_snowflake_wrong_database() {
     let env = SnowflakeTestEnv::load();
     let ctx = create_validation_context();
     let config = env.config("NONEXISTENT_DB_12345", &env.schema);
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "Snowflake Database Not Found");
@@ -152,7 +152,7 @@ async fn validate_snowflake_wrong_schema() {
     let env = SnowflakeTestEnv::load();
     let ctx = create_validation_context();
     let config = env.config(&env.database, "NONEXISTENT_SCHEMA_12345");
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "Snowflake Schema Not Found");
@@ -168,7 +168,7 @@ async fn validate_snowflake_empty_database() {
     let env = SnowflakeTestEnv::load();
     let ctx = create_validation_context();
     let config = env.config("", &env.schema);
-    let failures = validate_destination(&ctx, &config).await.unwrap();
+    let failures = validate_destination(&ctx, &config, None).await.unwrap();
 
     assert!(!failures.is_empty(), "Expected validation failure");
     assert_eq!(failures[0].name, "Snowflake Database Required");

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -398,15 +398,15 @@ where
     /// Prepares a table for BigQuery writes with schema-aware table creation.
     ///
     /// Creates or verifies the BigQuery table exists using the provided schema,
-    /// ensures the view points to the current versioned table, and validates
-    /// that the source replica identity is compatible with BigQuery deletes and
-    /// upserts. Uses caching to avoid redundant table creation checks.
+    /// ensures the view points to the current versioned table, and verifies the
+    /// source primary key needed by BigQuery CDC. Uses caching to avoid
+    /// redundant table creation checks.
     async fn prepare_table_for_streaming(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         use_cdc_sequence_column: bool,
     ) -> EtlResult<(SequencedBigQueryTableId, TableDescriptor)> {
-        validate_bigquery_replica_identity(replicated_table_schema)?;
+        validate_bigquery_table_shape(replicated_table_schema)?;
 
         // We hold the lock for the entire preparation to avoid race conditions since
         // the consistency of this code path is critical.
@@ -675,7 +675,7 @@ where
         &self,
         new_replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
-        validate_bigquery_replica_identity(new_replicated_table_schema)?;
+        validate_bigquery_table_shape(new_replicated_table_schema)?;
 
         let table_id = new_replicated_table_schema.id();
         let new_snapshot_id = new_replicated_table_schema.inner().snapshot_id;
@@ -912,7 +912,6 @@ where
                         entry.1.push(BigQueryTableRow::try_from(insert.table_row)?);
                     }
                     Event::Update(update) => {
-                        validate_bigquery_replica_identity(&update.replicated_table_schema)?;
                         let sequence_key = update.event_sequence_key();
                         let table_id = update.replicated_table_schema.id();
                         let table_row = match update.updated_table_row {
@@ -935,7 +934,6 @@ where
                         )?);
                     }
                     Event::Delete(delete) => {
-                        validate_bigquery_replica_identity(&delete.replicated_table_schema)?;
                         let sequence_key = bigquery_sequence_key(
                             delete.event_sequence_key(),
                             BIGQUERY_SEQUENCE_ORDINAL_FIRST,
@@ -1221,21 +1219,11 @@ where
     }
 }
 
-/// Validates that a replicated table schema can be applied in BigQuery.
+/// Validates that a replicated table schema can be written to BigQuery CDC.
 ///
 /// BigQuery matches CDC rows by the destination table primary key, so the
-/// source table must always expose that key.
-/// PostgreSQL replica identity may either:
-/// - match the source primary key directly, or
-/// - request full old-row images (`FULL`), which still let us recover the
-///   source primary key for deletes and primary-key-changing updates.
-///
-/// Alternative replica-identity indexes are not compatible with BigQuery's
-/// destination key because BigQuery would deduplicate against a different row
-/// identity than the source publisher.
-fn validate_bigquery_replica_identity(
-    replicated_table_schema: &ReplicatedTableSchema,
-) -> EtlResult<()> {
+/// source table must expose that key when creating or writing the table.
+fn validate_bigquery_table_shape(replicated_table_schema: &ReplicatedTableSchema) -> EtlResult<()> {
     if replicated_table_schema.primary_key_column_schemas().len() == 0 {
         bail!(
             ErrorKind::SourceSchemaError,
@@ -1264,6 +1252,22 @@ fn validate_bigquery_replica_identity(
         );
     }
 
+    Ok(())
+}
+
+/// Validates that a mutation event carries an identity BigQuery can apply.
+///
+/// PostgreSQL replica identity may either:
+/// - match the source primary key directly, or
+/// - request full old-row images (`FULL`), which still let us recover the
+///   source primary key for deletes and primary-key-changing updates.
+///
+/// Alternative replica-identity indexes are not compatible with BigQuery's
+/// destination key because BigQuery would deduplicate against a different row
+/// identity than the source publisher.
+fn validate_bigquery_mutation_identity(
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> EtlResult<()> {
     match replicated_table_schema.identity_type() {
         IdentityType::PrimaryKey | IdentityType::Full => Ok(()),
         identity_type => {
@@ -1380,6 +1384,8 @@ fn bigquery_update_rows(
     old_table_row: Option<OldTableRow>,
     sequence_key: EventSequenceKey,
 ) -> EtlResult<Vec<BigQueryTableRow>> {
+    validate_bigquery_mutation_identity(replicated_table_schema)?;
+
     let primary_key_changed = match old_table_row.as_ref() {
         // PostgreSQL omits the old-side image only when the publisher
         // determined it was unnecessary. For primary-key identity, that means
@@ -1542,6 +1548,8 @@ fn bigquery_primary_key_tagged_cells_from_old_row(
     replicated_table_schema: &ReplicatedTableSchema,
     old_table_row: OldTableRow,
 ) -> EtlResult<Vec<(usize, Cell)>> {
+    validate_bigquery_mutation_identity(replicated_table_schema)?;
+
     match old_table_row {
         OldTableRow::Full(row) => {
             let column_count = replicated_table_schema.column_schemas().len();
@@ -1994,33 +2002,40 @@ mod tests {
     }
 
     #[test]
-    fn validate_bigquery_replica_identity_accepts_primary_key() {
+    fn validate_bigquery_mutation_identity_accepts_primary_key() {
         let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
 
-        validate_bigquery_replica_identity(&replicated_table_schema).unwrap();
+        validate_bigquery_mutation_identity(&replicated_table_schema).unwrap();
     }
 
     #[test]
-    fn validate_bigquery_replica_identity_accepts_full() {
+    fn validate_bigquery_mutation_identity_accepts_full() {
         let replicated_table_schema = replicated_schema(IdentityType::Full);
 
-        validate_bigquery_replica_identity(&replicated_table_schema).unwrap();
+        validate_bigquery_mutation_identity(&replicated_table_schema).unwrap();
     }
 
     #[test]
-    fn validate_bigquery_replica_identity_rejects_alternative_key() {
+    fn validate_bigquery_mutation_identity_rejects_alternative_key() {
         let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
 
-        let error = validate_bigquery_replica_identity(&replicated_table_schema).unwrap_err();
+        let error = validate_bigquery_mutation_identity(&replicated_table_schema).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
     }
 
     #[test]
-    fn validate_bigquery_replica_identity_rejects_missing() {
+    fn validate_bigquery_mutation_identity_rejects_missing() {
         let replicated_table_schema = replicated_schema(IdentityType::Missing);
 
-        let error = validate_bigquery_replica_identity(&replicated_table_schema).unwrap_err();
+        let error = validate_bigquery_mutation_identity(&replicated_table_schema).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn validate_bigquery_table_shape_accepts_alternative_identity() {
+        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
+
+        validate_bigquery_table_shape(&replicated_table_schema).unwrap();
     }
 
     #[test]
@@ -2034,10 +2049,10 @@ mod tests {
     }
 
     #[test]
-    fn validate_bigquery_replica_identity_rejects_partial_primary_key() {
+    fn validate_bigquery_table_shape_rejects_partial_primary_key() {
         let replicated_table_schema = replicated_schema_with_partial_primary_key();
 
-        let error = validate_bigquery_replica_identity(&replicated_table_schema).unwrap_err();
+        let error = validate_bigquery_table_shape(&replicated_table_schema).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::SourceSchemaError);
         assert!(error.to_string().contains("tenant_id"));
     }

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1004,14 +1004,10 @@ where
                     Event::Update(update) => {
                         let sequence_key = update.event_sequence_key();
                         let table_id = update.replicated_table_schema.id();
-                        let table_row = match update.updated_table_row {
-                            UpdatedTableRow::Full(row) => row,
-                            UpdatedTableRow::Partial(_) => {
-                                return Err(bigquery_partial_update_row_error(
-                                    &update.replicated_table_schema,
-                                ));
-                            }
-                        };
+                        let table_row = bigquery_update_new_row(
+                            &update.replicated_table_schema,
+                            update.updated_table_row,
+                        )?;
 
                         let entry = table_id_to_data.entry(table_id).or_insert_with(|| {
                             (update.replicated_table_schema.clone(), Vec::new())
@@ -1028,18 +1024,10 @@ where
                             delete.event_sequence_key(),
                             BIGQUERY_SEQUENCE_ORDINAL_FIRST,
                         );
-                        let old_table_row = delete.old_table_row.ok_or_else(|| {
-                            etl_error!(
-                                ErrorKind::InvalidState,
-                                "BigQuery delete requires an old row image",
-                                format!(
-                                    "Table '{}' emitted a delete without an old row image. \
-                                     BigQuery deletes are keyed by the source primary key and \
-                                     cannot be applied safely without it.",
-                                    delete.replicated_table_schema.name()
-                                )
-                            )
-                        })?;
+                        let old_table_row = bigquery_delete_old_row(
+                            &delete.replicated_table_schema,
+                            delete.old_table_row,
+                        )?;
 
                         let table_id = delete.replicated_table_schema.id();
                         let entry = table_id_to_data.entry(table_id).or_insert_with(|| {
@@ -1345,36 +1333,6 @@ fn validate_bigquery_table_shape(replicated_table_schema: &ReplicatedTableSchema
     Ok(())
 }
 
-/// Validates that a mutation event carries an identity BigQuery can apply.
-///
-/// PostgreSQL replica identity may either:
-/// - match the source primary key directly, or
-/// - request full old-row images (`FULL`), which still let us recover the
-///   source primary key for deletes and primary-key-changing updates.
-///
-/// Alternative replica-identity indexes are not compatible with BigQuery's
-/// destination key because BigQuery would deduplicate against a different row
-/// identity than the source publisher.
-fn validate_bigquery_mutation_identity(
-    replicated_table_schema: &ReplicatedTableSchema,
-) -> EtlResult<()> {
-    match replicated_table_schema.identity_type() {
-        IdentityType::PrimaryKey | IdentityType::Full => Ok(()),
-        identity_type => {
-            bail!(
-                ErrorKind::SourceReplicaIdentityError,
-                "BigQuery requires primary-key or full replica identity",
-                format!(
-                    "Table '{}' uses replica identity {:?}, but BigQuery only supports source \
-                     primary-key identity or full old-row images",
-                    replicated_table_schema.name(),
-                    identity_type
-                )
-            );
-        }
-    }
-}
-
 impl<S> Destination for BigQueryDestination<S>
 where
     S: DestinationStore,
@@ -1474,8 +1432,6 @@ fn bigquery_update_rows(
     old_table_row: Option<OldTableRow>,
     sequence_key: EventSequenceKey,
 ) -> EtlResult<Vec<BigQueryTableRow>> {
-    validate_bigquery_mutation_identity(replicated_table_schema)?;
-
     let primary_key_changed = match old_table_row.as_ref() {
         // PostgreSQL omits the old-side image only when the publisher
         // determined it was unnecessary. For primary-key identity, that means
@@ -1484,7 +1440,10 @@ fn bigquery_update_rows(
         Some(old_table_row) => {
             bigquery_primary_key_changed(replicated_table_schema, old_table_row, &new_table_row)?
         }
-        None => false,
+        None => {
+            ensure_bigquery_update_without_old_row_can_skip_delete(replicated_table_schema)?;
+            false
+        }
     };
 
     let mut rows = Vec::with_capacity(1 + usize::from(primary_key_changed));
@@ -1519,17 +1478,83 @@ fn bigquery_update_rows(
     Ok(rows)
 }
 
-/// Builds an error for a partial update row BigQuery cannot safely apply.
-fn bigquery_partial_update_row_error(replicated_table_schema: &ReplicatedTableSchema) -> EtlError {
-    etl_error!(
-        ErrorKind::SourceReplicaIdentityError,
-        "BigQuery update requires a full new row image",
-        format!(
-            "Table '{}' emitted a partial update row. BigQuery CDC UPSERT does not preserve \
-             omitted columns.",
-            replicated_table_schema.name()
+/// Returns the full new row required for a BigQuery update upsert.
+fn bigquery_update_new_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    updated_table_row: UpdatedTableRow,
+) -> EtlResult<TableRow> {
+    match updated_table_row {
+        UpdatedTableRow::Full(row) => Ok(row),
+        UpdatedTableRow::Partial(_) => Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "BigQuery update requires a full new row image",
+            format!(
+                "Table '{}' emitted a partial update row. BigQuery CDC UPSERT does not preserve \
+                 omitted columns.",
+                replicated_table_schema.name()
+            )
+        )),
+    }
+}
+
+/// Returns the old row image required for a BigQuery delete.
+fn bigquery_delete_old_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: Option<OldTableRow>,
+) -> EtlResult<OldTableRow> {
+    old_table_row.ok_or_else(|| {
+        etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "BigQuery delete requires an old row image",
+            format!(
+                "Table '{}' emitted a delete without an old row image. BigQuery deletes are keyed \
+                 by the source primary key and cannot be applied safely without it.",
+                replicated_table_schema.name()
+            )
         )
-    )
+    })
+}
+
+/// Verifies that a BigQuery update without an old row cannot have changed the
+/// destination primary key.
+fn ensure_bigquery_update_without_old_row_can_skip_delete(
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> EtlResult<()> {
+    if matches!(replicated_table_schema.identity_type(), IdentityType::PrimaryKey) {
+        Ok(())
+    } else {
+        Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "BigQuery update requires old primary-key values",
+            format!(
+                "Table '{}' emitted an update without an old row image for replica identity {:?}. \
+                 BigQuery can only skip the generated delete when the source replica identity \
+                 matches the primary key.",
+                replicated_table_schema.name(),
+                replicated_table_schema.identity_type()
+            )
+        ))
+    }
+}
+
+/// Verifies that a key-only row image carries source primary-key values.
+fn ensure_bigquery_key_image_matches_primary_key(
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> EtlResult<()> {
+    if matches!(replicated_table_schema.identity_type(), IdentityType::PrimaryKey) {
+        Ok(())
+    } else {
+        Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "BigQuery key image does not match the source primary key",
+            format!(
+                "Table '{}' emitted a key image for replica identity {:?}, but BigQuery rows are \
+                 keyed by the source primary key",
+                replicated_table_schema.name(),
+                replicated_table_schema.identity_type()
+            )
+        ))
+    }
 }
 
 /// Returns whether an update changed the destination primary key.
@@ -1576,19 +1601,6 @@ fn bigquery_primary_key_changed(
                 }))
         }
         OldTableRow::Key(row) => {
-            if !replicated_table_schema.identity_matches_primary_key() {
-                bail!(
-                    ErrorKind::SourceReplicaIdentityError,
-                    "BigQuery key image does not match the source primary key",
-                    format!(
-                        "Table '{}' emitted a key image for replica identity {:?}, but BigQuery \
-                         rows are keyed by the source primary key",
-                        replicated_table_schema.name(),
-                        replicated_table_schema.identity_type()
-                    )
-                );
-            }
-
             let primary_key_column_count =
                 replicated_table_schema.primary_key_column_schemas().len();
             let old_key_values = row.values();
@@ -1604,6 +1616,8 @@ fn bigquery_primary_key_changed(
                     )
                 );
             }
+
+            ensure_bigquery_key_image_matches_primary_key(replicated_table_schema)?;
 
             let mut new_primary_key_values = replicated_table_schema
                 .column_schemas()
@@ -1638,8 +1652,6 @@ fn bigquery_primary_key_tagged_cells_from_old_row(
     replicated_table_schema: &ReplicatedTableSchema,
     old_table_row: OldTableRow,
 ) -> EtlResult<Vec<(usize, Cell)>> {
-    validate_bigquery_mutation_identity(replicated_table_schema)?;
-
     match old_table_row {
         OldTableRow::Full(row) => {
             let column_count = replicated_table_schema.column_schemas().len();
@@ -1670,19 +1682,6 @@ fn bigquery_primary_key_tagged_cells_from_old_row(
             Ok(tagged_cells)
         }
         OldTableRow::Key(row) => {
-            if !replicated_table_schema.identity_matches_primary_key() {
-                bail!(
-                    ErrorKind::SourceReplicaIdentityError,
-                    "BigQuery key image does not match the source primary key",
-                    format!(
-                        "Table '{}' emitted a key image for replica identity {:?}, but BigQuery \
-                         rows are keyed by the source primary key",
-                        replicated_table_schema.name(),
-                        replicated_table_schema.identity_type()
-                    )
-                );
-            }
-
             let primary_key_column_count =
                 replicated_table_schema.primary_key_column_schemas().len();
             if row.values().len() != primary_key_column_count {
@@ -1697,6 +1696,8 @@ fn bigquery_primary_key_tagged_cells_from_old_row(
                     )
                 );
             }
+
+            ensure_bigquery_key_image_matches_primary_key(replicated_table_schema)?;
 
             let mut tagged_cells = Vec::with_capacity(primary_key_column_count);
             let mut primary_key_columns =
@@ -2093,36 +2094,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_bigquery_mutation_identity_accepts_primary_key() {
-        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
-
-        validate_bigquery_mutation_identity(&replicated_table_schema).unwrap();
-    }
-
-    #[test]
-    fn validate_bigquery_mutation_identity_accepts_full() {
-        let replicated_table_schema = replicated_schema(IdentityType::Full);
-
-        validate_bigquery_mutation_identity(&replicated_table_schema).unwrap();
-    }
-
-    #[test]
-    fn validate_bigquery_mutation_identity_rejects_alternative_key() {
-        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
-
-        let error = validate_bigquery_mutation_identity(&replicated_table_schema).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
-    }
-
-    #[test]
-    fn validate_bigquery_mutation_identity_rejects_missing() {
-        let replicated_table_schema = replicated_schema(IdentityType::Missing);
-
-        let error = validate_bigquery_mutation_identity(&replicated_table_schema).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
-    }
-
-    #[test]
     fn validate_bigquery_table_shape_accepts_alternative_identity() {
         let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
 
@@ -2130,13 +2101,49 @@ mod tests {
     }
 
     #[test]
-    fn bigquery_partial_update_row_error_uses_replica_identity_kind() {
+    fn bigquery_update_new_row_rejects_partial_rows() {
         let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+        let partial_row =
+            etl::types::PartialTableRow::new(2, TableRow::new(vec![Cell::I32(1)]), vec![1]);
 
-        let error = bigquery_partial_update_row_error(&replicated_table_schema);
+        let error = bigquery_update_new_row(
+            &replicated_table_schema,
+            UpdatedTableRow::Partial(partial_row),
+        )
+        .unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
         assert!(error.to_string().contains("emitted a partial update row"));
+    }
+
+    #[test]
+    fn bigquery_delete_old_row_rejects_missing_old_rows() {
+        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+
+        let error = bigquery_delete_old_row(&replicated_table_schema, None).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn ensure_bigquery_key_image_matches_primary_key_rejects_alternative_key() {
+        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
+
+        let error =
+            ensure_bigquery_key_image_matches_primary_key(&replicated_table_schema).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn ensure_bigquery_update_without_old_row_rejects_alternative_key() {
+        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
+
+        let error =
+            ensure_bigquery_update_without_old_row_can_skip_delete(&replicated_table_schema)
+                .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
     }
 
     #[test]
@@ -2608,5 +2615,40 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn bigquery_update_rows_accepts_alternative_identity_when_full_old_row_is_available() {
+        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
+        let sequence_key = EventSequenceKey::new(PgLsn::from(1), 0);
+
+        let rows = bigquery_update_rows(
+            &replicated_table_schema,
+            TableRow::new(vec![Cell::I32(2), Cell::String("updated".to_owned())]),
+            Some(OldTableRow::Full(TableRow::new(vec![
+                Cell::I32(1),
+                Cell::String("before".to_owned()),
+            ]))),
+            sequence_key,
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn bigquery_update_rows_rejects_alternative_identity_without_old_row() {
+        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
+        let sequence_key = EventSequenceKey::new(PgLsn::from(1), 0);
+
+        let error = bigquery_update_rows(
+            &replicated_table_schema,
+            TableRow::new(vec![Cell::I32(2), Cell::String("updated".to_owned())]),
+            None,
+            sequence_key,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
     }
 }

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -510,7 +510,7 @@ where
         &self,
         schema: &ReplicatedTableSchema,
     ) -> EtlResult<(String, Arc<[bool]>)> {
-        validate_replica_identity_for_clickhouse(schema, self.inserter_config.engine)?;
+        validate_clickhouse_table_shape(schema, self.inserter_config.engine)?;
         let clickhouse_table_name = try_stringify_table_name(schema.name())?;
 
         if let Some(flags) = self.table_cache.read().get(&clickhouse_table_name).cloned() {
@@ -682,7 +682,7 @@ where
     /// Handles a schema change event (Relation) by computing the diff and
     /// applying ALTER TABLE statements.
     async fn handle_relation_event(&self, new_schema: &ReplicatedTableSchema) -> EtlResult<()> {
-        validate_replica_identity_for_clickhouse(new_schema, self.inserter_config.engine)?;
+        validate_clickhouse_table_shape(new_schema, self.inserter_config.engine)?;
 
         let table_id = new_schema.id();
         let new_snapshot_id = new_schema.inner().snapshot_id;
@@ -902,6 +902,10 @@ where
                         });
                     }
                     Event::Update(update) => {
+                        validate_replacing_merge_tree_mutation_identity(
+                            &update.replicated_table_schema,
+                            self.inserter_config.engine,
+                        )?;
                         let UpdatedTableRow::Full(table_row) = update.updated_table_row else {
                             return Err(etl_error!(
                                 ErrorKind::SourceReplicaIdentityError,
@@ -936,7 +940,7 @@ where
                         let old_row = match old_table_row {
                             OldTableRow::Full(row) => row,
                             OldTableRow::Key(key_row) => {
-                                expand_key_row(key_row, &delete.replicated_table_schema)
+                                expand_key_row(key_row, &delete.replicated_table_schema)?
                             }
                         };
                         let table_id = delete.replicated_table_schema.id();
@@ -1127,20 +1131,13 @@ fn ensure_engine_supported(engine: ClickHouseEngine, server_version: (u32, u32))
     Ok(())
 }
 
-/// Rejects replica identities and schemas the ClickHouse destination cannot
-/// represent for the configured engine.
-///
-/// Common to both engines: `expand_key_row` assumes the key-only old-row image
-/// carries primary-key values, so the row identity must match the primary key.
-/// `Full` is also fine because it bypasses `expand_key_row` entirely.
-/// `AlternativeKey` (a non-PK unique index) and `Missing` would either land
-/// identity values in the wrong PK slots or leave us without enough data to
-/// write a well-formed tombstone.
+/// Rejects source schemas the ClickHouse destination cannot represent for the
+/// configured engine.
 ///
 /// ReplacingMergeTree-only: the source table must have a primary key.
 /// ReplacingMergeTree uses the PK as `ORDER BY`, which is also the dedup key;
 /// without a PK there is nothing to merge on.
-fn validate_replica_identity_for_clickhouse(
+fn validate_clickhouse_table_shape(
     replicated_table_schema: &ReplicatedTableSchema,
     engine: ClickHouseEngine,
 ) -> EtlResult<()> {
@@ -1175,9 +1172,37 @@ fn validate_replica_identity_for_clickhouse(
         ));
     }
 
-    match replicated_table_schema.identity_type() {
-        IdentityType::PrimaryKey | IdentityType::Full => Ok(()),
-        identity_type => Err(etl_error!(
+    Ok(())
+}
+
+/// Validates the replica identity for a ReplacingMergeTree mutation.
+///
+/// ReplacingMergeTree uses the source primary key as its dedup key. Updates and
+/// deletes therefore need either primary-key identity or full row images so PK
+/// changes do not leave stale rows behind.
+fn validate_replacing_merge_tree_mutation_identity(
+    replicated_table_schema: &ReplicatedTableSchema,
+    engine: ClickHouseEngine,
+) -> EtlResult<()> {
+    if !matches!(engine, ClickHouseEngine::ReplacingMergeTree) {
+        return Ok(());
+    }
+
+    validate_clickhouse_key_identity(replicated_table_schema)
+}
+
+/// Validates that a key-only old-row image can be interpreted as source PK
+/// values.
+fn validate_clickhouse_key_identity(
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> EtlResult<()> {
+    if replicated_table_schema.identity_matches_primary_key()
+        || matches!(replicated_table_schema.identity_type(), IdentityType::Full)
+    {
+        Ok(())
+    } else {
+        let identity_type = replicated_table_schema.identity_type();
+        Err(etl_error!(
             ErrorKind::SourceReplicaIdentityError,
             "ClickHouse requires primary-key or full replica identity",
             format!(
@@ -1188,7 +1213,7 @@ fn validate_replica_identity_for_clickhouse(
                 replicated_table_schema.name(),
                 identity_type
             )
-        )),
+        ))
     }
 }
 
@@ -1198,10 +1223,11 @@ fn validate_replica_identity_for_clickhouse(
 /// nullable, or a type-appropriate zero value if non-nullable (since RowBinary
 /// rejects NULL for non-nullable columns).
 ///
-/// Caller must ensure the source replica identity is `PrimaryKey` (or `Full`,
-/// in which case this function isn't invoked) -- see
-/// [`validate_replica_identity_for_clickhouse`].
-fn expand_key_row(key_row: TableRow, schema: &ReplicatedTableSchema) -> TableRow {
+/// Caller only reaches this path for key-only deletes, so this function
+/// validates that the key row can be interpreted as source primary-key values.
+fn expand_key_row(key_row: TableRow, schema: &ReplicatedTableSchema) -> EtlResult<TableRow> {
+    validate_clickhouse_key_identity(schema)?;
+
     let key_cells = key_row.into_values();
     let mut key_iter = key_cells.into_iter();
     let cells: Vec<Cell> = schema
@@ -1219,7 +1245,7 @@ fn expand_key_row(key_row: TableRow, schema: &ReplicatedTableSchema) -> TableRow
             }
         })
         .collect();
-    TableRow::new(cells)
+    Ok(TableRow::new(cells))
 }
 
 /// Returns a zero-value Cell for a Postgres type, used to fill non-PK columns
@@ -1378,46 +1404,55 @@ mod tests {
     }
 
     #[test]
-    fn validate_replica_identity_for_clickhouse_accepts_primary_key() {
-        validate_replica_identity_for_clickhouse(
+    fn validate_replacing_merge_tree_mutation_identity_accepts_primary_key() {
+        validate_replacing_merge_tree_mutation_identity(
             &replicated_schema(IdentityType::PrimaryKey),
-            ClickHouseEngine::MergeTree,
+            ClickHouseEngine::ReplacingMergeTree,
         )
         .unwrap();
     }
 
     #[test]
-    fn validate_replica_identity_for_clickhouse_accepts_full() {
-        validate_replica_identity_for_clickhouse(
+    fn validate_replacing_merge_tree_mutation_identity_accepts_full() {
+        validate_replacing_merge_tree_mutation_identity(
             &replicated_schema(IdentityType::Full),
-            ClickHouseEngine::MergeTree,
+            ClickHouseEngine::ReplacingMergeTree,
         )
         .unwrap();
     }
 
     #[test]
-    fn validate_replica_identity_for_clickhouse_rejects_alternative_key() {
-        let err = validate_replica_identity_for_clickhouse(
+    fn validate_replacing_merge_tree_mutation_identity_rejects_alternative_key() {
+        let err = validate_replacing_merge_tree_mutation_identity(
+            &replicated_schema(IdentityType::AlternativeKey),
+            ClickHouseEngine::ReplacingMergeTree,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn validate_replacing_merge_tree_mutation_identity_rejects_missing() {
+        let err = validate_replacing_merge_tree_mutation_identity(
+            &replicated_schema(IdentityType::Missing),
+            ClickHouseEngine::ReplacingMergeTree,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn validate_clickhouse_table_shape_accepts_alternative_identity() {
+        validate_clickhouse_table_shape(
             &replicated_schema(IdentityType::AlternativeKey),
             ClickHouseEngine::MergeTree,
         )
-        .unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::SourceReplicaIdentityError);
+        .unwrap();
     }
 
     #[test]
-    fn validate_replica_identity_for_clickhouse_rejects_missing() {
-        let err = validate_replica_identity_for_clickhouse(
-            &replicated_schema(IdentityType::Missing),
-            ClickHouseEngine::MergeTree,
-        )
-        .unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::SourceReplicaIdentityError);
-    }
-
-    #[test]
-    fn validate_replica_identity_for_clickhouse_rejects_partial_primary_key() {
-        let err = validate_replica_identity_for_clickhouse(
+    fn validate_clickhouse_table_shape_rejects_partial_primary_key() {
+        let err = validate_clickhouse_table_shape(
             &replicated_schema_with_partial_primary_key(),
             ClickHouseEngine::MergeTree,
         )
@@ -1427,7 +1462,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_replica_identity_for_clickhouse_rejects_pkless_schema_under_replacing_merge_tree() {
+    fn validate_clickhouse_table_shape_rejects_pkless_schema_under_replacing_merge_tree() {
         // --- GIVEN: a PK-less schema and engine = ReplacingMergeTree ---
         let table_schema = Arc::new(TableSchema::new(
             TableId::new(2),
@@ -1440,9 +1475,8 @@ mod tests {
             ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask);
 
         // --- WHEN: validating under ReplacingMergeTree ---
-        let err =
-            validate_replica_identity_for_clickhouse(&schema, ClickHouseEngine::ReplacingMergeTree)
-                .unwrap_err();
+        let err = validate_clickhouse_table_shape(&schema, ClickHouseEngine::ReplacingMergeTree)
+            .unwrap_err();
 
         // --- THEN: rejected with SourceSchemaError ---
         assert_eq!(err.kind(), ErrorKind::SourceSchemaError);

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -970,25 +970,11 @@ where
                         });
                     }
                     Event::Update(update) => {
-                        validate_replacing_merge_tree_mutation_identity(
+                        let table_row = clickhouse_update_row(
                             &update.replicated_table_schema,
+                            update.updated_table_row,
                             self.inserter_config.engine,
                         )?;
-                        let UpdatedTableRow::Full(table_row) = update.updated_table_row else {
-                            return Err(etl_error!(
-                                ErrorKind::SourceReplicaIdentityError,
-                                "ClickHouse update requires a full new row image",
-                                format!(
-                                    "Table '{}' emitted a partial update row: some column values \
-                                     could not be reconstructed. Writing it would record NULL for \
-                                     the missing columns and misrepresent the source. Configuring \
-                                     the source so that all column values are available in the \
-                                     new- or old-row image (e.g. REPLICA IDENTITY FULL) prevents \
-                                     this.",
-                                    update.replicated_table_schema.name()
-                                )
-                            ));
-                        };
                         let table_id = update.replicated_table_schema.id();
                         let entry = pending
                             .entry(table_id)
@@ -1001,10 +987,10 @@ where
                         });
                     }
                     Event::Delete(delete) => {
-                        let Some(old_table_row) = delete.old_table_row else {
-                            debug!("delete event has no row data, skipping");
-                            continue;
-                        };
+                        let old_table_row = clickhouse_delete_old_row(
+                            &delete.replicated_table_schema,
+                            delete.old_table_row,
+                        )?;
                         let old_row = match old_table_row {
                             OldTableRow::Full(row) => row,
                             OldTableRow::Key(key_row) => {
@@ -1248,30 +1234,62 @@ fn validate_clickhouse_table_shape(
     Ok(())
 }
 
-/// Validates the replica identity for a ReplacingMergeTree mutation.
+/// Returns the full new row required for a ClickHouse update.
 ///
-/// ReplacingMergeTree uses the source primary key as its dedup key. Updates and
-/// deletes therefore need either primary-key identity or full row images so PK
-/// changes do not leave stale rows behind.
-fn validate_replacing_merge_tree_mutation_identity(
+/// ReplacingMergeTree also uses the source primary key as its dedup key, so
+/// update events must be keyed by the primary key or carry full row images.
+fn clickhouse_update_row(
     replicated_table_schema: &ReplicatedTableSchema,
+    updated_table_row: UpdatedTableRow,
     engine: ClickHouseEngine,
-) -> EtlResult<()> {
-    if !matches!(engine, ClickHouseEngine::ReplacingMergeTree) {
-        return Ok(());
+) -> EtlResult<TableRow> {
+    let UpdatedTableRow::Full(row) = updated_table_row else {
+        return Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "ClickHouse update requires a full new row image",
+            format!(
+                "Table '{}' emitted a partial update row: some column values could not be \
+                 reconstructed. Writing it would record NULL for the missing columns and \
+                 misrepresent the source.",
+                replicated_table_schema.name()
+            )
+        ));
+    };
+
+    if matches!(engine, ClickHouseEngine::ReplacingMergeTree) {
+        ensure_clickhouse_key_identity_is_primary_key(replicated_table_schema)?;
     }
 
-    validate_clickhouse_key_identity(replicated_table_schema)
+    Ok(row)
+}
+
+/// Returns the old row image required for a ClickHouse delete tombstone.
+fn clickhouse_delete_old_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: Option<OldTableRow>,
+) -> EtlResult<OldTableRow> {
+    old_table_row.ok_or_else(|| {
+        etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "ClickHouse delete requires an old row image",
+            format!(
+                "Table '{}' emitted a delete without an old row image. ClickHouse deletes need \
+                 either a full old row or a key image that can be expanded into a tombstone.",
+                replicated_table_schema.name()
+            )
+        )
+    })
 }
 
 /// Validates that a key-only old-row image can be interpreted as source PK
 /// values.
-fn validate_clickhouse_key_identity(
+fn ensure_clickhouse_key_identity_is_primary_key(
     replicated_table_schema: &ReplicatedTableSchema,
 ) -> EtlResult<()> {
-    if replicated_table_schema.identity_matches_primary_key()
-        || matches!(replicated_table_schema.identity_type(), IdentityType::Full)
-    {
+    if matches!(
+        replicated_table_schema.identity_type(),
+        IdentityType::PrimaryKey | IdentityType::Full
+    ) {
         Ok(())
     } else {
         let identity_type = replicated_table_schema.identity_type();
@@ -1299,7 +1317,21 @@ fn validate_clickhouse_key_identity(
 /// Caller only reaches this path for key-only deletes, so this function
 /// validates that the key row can be interpreted as source primary-key values.
 fn expand_key_row(key_row: TableRow, schema: &ReplicatedTableSchema) -> EtlResult<TableRow> {
-    validate_clickhouse_key_identity(schema)?;
+    let primary_key_column_count = schema.primary_key_column_schemas().len();
+    if key_row.values().len() != primary_key_column_count {
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            "ClickHouse key image does not match the source primary key",
+            format!(
+                "Expected {} key values for table '{}', got {}",
+                primary_key_column_count,
+                schema.name(),
+                key_row.values().len()
+            )
+        ));
+    }
+
+    ensure_clickhouse_key_identity_is_primary_key(schema)?;
 
     let key_cells = key_row.into_values();
     let mut key_iter = key_cells.into_iter();
@@ -1431,7 +1463,8 @@ where
 #[cfg(test)]
 mod tests {
     use etl::types::{
-        ArrayCell, ColumnSchema, IdentityMask, ReplicationMask, TableName, TableSchema,
+        ArrayCell, ColumnSchema, IdentityMask, PartialTableRow, ReplicationMask, TableName,
+        TableSchema,
     };
 
     use super::*;
@@ -1478,27 +1511,40 @@ mod tests {
     }
 
     #[test]
-    fn validate_replacing_merge_tree_mutation_identity_accepts_primary_key() {
-        validate_replacing_merge_tree_mutation_identity(
+    fn clickhouse_update_row_accepts_primary_key_identity_under_replacing_merge_tree() {
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let result = clickhouse_update_row(
             &replicated_schema(IdentityType::PrimaryKey),
+            UpdatedTableRow::Full(row.clone()),
             ClickHouseEngine::ReplacingMergeTree,
         )
         .unwrap();
+
+        assert_eq!(result, row);
     }
 
     #[test]
-    fn validate_replacing_merge_tree_mutation_identity_accepts_full() {
-        validate_replacing_merge_tree_mutation_identity(
+    fn clickhouse_update_row_accepts_full_identity_under_replacing_merge_tree() {
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let result = clickhouse_update_row(
             &replicated_schema(IdentityType::Full),
+            UpdatedTableRow::Full(row.clone()),
             ClickHouseEngine::ReplacingMergeTree,
         )
         .unwrap();
+
+        assert_eq!(result, row);
     }
 
     #[test]
-    fn validate_replacing_merge_tree_mutation_identity_rejects_alternative_key() {
-        let err = validate_replacing_merge_tree_mutation_identity(
+    fn clickhouse_update_row_rejects_alternative_key_under_replacing_merge_tree() {
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let err = clickhouse_update_row(
             &replicated_schema(IdentityType::AlternativeKey),
+            UpdatedTableRow::Full(row),
             ClickHouseEngine::ReplacingMergeTree,
         )
         .unwrap_err();
@@ -1506,13 +1552,49 @@ mod tests {
     }
 
     #[test]
-    fn validate_replacing_merge_tree_mutation_identity_rejects_missing() {
-        let err = validate_replacing_merge_tree_mutation_identity(
+    fn clickhouse_update_row_rejects_missing_identity_under_replacing_merge_tree() {
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let err = clickhouse_update_row(
             &replicated_schema(IdentityType::Missing),
+            UpdatedTableRow::Full(row),
             ClickHouseEngine::ReplacingMergeTree,
         )
         .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn clickhouse_update_row_rejects_partial_rows_before_identity_checks() {
+        let partial_row = PartialTableRow::new(2, TableRow::new(vec![Cell::I32(1)]), vec![1]);
+
+        let err = clickhouse_update_row(
+            &replicated_schema(IdentityType::AlternativeKey),
+            UpdatedTableRow::Partial(partial_row),
+            ClickHouseEngine::ReplacingMergeTree,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::SourceReplicaIdentityError);
+        assert!(err.to_string().contains("partial update row"));
+    }
+
+    #[test]
+    fn clickhouse_delete_old_row_rejects_missing_old_rows() {
+        let err = clickhouse_delete_old_row(&replicated_schema(IdentityType::PrimaryKey), None)
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn expand_key_row_rejects_short_key_payload_before_identity_checks() {
+        let err =
+            expand_key_row(TableRow::new(vec![]), &replicated_schema(IdentityType::AlternativeKey))
+                .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidState);
+        assert!(err.to_string().contains("Expected 1 key values"));
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -1866,7 +1866,7 @@ where
                         )?;
                         let Some(old_row) = delete.old_table_row else {
                             return Err(etl_error!(
-                                ErrorKind::InvalidState,
+                                ErrorKind::SourceReplicaIdentityError,
                                 "DuckLake delete requires an old row image",
                                 format!(
                                     "Table '{}' emitted a delete without an old row despite \

--- a/crates/etl-destinations/src/iceberg/core.rs
+++ b/crates/etl-destinations/src/iceberg/core.rs
@@ -15,8 +15,8 @@ use etl::{
     state::destination_table_metadata::DestinationTableMetadata,
     store::SharedStateStore,
     types::{
-        Cell, ColumnSchema, Event, IdentityType, OldTableRow, ReplicatedTableSchema, TableId,
-        TableName, TableRow, Type, generate_sequence_number,
+        Cell, ColumnSchema, Event, OldTableRow, ReplicatedTableSchema, TableId, TableName,
+        TableRow, Type, generate_sequence_number,
     },
 };
 use tokio::{sync::Mutex, task::JoinSet};
@@ -338,7 +338,6 @@ where
                         entry.1.push(insert.table_row);
                     }
                     Event::Update(update) => {
-                        validate_iceberg_replica_identity(&update.replicated_table_schema)?;
                         let sequence_key = update.event_sequence_key().to_string();
                         let mut table_row = match update.updated_table_row {
                             etl::types::UpdatedTableRow::Full(row) => row,
@@ -365,11 +364,10 @@ where
                         entry.1.push(table_row);
                     }
                     Event::Delete(delete) => {
-                        validate_iceberg_replica_identity(&delete.replicated_table_schema)?;
                         let sequence_key = delete.event_sequence_key().to_string();
                         let Some(old_table_row) = delete.old_table_row else {
                             return Err(etl_error!(
-                                ErrorKind::InvalidState,
+                                ErrorKind::SourceReplicaIdentityError,
                                 "Iceberg delete requires an old row image",
                                 format!(
                                     "Table '{}' emitted a delete without an old row image even \
@@ -380,7 +378,7 @@ where
                         };
                         let OldTableRow::Full(mut old_table_row) = old_table_row else {
                             return Err(etl_error!(
-                                ErrorKind::InvalidState,
+                                ErrorKind::SourceReplicaIdentityError,
                                 "Iceberg delete requires a full old row image",
                                 format!(
                                     "Table '{}' emitted a key-only delete image. Configure \
@@ -399,8 +397,6 @@ where
                         entry.1.push(old_table_row);
                     }
                     Event::Relation(relation) => {
-                        validate_iceberg_replica_identity(&relation.replicated_table_schema)?;
-
                         // Check if schema has changed - if so, error since Iceberg doesn't
                         // support schema changes yet.
                         let table_id = relation.replicated_table_schema.id();
@@ -491,11 +487,9 @@ where
     /// Prepares a table for Iceberg writes with schema-aware table creation.
     ///
     /// Augments the provided schema with CDC columns and ensures the
-    /// corresponding Iceberg table exists in the namespace. Also validates
-    /// that the source table uses `REPLICA IDENTITY FULL`, which Iceberg needs
-    /// for delete replay. Uses caching to avoid redundant table creation
-    /// checks and holds a lock during the entire preparation to prevent race
-    /// conditions.
+    /// corresponding Iceberg table exists in the namespace. Uses caching to
+    /// avoid redundant table creation checks and holds a lock during the entire
+    /// preparation to prevent race conditions.
     ///
     /// Follows the applying -> applied pattern for crash recovery:
     /// 1. Store metadata with `Applying` status before creating the table
@@ -506,8 +500,6 @@ where
         inner: &mut Inner,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<(String, IcebergTableName)> {
-        validate_iceberg_replica_identity(replicated_table_schema)?;
-
         let table_id = replicated_table_schema.id();
         let table_name = replicated_table_schema.name();
         let snapshot_id = replicated_table_schema.inner().snapshot_id;
@@ -684,29 +676,6 @@ where
     }
 }
 
-/// Validates that a replicated table schema can be applied in Iceberg.
-///
-/// Iceberg changelog replay requires full old-row images so deletes can be
-/// represented correctly. That means source tables must use
-/// `REPLICA IDENTITY FULL`.
-fn validate_iceberg_replica_identity(
-    replicated_table_schema: &ReplicatedTableSchema,
-) -> EtlResult<()> {
-    match replicated_table_schema.identity_type() {
-        IdentityType::Full => Ok(()),
-        identity_type => Err(etl_error!(
-            ErrorKind::SourceReplicaIdentityError,
-            "Iceberg requires full replica identity",
-            format!(
-                "Table '{}' uses replica identity {:?}, but Iceberg only supports source tables \
-                 with FULL replica identity.",
-                replicated_table_schema.name(),
-                identity_type
-            )
-        )),
-    }
-}
-
 /// Creates a unique columns name with prefix `new_column_name` to avoid
 /// collissions with existing columns in `column_schemas` by adding a numeric
 /// suffix.
@@ -770,40 +739,11 @@ fn schema_to_namespace(schema: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use etl::{
-        error::ErrorKind,
-        types::{
-            ColumnSchema, IdentityMask, IdentityType, ReplicatedTableSchema, ReplicationMask,
-            TableId, TableName, TableSchema, Type,
-        },
-    };
+    use etl::types::{ColumnSchema, Type};
 
     use crate::iceberg::core::{
         CDC_OPERATION_COLUMN_NAME, find_unique_column_name, schema_to_namespace,
-        validate_iceberg_replica_identity,
     };
-
-    fn replicated_schema(identity_type: IdentityType) -> ReplicatedTableSchema {
-        let table_schema = Arc::new(TableSchema::new(
-            TableId::new(1),
-            TableName::new("public".to_owned(), "users".to_owned()),
-            vec![
-                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, Some(1), false),
-                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, None, true),
-            ],
-        ));
-        let replication_mask = ReplicationMask::all(&table_schema);
-        let identity_mask = match identity_type {
-            IdentityType::Full => IdentityMask::from_bytes(vec![1, 1]),
-            IdentityType::PrimaryKey => IdentityMask::from_bytes(vec![1, 0]),
-            IdentityType::AlternativeKey => IdentityMask::from_bytes(vec![0, 1]),
-            IdentityType::Missing => IdentityMask::from_bytes(vec![0, 0]),
-        };
-
-        ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask)
-    }
 
     /// Creates a test column schema with common defaults.
     ///
@@ -990,36 +930,5 @@ mod tests {
         assert_eq!(schema_to_namespace("storage"), "storage");
         assert_eq!(schema_to_namespace("pg_catalog"), "pg_catalog");
         assert_eq!(schema_to_namespace("information_schema"), "information_schema");
-    }
-
-    #[test]
-    fn validate_iceberg_replica_identity_accepts_full() {
-        let replicated_table_schema = replicated_schema(IdentityType::Full);
-
-        validate_iceberg_replica_identity(&replicated_table_schema).unwrap();
-    }
-
-    #[test]
-    fn validate_iceberg_replica_identity_rejects_primary_key() {
-        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
-
-        let error = validate_iceberg_replica_identity(&replicated_table_schema).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
-    }
-
-    #[test]
-    fn validate_iceberg_replica_identity_rejects_alternative_key() {
-        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
-
-        let error = validate_iceberg_replica_identity(&replicated_table_schema).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
-    }
-
-    #[test]
-    fn validate_iceberg_replica_identity_rejects_missing() {
-        let replicated_table_schema = replicated_schema(IdentityType::Missing);
-
-        let error = validate_iceberg_replica_identity(&replicated_table_schema).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
     }
 }

--- a/crates/etl-destinations/src/iceberg/core.rs
+++ b/crates/etl-destinations/src/iceberg/core.rs
@@ -16,7 +16,7 @@ use etl::{
     store::SharedStateStore,
     types::{
         Cell, ColumnSchema, Event, OldTableRow, ReplicatedTableSchema, TableId, TableName,
-        TableRow, Type, generate_sequence_number,
+        TableRow, Type, UpdatedTableRow, generate_sequence_number,
     },
 };
 use tokio::{sync::Mutex, task::JoinSet};
@@ -339,21 +339,10 @@ where
                     }
                     Event::Update(update) => {
                         let sequence_key = update.event_sequence_key().to_string();
-                        let mut table_row = match update.updated_table_row {
-                            etl::types::UpdatedTableRow::Full(row) => row,
-                            etl::types::UpdatedTableRow::Partial(_) => {
-                                return Err(etl_error!(
-                                    ErrorKind::InvalidState,
-                                    "Iceberg update requires a full new row image",
-                                    format!(
-                                        "Table '{}' emitted a partial update row. Configure \
-                                         replication so all updated values are available before \
-                                         writing to Iceberg.",
-                                        update.replicated_table_schema.name()
-                                    )
-                                ));
-                            }
-                        };
+                        let mut table_row = iceberg_update_row(
+                            &update.replicated_table_schema,
+                            update.updated_table_row,
+                        )?;
                         table_row.values_mut().push(IcebergOperationType::Update.into());
                         table_row.values_mut().push(Cell::String(sequence_key));
 
@@ -365,28 +354,10 @@ where
                     }
                     Event::Delete(delete) => {
                         let sequence_key = delete.event_sequence_key().to_string();
-                        let Some(old_table_row) = delete.old_table_row else {
-                            return Err(etl_error!(
-                                ErrorKind::SourceReplicaIdentityError,
-                                "Iceberg delete requires an old row image",
-                                format!(
-                                    "Table '{}' emitted a delete without an old row image even \
-                                     though Iceberg requires FULL replica identity.",
-                                    delete.replicated_table_schema.name()
-                                )
-                            ));
-                        };
-                        let OldTableRow::Full(mut old_table_row) = old_table_row else {
-                            return Err(etl_error!(
-                                ErrorKind::SourceReplicaIdentityError,
-                                "Iceberg delete requires a full old row image",
-                                format!(
-                                    "Table '{}' emitted a key-only delete image. Configure \
-                                     REPLICA IDENTITY FULL for Iceberg delete support.",
-                                    delete.replicated_table_schema.name()
-                                )
-                            ));
-                        };
+                        let mut old_table_row = iceberg_delete_row(
+                            &delete.replicated_table_schema,
+                            delete.old_table_row,
+                        )?;
                         old_table_row.values_mut().push(IcebergOperationType::Delete.into());
                         old_table_row.values_mut().push(Cell::String(sequence_key));
 
@@ -676,6 +647,53 @@ where
     }
 }
 
+/// Returns the full new row required for an Iceberg update changelog row.
+fn iceberg_update_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    updated_table_row: UpdatedTableRow,
+) -> EtlResult<TableRow> {
+    match updated_table_row {
+        UpdatedTableRow::Full(row) => Ok(row),
+        UpdatedTableRow::Partial(_) => Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "Iceberg update requires a full new row image",
+            format!(
+                "Table '{}' emitted a partial update row. Configure the source so all updated \
+                 values are available before writing update events to Iceberg.",
+                replicated_table_schema.name()
+            )
+        )),
+    }
+}
+
+/// Returns the full old row required for an Iceberg delete changelog row.
+fn iceberg_delete_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: Option<OldTableRow>,
+) -> EtlResult<TableRow> {
+    match old_table_row {
+        Some(OldTableRow::Full(row)) => Ok(row),
+        Some(OldTableRow::Key(_)) => Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "Iceberg delete requires a full old row image",
+            format!(
+                "Table '{}' emitted a key-only delete image. Configure the source so full old \
+                 rows are available before writing delete events to Iceberg.",
+                replicated_table_schema.name()
+            )
+        )),
+        None => Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "Iceberg delete requires an old row image",
+            format!(
+                "Table '{}' emitted a delete without an old row image. Configure the source so \
+                 old rows are available before writing delete events to Iceberg.",
+                replicated_table_schema.name()
+            )
+        )),
+    }
+}
+
 /// Creates a unique columns name with prefix `new_column_name` to avoid
 /// collissions with existing columns in `column_schemas` by adding a numeric
 /// suffix.
@@ -739,10 +757,19 @@ fn schema_to_namespace(schema: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use etl::types::{ColumnSchema, Type};
+    use std::sync::Arc;
+
+    use etl::{
+        error::ErrorKind,
+        types::{
+            Cell, ColumnSchema, IdentityMask, OldTableRow, PartialTableRow, ReplicatedTableSchema,
+            ReplicationMask, TableId, TableName, TableRow, TableSchema, Type, UpdatedTableRow,
+        },
+    };
 
     use crate::iceberg::core::{
-        CDC_OPERATION_COLUMN_NAME, find_unique_column_name, schema_to_namespace,
+        CDC_OPERATION_COLUMN_NAME, find_unique_column_name, iceberg_delete_row, iceberg_update_row,
+        schema_to_namespace,
     };
 
     /// Creates a test column schema with common defaults.
@@ -759,6 +786,71 @@ mod tests {
     ) -> ColumnSchema {
         ColumnSchema::new(name.to_owned(), typ, -1, ordinal_position, nullable)
             .with_primary_key_ordinal_position(primary_key_ordinal)
+    }
+
+    /// Creates a replicated table schema for operation-level row-image tests.
+    fn replicated_schema() -> ReplicatedTableSchema {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_owned(), "users".to_owned()),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+            ],
+        ));
+        let replication_mask = ReplicationMask::all(&table_schema);
+        let identity_mask = IdentityMask::from_bytes(vec![1, 0]);
+
+        ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask)
+    }
+
+    #[test]
+    fn iceberg_update_row_accepts_full_new_row() {
+        let schema = replicated_schema();
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let result = iceberg_update_row(&schema, UpdatedTableRow::Full(row.clone())).unwrap();
+
+        assert_eq!(result, row);
+    }
+
+    #[test]
+    fn iceberg_update_row_rejects_partial_new_row() {
+        let schema = replicated_schema();
+        let partial_row = PartialTableRow::new(2, TableRow::new(vec![Cell::I32(1)]), vec![1]);
+
+        let error = iceberg_update_row(&schema, UpdatedTableRow::Partial(partial_row)).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn iceberg_delete_row_accepts_full_old_row() {
+        let schema = replicated_schema();
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let result = iceberg_delete_row(&schema, Some(OldTableRow::Full(row.clone()))).unwrap();
+
+        assert_eq!(result, row);
+    }
+
+    #[test]
+    fn iceberg_delete_row_rejects_key_only_old_row() {
+        let schema = replicated_schema();
+        let old_row = OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]));
+
+        let error = iceberg_delete_row(&schema, Some(old_row)).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn iceberg_delete_row_rejects_missing_old_row() {
+        let schema = replicated_schema();
+
+        let error = iceberg_delete_row(&schema, None).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
     }
 
     #[test]

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -237,18 +237,7 @@ where
         builders: &mut HashMap<TableId, RowBatchBuilder>,
         column_cache: &mut HashMap<TableId, Vec<ColumnSchema>>,
     ) -> EtlResult<()> {
-        // Accept only full rows, otherwise NULL will be recorded for missing columns
-        // (not that they are not changed).
-        let full_row = match e.updated_table_row {
-            UpdatedTableRow::Full(row) => row,
-            UpdatedTableRow::Partial(_) => {
-                bail!(
-                    ErrorKind::SourceReplicaIdentityError,
-                    "Partial update rows not supported",
-                    "Snowflake destination requires REPLICA IDENTITY FULL for update events"
-                );
-            }
-        };
+        let full_row = snowflake_update_row(&e.replicated_table_schema, e.updated_table_row)?;
 
         let table_id = e.replicated_table_schema.id();
         self.ensure_column_cache(column_cache, table_id, &e.replicated_table_schema).await?;
@@ -271,8 +260,8 @@ where
         let table_id = e.replicated_table_schema.id();
         let offset = OffsetToken::new(e.commit_lsn, e.tx_ordinal);
 
-        match e.old_table_row {
-            Some(OldTableRow::Full(row)) => {
+        match snowflake_delete_row(&e.replicated_table_schema, e.old_table_row)? {
+            SnowflakeDeleteRow::Full(row) => {
                 self.ensure_column_cache(column_cache, table_id, &e.replicated_table_schema)
                     .await?;
                 let cols = &column_cache[&table_id];
@@ -287,7 +276,7 @@ where
                     )
                     .map_err(EtlError::from)
             }
-            Some(OldTableRow::Key(key_row)) => {
+            SnowflakeDeleteRow::Key(key_row) => {
                 self.ensure_column_cache(column_cache, table_id, &e.replicated_table_schema)
                     .await?;
                 let identity_cols: Vec<_> =
@@ -302,10 +291,6 @@ where
                         &offset,
                     )
                     .map_err(EtlError::from)
-            }
-            None => {
-                info!(table_id = ?table_id, "delete event has no old row data, skipping");
-                Ok(())
             }
         }
     }
@@ -416,6 +401,54 @@ where
     }
 }
 
+/// Delete row payloads Snowflake can encode.
+#[derive(Debug)]
+enum SnowflakeDeleteRow {
+    /// A full old row image.
+    Full(TableRow),
+    /// A key-only old row image.
+    Key(TableRow),
+}
+
+/// Returns the full new row required for a Snowflake update row.
+fn snowflake_update_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    updated_table_row: UpdatedTableRow,
+) -> EtlResult<TableRow> {
+    match updated_table_row {
+        UpdatedTableRow::Full(row) => Ok(row),
+        UpdatedTableRow::Partial(_) => Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "Snowflake update requires a full new row image",
+            format!(
+                "Table '{}' emitted a partial update row. Snowflake update rows must include all \
+                 replicated column values.",
+                replicated_table_schema.name()
+            )
+        )),
+    }
+}
+
+/// Returns the old row image required for a Snowflake delete row.
+fn snowflake_delete_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: Option<OldTableRow>,
+) -> EtlResult<SnowflakeDeleteRow> {
+    match old_table_row {
+        Some(OldTableRow::Full(row)) => Ok(SnowflakeDeleteRow::Full(row)),
+        Some(OldTableRow::Key(row)) => Ok(SnowflakeDeleteRow::Key(row)),
+        None => Err(etl_error!(
+            ErrorKind::SourceReplicaIdentityError,
+            "Snowflake delete requires an old row image",
+            format!(
+                "Table '{}' emitted a delete without an old row image. Snowflake deletes need \
+                 either a full old row or a key image.",
+                replicated_table_schema.name()
+            )
+        )),
+    }
+}
+
 impl<S, T, C> etl::destination::Destination for Destination<S, T, C>
 where
     S: DestinationStore,
@@ -475,5 +508,87 @@ where
             .await;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use etl::types::{
+        Cell, IdentityMask, PartialTableRow, ReplicationMask, TableName, TableSchema, Type,
+    };
+
+    use super::*;
+
+    fn replicated_schema() -> ReplicatedTableSchema {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_owned(), "users".to_owned()),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+            ],
+        ));
+        let replication_mask = ReplicationMask::all(&table_schema);
+        let identity_mask = IdentityMask::from_bytes(vec![1, 0]);
+
+        ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask)
+    }
+
+    #[test]
+    fn snowflake_update_row_accepts_full_new_row() {
+        let schema = replicated_schema();
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let result = snowflake_update_row(&schema, UpdatedTableRow::Full(row.clone())).unwrap();
+
+        assert_eq!(result, row);
+    }
+
+    #[test]
+    fn snowflake_update_row_rejects_partial_new_row() {
+        let schema = replicated_schema();
+        let partial_row = PartialTableRow::new(2, TableRow::new(vec![Cell::I32(1)]), vec![1]);
+
+        let error =
+            snowflake_update_row(&schema, UpdatedTableRow::Partial(partial_row)).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
+    }
+
+    #[test]
+    fn snowflake_delete_row_accepts_full_old_row() {
+        let schema = replicated_schema();
+        let row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let result = snowflake_delete_row(&schema, Some(OldTableRow::Full(row.clone()))).unwrap();
+
+        match result {
+            SnowflakeDeleteRow::Full(result) => assert_eq!(result, row),
+            SnowflakeDeleteRow::Key(_) => panic!("expected full old row"),
+        }
+    }
+
+    #[test]
+    fn snowflake_delete_row_accepts_key_only_old_row() {
+        let schema = replicated_schema();
+        let row = TableRow::new(vec![Cell::I32(1)]);
+
+        let result = snowflake_delete_row(&schema, Some(OldTableRow::Key(row.clone()))).unwrap();
+
+        match result {
+            SnowflakeDeleteRow::Key(result) => assert_eq!(result, row),
+            SnowflakeDeleteRow::Full(_) => panic!("expected key old row"),
+        }
+    }
+
+    #[test]
+    fn snowflake_delete_row_rejects_missing_old_row() {
+        let schema = replicated_schema();
+
+        let error = snowflake_delete_row(&schema, None).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::SourceReplicaIdentityError);
     }
 }

--- a/crates/etl-postgres/src/types/schema.rs
+++ b/crates/etl-postgres/src/types/schema.rs
@@ -915,25 +915,6 @@ impl ReplicatedTableSchema {
         self.identity_type
     }
 
-    /// Returns whether the runtime identity matches the table primary key.
-    ///
-    /// This is the semantic question destinations usually care about. A table
-    /// configured with `REPLICA IDENTITY USING INDEX` can still return `true`
-    /// here if the chosen index resolves to the same current columns as the
-    /// primary key.
-    ///
-    /// This comparison is structural over the runtime schema identity, not a
-    /// direct comparison of PostgreSQL identity modes or index OIDs. Because
-    /// ETL tracks DDL/schema changes, that gives the intended notion of
-    /// primary-key equivalence across schema evolution.
-    pub fn identity_matches_primary_key(&self) -> bool {
-        self.identity_mask.as_slice().iter().eq(Self::primary_key_identity_mask(
-            &self.table_schema,
-            &self.replication_mask,
-        )
-        .as_slice())
-    }
-
     /// Returns an iterator over only the column schemas that are being
     /// replicated.
     ///
@@ -1380,7 +1361,6 @@ mod tests {
         let replicated_table_schema = ReplicatedTableSchema::from_mask(schema, replication_mask);
 
         assert_eq!(replicated_table_schema.identity_type(), IdentityType::PrimaryKey);
-        assert!(replicated_table_schema.identity_matches_primary_key());
     }
 
     #[test]
@@ -1392,7 +1372,6 @@ mod tests {
             ReplicatedTableSchema::from_masks(schema, replication_mask, identity_mask);
 
         assert_eq!(replicated_table_schema.identity_type(), IdentityType::AlternativeKey);
-        assert!(!replicated_table_schema.identity_matches_primary_key());
     }
 
     #[test]
@@ -1404,7 +1383,6 @@ mod tests {
             ReplicatedTableSchema::from_masks(schema, replication_mask, identity_mask);
 
         assert_eq!(replicated_table_schema.identity_type(), IdentityType::Full);
-        assert!(!replicated_table_schema.identity_matches_primary_key());
     }
 
     #[test]
@@ -1416,7 +1394,6 @@ mod tests {
             ReplicatedTableSchema::from_masks(schema, replication_mask, identity_mask);
 
         assert_eq!(replicated_table_schema.identity_type(), IdentityType::Missing);
-        assert!(!replicated_table_schema.identity_matches_primary_key());
     }
 
     #[test]

--- a/crates/etl/src/conversions/event.rs
+++ b/crates/etl/src/conversions/event.rs
@@ -71,9 +71,8 @@ impl SchemaChangeMessage {
     /// detected. The snapshot_id should be the start_lsn of the DDL
     /// message.
     pub(crate) fn into_table_schema(self, snapshot_id: SnapshotId) -> TableSchema {
-        let table_id = self.table_id();
         build_table_schema(
-            table_id,
+            self.table_id(),
             TableName::new(self.nspname, self.relname),
             self.columns,
             self.identity.primary_key_attnums,

--- a/crates/etl/src/replication/client/raw.rs
+++ b/crates/etl/src/replication/client/raw.rs
@@ -513,7 +513,7 @@ impl PgReplicationClient {
 
     /// Retrieves the OIDs of all tables included in a publication.
     ///
-    /// This follows `pg_publication_tables`, which applies PostgreSQL's
+    /// This follows `pg_get_publication_tables`, which applies PostgreSQL's
     /// logical replication identity rules for partitioned tables. With
     /// `publish_via_partition_root=true`, PostgreSQL returns the published
     /// partition root or subtree root used for relation messages. With
@@ -531,13 +531,9 @@ impl PgReplicationClient {
     ) -> EtlResult<Vec<TableId>> {
         let query = format!(
             r#"
-            select distinct c.oid
-            from pg_publication_tables pt
-            join pg_class c on c.relname = pt.tablename
-            join pg_namespace n on n.oid = c.relnamespace
-             and n.nspname = pt.schemaname
-            where pt.pubname = {pub}
-            order by c.oid;
+            select distinct gpt.relid::oid as oid
+            from pg_get_publication_tables({pub}) gpt
+            order by oid;
             "#,
             pub = quote_literal(publication_name)
         );

--- a/crates/etl/src/replication/table_sync.rs
+++ b/crates/etl/src/replication/table_sync.rs
@@ -254,14 +254,6 @@ where
             let (table_schema, identity) =
                 replication_transaction.get_table_schema_with_identity(table_id).await?;
 
-            if !table_schema.has_primary_keys() {
-                bail!(
-                    ErrorKind::SourceSchemaError,
-                    "Primary key not found",
-                    format!("Table '{}' has no primary key", table_schema.name)
-                );
-            }
-
             // We store the table schema in the schema store to be able to retrieve it even
             // when the pipeline is restarted, since it's outside the lifecycle
             // of the pipeline.

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -1339,60 +1339,6 @@ async fn table_processing_converges_to_apply_loop_with_no_events_coming() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn table_without_primary_key_is_errored() {
-    init_test_tracing();
-    let database = spawn_source_database().await;
-
-    let table_name = test_table_name("no_primary_key_table");
-    let table_id =
-        database.create_table(table_name.clone(), false, &[("name", "text")]).await.unwrap();
-
-    let publication_name = "test_pub".to_owned();
-    database
-        .create_publication(&publication_name, std::slice::from_ref(&table_name))
-        .await
-        .expect("Failed to create publication");
-
-    // Insert a row to later check that this doesn't appear in destination's table
-    // rows.
-    database.insert_values(table_name.clone(), &["name"], &[&"abc"]).await.unwrap();
-
-    let state_store = NotifyingStore::new();
-    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(state_store.clone()));
-
-    let pipeline_id: PipelineId = random();
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name,
-        state_store.clone(),
-        destination.clone(),
-    );
-
-    // We wait for the table to be errored.
-    let errored_state =
-        state_store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
-
-    pipeline.start().await.unwrap();
-
-    // Insert a row to later check that it is not processed by the apply worker.
-    database.insert_values(table_name.clone(), &["name"], &[&"abc1"]).await.unwrap();
-
-    errored_state.notified().await;
-
-    pipeline.shutdown_and_wait().await.unwrap();
-
-    let table_state = state_store.get_table_state(table_id).await.unwrap().unwrap();
-    assert!(matches!(table_state, TableState::Errored { .. }));
-
-    // We expect the insert events to not be saved.
-    let events = destination.get_events().await;
-    let grouped_events = group_events_by_type_and_table_id(&events);
-    let insert_events = grouped_events.get(&(EventType::Insert, table_id));
-    assert!(insert_events.is_none());
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn pipeline_respects_column_level_publication() {
     init_test_tracing();
     let database = spawn_source_database().await;

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use etl::{
     error::ErrorKind,
     state::{TableState, TableStateType},
-    store::{schema::SchemaStore, state::StateStore},
+    store::schema::SchemaStore,
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::{EventCondition, group_events_by_type_and_table_id},


### PR DESCRIPTION
## Summary

- Adds source-aware destination validation so `/destinations/validate` can check a destination together with a source and pipeline publication.
- Adds destination-specific publication table compatibility checks for replica identity and source primary keys.
  - BigQuery and ClickHouse accept primary-key or full replica identity.
  - Iceberg and Snowflake require full replica identity.
  - DuckLake accepts primary-key, alternative-key, or full replica identity.
  - BigQuery and ClickHouse ReplacingMergeTree require source primary keys, and ClickHouse/BigQuery now reject publication column lists that omit source primary-key columns.
- Moves primary-key validation out of generic pipeline validation and into destination validation, so PK requirements match the selected destination.
- Improves validation failure messages across source, pipeline, and destination checks.
- Updates publication table discovery to use `pg_get_publication_tables`, aligning table OID lookup with PostgreSQL logical replication behavior for partitioned publications.
- Rework replica identity validation in destinations, that now fail only when they need a certain replica identity for resolving an operation. The rationale is to allow the `etl-api` to do all pre-flight checks and the pipeline should just try best effort to stream data and fail when it can't.