### PR TITLE
chore(deps): bump sqlx to 0.9.0 and rust to 1.95.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,7 +1362,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
@@ -1665,7 +1676,6 @@ dependencies = [
  "const-oid 0.9.6",
  "der_derive",
  "flagset",
- "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -1676,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
- "pem-rfc7468 1.0.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1930,13 +1940,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2075,7 +2084,7 @@ dependencies = [
  "parking_lot",
  "parquet",
  "pg_escape",
- "pkcs8 0.11.0",
+ "pkcs8",
  "prost",
  "r2d2",
  "rand 0.9.4",
@@ -2331,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2570,6 +2579,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2689,6 +2699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,7 +2719,7 @@ dependencies = [
  "http 1.4.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -2737,11 +2756,11 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2910,7 +2929,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2959,7 +2978,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3525,9 +3544,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -3745,6 +3761,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,22 +3974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,17 +3994,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -4224,7 +4223,7 @@ dependencies = [
  "http-body",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
@@ -4434,15 +4433,6 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
@@ -4588,17 +4578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
 name = "pkcs5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4612,16 +4591,6 @@ dependencies = [
  "scrypt",
  "sha2 0.11.0",
  "spki 0.8.0",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
 ]
 
 [[package]]
@@ -4683,7 +4652,7 @@ dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
  "hmac 0.12.1",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "rand 0.8.6",
  "sha2 0.10.9",
@@ -4918,7 +4887,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5017,6 +4986,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5196,7 +5176,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tokio",
 ]
@@ -5246,7 +5226,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5300,26 +5280,6 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "signature",
- "spki 0.7.3",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -5992,6 +5952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6044,7 +6015,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6150,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decccfa5f2f3eac95eb68085cfe69a0172fa9711666c3a634cfc806d4fb74a47"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -6163,9 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86854e8c6aba0dafcf1c04b4836b0b7fa3a20c560e3554567afefe1258fa4e60"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
@@ -6180,7 +6150,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.16.1",
- "hashlink 0.10.0",
+ "hashlink 0.11.1",
  "indexmap 2.14.0",
  "log",
  "memchr",
@@ -6195,14 +6165,14 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7aab9442ed1568e3aed6c368737226ee4e0e8d1deb0e0887fa6bf15282ace44"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6213,9 +6183,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34eb4976b8f02ac57ee98d4ce40cd1aad7ab31d9792977bc3171f787ba6ba2fb"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
  "cfg-if",
  "dotenvy",
@@ -6239,51 +6209,36 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fef16f3d52a3710a672b48175b713e86476e2df85576a753c8b37ad11a483c0"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5",
- "memchr",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053cf36ecb2793a9d9bb02d01bbad1ef66481d5db6ff5ab2dfb7b070cc0d13c"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -6298,33 +6253,33 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.12.1",
- "home",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
+ "whoami 2.1.2",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.9.0-alpha.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2cd6cee87120b1e1dd31356b5589911995c777707e49f2750eec7c7fe43eef"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -6334,7 +6289,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -6728,7 +6682,7 @@ dependencies = [
  "socket2 0.5.10",
  "tokio",
  "tokio-util",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -7470,15 +7424,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -7496,6 +7441,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.package]
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.93.1"
+rust-version = "1.95.0"
 repository = "https://github.com/supabase/etl"
 homepage = "https://supabase.github.io/etl/"
 
@@ -118,8 +118,7 @@ sentry = { version = "0.42.0" }
 serde = { version = "1.0.219", default-features = false }
 serde_json = { version = "1.0.141", default-features = false }
 sha2 = { version = "0.11", default-features = false }
-# Use the 0.9 alpha for the rustls VerifyCa fix in https://github.com/launchbadge/sqlx/pull/3861.
-sqlx = { version = "0.9.0-alpha.1", default-features = false }
+sqlx = { version = "0.9.0", default-features = false }
 sysinfo = { version = "0.38.2", default-features = false }
 tempfile = { version = "3.23.0", default-features = false }
 thiserror = "2.0.12"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,7 @@ Before starting, ensure you have the following installed:
 Install SQLx CLI:
 
 ```bash
-cargo install --version 0.9.0-alpha.1 sqlx-cli --no-default-features --features rustls,postgres --locked
+cargo install --version 0.9.0 sqlx-cli --no-default-features --features rustls,postgres --locked
 ```
 
 ### Optional Tools

--- a/crates/etl-api/Dockerfile
+++ b/crates/etl-api/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage with cargo-chef for better layer caching.
 # Native build: each runner builds for its own architecture.
-FROM rust:1.93.1-slim-bookworm AS chef
+FROM rust:1.95.0-slim-bookworm AS chef
 WORKDIR /app
 RUN cargo install cargo-chef --version 0.1.72 --locked
 

--- a/crates/etl-api/tests/support/database.rs
+++ b/crates/etl-api/tests/support/database.rs
@@ -203,14 +203,14 @@ pub(crate) async fn run_etl_migrations_on_source_database(source_db_config: &PgC
     let mut store_migrator = sqlx::migrate!("../etl/migrations/postgres_store");
     store_migrator.set_ignore_missing(true);
     store_migrator
-        .run_direct(None, &mut connection)
+        .run_direct(None, &mut connection, false)
         .await
         .expect("failed to run ETL Postgres store migrations");
 
     let mut source_migrator = sqlx::migrate!("../etl/migrations/source");
     source_migrator.set_ignore_missing(true);
     source_migrator
-        .run_direct(None, &mut connection)
+        .run_direct(None, &mut connection, false)
         .await
         .expect("failed to run ETL source migrations");
 }

--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -787,7 +787,10 @@ pub async fn run_etl_migrations(args: &PgConnectionArgs) -> Result<()> {
 
     let mut migrator = sqlx::migrate!("../etl/migrations/source");
     migrator.set_ignore_missing(true);
-    migrator.run_direct(None, &mut connection).await.context("failed to run ETL migrations")?;
+    migrator
+        .run_direct(None, &mut connection, false)
+        .await
+        .context("failed to run ETL migrations")?;
 
     Ok(())
 }

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -333,8 +333,7 @@ fn storage_write_metadata_lag_timeout_error(detail: &str) -> EtlError {
 /// Converts BigQuery row errors to ETL destination errors.
 fn row_error_to_etl_error(err: RowError) -> EtlError {
     let code = RowErrorCode::try_from(err.code)
-        .map(|code| code.as_str_name())
-        .unwrap_or("UNKNOWN_ROW_ERROR_CODE");
+        .map_or("UNKNOWN_ROW_ERROR_CODE", |code| code.as_str_name());
 
     etl_error!(
         ErrorKind::DestinationError,

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1761,8 +1761,7 @@ fn calculate_target_batches_for_table_copy(table_rows: &[BigQueryTableRow]) -> E
     let estimated_row_size = encoded_row.encoded_len();
 
     // Calculate how many rows would fit in target batch size.
-    let rows_per_batch =
-        if estimated_row_size > 0 { MAX_BATCH_SIZE_BYTES / estimated_row_size } else { total_rows };
+    let rows_per_batch = MAX_BATCH_SIZE_BYTES.checked_div(estimated_row_size).unwrap_or(total_rows);
 
     // Calculate target number of batches, ensuring at least 1. We don't care about
     // the limit of inflight requests since that is enforced by the client.

--- a/crates/etl-destinations/src/ducklake/config.rs
+++ b/crates/etl-destinations/src/ducklake/config.rs
@@ -285,7 +285,7 @@ fn ensure_vendored_extension_dir(directory: &Path) -> EtlResult<()> {
 }
 
 fn vendored_extension_path(extension_dir: &Path, filename: &str) -> EtlResult<String> {
-    extension_dir.join(filename).to_str().map(std::string::ToString::to_string).ok_or_else(|| {
+    extension_dir.join(filename).to_str().map(str::to_owned).ok_or_else(|| {
         etl_error!(
             ErrorKind::ConfigError,
             "Vendored DuckDB extension path contains non-utf8 characters",

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -3278,8 +3278,7 @@ mod tests {
             [],
             |row| row.get::<_, i64>(0),
         )
-        .map(|count| count > 0)
-        .unwrap_or(false)
+        .is_ok_and(|count| count > 0)
     }
 
     async fn open_lake_conn_when_table_visible(

--- a/crates/etl-destinations/tests/ducklake/destination.rs
+++ b/crates/etl-destinations/tests/ducklake/destination.rs
@@ -146,8 +146,7 @@ fn lake_table_exists(conn: &Connection, table_name: &str) -> bool {
         [],
         |row| row.get::<_, i64>(0),
     )
-    .map(|count| count > 0)
-    .unwrap_or(false)
+    .is_ok_and(|count| count > 0)
 }
 
 async fn open_lake_conn_when_tables_visible(

--- a/crates/etl-destinations/tests/support/bigquery.rs
+++ b/crates/etl-destinations/tests/support/bigquery.rs
@@ -235,7 +235,7 @@ impl From<TableRow> for NullableColsScalar {
         fn parse_unix_timestamp_from_cell(table_cell: TableCell) -> Option<DateTime<Utc>> {
             table_cell
                 .value
-                .and_then(|v| v.as_str().map(ToString::to_string))
+                .and_then(|v| v.as_str().map(str::to_owned))
                 .and_then(|s| s.parse::<f64>().ok())
                 .and_then(|timestamp| {
                     let secs = timestamp.trunc() as i64;
@@ -660,7 +660,7 @@ impl From<TableRow> for NonNullableColsScalar {
         fn parse_unix_timestamp_from_cell(table_cell: TableCell) -> DateTime<Utc> {
             table_cell
                 .value
-                .and_then(|v| v.as_str().map(ToString::to_string))
+                .and_then(|v| v.as_str().map(str::to_owned))
                 .and_then(|s| s.parse::<f64>().ok())
                 .and_then(|timestamp| {
                     let secs = timestamp.trunc() as i64;

--- a/crates/etl-maintenance/src/coordination/postgres.rs
+++ b/crates/etl-maintenance/src/coordination/postgres.rs
@@ -96,7 +96,7 @@ impl PostgresExternalMaintenanceStore {
             sqlx_error(error, "Failed to configure external maintenance migration search path")
         })?;
 
-        postgres_migrator().run_direct(None, &mut *connection).await.map_err(|error| {
+        postgres_migrator().run_direct(None, &mut *connection, false).await.map_err(|error| {
             migration_error(error, "Failed to run external maintenance migrations")
         })?;
 

--- a/crates/etl-maintenance/src/ducklake/runner.rs
+++ b/crates/etl-maintenance/src/ducklake/runner.rs
@@ -292,7 +292,7 @@ fn ensure_vendored_extension_dir(directory: &Path) -> EtlResult<()> {
 }
 
 fn vendored_extension_path(extension_dir: &Path, filename: &str) -> EtlResult<String> {
-    extension_dir.join(filename).to_str().map(std::string::ToString::to_string).ok_or_else(|| {
+    extension_dir.join(filename).to_str().map(str::to_owned).ok_or_else(|| {
         etl_error!(
             ErrorKind::ConfigError,
             "Vendored DuckDB extension path contains non-utf8 characters",

--- a/crates/etl-postgres/src/test_utils.rs
+++ b/crates/etl-postgres/src/test_utils.rs
@@ -7,8 +7,7 @@ const DEFAULT_DATABASE_TLS_ROOT_CERT: &str = "target/postgres-tls/root.crt";
 /// Returns whether test database clients should require TLS.
 pub fn test_tls_enabled_from_env() -> bool {
     std::env::var("TESTS_DATABASE_TLS_ENABLED")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
-        .unwrap_or(false)
+        .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
 }
 
 /// Returns TLS settings for local test database clients.

--- a/crates/etl-replicator/Dockerfile
+++ b/crates/etl-replicator/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage with cargo-chef for better layer caching.
 # Native build: each runner builds for its own architecture.
-FROM rust:1.93.1-slim-bookworm AS chef
+FROM rust:1.95.0-slim-bookworm AS chef
 WORKDIR /app
 RUN cargo install cargo-chef --version 0.1.72 --locked
 

--- a/crates/etl/src/conversions/event.rs
+++ b/crates/etl/src/conversions/event.rs
@@ -331,7 +331,7 @@ pub(crate) fn parse_replicated_column_names(
     let column_names = relation_body
         .columns()
         .iter()
-        .map(|column| column.name().map(ToString::to_string))
+        .map(|column| column.name().map(str::to_owned))
         .collect::<Result<HashSet<String>, _>>()?;
 
     Ok(column_names)
@@ -355,7 +355,7 @@ pub(crate) fn parse_replica_identity_column_names(
         protocol::ReplicaIdentity::Full => relation_body
             .columns()
             .iter()
-            .map(|column| column.name().map(ToString::to_string))
+            .map(|column| column.name().map(str::to_owned))
             .collect::<Result<HashSet<String>, _>>()?,
         _ => relation_body
             .columns()
@@ -364,7 +364,7 @@ pub(crate) fn parse_replica_identity_column_names(
             // LOGICALREP_IS_REPLICA_IDENTITY, so `& 1` tests only that bit
             // while ignoring any other protocol flags that may be present.
             .filter(|column| column.flags() & 1 == 1)
-            .map(|column| column.name().map(ToString::to_string))
+            .map(|column| column.name().map(str::to_owned))
             .collect::<Result<HashSet<String>, _>>()?,
     };
 

--- a/crates/etl/src/migrations.rs
+++ b/crates/etl/src/migrations.rs
@@ -69,7 +69,7 @@ async fn run_migration_set(
     let mut conn = create_migration_connection(connection_config).await?;
 
     debug!(migration_set = label, "applying ETL migrations");
-    migrator.run_direct(None, &mut conn).await?;
+    migrator.run_direct(None, &mut conn, false).await?;
     debug!(migration_set = label, "ETL migrations successfully applied");
 
     Ok(())

--- a/crates/etl/tests/migrations.rs
+++ b/crates/etl/tests/migrations.rs
@@ -270,7 +270,7 @@ async fn postgres_store_schema_storage_migration_round_trips_old_state() {
     let database = spawn_unmigrated_database().await;
 
     let mut conn = migration_connection(&database.config).await;
-    postgres_store_migrator().run_direct(None, &mut conn).await.unwrap();
+    postgres_store_migrator().run_direct(None, &mut conn, false).await.unwrap();
     postgres_store_migrator().undo(&mut conn, POSTGRES_STORE_BASE_VERSION).await.unwrap();
     drop(conn);
 
@@ -353,7 +353,7 @@ async fn postgres_store_schema_storage_migration_round_trips_old_state() {
         .unwrap();
 
     let mut conn = migration_connection(&database.config).await;
-    postgres_store_migrator().run_direct(None, &mut conn).await.unwrap();
+    postgres_store_migrator().run_direct(None, &mut conn, false).await.unwrap();
     drop(conn);
 
     let migrated_columns: String = client

--- a/crates/xtask/src/commands/benchmark.rs
+++ b/crates/xtask/src/commands/benchmark.rs
@@ -788,8 +788,9 @@ fn recommended_threads(warehouses: u16) -> u16 {
     let warehouse_threads =
         usize::from(warehouses).saturating_mul(DEFAULT_TPCC_THREADS_PER_WAREHOUSE);
     let cpu_threads = std::thread::available_parallelism()
-        .map(|parallelism| parallelism.get().saturating_mul(DEFAULT_TPCC_THREADS_PER_CPU))
-        .unwrap_or(DEFAULT_TPCC_MIN_THREADS);
+        .map_or(DEFAULT_TPCC_MIN_THREADS, |parallelism| {
+            parallelism.get().saturating_mul(DEFAULT_TPCC_THREADS_PER_CPU)
+        });
     warehouse_threads.max(cpu_threads).clamp(DEFAULT_TPCC_MIN_THREADS, DEFAULT_TPCC_MAX_THREADS)
         as u16
 }

--- a/docs/src/content/docs/guides/first-pipeline.md
+++ b/docs/src/content/docs/guides/first-pipeline.md
@@ -17,7 +17,7 @@ A real-time data pipeline that:
 
 ## Prerequisites
 
-- Rust toolchain 1.93.1, matching `rust-toolchain.toml`
+- Rust toolchain 1.95.0, matching `rust-toolchain.toml`
 - Postgres 14+ with logical replication enabled (`wal_level = logical` in `postgresql.conf`)
 - Basic familiarity with Rust and SQL
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
Updates sqlx to a stable release `0.9.0-alpha.1 -> 0.9.0`. Since sqlx `0.9.0` requires MSRV `1.94.0`, update rust version as well `1.93.1 -> 1.95.0`.

Related issue: https://github.com/supabase/etl/issues/821