### PR TITLE
fix(xtask): better quote identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7978,6 +7978,7 @@ dependencies = [
  "etl-config",
  "k8s-openapi",
  "kube",
+ "pg_escape",
  "reqwest",
  "schemars 0.8.22",
  "serde",

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -11,6 +11,7 @@ etl-api = { path = "../etl-api", default-features = false }
 etl-config = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 kube = { workspace = true, features = ["client", "derive", "rustls-tls", "ring"] }
+pg_escape = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }
 schemars = "0.8"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/xtask/src/commands/benchmark.rs
+++ b/crates/xtask/src/commands/benchmark.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, ValueEnum};
+use pg_escape::{quote_identifier, quote_literal};
 use serde_json::{Map, Number, Value};
 
 const DEFAULT_DB_HOST: &str = "localhost";
@@ -307,7 +308,7 @@ impl BenchmarkArgs {
 
         self.psql_status(
             "postgres",
-            &format!("create database {}", quote_identifier(&self.database)?),
+            &format!("create database {}", quote_identifier(&self.database)),
         )
         .context("failed to create benchmark database")
     }
@@ -433,8 +434,8 @@ impl BenchmarkArgs {
     fn fetch_expected_row_count(&self, tables: &[String]) -> Result<u64> {
         let query = tables
             .iter()
-            .map(|table| Ok(format!("(select count(*) from {})", quote_identifier(table)?)))
-            .collect::<Result<Vec<_>>>()?
+            .map(|table| format!("(select count(*) from {})", quote_identifier(table)))
+            .collect::<Vec<_>>()
             .join(" + ");
         let count = self.psql_query(&self.database, &format!("select {query}"))?;
 
@@ -442,11 +443,11 @@ impl BenchmarkArgs {
     }
 
     fn create_publication(&self, publication_name: &str, tables: &[String]) -> Result<()> {
-        let publication_name = quote_identifier(publication_name)?;
+        let publication_name = quote_identifier(publication_name);
         let table_list = tables
             .iter()
-            .map(|table| quote_identifier(table))
-            .collect::<Result<Vec<_>>>()?
+            .map(|table| quote_identifier(table).into_owned())
+            .collect::<Vec<_>>()
             .join(", ");
         self.psql_status(
             &self.database,
@@ -459,7 +460,7 @@ impl BenchmarkArgs {
     }
 
     fn drop_publication(&self, publication_name: &str) -> Result<()> {
-        let publication_name = quote_identifier(publication_name)?;
+        let publication_name = quote_identifier(publication_name);
         self.psql_status(&self.database, &format!("drop publication if exists {publication_name}"))
             .context("failed to drop benchmark publication")
     }
@@ -1372,18 +1373,6 @@ fn format_integer(value: u64) -> String {
     }
 
     formatted
-}
-
-fn quote_identifier(identifier: &str) -> Result<String> {
-    if identifier.is_empty() {
-        bail!("identifier cannot be empty");
-    }
-
-    Ok(format!("\"{}\"", identifier.replace('"', "\"\"")))
-}
-
-fn quote_literal(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
 }
 
 #[cfg(test)]

--- a/crates/xtask/src/commands/seed.rs
+++ b/crates/xtask/src/commands/seed.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use clap::Args;
+use pg_escape::{quote_identifier, quote_literal};
 use xshell::{Shell, cmd};
 
 #[derive(Args)]
@@ -55,8 +56,7 @@ impl SeedArgs {
         let publication = &self.publication;
         let user_count = (self.rows / 10).max(10);
 
-        // Check if database exists
-        let check_sql = format!("SELECT 1 FROM pg_database WHERE datname = '{database}'");
+        let check_sql = database_exists_sql(database)?;
         let exists =
             cmd!(sh, "psql -q -h {host} -p {port} -U {user} -d postgres -tA -c {check_sql}")
                 .quiet()
@@ -70,7 +70,7 @@ impl SeedArgs {
 
         if db_exists {
             println!("[seed] dropping database {database} (--force)...");
-            let drop_sql = format!("DROP DATABASE IF EXISTS \"{database}\" WITH (FORCE)");
+            let drop_sql = drop_database_sql(database)?;
             cmd!(sh, "psql -q -h {host} -p {port} -U {user} -d postgres -c {drop_sql}")
                 .quiet()
                 .run()
@@ -78,14 +78,68 @@ impl SeedArgs {
         }
 
         println!("[seed] creating database {database}...");
-        let create_db = format!("CREATE DATABASE \"{database}\"");
+        let create_db = create_database_sql(database)?;
         cmd!(sh, "psql -q -h {host} -p {port} -U {user} -d postgres -c {create_db}")
             .quiet()
             .run()
             .context("failed to create database")?;
 
-        let sql = format!(
-            r#"
+        let sql = seed_sql(self.rows, user_count, publication)?;
+
+        println!(
+            "[seed] creating tables and seeding {rows} rows ({user_count} users, {rows} orders, \
+             {rows} events)...",
+            rows = self.rows
+        );
+
+        cmd!(sh, "psql -q -h {host} -p {port} -U {user} -d {database} -c {sql}")
+            .quiet()
+            .run()
+            .context("failed to seed database")?;
+
+        let count_sql = "SELECT 'users: ' || count(*) FROM users UNION ALL SELECT 'orders: ' || \
+                         count(*) FROM orders UNION ALL SELECT 'events: ' || count(*) FROM events";
+        let counts =
+            cmd!(sh, "psql -q -h {host} -p {port} -U {user} -d {database} -t -c {count_sql}")
+                .quiet()
+                .read()
+                .unwrap_or_default();
+
+        println!("[seed] done!");
+        for line in counts.lines() {
+            let line = line.trim();
+            if !line.is_empty() {
+                println!("  {line}");
+            }
+        }
+        println!("[seed] publication: {publication}");
+        println!("[seed] connect with: psql -h {host} -p {port} -U {user} -d {database}");
+
+        Ok(())
+    }
+}
+
+fn database_exists_sql(database: &str) -> Result<String> {
+    ensure_database_name(database)?;
+    Ok(format!("SELECT 1 FROM pg_database WHERE datname = {}", quote_literal(database)))
+}
+
+fn drop_database_sql(database: &str) -> Result<String> {
+    ensure_database_name(database)?;
+    Ok(format!("DROP DATABASE IF EXISTS {} WITH (FORCE)", quote_identifier(database)))
+}
+
+fn create_database_sql(database: &str) -> Result<String> {
+    ensure_database_name(database)?;
+    Ok(format!("CREATE DATABASE {}", quote_identifier(database)))
+}
+
+fn seed_sql(rows: u64, user_count: u64, publication: &str) -> Result<String> {
+    ensure_publication_name(publication)?;
+    let publication = quote_identifier(publication);
+
+    Ok(format!(
+        r#"
 CREATE TABLE users (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -147,39 +201,22 @@ SELECT
 FROM generate_series(1, {rows}) n;
 
 CREATE PUBLICATION {publication} FOR TABLE users, orders, events;
-"#,
-            rows = self.rows,
-        );
+"#
+    ))
+}
 
-        println!(
-            "[seed] creating tables and seeding {rows} rows ({user_count} users, {rows} orders, \
-             {rows} events)...",
-            rows = self.rows
-        );
+fn ensure_database_name(database: &str) -> Result<()> {
+    ensure_identifier_is_not_empty("Database", database)
+}
 
-        cmd!(sh, "psql -q -h {host} -p {port} -U {user} -d {database} -c {sql}")
-            .quiet()
-            .run()
-            .context("failed to seed database")?;
+fn ensure_publication_name(publication: &str) -> Result<()> {
+    ensure_identifier_is_not_empty("Publication", publication)
+}
 
-        let count_sql = "SELECT 'users: ' || count(*) FROM users UNION ALL SELECT 'orders: ' || \
-                         count(*) FROM orders UNION ALL SELECT 'events: ' || count(*) FROM events";
-        let counts =
-            cmd!(sh, "psql -q -h {host} -p {port} -U {user} -d {database} -t -c {count_sql}")
-                .quiet()
-                .read()
-                .unwrap_or_default();
-
-        println!("[seed] done!");
-        for line in counts.lines() {
-            let line = line.trim();
-            if !line.is_empty() {
-                println!("  {line}");
-            }
-        }
-        println!("[seed] publication: {publication}");
-        println!("[seed] connect with: psql -h {host} -p {port} -U {user} -d {database}");
-
-        Ok(())
+fn ensure_identifier_is_not_empty(kind: &str, identifier: &str) -> Result<()> {
+    if identifier.is_empty() {
+        bail!("{kind} name cannot be empty");
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- use `pg_escape` in `xtask` for Postgres identifier/literal quoting
- quote `cargo x seed` database and publication inputs before formatting SQL
- remove duplicate benchmark SQL quoting helpers in favor of `pg_escape`

