### PR TITLE
ref(api): Improve api status codes

### DIFF
--- a/crates/etl-api/src/http_metrics.rs
+++ b/crates/etl-api/src/http_metrics.rs
@@ -21,6 +21,10 @@ const ENDPOINT_LABEL: &str = "endpoint";
 const METHOD_LABEL: &str = "method";
 /// Response status label key.
 const STATUS_LABEL: &str = "status";
+/// Bounded label for unmatched API requests.
+const UNMATCHED_API_ENDPOINT: &str = "/v1/__unmatched__";
+/// Bounded label for unmatched non-API requests.
+const UNMATCHED_ENDPOINT: &str = "__unmatched__";
 
 /// Records request count and latency metrics for each HTTP response.
 pub(crate) async fn record_http_metrics(request: Request, next: Next) -> Response {
@@ -55,8 +59,15 @@ fn register_http_metrics() {
 
 /// Returns the low-cardinality route pattern for a request.
 fn request_endpoint(request: &Request) -> String {
-    request
-        .extensions()
-        .get::<MatchedPath>()
-        .map_or_else(|| request.uri().path().to_owned(), |path| path.as_str().to_owned())
+    request.extensions().get::<MatchedPath>().map_or_else(
+        || {
+            let path = request.uri().path();
+            if path == "/v1" || path.starts_with("/v1/") {
+                UNMATCHED_API_ENDPOINT.to_owned()
+            } else {
+                UNMATCHED_ENDPOINT.to_owned()
+            }
+        },
+        |path| path.as_str().to_owned(),
+    )
 }

--- a/crates/etl-api/src/routes/destinations.rs
+++ b/crates/etl-api/src/routes/destinations.rs
@@ -422,9 +422,9 @@ pub(crate) async fn read_all_destinations(
         (status = 200, description = "Validation completed", body = ValidateDestinationResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
-        (status = 502, description = "Destination or source dependency returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Destination or source dependency unavailable", body = ErrorMessage),
-        (status = 504, description = "Destination or source dependency request timed out", body = ErrorMessage),
+        (status = 502, description = "Destination dependency or your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Destination dependency or your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to destination dependency or your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations"

--- a/crates/etl-api/src/routes/destinations.rs
+++ b/crates/etl-api/src/routes/destinations.rs
@@ -242,6 +242,7 @@ pub(crate) async fn create_destination(
     ),
     responses(
         (status = 200, description = "Destination retrieved successfully", body = ReadDestinationResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Destination not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
@@ -282,6 +283,7 @@ pub(crate) async fn read_destination(
     ),
     responses(
         (status = 200, description = "Destination updated successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Destination not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
@@ -323,6 +325,7 @@ pub(crate) async fn update_destination(
     ),
     responses(
         (status = 200, description = "Destination deleted successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 409, description = "Destination has an active pipeline or is still used by pipelines", body = ErrorMessage),
         (status = 404, description = "Destination not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
@@ -373,6 +376,7 @@ pub(crate) async fn delete_destination(
     description = "Returns all destinations for the specified tenant.",
     responses(
         (status = 200, description = "Destinations listed successfully", body = ReadDestinationsResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     params(
@@ -417,6 +421,10 @@ pub(crate) async fn read_all_destinations(
     responses(
         (status = 200, description = "Validation completed", body = ValidateDestinationResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source not found", body = ErrorMessage),
+        (status = 502, description = "Destination or source dependency returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Destination or source dependency unavailable", body = ErrorMessage),
+        (status = 504, description = "Destination or source dependency request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations"

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -251,7 +251,7 @@ fn validate_pipeline_request(
     ),
     responses(
         (status = 200, description = "Destination and pipeline created successfully", body = CreateDestinationPipelineResponse),
-        (status = 409, description = "Conflict – a pipeline already exists for this source and destination or tenant pipeline limit reached", body = ErrorMessage),
+        (status = 409, description = "Conflict: a pipeline already exists for this source and destination or tenant pipeline limit reached", body = ErrorMessage),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
@@ -331,7 +331,7 @@ pub(crate) async fn create_destination_and_pipeline(
         (status = 200, description = "Destination and pipeline updated successfully"),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source, pipeline, destination, or destination-pipeline link not found", body = ErrorMessage),
-        (status = 409, description = "Conflict – a pipeline already exists for this source and destination", body = ErrorMessage),
+        (status = 409, description = "Conflict: a pipeline already exists for this source and destination", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations and Pipelines"

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -29,8 +29,8 @@ use crate::{
         images::ImagesDbError,
         pipelines::{
             MAX_PIPELINES_PER_TENANT, PipelinesDbError, count_pipelines_for_tenant,
-            delete_pipeline_api_and_source_state, delete_pipeline_api_state,
-            delete_pipeline_replication_slots, read_pipeline, read_pipeline_for_deletion,
+            delete_pipeline_api_state, delete_pipeline_replication_slots,
+            delete_pipeline_source_state, read_pipeline, read_pipeline_for_deletion,
             read_pipelines_for_destination_for_deletion,
         },
         sources::SourcesDbError,
@@ -87,6 +87,12 @@ pub(crate) enum DestinationPipelineError {
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
 
+    #[error("Source database error: {0}")]
+    SourceDatabase(sqlx::Error),
+
+    #[error("Source pipeline state operation failed: {0}")]
+    SourcePipelineState(PipelinesDbError),
+
     #[error(transparent)]
     TrustedRootCerts(#[from] TrustedRootCertsError),
 
@@ -130,7 +136,12 @@ impl DestinationPipelineError {
             | DestinationPipelineError::PipelinesDb(PipelinesDbError::Database(_))
             | DestinationPipelineError::Database(_)
             | DestinationPipelineError::NoDefaultImageFound
+            | DestinationPipelineError::TrustedRootCerts(_)
             | DestinationPipelineError::K8sCore(_) => "Internal server error".to_owned(),
+            DestinationPipelineError::SourceDatabase(_)
+            | DestinationPipelineError::SourcePipelineState(_) => {
+                "Could not query the source database".to_owned()
+            }
             DestinationPipelineError::Validation(error) => {
                 utils::validation_error_message(error).to_owned()
             }
@@ -152,14 +163,23 @@ impl IntoResponse for DestinationPipelineError {
             | DestinationPipelineError::Database(_)
             | DestinationPipelineError::K8sCore(_)
             | DestinationPipelineError::TrustedRootCerts(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            DestinationPipelineError::SourceDatabase(error) => {
+                utils::source_database_error_status_code(error)
+            }
+            DestinationPipelineError::SourcePipelineState(error) => match error {
+                PipelinesDbError::Database(error) => {
+                    utils::source_database_error_status_code(error)
+                }
+                _ => StatusCode::BAD_GATEWAY,
+            },
             DestinationPipelineError::Validation(error) => {
                 utils::validation_error_status_code(error)
             }
-            DestinationPipelineError::TenantId(_)
-            | DestinationPipelineError::SourceNotFound(_)
+            DestinationPipelineError::SourceNotFound(_)
             | DestinationPipelineError::DestinationNotFound(_)
             | DestinationPipelineError::PipelineNotFound(_)
-            | DestinationPipelineError::PipelineDestinationMismatch(_, _)
+            | DestinationPipelineError::PipelineDestinationMismatch(_, _) => StatusCode::NOT_FOUND,
+            DestinationPipelineError::TenantId(_)
             | DestinationPipelineError::InvalidPipelineRequest(_) => StatusCode::BAD_REQUEST,
             DestinationPipelineError::DuplicatePipeline
             | DestinationPipelineError::ActivePipeline(_) => StatusCode::CONFLICT,
@@ -235,6 +255,8 @@ fn validate_pipeline_request(
         (status = 200, description = "Destination and pipeline created successfully", body = CreateDestinationPipelineResponse),
         (status = 409, description = "Conflict – a pipeline already exists for this source and destination", body = ErrorMessage),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source not found", body = ErrorMessage),
+        (status = 422, description = "Pipeline limit reached", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations and Pipelines"
@@ -310,8 +332,9 @@ pub(crate) async fn create_destination_and_pipeline(
     ),
     responses(
         (status = 200, description = "Destination and pipeline updated successfully"),
-        (status = 404, description = "Pipeline or destination not found", body = ErrorMessage),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source, pipeline, destination, or destination-pipeline link not found", body = ErrorMessage),
+        (status = 409, description = "Conflict – a pipeline already exists for this source and destination", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations and Pipelines"
@@ -393,8 +416,11 @@ pub(crate) async fn update_destination_and_pipeline(
     responses(
         (status = 200, description = "Pipeline deleted successfully, with destination deletion status included in the response body", body = DeleteDestinationPipelineResponse),
         (status = 409, description = "Pipeline is active", body = ErrorMessage),
-        (status = 404, description = "Pipeline or destination not found", body = ErrorMessage),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source, pipeline, destination, or destination-pipeline link not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations and Pipelines"
@@ -456,18 +482,15 @@ pub(crate) async fn delete_destination_and_pipeline(
     };
     let mut api_txn = pool.begin().await?;
     let mut source_txn = if let Some(source_pool) = source_pool.as_ref() {
-        Some(source_pool.begin().await?)
+        Some(source_pool.begin().await.map_err(DestinationPipelineError::SourceDatabase)?)
     } else {
         None
     };
     if let Some(source_txn) = source_txn.as_mut() {
-        delete_pipeline_api_and_source_state(
-            api_txn.deref_mut(),
-            source_txn.deref_mut(),
-            tenant_id,
-            &pipeline,
-        )
-        .await?;
+        delete_pipeline_api_state(api_txn.deref_mut(), tenant_id, &pipeline).await?;
+        delete_pipeline_source_state(source_txn.deref_mut(), pipeline.id)
+            .await
+            .map_err(DestinationPipelineError::SourcePipelineState)?;
     } else {
         delete_pipeline_api_state(api_txn.deref_mut(), tenant_id, &pipeline).await?;
     }
@@ -488,10 +511,12 @@ pub(crate) async fn delete_destination_and_pipeline(
     // reference pipeline state that no longer exists in the source database.
     api_txn.commit().await?;
     if let Some(source_txn) = source_txn {
-        source_txn.commit().await?;
+        source_txn.commit().await.map_err(DestinationPipelineError::SourceDatabase)?;
     }
     if let Some(source_pool) = source_pool.as_ref() {
-        delete_pipeline_replication_slots(source_pool, pipeline.id).await?;
+        delete_pipeline_replication_slots(source_pool, pipeline.id)
+            .await
+            .map_err(DestinationPipelineError::SourcePipelineState)?;
     }
 
     Ok(Json(DeleteDestinationPipelineResponse {

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -140,7 +140,7 @@ impl DestinationPipelineError {
             | DestinationPipelineError::K8sCore(_) => "Internal server error".to_owned(),
             DestinationPipelineError::SourceDatabase(_)
             | DestinationPipelineError::SourcePipelineState(_) => {
-                "Could not query the source database".to_owned()
+                "Could not query your source database".to_owned()
             }
             DestinationPipelineError::Validation(error) => {
                 utils::validation_error_message(error).to_owned()
@@ -415,9 +415,9 @@ pub(crate) async fn update_destination_and_pipeline(
         (status = 409, description = "Pipeline is active", body = ErrorMessage),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source, pipeline, destination, or destination-pipeline link not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations and Pipelines"

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -182,10 +182,8 @@ impl IntoResponse for DestinationPipelineError {
             DestinationPipelineError::TenantId(_)
             | DestinationPipelineError::InvalidPipelineRequest(_) => StatusCode::BAD_REQUEST,
             DestinationPipelineError::DuplicatePipeline
-            | DestinationPipelineError::ActivePipeline(_) => StatusCode::CONFLICT,
-            DestinationPipelineError::PipelineLimitReached { .. } => {
-                StatusCode::UNPROCESSABLE_ENTITY
-            }
+            | DestinationPipelineError::ActivePipeline(_)
+            | DestinationPipelineError::PipelineLimitReached { .. } => StatusCode::CONFLICT,
         };
 
         error_response_with_internal_error(status_code, self.to_message(), &self)
@@ -253,10 +251,9 @@ fn validate_pipeline_request(
     ),
     responses(
         (status = 200, description = "Destination and pipeline created successfully", body = CreateDestinationPipelineResponse),
-        (status = 409, description = "Conflict – a pipeline already exists for this source and destination", body = ErrorMessage),
+        (status = 409, description = "Conflict – a pipeline already exists for this source and destination or tenant pipeline limit reached", body = ErrorMessage),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
-        (status = 422, description = "Pipeline limit reached", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Destinations and Pipelines"

--- a/crates/etl-api/src/routes/images.rs
+++ b/crates/etl-api/src/routes/images.rs
@@ -38,7 +38,7 @@ impl ImageError {
 impl IntoResponse for ImageError {
     fn into_response(self) -> Response {
         let status_code = match &self {
-            ImageError::ImagesDb(ImagesDbError::CannotDeleteDefault) => StatusCode::BAD_REQUEST,
+            ImageError::ImagesDb(ImagesDbError::CannotDeleteDefault) => StatusCode::CONFLICT,
             ImageError::ImagesDb(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ImageError::ImageNotFound(_) => StatusCode::NOT_FOUND,
         };
@@ -182,6 +182,7 @@ pub(crate) async fn update_image(
     ),
     responses(
         (status = 200, description = "Image deleted successfully"),
+        (status = 409, description = "Image is the current default", body = ErrorMessage),
         (status = 404, description = "Image not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),

--- a/crates/etl-api/src/routes/metrics.rs
+++ b/crates/etl-api/src/routes/metrics.rs
@@ -5,7 +5,7 @@ use metrics_exporter_prometheus::PrometheusHandle;
     get,
     path = "/metrics",
     summary = "Get prometheus metrics",
-    description = "Returns prometheus metrics collected since the last call to this endpoint.",
+    description = "Returns the current prometheus metrics snapshot.",
     responses(
         (status = 200, description = "Metrics returned successfully", body = String),
     ),

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -1282,7 +1282,7 @@ pub(crate) async fn get_pipeline_replication_status(
     ),
     responses(
         (status = 200, description = "Table state(s) rolled back successfully", body = RollbackTablesResponse),
-        (status = 400, description = "Bad request – state not rollbackable", body = ErrorMessage),
+        (status = 400, description = "Bad request: state not rollbackable", body = ErrorMessage),
         (status = 404, description = "Pipeline or table not found", body = ErrorMessage),
         (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
         (status = 503, description = "Source database unavailable", body = ErrorMessage),

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -203,7 +203,7 @@ impl PipelineError {
             ) => "Internal server error".to_owned(),
             PipelineError::SourceDatabase(_)
             | PipelineError::SourcePipelineState(_)
-            | PipelineError::TableLookup(_) => "Could not query the source database".to_owned(),
+            | PipelineError::TableLookup(_) => "Could not query your source database".to_owned(),
             PipelineError::Validation(error) => {
                 route_utils::validation_error_message(error).to_owned()
             }
@@ -580,7 +580,7 @@ pub struct ValidatePipelineRequest {
 pub struct ValidationFailureResponse {
     #[schema(example = "Publication Not Found")]
     pub name: String,
-    #[schema(example = "Publication 'my_publication' does not exist in the source database")]
+    #[schema(example = "Publication 'my_publication' does not exist in your source database")]
     pub reason: String,
     #[schema(example = "critical")]
     pub failure_type: FailureType,
@@ -820,9 +820,9 @@ pub(crate) async fn update_pipeline(
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 409, description = "Pipeline is active", body = ErrorMessage),
         (status = 404, description = "Pipeline or source not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -1178,9 +1178,9 @@ pub(crate) async fn get_pipeline_status(
         (status = 200, description = "Replication status retrieved successfully", body = GetPipelineReplicationStatusResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Pipeline not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -1284,9 +1284,9 @@ pub(crate) async fn get_pipeline_replication_status(
         (status = 200, description = "Table state(s) rolled back successfully", body = RollbackTablesResponse),
         (status = 400, description = "Bad request: state not rollbackable", body = ErrorMessage),
         (status = 404, description = "Pipeline or table not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -1536,7 +1536,7 @@ pub(crate) async fn update_pipeline_version(
     post,
     path = "/pipelines/validate",
     summary = "Validate pipeline configuration",
-    description = "Validates pipeline prerequisites against the source database.",
+    description = "Validates pipeline prerequisites against your source database.",
     request_body = ValidatePipelineRequest,
     params(
         ("tenant_id" = String, Header, description = "Tenant ID used to scope the request")
@@ -1545,9 +1545,9 @@ pub(crate) async fn update_pipeline_version(
         (status = 200, description = "Validation completed", body = ValidatePipelineResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -25,9 +25,9 @@ use crate::{
         destinations::{DestinationsDbError, destination_exists},
         images::ImagesDbError,
         pipelines::{
-            MAX_PIPELINES_PER_TENANT, PipelinesDbError, delete_pipeline_api_and_source_state,
-            delete_pipeline_api_state, delete_pipeline_replication_slots, read_pipeline_components,
-            read_pipeline_for_deletion,
+            MAX_PIPELINES_PER_TENANT, PipelinesDbError, delete_pipeline_api_state,
+            delete_pipeline_replication_slots, delete_pipeline_source_state,
+            read_pipeline_components, read_pipeline_for_deletion,
         },
         replicators::ReplicatorsDbError,
         sources::SourcesDbError,
@@ -125,6 +125,12 @@ pub enum PipelineError {
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
 
+    #[error("Source database error: {0}")]
+    SourceDatabase(sqlx::Error),
+
+    #[error("Source pipeline state operation failed: {0}")]
+    SourcePipelineState(PipelinesDbError),
+
     #[error("Could not load app environment")]
     MissingEnvironment,
 
@@ -176,12 +182,11 @@ impl PipelineError {
             // Do not expose internal details in error messages. These all map to 500 status
             // codes and the underlying causes (database, k8s, replicator/image plumbing,
             // missing config) are not actionable by the user.
-            PipelineError::SourcesDb(SourcesDbError::Database(_))
-            | PipelineError::DestinationsDb(DestinationsDbError::Database(_))
-            | PipelineError::PipelinesDb(PipelinesDbError::Database(_))
-            | PipelineError::ReplicatorsDb(ReplicatorsDbError::Database(_))
-            | PipelineError::ImagesDb(ImagesDbError::Database(_))
-            | PipelineError::TableLookup(_)
+            PipelineError::SourcesDb(_)
+            | PipelineError::DestinationsDb(_)
+            | PipelineError::PipelinesDb(_)
+            | PipelineError::ReplicatorsDb(_)
+            | PipelineError::ImagesDb(_)
             | PipelineError::Database(_)
             | PipelineError::ReplicatorNotFound(_)
             | PipelineError::ImageNotFound(_)
@@ -189,12 +194,16 @@ impl PipelineError {
             | PipelineError::InvalidConfig(_)
             | PipelineError::MaintenanceMaterialization(_)
             | PipelineError::K8s(_)
+            | PipelineError::TrustedRootCerts(_)
             | PipelineError::MissingEnvironment
             | PipelineError::MissingTableState
             | PipelineError::InvalidTableState(_)
             | PipelineError::Validation(
                 ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_),
             ) => "Internal server error".to_owned(),
+            PipelineError::SourceDatabase(_)
+            | PipelineError::SourcePipelineState(_)
+            | PipelineError::TableLookup(_) => "Could not query the source database".to_owned(),
             PipelineError::Validation(error) => {
                 route_utils::validation_error_message(error).to_owned()
             }
@@ -219,10 +228,24 @@ impl IntoResponse for PipelineError {
             | PipelineError::MaintenanceMaterialization(_)
             | PipelineError::TrustedRootCerts(_)
             | PipelineError::Database(_)
-            | PipelineError::TableLookup(_)
             | PipelineError::InvalidTableState(_)
             | PipelineError::MissingEnvironment
             | PipelineError::MissingTableState => StatusCode::INTERNAL_SERVER_ERROR,
+            PipelineError::SourceDatabase(error) => {
+                route_utils::source_database_error_status_code(error)
+            }
+            PipelineError::SourcePipelineState(error) => match error {
+                PipelinesDbError::Database(error) => {
+                    route_utils::source_database_error_status_code(error)
+                }
+                _ => StatusCode::BAD_GATEWAY,
+            },
+            PipelineError::TableLookup(error) => match error {
+                TableLookupError::Database(error) => {
+                    route_utils::source_database_error_status_code(error)
+                }
+                TableLookupError::TableNotFound(_) => StatusCode::BAD_GATEWAY,
+            },
             PipelineError::Validation(error) => route_utils::validation_error_status_code(error),
             PipelineError::ActivePipeline(_) | PipelineError::DuplicatePipeline => {
                 StatusCode::CONFLICT
@@ -590,6 +613,9 @@ pub struct ValidatePipelineResponse {
     responses(
         (status = 200, description = "Pipeline created successfully", body = CreatePipelineResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source or destination not found", body = ErrorMessage),
+        (status = 409, description = "Pipeline already exists for this source and destination", body = ErrorMessage),
+        (status = 422, description = "Pipeline limit reached", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Pipelines"
@@ -659,6 +685,7 @@ pub(crate) async fn create_pipeline(
     ),
     responses(
         (status = 200, description = "Pipeline retrieved successfully", body = ReadPipelineResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Pipeline not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
@@ -704,7 +731,9 @@ pub(crate) async fn read_pipeline(
     ),
     responses(
         (status = 200, description = "Pipeline updated successfully"),
-        (status = 404, description = "Pipeline not found", body = ErrorMessage),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Pipeline, source, or destination not found", body = ErrorMessage),
+        (status = 409, description = "Pipeline already exists for this source and destination", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -789,8 +818,12 @@ pub(crate) async fn update_pipeline(
     ),
     responses(
         (status = 200, description = "Pipeline deleted successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 409, description = "Pipeline is active", body = ErrorMessage),
-        (status = 404, description = "Pipeline not found", body = ErrorMessage),
+        (status = 404, description = "Pipeline or source not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -844,17 +877,16 @@ pub(crate) async fn delete_pipeline(
     };
     let mut api_txn = pool.begin().await?;
     if let Some(source_pool) = source_pool {
-        let mut source_txn = source_pool.begin().await?;
-        delete_pipeline_api_and_source_state(
-            api_txn.deref_mut(),
-            source_txn.deref_mut(),
-            tenant_id,
-            &pipeline,
-        )
-        .await?;
+        let mut source_txn = source_pool.begin().await.map_err(PipelineError::SourceDatabase)?;
+        delete_pipeline_api_state(api_txn.deref_mut(), tenant_id, &pipeline).await?;
+        delete_pipeline_source_state(source_txn.deref_mut(), pipeline.id)
+            .await
+            .map_err(PipelineError::SourcePipelineState)?;
         api_txn.commit().await?;
-        source_txn.commit().await?;
-        delete_pipeline_replication_slots(&source_pool, pipeline.id).await?;
+        source_txn.commit().await.map_err(PipelineError::SourceDatabase)?;
+        delete_pipeline_replication_slots(&source_pool, pipeline.id)
+            .await
+            .map_err(PipelineError::SourcePipelineState)?;
     } else {
         delete_pipeline_api_state(api_txn.deref_mut(), tenant_id, &pipeline).await?;
         api_txn.commit().await?;
@@ -873,6 +905,7 @@ pub(crate) async fn delete_pipeline(
     ),
     responses(
         (status = 200, description = "Pipelines listed successfully", body = ReadPipelinesResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -914,6 +947,8 @@ pub(crate) async fn read_all_pipelines(
     ),
     responses(
         (status = 200, description = "Pipeline started successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Pipeline, source, or destination not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -965,6 +1000,8 @@ pub(crate) async fn start_pipeline(
     ),
     responses(
         (status = 200, description = "Pipeline stopped successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Pipeline not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -979,6 +1016,9 @@ pub(crate) async fn stop_pipeline(
     let pipeline_id = pipeline_id.into_inner();
 
     let mut txn = pool.begin().await?;
+    data::pipelines::read_pipeline(txn.deref_mut(), tenant_id, pipeline_id)
+        .await?
+        .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
     let replicator =
         data::replicators::read_replicator_by_pipeline_id(txn.deref_mut(), tenant_id, pipeline_id)
             .await?
@@ -1000,6 +1040,7 @@ pub(crate) async fn stop_pipeline(
     ),
     responses(
         (status = 200, description = "All pipelines stopped successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -1032,6 +1073,7 @@ pub(crate) async fn stop_all_pipelines(
     ),
     responses(
         (status = 200, description = "Pipeline version retrieved successfully", body = GetPipelineVersionResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Pipeline not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
@@ -1092,6 +1134,8 @@ pub(crate) async fn get_pipeline_version(
     ),
     responses(
         (status = 200, description = "Pipeline status retrieved successfully", body = GetPipelineStatusResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Pipeline not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -1105,6 +1149,9 @@ pub(crate) async fn get_pipeline_status(
     let tenant_id = extract_tenant_id(&headers)?;
     let pipeline_id = pipeline_id.into_inner();
 
+    data::pipelines::read_pipeline(&pool, tenant_id, pipeline_id)
+        .await?
+        .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
     let replicator =
         data::replicators::read_replicator_by_pipeline_id(&pool, tenant_id, pipeline_id)
             .await?
@@ -1130,7 +1177,11 @@ pub(crate) async fn get_pipeline_status(
     ),
     responses(
         (status = 200, description = "Replication status retrieved successfully", body = GetPipelineReplicationStatusResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Pipeline not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -1165,20 +1216,27 @@ pub(crate) async fn get_pipeline_replication_status(
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
         connect_to_source_database_from_api(&source.config.into_connection_config(tls_config))
-            .await?;
+            .await
+            .map_err(PipelineError::SourceDatabase)?;
 
     // Start transaction for all source database operations
-    let mut source_txn = source_pool.begin().await?;
+    let mut source_txn = source_pool.begin().await.map_err(PipelineError::SourceDatabase)?;
 
     // Ensure ETL tables exist in the source DB
-    if !health::etl_tables_present(source_txn.deref_mut()).await? {
+    if !health::etl_tables_present(source_txn.deref_mut())
+        .await
+        .map_err(PipelineError::SourceDatabase)?
+    {
         return Err(PipelineError::EtlStateNotInitialized);
     }
 
     // Fetch table state for all tables in this pipeline
-    let state_rows = table_state::get_table_state_rows(source_txn.deref_mut(), pipeline_id).await?;
-    let mut lag_metrics =
-        lag::get_pipeline_lag_metrics(source_txn.deref_mut(), pipeline_id as u64).await?;
+    let state_rows = table_state::get_table_state_rows(source_txn.deref_mut(), pipeline_id)
+        .await
+        .map_err(PipelineError::SourceDatabase)?;
+    let mut lag_metrics = lag::get_pipeline_lag_metrics(source_txn.deref_mut(), pipeline_id as u64)
+        .await
+        .map_err(PipelineError::SourceDatabase)?;
     let apply_lag = lag_metrics.apply.map(Into::into);
 
     // Collect all table IDs and fetch their names in a single batch query
@@ -1227,6 +1285,9 @@ pub(crate) async fn get_pipeline_replication_status(
         (status = 200, description = "Table state(s) rolled back successfully", body = RollbackTablesResponse),
         (status = 400, description = "Bad request – state not rollbackable", body = ErrorMessage),
         (status = 404, description = "Pipeline or table not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"
@@ -1263,18 +1324,24 @@ pub(crate) async fn rollback_tables(
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
         connect_to_source_database_from_api(&source.config.into_connection_config(tls_config))
-            .await?;
+            .await
+            .map_err(PipelineError::SourceDatabase)?;
 
     // Start transaction for all source database operations
-    let mut source_txn = source_pool.begin().await?;
+    let mut source_txn = source_pool.begin().await.map_err(PipelineError::SourceDatabase)?;
 
     // Ensure ETL tables exist in the source DB
-    if !health::etl_tables_present(source_txn.deref_mut()).await? {
+    if !health::etl_tables_present(source_txn.deref_mut())
+        .await
+        .map_err(PipelineError::SourceDatabase)?
+    {
         return Err(PipelineError::EtlStateNotInitialized);
     }
 
     // Get all table states for this pipeline
-    let state_rows = table_state::get_table_state_rows(source_txn.deref_mut(), pipeline_id).await?;
+    let state_rows = table_state::get_table_state_rows(source_txn.deref_mut(), pipeline_id)
+        .await
+        .map_err(PipelineError::SourceDatabase)?;
 
     // Determine which tables to rollback based on target
     let target_table_ids: Vec<u32> = match &rollback_request.target {
@@ -1327,7 +1394,8 @@ pub(crate) async fn rollback_tables(
                     pipeline_id,
                     TableId::new(table_id),
                 )
-                .await?
+                .await
+                .map_err(PipelineError::SourceDatabase)?
                 else {
                     return Err(PipelineError::NotRollbackable(format!(
                         "No previous state to rollback to for table {table_id}",
@@ -1336,14 +1404,13 @@ pub(crate) async fn rollback_tables(
 
                 new_state_row
             }
-            RollbackType::Full => {
-                table_state::reset_table_state(
-                    source_txn.deref_mut(),
-                    pipeline_id,
-                    TableId::new(table_id),
-                )
-                .await?
-            }
+            RollbackType::Full => table_state::reset_table_state(
+                source_txn.deref_mut(),
+                pipeline_id,
+                TableId::new(table_id),
+            )
+            .await
+            .map_err(PipelineError::SourceDatabase)?,
         };
 
         let new_state: TableState = new_state_row
@@ -1354,7 +1421,7 @@ pub(crate) async fn rollback_tables(
         rolled_back_tables.push(RolledBackTable { table_id, new_state: new_state.into() });
     }
 
-    source_txn.commit().await?;
+    source_txn.commit().await.map_err(PipelineError::SourceDatabase)?;
 
     let response = RollbackTablesResponse { pipeline_id, tables: rolled_back_tables };
 
@@ -1478,6 +1545,10 @@ pub(crate) async fn update_pipeline_version(
     responses(
         (status = 200, description = "Validation completed", body = ValidatePipelineResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Pipelines"

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -259,7 +259,7 @@ impl IntoResponse for PipelineError {
                 StatusCode::BAD_REQUEST
             }
             PipelineError::InvalidPipelineRequest(_) => StatusCode::BAD_REQUEST,
-            PipelineError::PipelineLimitReached { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+            PipelineError::PipelineLimitReached { .. } => StatusCode::CONFLICT,
         };
 
         error_response_with_internal_error(status_code, self.to_message(), &self)
@@ -614,8 +614,7 @@ pub struct ValidatePipelineResponse {
         (status = 200, description = "Pipeline created successfully", body = CreatePipelineResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source or destination not found", body = ErrorMessage),
-        (status = 409, description = "Pipeline already exists for this source and destination", body = ErrorMessage),
-        (status = 422, description = "Pipeline limit reached", body = ErrorMessage),
+        (status = 409, description = "Pipeline already exists for this source and destination or tenant pipeline limit reached", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Pipelines"

--- a/crates/etl-api/src/routes/sources.rs
+++ b/crates/etl-api/src/routes/sources.rs
@@ -192,9 +192,9 @@ pub struct ValidateSourceResponse {
         (status = 200, description = "Source created successfully", body = CreateSourceResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 422, description = "Source profile validation failed", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Sources"
@@ -243,9 +243,9 @@ pub(crate) async fn create_source(
     responses(
         (status = 200, description = "Validation completed", body = ValidateSourceResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Sources"
@@ -326,9 +326,9 @@ pub(crate) async fn read_source(
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
         (status = 422, description = "Source profile validation failed", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Sources"

--- a/crates/etl-api/src/routes/sources.rs
+++ b/crates/etl-api/src/routes/sources.rs
@@ -70,9 +70,9 @@ impl SourceError {
     pub fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
-            SourceError::SourcesDb(SourcesDbError::Database(_))
-            | SourceError::PipelinesDb(PipelinesDbError::Database(_))
-            | SourceError::K8sCore(_) => "Internal server error".to_owned(),
+            SourceError::SourcesDb(_) | SourceError::PipelinesDb(_) | SourceError::K8sCore(_) => {
+                "Internal server error".to_owned()
+            }
             SourceError::Validation(error) => utils::validation_error_message(error).to_owned(),
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
@@ -192,6 +192,9 @@ pub struct ValidateSourceResponse {
         (status = 200, description = "Source created successfully", body = CreateSourceResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 422, description = "Source profile validation failed", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Sources"
@@ -240,6 +243,9 @@ pub(crate) async fn create_source(
     responses(
         (status = 200, description = "Validation completed", body = ValidateSourceResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     ),
     tag = "Sources"
@@ -277,6 +283,7 @@ pub(crate) async fn validate_source(
     ),
     responses(
         (status = 200, description = "Source retrieved successfully", body = ReadSourceResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
@@ -316,8 +323,12 @@ pub(crate) async fn read_source(
     ),
     responses(
         (status = 200, description = "Source updated successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
         (status = 422, description = "Source profile validation failed", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Sources"
@@ -367,6 +378,7 @@ pub(crate) async fn update_source(
     ),
     responses(
         (status = 200, description = "Source deleted successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 409, description = "Source has an active pipeline or is still used by pipelines", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
@@ -419,6 +431,7 @@ pub(crate) async fn delete_source(
     ),
     responses(
         (status = 200, description = "Sources listed successfully", body = ReadSourcesResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Sources"

--- a/crates/etl-api/src/routes/sources/publications.rs
+++ b/crates/etl-api/src/routes/sources/publications.rs
@@ -55,7 +55,7 @@ impl PublicationError {
     fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
-            PublicationError::SourcesDb(SourcesDbError::Database(_)) => {
+            PublicationError::SourcesDb(_) | PublicationError::TrustedRootCerts(_) => {
                 "Internal server error".to_owned()
             }
             PublicationError::PublicationsDb(PublicationsDbError::Database(_))
@@ -113,9 +113,15 @@ pub struct ReadPublicationsResponse {
     request_body = CreatePublicationRequest,
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Publication created successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -156,10 +162,15 @@ pub(crate) async fn create_publication(
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
         ("publication_name" = String, Path, description = "Publication name within the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Publication retrieved successfully", body = Publication),
-        (status = 404, description = "Publication not found", body = ErrorMessage),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source or publication not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -200,10 +211,15 @@ pub(crate) async fn read_publication(
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
         ("publication_name" = String, Path, description = "Publication name within the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Publication updated successfully"),
-        (status = 404, description = "Publication not found", body = ErrorMessage),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source or publication not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -249,10 +265,15 @@ pub(crate) async fn update_publication(
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
         ("publication_name" = String, Path, description = "Publication name within the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Publication deleted successfully"),
-        (status = 404, description = "Publication not found", body = ErrorMessage),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source or publication not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -289,9 +310,15 @@ pub(crate) async fn delete_publication(
     tag = "Publications",
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Publications listed successfully", body = ReadPublicationsResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -331,10 +358,15 @@ pub(crate) async fn read_all_publications(
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
         ("publication_name" = String, Path, description = "Publication name within the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Tables added successfully"),
-        (status = 404, description = "Publication not found", body = ErrorMessage),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source or publication not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -379,10 +411,15 @@ pub(crate) async fn add_tables_to_publication(
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
         ("publication_name" = String, Path, description = "Publication name within the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Tables removed successfully"),
-        (status = 404, description = "Publication not found", body = ErrorMessage),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source or publication not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -427,10 +464,15 @@ pub(crate) async fn drop_tables_from_publication(
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
         ("publication_name" = String, Path, description = "Publication name within the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Tables replaced successfully"),
-        (status = 404, description = "Publication not found", body = ErrorMessage),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source or publication not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]

--- a/crates/etl-api/src/routes/sources/publications.rs
+++ b/crates/etl-api/src/routes/sources/publications.rs
@@ -59,7 +59,7 @@ impl PublicationError {
                 "Internal server error".to_owned()
             }
             PublicationError::PublicationsDb(PublicationsDbError::Database(_))
-            | PublicationError::Database(_) => "Could not query the source database".to_owned(),
+            | PublicationError::Database(_) => "Could not query your source database".to_owned(),
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
         }
@@ -119,9 +119,9 @@ pub struct ReadPublicationsResponse {
         (status = 200, description = "Publication created successfully"),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -168,9 +168,9 @@ pub(crate) async fn create_publication(
         (status = 200, description = "Publication retrieved successfully", body = Publication),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source or publication not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -217,9 +217,9 @@ pub(crate) async fn read_publication(
         (status = 200, description = "Publication updated successfully"),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source or publication not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -271,9 +271,9 @@ pub(crate) async fn update_publication(
         (status = 200, description = "Publication deleted successfully"),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source or publication not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -316,9 +316,9 @@ pub(crate) async fn delete_publication(
         (status = 200, description = "Publications listed successfully", body = ReadPublicationsResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -364,9 +364,9 @@ pub(crate) async fn read_all_publications(
         (status = 200, description = "Tables added successfully"),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source or publication not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -417,9 +417,9 @@ pub(crate) async fn add_tables_to_publication(
         (status = 200, description = "Tables removed successfully"),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source or publication not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]
@@ -470,9 +470,9 @@ pub(crate) async fn drop_tables_from_publication(
         (status = 200, description = "Tables replaced successfully"),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source or publication not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]

--- a/crates/etl-api/src/routes/sources/publications.rs
+++ b/crates/etl-api/src/routes/sources/publications.rs
@@ -23,7 +23,7 @@ use crate::{
     k8s::{TrustedRootCertsCache, TrustedRootCertsError},
     routes::{
         ErrorMessage, IntoInner, TenantIdError, error_response_with_internal_error,
-        extract_tenant_id,
+        extract_tenant_id, utils,
     },
 };
 
@@ -55,9 +55,11 @@ impl PublicationError {
     fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
-            PublicationError::SourcesDb(SourcesDbError::Database(_))
-            | PublicationError::PublicationsDb(PublicationsDbError::Database(_))
-            | PublicationError::Database(_) => "Internal server error".to_owned(),
+            PublicationError::SourcesDb(SourcesDbError::Database(_)) => {
+                "Internal server error".to_owned()
+            }
+            PublicationError::PublicationsDb(PublicationsDbError::Database(_))
+            | PublicationError::Database(_) => "Could not query the source database".to_owned(),
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
         }
@@ -67,10 +69,11 @@ impl PublicationError {
 impl IntoResponse for PublicationError {
     fn into_response(self) -> Response {
         let status_code = match &self {
-            PublicationError::SourcesDb(_)
-            | PublicationError::PublicationsDb(_)
-            | PublicationError::Database(_)
-            | PublicationError::TrustedRootCerts(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            PublicationError::SourcesDb(_) | PublicationError::TrustedRootCerts(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            PublicationError::PublicationsDb(PublicationsDbError::Database(error))
+            | PublicationError::Database(error) => utils::source_database_error_status_code(error),
             PublicationError::SourceNotFound(_) | PublicationError::PublicationNotFound(_) => {
                 StatusCode::NOT_FOUND
             }
@@ -460,4 +463,26 @@ pub(crate) async fn set_publication_tables(
     data::publications::update_publication(&publication, &source_pool).await?;
 
     Ok(StatusCode::OK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_connection_timeout_is_reported_as_upstream_unavailable() {
+        let response = PublicationError::Database(sqlx::Error::PoolTimedOut).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn source_query_error_is_reported_as_bad_gateway() {
+        let response = PublicationError::PublicationsDb(PublicationsDbError::Database(
+            sqlx::Error::Protocol("bad source response".to_owned()),
+        ))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    }
 }

--- a/crates/etl-api/src/routes/sources/tables.rs
+++ b/crates/etl-api/src/routes/sources/tables.rs
@@ -55,7 +55,7 @@ impl TableError {
                 "Internal server error".to_owned()
             }
             TableError::TablesDb(TablesDbError::Database(_)) | TableError::Database(_) => {
-                "Could not query the source database".to_owned()
+                "Could not query your source database".to_owned()
             }
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
@@ -100,9 +100,9 @@ impl IntoResponse for TableError {
         (status = 200, description = "Tables listed successfully", body = ReadTablesResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Source not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]

--- a/crates/etl-api/src/routes/sources/tables.rs
+++ b/crates/etl-api/src/routes/sources/tables.rs
@@ -22,7 +22,7 @@ use crate::{
     k8s::{TrustedRootCertsCache, TrustedRootCertsError},
     routes::{
         ErrorMessage, IntoInner, TenantIdError, error_response_with_internal_error,
-        extract_tenant_id,
+        extract_tenant_id, utils,
     },
 };
 
@@ -51,9 +51,12 @@ impl TableError {
     fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
-            TableError::SourcesDb(SourcesDbError::Database(_))
-            | TableError::TablesDb(TablesDbError::Database(_))
-            | TableError::Database(_) => "Internal server error".to_owned(),
+            TableError::SourcesDb(SourcesDbError::Database(_)) => {
+                "Internal server error".to_owned()
+            }
+            TableError::TablesDb(TablesDbError::Database(_)) | TableError::Database(_) => {
+                "Could not query the source database".to_owned()
+            }
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
         }
@@ -69,10 +72,12 @@ pub struct ReadTablesResponse {
 impl IntoResponse for TableError {
     fn into_response(self) -> Response {
         let status_code = match &self {
-            TableError::SourcesDb(_)
-            | TableError::TablesDb(_)
-            | TableError::Database(_)
-            | TableError::TrustedRootCerts(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            TableError::SourcesDb(_) | TableError::TrustedRootCerts(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            TableError::TablesDb(TablesDbError::Database(error)) | TableError::Database(error) => {
+                utils::source_database_error_status_code(error)
+            }
             TableError::SourceNotFound(_) => StatusCode::NOT_FOUND,
             TableError::TenantId(_) => StatusCode::BAD_REQUEST,
         };
@@ -119,4 +124,26 @@ pub(crate) async fn read_table_names(
     let response = ReadTablesResponse { tables };
 
     Ok(Json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_connection_timeout_is_reported_as_upstream_unavailable() {
+        let response = TableError::Database(sqlx::Error::PoolTimedOut).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn source_query_error_is_reported_as_bad_gateway() {
+        let response = TableError::TablesDb(TablesDbError::Database(sqlx::Error::Protocol(
+            "bad source response".to_owned(),
+        )))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    }
 }

--- a/crates/etl-api/src/routes/sources/tables.rs
+++ b/crates/etl-api/src/routes/sources/tables.rs
@@ -51,7 +51,7 @@ impl TableError {
     fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
-            TableError::SourcesDb(SourcesDbError::Database(_)) => {
+            TableError::SourcesDb(_) | TableError::TrustedRootCerts(_) => {
                 "Internal server error".to_owned()
             }
             TableError::TablesDb(TablesDbError::Database(_)) | TableError::Database(_) => {
@@ -94,9 +94,15 @@ impl IntoResponse for TableError {
     tag = "Tables",
     params(
         ("source_id" = i64, Path, description = "Unique ID of the source"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request"),
     ),
     responses(
         (status = 200, description = "Tables listed successfully", body = ReadTablesResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Source not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage)
     )
 )]

--- a/crates/etl-api/src/routes/tenants.rs
+++ b/crates/etl-api/src/routes/tenants.rs
@@ -81,7 +81,7 @@ impl TenantError {
             | TenantError::TrustedRootCerts(_)
             | TenantError::K8sCore(_) => "Internal server error".to_owned(),
             TenantError::SourceDatabase(_) | TenantError::SourcePipelineState(_) => {
-                "Could not query the source database".to_owned()
+                "Could not query your source database".to_owned()
             }
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
@@ -308,9 +308,9 @@ pub(crate) async fn update_tenant(
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 409, description = "Tenant has active pipelines or pipelines still defined", body = ErrorMessage),
         (status = 404, description = "Tenant not found", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Tenants"

--- a/crates/etl-api/src/routes/tenants.rs
+++ b/crates/etl-api/src/routes/tenants.rs
@@ -29,7 +29,7 @@ use crate::{
         core::{K8sCoreError, first_active_pipeline_id},
     },
     routes::{
-        ErrorMessage, IntoInner, TenantIdError, error_response_with_internal_error,
+        ErrorMessage, IntoInner, TenantIdError, error_response_with_internal_error, utils,
         validate_tenant_id,
     },
 };
@@ -51,6 +51,12 @@ pub enum TenantError {
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
 
+    #[error("Source database error: {0}")]
+    SourceDatabase(sqlx::Error),
+
+    #[error("Source pipeline state operation failed: {0}")]
+    SourcePipelineState(PipelinesDbError),
+
     #[error(transparent)]
     TrustedRootCerts(#[from] TrustedRootCertsError),
 
@@ -69,11 +75,14 @@ impl TenantError {
         match self {
             // Do not expose internal database details in error messages
             TenantError::TenantsDb(TenantsDbError::Database(_))
-            | TenantError::SourcesDb(SourcesDbError::Database(_))
-            | TenantError::PipelinesDb(PipelinesDbError::Database(_))
+            | TenantError::SourcesDb(_)
+            | TenantError::PipelinesDb(_)
             | TenantError::Database(_)
             | TenantError::TrustedRootCerts(_)
             | TenantError::K8sCore(_) => "Internal server error".to_owned(),
+            TenantError::SourceDatabase(_) | TenantError::SourcePipelineState(_) => {
+                "Could not query the source database".to_owned()
+            }
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
         }
@@ -92,6 +101,13 @@ impl IntoResponse for TenantError {
             | TenantError::Database(_)
             | TenantError::TrustedRootCerts(_)
             | TenantError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            TenantError::SourceDatabase(error) => utils::source_database_error_status_code(error),
+            TenantError::SourcePipelineState(error) => match error {
+                PipelinesDbError::Database(error) => {
+                    utils::source_database_error_status_code(error)
+                }
+                _ => StatusCode::BAD_GATEWAY,
+            },
             TenantError::TenantNotFound(_) => StatusCode::NOT_FOUND,
         };
 
@@ -157,6 +173,7 @@ pub struct ReadTenantsResponse {
     responses(
         (status = 200, description = "Tenant created successfully", body = CreateTenantResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 409, description = "Tenant already exists", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Tenants"
@@ -220,6 +237,7 @@ pub(crate) async fn create_or_update_tenant(
     ),
     responses(
         (status = 200, description = "Tenant retrieved successfully", body = ReadTenantResponse),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Tenant not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
@@ -253,6 +271,7 @@ pub(crate) async fn read_tenant(
     ),
     responses(
         (status = 200, description = "Tenant updated successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 404, description = "Tenant not found", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
@@ -286,8 +305,12 @@ pub(crate) async fn update_tenant(
     ),
     responses(
         (status = 200, description = "Tenant deleted successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 409, description = "Tenant has active pipelines or pipelines still defined", body = ErrorMessage),
         (status = 404, description = "Tenant not found", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Tenants"
@@ -346,20 +369,28 @@ pub(crate) async fn delete_tenant(
                 continue;
             }
         };
-        let mut source_txn = source_pool.begin().await?;
+        let mut source_txn = source_pool.begin().await.map_err(TenantError::SourceDatabase)?;
         let deleted_pipeline_ids =
-            delete_pipelines_source_state(source_txn.deref_mut(), &source_pipelines).await?;
-        data::sources::uninstall_source_installation(source_txn.deref_mut()).await?;
-        source_txn.commit().await?;
+            delete_pipelines_source_state(source_txn.deref_mut(), &source_pipelines)
+                .await
+                .map_err(TenantError::SourcePipelineState)?;
+        data::sources::uninstall_source_installation(source_txn.deref_mut())
+            .await
+            .map_err(TenantError::SourceDatabase)?;
+        source_txn.commit().await.map_err(TenantError::SourceDatabase)?;
         for pipeline_id in deleted_pipeline_ids {
-            delete_pipeline_replication_slots(&source_pool, pipeline_id).await?;
+            delete_pipeline_replication_slots(&source_pool, pipeline_id)
+                .await
+                .map_err(TenantError::SourcePipelineState)?;
         }
     }
 
     // Deleting the tenant is enough for API-side cleanup because Postgres cascades
     // tenant-owned rows in the app schema; we only clean source databases
     // manually above.
-    data::tenants::delete_tenant(&pool, &tenant_id).await?;
+    data::tenants::delete_tenant(&pool, &tenant_id)
+        .await?
+        .ok_or(TenantError::TenantNotFound(tenant_id))?;
 
     Ok(StatusCode::OK)
 }

--- a/crates/etl-api/src/routes/tenants_sources.rs
+++ b/crates/etl-api/src/routes/tenants_sources.rs
@@ -47,10 +47,14 @@ impl TenantSourceError {
     fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
+            TenantSourceError::TenantSourceDb(TenantSourceDbError::Tenants(
+                TenantsDbError::Conflict(_),
+            )) => self.to_string(),
             TenantSourceError::TenantSourceDb(
                 TenantSourceDbError::Database(_)
                 | TenantSourceDbError::Sources(_)
-                | TenantSourceDbError::Tenants(_),
+                | TenantSourceDbError::Tenants(_)
+                | TenantSourceDbError::DbSerialization(_),
             )
             | TenantSourceError::Database(_) => "Internal server error".to_owned(),
             TenantSourceError::Validation(error) => {
@@ -129,7 +133,11 @@ pub struct CreateTenantSourceResponse {
     responses(
         (status = 200, description = "Tenant and source created successfully", body = CreateTenantSourceResponse),
         (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 409, description = "Tenant already exists", body = ErrorMessage),
         (status = 422, description = "Source profile validation failed", body = ErrorMessage),
+        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Source database unavailable", body = ErrorMessage),
+        (status = 504, description = "Source database request timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Tenants & Sources"

--- a/crates/etl-api/src/routes/tenants_sources.rs
+++ b/crates/etl-api/src/routes/tenants_sources.rs
@@ -135,9 +135,9 @@ pub struct CreateTenantSourceResponse {
         (status = 400, description = "Bad request", body = ErrorMessage),
         (status = 409, description = "Tenant already exists", body = ErrorMessage),
         (status = 422, description = "Source profile validation failed", body = ErrorMessage),
-        (status = 502, description = "Source database returned an invalid response", body = ErrorMessage),
-        (status = 503, description = "Source database unavailable", body = ErrorMessage),
-        (status = 504, description = "Source database request timed out", body = ErrorMessage),
+        (status = 502, description = "Your source database returned an invalid response", body = ErrorMessage),
+        (status = 503, description = "Your source database is unavailable", body = ErrorMessage),
+        (status = 504, description = "Request to your source database timed out", body = ErrorMessage),
         (status = 500, description = "Internal server error", body = ErrorMessage),
     ),
     tag = "Tenants & Sources"

--- a/crates/etl-api/src/routes/utils.rs
+++ b/crates/etl-api/src/routes/utils.rs
@@ -7,23 +7,22 @@ use crate::validation::{ValidationError, ValidationFailure};
 /// Returns the public HTTP status code for a validation execution error.
 pub fn validation_error_status_code(error: &ValidationError) -> StatusCode {
     match error {
-        ValidationError::Database { source: sqlx::Error::PoolTimedOut } => {
-            StatusCode::SERVICE_UNAVAILABLE
-        }
-        ValidationError::Database { source: sqlx::Error::PoolClosed } => {
-            StatusCode::SERVICE_UNAVAILABLE
-        }
-        ValidationError::Database { source: sqlx::Error::Io(error) }
-            if error.kind() == ErrorKind::TimedOut =>
-        {
-            StatusCode::GATEWAY_TIMEOUT
-        }
-        ValidationError::Database { .. }
-        | ValidationError::BigQuery(_)
-        | ValidationError::Iceberg(_) => StatusCode::BAD_GATEWAY,
+        ValidationError::Database { source } => source_database_error_status_code(source),
+        ValidationError::BigQuery(_) | ValidationError::Iceberg(_) => StatusCode::BAD_GATEWAY,
         ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_) => {
             StatusCode::INTERNAL_SERVER_ERROR
         }
+    }
+}
+
+/// Returns the public HTTP status code for source database execution errors.
+pub fn source_database_error_status_code(error: &sqlx::Error) -> StatusCode {
+    match error {
+        sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed => StatusCode::SERVICE_UNAVAILABLE,
+        sqlx::Error::Io(error) if error.kind() == ErrorKind::TimedOut => {
+            StatusCode::GATEWAY_TIMEOUT
+        }
+        _ => StatusCode::BAD_GATEWAY,
     }
 }
 
@@ -78,5 +77,12 @@ mod tests {
         assert_eq!(validation_error_status_code(&error), StatusCode::GATEWAY_TIMEOUT);
         assert_eq!(validation_error_message(&error), "Could not reach the source database in time");
         assert_eq!(error.to_string(), "Database query failed");
+    }
+
+    #[test]
+    fn source_database_errors_are_reported_as_upstream_failures() {
+        let error = sqlx::Error::Protocol("bad source response".to_owned());
+
+        assert_eq!(source_database_error_status_code(&error), StatusCode::BAD_GATEWAY);
     }
 }

--- a/crates/etl-api/src/routes/utils.rs
+++ b/crates/etl-api/src/routes/utils.rs
@@ -38,17 +38,17 @@ fn source_database_unavailable_error(error: &dyn DatabaseError) -> bool {
 pub fn validation_error_message(error: &ValidationError) -> &'static str {
     match error {
         ValidationError::Database { source: sqlx::Error::PoolTimedOut } => {
-            "Could not reach the source database in time"
+            "Could not reach your source database in time"
         }
         ValidationError::Database { source: sqlx::Error::PoolClosed } => {
-            "The source database is currently unavailable"
+            "Your source database is currently unavailable"
         }
         ValidationError::Database { source: sqlx::Error::Io(error) }
             if error.kind() == ErrorKind::TimedOut =>
         {
-            "Could not reach the source database in time"
+            "Could not reach your source database in time"
         }
-        ValidationError::Database { .. } => "Could not validate the source database connection",
+        ValidationError::Database { .. } => "Could not validate your source database connection",
         ValidationError::BigQuery(_) => "Could not connect to BigQuery",
         ValidationError::Iceberg(_) => "Could not connect to the Iceberg endpoint",
         ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_) => {
@@ -71,7 +71,10 @@ mod tests {
         let error = ValidationError::from(sqlx::Error::PoolTimedOut);
 
         assert_eq!(validation_error_status_code(&error), StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(validation_error_message(&error), "Could not reach the source database in time");
+        assert_eq!(
+            validation_error_message(&error),
+            "Could not reach your source database in time"
+        );
         assert_eq!(error.to_string(), "Database query failed");
     }
 
@@ -83,7 +86,10 @@ mod tests {
         )));
 
         assert_eq!(validation_error_status_code(&error), StatusCode::GATEWAY_TIMEOUT);
-        assert_eq!(validation_error_message(&error), "Could not reach the source database in time");
+        assert_eq!(
+            validation_error_message(&error),
+            "Could not reach your source database in time"
+        );
         assert_eq!(error.to_string(), "Database query failed");
     }
 

--- a/crates/etl-api/src/routes/utils.rs
+++ b/crates/etl-api/src/routes/utils.rs
@@ -1,6 +1,7 @@
 use std::io::ErrorKind;
 
 use axum::http::StatusCode;
+use sqlx::error::DatabaseError;
 
 use crate::validation::{ValidationError, ValidationFailure};
 
@@ -19,11 +20,18 @@ pub fn validation_error_status_code(error: &ValidationError) -> StatusCode {
 pub fn source_database_error_status_code(error: &sqlx::Error) -> StatusCode {
     match error {
         sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed => StatusCode::SERVICE_UNAVAILABLE,
+        sqlx::Error::Database(error) if source_database_unavailable_error(error.as_ref()) => {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
         sqlx::Error::Io(error) if error.kind() == ErrorKind::TimedOut => {
             StatusCode::GATEWAY_TIMEOUT
         }
         _ => StatusCode::BAD_GATEWAY,
     }
+}
+
+fn source_database_unavailable_error(error: &dyn DatabaseError) -> bool {
+    matches!(error.code().as_deref(), Some("57P01" | "57P02" | "57P03"))
 }
 
 /// Returns the public error message for a validation execution error.

--- a/crates/etl-api/src/sentry_scrubbing.rs
+++ b/crates/etl-api/src/sentry_scrubbing.rs
@@ -95,7 +95,7 @@ pub async fn mark_sensitive_sentry_scope(request: Request, next: Next) -> Respon
     next.run(request).await
 }
 
-/// Captures Sentry events for HTTP 5xx responses.
+/// Captures Sentry events for internal HTTP 500 responses.
 ///
 /// Axum route errors are converted into JSON responses before they reach Tower,
 /// so this middleware restores the Actix behavior of reporting server-error
@@ -107,7 +107,7 @@ pub(crate) async fn capture_server_errors(request: Request, next: Next) -> Respo
     let response = next.run(request).await;
     let status = response.status();
 
-    if status.is_server_error() {
+    if status == StatusCode::INTERNAL_SERVER_ERROR {
         capture_server_error(
             &method,
             &route,
@@ -175,7 +175,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn capture_server_errors_records_sentry_event_for_5xx_response() {
+    fn capture_server_errors_records_sentry_event_for_internal_server_error() {
         let events = sentry::test::with_captured_events(|| {
             run_request(
                 Router::new()
@@ -252,13 +252,27 @@ mod tests {
     }
 
     #[test]
-    fn capture_server_errors_ignores_non_5xx_response() {
+    fn capture_server_errors_ignores_non_internal_server_error_response() {
         let events = sentry::test::with_captured_events(|| {
             run_request(
                 Router::new()
                     .route("/missing", get(|| async { StatusCode::NOT_FOUND }))
                     .layer(middleware::from_fn(capture_server_errors)),
                 "/missing",
+            );
+        });
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn capture_server_errors_ignores_upstream_failure_response() {
+        let events = sentry::test::with_captured_events(|| {
+            run_request(
+                Router::new()
+                    .route("/upstream", get(|| async { StatusCode::BAD_GATEWAY }))
+                    .layer(middleware::from_fn(capture_server_errors)),
+                "/upstream",
             );
         });
 

--- a/crates/etl-api/src/validation/validators/pipeline.rs
+++ b/crates/etl-api/src/validation/validators/pipeline.rs
@@ -36,7 +36,7 @@ impl Validator for PublicationExistsValidator {
             Ok(vec![ValidationFailure::critical(
                 "Publication Not Found",
                 format!(
-                    "Publication `{}` does not exist in the source database.\n\nCreate the \
+                    "Publication `{}` does not exist in your source database.\n\nCreate the \
                      publication, or choose an existing publication for this pipeline. For \
                      example: `CREATE PUBLICATION {} FOR TABLE <table_name>, ...`.",
                     self.publication_name, self.publication_name
@@ -90,7 +90,7 @@ impl Validator for ReplicationSlotsValidator {
             Ok(vec![ValidationFailure::critical(
                 "Insufficient Replication Slots",
                 format!(
-                    "The source database has {free_slots} free replication slots, but this \
+                    "Your source database has {free_slots} free replication slots, but this \
                      pipeline can need up to {required_slots} during the initial table copy \
                      ({used_slots}/{max_slots} slots are currently in use).\n\nIncrease \
                      `max_replication_slots`, remove unused replication slots, or reduce \
@@ -125,7 +125,7 @@ impl Validator for WalLevelValidator {
             Ok(vec![ValidationFailure::critical(
                 "Invalid WAL Level",
                 format!(
-                    "The source database WAL level is `{wal_level}`, but logical replication \
+                    "Your source database WAL level is `{wal_level}`, but logical replication \
                      requires `logical`.\n\nSet `wal_level = 'logical'` in `postgresql.conf` and \
                      restart PostgreSQL."
                 ),
@@ -161,8 +161,8 @@ impl Validator for ReplicationPermissionsValidator {
         } else {
             Ok(vec![ValidationFailure::critical(
                 "Missing Replication Permission",
-                "The source database user does not have replication privileges.\n\nGrant the user \
-                 the `REPLICATION` attribute or connect with a role that already has it.",
+                "Your source database user does not have replication privileges.\n\nGrant the \
+                 user the `REPLICATION` attribute or connect with a role that already has it.",
             )])
         }
     }

--- a/crates/etl-api/src/validation/validators/source.rs
+++ b/crates/etl-api/src/validation/validators/source.rs
@@ -135,7 +135,7 @@ impl Validator for SourceValidator {
             return Ok(vec![ValidationFailure::critical(
                 "Invalid Source Role Attributes",
                 format!(
-                    "The trusted ETL role `{expected_username}` was not found in the source \
+                    "The trusted ETL role `{expected_username}` was not found in your source \
                      database.\n\nCreate the role or update the source credentials to use the \
                      configured trusted role."
                 ),
@@ -154,8 +154,8 @@ impl Validator for SourceValidator {
         if !has_required_role_attributes {
             failures.push(ValidationFailure::critical(
                 "Invalid Source Role Attributes",
-                "The trusted ETL role does not have the required source database \
-                 attributes.\n\nIt must be able to `LOGIN`, use `REPLICATION`, `BYPASSRLS`, and \
+                "The trusted ETL role does not have the required attributes for your source \
+                 database.\n\nIt must be able to `LOGIN`, use `REPLICATION`, `BYPASSRLS`, and \
                  `INHERIT` privileges, and avoid superuser-style `CREATEROLE` or `CREATEDB` \
                  permissions.",
             ));
@@ -173,7 +173,7 @@ impl Validator for SourceValidator {
             failures.push(ValidationFailure::critical(
                 "Invalid Source ETL Schema Permissions",
                 format!(
-                    "The trusted ETL role cannot manage the `{ETL_SCHEMA_NAME}` schema in the \
+                    "The trusted ETL role cannot manage the `{ETL_SCHEMA_NAME}` schema in your \
                      source database.\n\nGrant it permission to create the schema if it does not \
                      exist, or `USAGE` and `CREATE` on the schema plus ownership access to \
                      existing ETL tables."

--- a/crates/etl-api/tests/destinations_pipelines.rs
+++ b/crates/etl-api/tests/destinations_pipelines.rs
@@ -274,7 +274,7 @@ async fn destination_and_pipeline_with_another_tenants_source_cannot_be_created(
     let response = app.create_destination_pipeline(tenant1_id, &destination_pipeline).await;
 
     // Assert
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -425,7 +425,7 @@ async fn destination_and_pipeline_with_another_tenants_source_cannot_be_updated(
         .await;
 
     // Assert
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -528,7 +528,7 @@ async fn destination_and_pipeline_with_another_tenants_destination_cannot_be_upd
         .await;
 
     // Assert
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -591,7 +591,7 @@ async fn destination_and_pipeline_with_another_tenants_pipeline_cannot_be_update
         .await;
 
     // Assert
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 // TODO: Re-enable these tests once MAX_PIPELINES_PER_TENANT is lifted from 1.

--- a/crates/etl-api/tests/destinations_pipelines.rs
+++ b/crates/etl-api/tests/destinations_pipelines.rs
@@ -242,7 +242,7 @@ async fn tenant_cannot_create_more_than_max_destinations_pipelines() {
     let response = app.create_destination_pipeline(tenant_id, &destination_pipeline).await;
 
     // Assert
-    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/images.rs
+++ b/crates/etl-api/tests/images.rs
@@ -216,7 +216,7 @@ async fn cannot_delete_default_image() {
     let response = app.delete_image(image_id).await;
 
     // Assert - Should fail with 400 Bad Request
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 
     // Verify the image still exists
     let response = app.read_image(image_id).await;

--- a/crates/etl-api/tests/metrics.rs
+++ b/crates/etl-api/tests/metrics.rs
@@ -51,6 +51,40 @@ async fn metrics_endpoint_includes_http_request_metrics() {
     assert!(has_health_request_metric(&metrics, "http_requests_duration_seconds"));
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn unmatched_api_routes_use_bounded_metric_endpoint_label() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app().await;
+
+    let client = reqwest::Client::new();
+
+    // Act
+    let missing_response = client
+        .get(local_test_url(&app.address, "/v1/not-a-real-resource/secret-ish-id"))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+    let metrics = client
+        .get(local_test_url(&app.address, "/metrics"))
+        .send()
+        .await
+        .expect("Failed to execute request.")
+        .text()
+        .await
+        .expect("Failed to read metrics response.");
+
+    // Assert
+    assert_eq!(missing_response.status(), reqwest::StatusCode::NOT_FOUND);
+    assert!(metrics.lines().any(|line| {
+        line.starts_with("http_requests_total{")
+            && line.contains(r#"endpoint="/v1/__unmatched__""#)
+            && line.contains(r#"method="GET""#)
+            && line.contains(r#"status="404""#)
+    }));
+    assert!(!metrics.contains("/v1/not-a-real-resource/secret-ish-id"));
+}
+
 fn has_health_request_metric(metrics: &str, prefix: &str) -> bool {
     metrics.lines().any(|line| {
         line.starts_with(prefix)

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -281,7 +281,7 @@ async fn tenant_cannot_create_more_than_max_pipelines() {
         CreatePipelineRequest { source_id, destination_id, config: new_pipeline_config() };
     let response = app.create_pipeline(tenant_id, &pipeline).await;
 
-    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/sources.rs
+++ b/crates/etl-api/tests/sources.rs
@@ -482,7 +482,7 @@ async fn source_creation_with_matching_trusted_username_but_invalid_role_profile
     let body = response.text().await.expect("failed to read response body");
 
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-    assert!(body.contains("required source database attributes"));
+    assert!(body.contains("required attributes for your source database"));
 
     drop_pg_database(&source_db_config).await;
 }

--- a/crates/etl-api/tests/tenants.rs
+++ b/crates/etl-api/tests/tenants.rs
@@ -246,7 +246,7 @@ async fn an_existing_tenant_can_be_deleted() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn deleting_non_existing_tenant_returns_ok() {
+async fn deleting_non_existing_tenant_returns_not_found() {
     init_test_tracing();
     // Arrange
     let app = spawn_test_app().await;
@@ -255,7 +255,7 @@ async fn deleting_non_existing_tenant_returns_ok() {
     let response = app.delete_tenant("42").await;
 
     // Assert
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/tenants_sources.rs
+++ b/crates/etl-api/tests/tenants_sources.rs
@@ -170,7 +170,7 @@ async fn tenant_and_source_creation_with_invalid_trusted_role_profile_fails() {
     let body = response.text().await.expect("failed to read response body");
 
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-    assert!(body.contains("required source database attributes"));
+    assert!(body.contains("required attributes for your source database"));
 
     drop_pg_database(&source_db_config).await;
 }


### PR DESCRIPTION
## Summary

This PR aligns ETL API error semantics with the API availability/latency SLOs.

API changes:
- Classify source/customer database dependency failures as `502`, `503`, or `504` instead of API-owned `500`s.
- Keep API metadata DB, Kubernetes, trusted cert, image/replicator, and internal serialization failures as internal `500`s.
- Ensure public error bodies are sanitized consistently and do not leak DB/config/deserialization details.
- Capture Sentry events only for internal `500` responses, excluding expected upstream/customer dependency failures.
- Bound unmatched API route metric labels to avoid high-cardinality raw paths.