### PR TITLE
fix(api): correct pipeline endpoint error mapping

### DIFF
--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -107,6 +107,7 @@ impl From<DestinationPipelinesDbError> for DestinationPipelineError {
     fn from(e: DestinationPipelinesDbError) -> Self {
         match e {
             DestinationPipelinesDbError::Database(err)
+            | DestinationPipelinesDbError::PipelinesDb(PipelinesDbError::Database(err))
                 if data::utils::is_unique_constraint_violation_error(&err) =>
             {
                 DestinationPipelineError::DuplicatePipeline

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -1047,6 +1047,10 @@ pub(crate) async fn get_pipeline_version(
 
     let mut txn = pool.begin().await?;
 
+    data::pipelines::read_pipeline(txn.deref_mut(), tenant_id, pipeline_id)
+        .await?
+        .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
+
     let replicator =
         data::replicators::read_replicator_by_pipeline_id(txn.deref_mut(), tenant_id, pipeline_id)
             .await?

--- a/crates/etl-api/tests/destinations_pipelines.rs
+++ b/crates/etl-api/tests/destinations_pipelines.rs
@@ -1,4 +1,5 @@
 use etl_api::{
+    data,
     k8s::PodStatus,
     routes::{
         destinations::ReadDestinationResponse,
@@ -8,6 +9,7 @@ use etl_api::{
         },
         pipelines::ReadPipelineResponse,
     },
+    startup::get_connection_pool,
 };
 use etl_config::shared::PgConnectionConfig;
 use etl_postgres::sqlx::test_utils::drop_pg_database;
@@ -424,6 +426,57 @@ async fn destination_and_pipeline_with_another_tenants_source_cannot_be_updated(
 
     // Assert
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn updating_destination_pipeline_to_duplicate_source_destination_returns_conflict() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+    let tenant_id = &create_tenant(&app).await;
+    let image_id = create_default_image(&app).await;
+    let source1_id = create_source(&app, tenant_id).await;
+    let source2_id = create_source(&app, tenant_id).await;
+
+    let destination_pipeline = CreateDestinationPipelineRequest {
+        destination_name: new_name(),
+        destination_config: new_bigquery_destination_config(),
+        source_id: source1_id,
+        pipeline_config: new_pipeline_config(),
+    };
+    let response = app.create_destination_pipeline(tenant_id, &destination_pipeline).await;
+    assert!(response.status().is_success());
+    let response: CreateDestinationPipelineResponse =
+        response.json().await.expect("failed to deserialize response");
+    let CreateDestinationPipelineResponse { destination_id, pipeline_id } = response;
+
+    let pool = get_connection_pool(app.database_config());
+    let mut txn = pool.begin().await.expect("failed to begin transaction");
+    data::pipelines::create_pipeline(
+        &mut txn,
+        tenant_id,
+        source2_id,
+        destination_id,
+        image_id,
+        new_pipeline_config(),
+    )
+    .await
+    .expect("failed to create duplicate-conflict fixture pipeline");
+    txn.commit().await.expect("failed to commit transaction");
+
+    // Act
+    let destination_pipeline = UpdateDestinationPipelineRequest {
+        destination_name: updated_name(),
+        destination_config: updated_destination_config(),
+        source_id: source2_id,
+        pipeline_config: updated_pipeline_config(),
+    };
+    let response = app
+        .update_destination_pipeline(tenant_id, destination_id, pipeline_id, &destination_pipeline)
+        .await;
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -1657,6 +1657,20 @@ async fn pipeline_version_includes_new_default_version_when_available() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn pipeline_version_returns_not_found_for_missing_pipeline() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+
+    // Act
+    let response = app.get_pipeline_version(&tenant_id, 42).await;
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn rollback_tables_all_errored_succeeds() {
     init_test_tracing();
     let (app, tenant_id, pipeline_id, source_db_pool, source_db_config) =


### PR DESCRIPTION
## Summary

- Return 404 from `GET /pipelines/{id}/version` when the pipeline is missing.
- Preserve 500 for existing-pipeline/missing-replicator inconsistencies.
- Return 409 from combined destination-pipeline updates when the update hits the pipeline source/destination uniqueness constraint.