### PR TITLE
ref(connection): Improve connection building

### DIFF
--- a/crates/etl-api/src/data/mod.rs
+++ b/crates/etl-api/src/data/mod.rs
@@ -1,4 +1,6 @@
-use etl_config::shared::{ETL_API_OPTIONS, PgConnectionConfig};
+use std::sync::LazyLock;
+
+use etl_config::shared::{PgConnectionConfig, PgConnectionOptions};
 use etl_postgres::replication::connect_to_source_database;
 use sqlx::PgPool;
 
@@ -18,6 +20,14 @@ pub mod utils;
 const MIN_POOL_CONNECTIONS: u32 = 1;
 /// Maximum number of connections for the source Postgres connection pool.
 const MAX_POOL_CONNECTIONS: u32 = 1;
+/// Application name for ETL API source database connections.
+const APP_NAME_API: &str = "supabase_etl_api";
+
+/// Connection options for API source database queries.
+///
+/// Uses strict timeouts to keep API requests responsive under contention.
+static API_OPTIONS: LazyLock<PgConnectionOptions> =
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_API).lock_timeout(5_000).build());
 
 /// Connects to the source database with the specified configuration and default
 /// connection pool size.
@@ -33,7 +43,7 @@ pub async fn connect_to_source_database_from_api(
         config,
         MIN_POOL_CONNECTIONS,
         MAX_POOL_CONNECTIONS,
-        Some(&ETL_API_OPTIONS),
+        Some(&API_OPTIONS),
     )
     .await
 }

--- a/crates/etl-api/src/data/mod.rs
+++ b/crates/etl-api/src/data/mod.rs
@@ -27,7 +27,7 @@ const APP_NAME_API: &str = "supabase_etl_api";
 ///
 /// Uses strict timeouts to keep API requests responsive under contention.
 static API_OPTIONS: LazyLock<PgConnectionOptions> =
-    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_API).lock_timeout(5_000).build());
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_API).build());
 
 /// Connects to the source database with the specified configuration and default
 /// connection pool size.

--- a/crates/etl-api/tests/support/database.rs
+++ b/crates/etl-api/tests/support/database.rs
@@ -27,9 +27,8 @@ const DEFAULT_DATABASE_USERNAME: &str = "postgres";
 const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
 const APP_NAME_TEST_MIGRATIONS: &str = "supabase_etl_api_test_migrations";
 
-static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
-    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).build()
-});
+static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> =
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).build());
 
 /// Creates a database configuration from TESTS_DATABASE_* environment
 /// variables.

--- a/crates/etl-api/tests/support/database.rs
+++ b/crates/etl-api/tests/support/database.rs
@@ -28,7 +28,7 @@ const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
 const APP_NAME_TEST_MIGRATIONS: &str = "supabase_etl_api_test_migrations";
 
 static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
-    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).statement_timeout(300_000).build()
+    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).build()
 });
 
 /// Creates a database configuration from TESTS_DATABASE_* environment

--- a/crates/etl-api/tests/support/database.rs
+++ b/crates/etl-api/tests/support/database.rs
@@ -1,12 +1,14 @@
 #![allow(dead_code)]
 
+use std::sync::LazyLock;
+
 use etl_api::{
     configs::source::FullApiSourceConfig,
     routes::sources::{CreateSourceRequest, CreateSourceResponse},
 };
 use etl_config::{
     SerializableSecretString,
-    shared::{ETL_MIGRATION_OPTIONS, IntoConnectOptions, PgConnectionConfig, TcpKeepaliveConfig},
+    shared::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions, TcpKeepaliveConfig},
 };
 use etl_postgres::{
     sqlx::test_utils::create_pg_database,
@@ -23,6 +25,12 @@ const DEFAULT_DATABASE_HOST: &str = "localhost";
 const DEFAULT_DATABASE_PORT: &str = "5430";
 const DEFAULT_DATABASE_USERNAME: &str = "postgres";
 const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
+const APP_NAME_TEST_MIGRATIONS: &str = "supabase_etl_api_test_migrations";
+
+static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
+    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).statement_timeout(300_000).build()
+});
+
 /// Creates a database configuration from TESTS_DATABASE_* environment
 /// variables.
 ///
@@ -183,7 +191,7 @@ pub(crate) async fn drop_trusted_source_database(database: TrustedSourceDatabase
 /// Panics if database connection fails, schema creation fails, or migrations
 /// fail.
 pub(crate) async fn run_etl_migrations_on_source_database(source_db_config: &PgConnectionConfig) {
-    let options = source_db_config.with_db(Some(&ETL_MIGRATION_OPTIONS));
+    let options = source_db_config.with_db(Some(&TEST_MIGRATION_OPTIONS));
     let mut connection =
         PgConnection::connect_with(&options).await.expect("failed to connect to source database");
 

--- a/crates/etl-config/src/shared/connection.rs
+++ b/crates/etl-config/src/shared/connection.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, sync::LazyLock, time::Duration};
+use std::{net::IpAddr, time::Duration};
 
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -24,96 +24,12 @@ const COMMON_INTERVALSTYLE: &str = "postgres";
 const COMMON_EXTRA_FLOAT_DIGITS: i32 = 3;
 const COMMON_CLIENT_ENCODING: &str = "UTF8";
 const COMMON_TIMEZONE: &str = "UTC";
-
-/// Application name for ETL API connections.
-const APP_NAME_API: &str = "supabase_etl_api";
-
-/// Application name for ETL replicator migration connections.
-const APP_NAME_REPLICATOR_MIGRATIONS: &str = "supabase_etl_replicator_migrations";
-
-/// Application name for ETL out-of-band Postgres connections.
-const APP_NAME_REPLICATOR_OUT_OF_BAND: &str = "supabase_etl_replicator_out_of_band";
-
-/// Application name for ETL logical replication streaming connections.
-const APP_NAME_REPLICATOR_STREAMING: &str = "supabase_etl_replicator_streaming";
-
-/// Connection options for the API's metadata database.
-///
-/// Uses strict timeouts (30s statement, 5s lock, 60s idle) to maintain
-/// responsiveness and fail fast when contention occurs, preventing API request
-/// timeouts.
-pub static ETL_API_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| PgConnectionOptions {
-    datestyle: COMMON_DATESTYLE.to_owned(),
-    intervalstyle: COMMON_INTERVALSTYLE.to_owned(),
-    extra_float_digits: COMMON_EXTRA_FLOAT_DIGITS,
-    client_encoding: COMMON_CLIENT_ENCODING.to_owned(),
-    timezone: COMMON_TIMEZONE.to_owned(),
-    statement_timeout: 30_000,
-    lock_timeout: 5_000,
-    idle_in_transaction_session_timeout: 60_000,
-    application_name: APP_NAME_API.to_owned(),
-});
-
-/// Connection options for database migrations.
-///
-/// Uses extended statement timeout (5 minutes) to accommodate long-running DDL
-/// operations while maintaining moderate lock and idle timeouts (10s lock, 60s
-/// idle).
-pub static ETL_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> =
-    LazyLock::new(|| PgConnectionOptions {
-        datestyle: COMMON_DATESTYLE.to_owned(),
-        intervalstyle: COMMON_INTERVALSTYLE.to_owned(),
-        extra_float_digits: COMMON_EXTRA_FLOAT_DIGITS,
-        client_encoding: COMMON_CLIENT_ENCODING.to_owned(),
-        timezone: COMMON_TIMEZONE.to_owned(),
-        statement_timeout: 300_000,
-        lock_timeout: 10_000,
-        idle_in_transaction_session_timeout: 60_000,
-        application_name: APP_NAME_REPLICATOR_MIGRATIONS.to_owned(),
-    });
-
-/// Connection options for logical replication streams.
-///
-/// Disables statement, lock, and idle timeouts to allow large COPY operations
-/// and long-running transactions during initial table synchronization and WAL
-/// streaming.
-///
-/// Keep the session timezone at UTC so Postgres renders `timestamptz` text
-/// output with a deterministic UTC offset for replication parsing.
-///
-/// Lock timeout is disabled because `CREATE_REPLICATION_SLOT` must wait for all
-/// in-progress write transactions to reach a consistent snapshot point. On
-/// heavily-loaded databases this can take minutes, and a timeout would only
-/// cause retries that will also fail.
-pub static ETL_REPLICATION_OPTIONS: LazyLock<PgConnectionOptions> =
-    LazyLock::new(|| PgConnectionOptions {
-        datestyle: COMMON_DATESTYLE.to_owned(),
-        intervalstyle: COMMON_INTERVALSTYLE.to_owned(),
-        extra_float_digits: COMMON_EXTRA_FLOAT_DIGITS,
-        client_encoding: COMMON_CLIENT_ENCODING.to_owned(),
-        timezone: COMMON_TIMEZONE.to_owned(),
-        statement_timeout: 0,
-        lock_timeout: 0,
-        idle_in_transaction_session_timeout: 0,
-        application_name: APP_NAME_REPLICATOR_STREAMING.to_owned(),
-    });
-
-/// Connection options for out-of-band ETL queries to Postgres.
-///
-/// Applies moderate timeouts (30s statement, 10s lock, 60s idle) since these
-/// queries should execute quickly and should not block other operations.
-pub static ETL_OUT_OF_BAND_OPTIONS: LazyLock<PgConnectionOptions> =
-    LazyLock::new(|| PgConnectionOptions {
-        datestyle: COMMON_DATESTYLE.to_owned(),
-        intervalstyle: COMMON_INTERVALSTYLE.to_owned(),
-        extra_float_digits: COMMON_EXTRA_FLOAT_DIGITS,
-        client_encoding: COMMON_CLIENT_ENCODING.to_owned(),
-        timezone: COMMON_TIMEZONE.to_owned(),
-        statement_timeout: 30_000,
-        lock_timeout: 10_000,
-        idle_in_transaction_session_timeout: 60_000,
-        application_name: APP_NAME_REPLICATOR_OUT_OF_BAND.to_owned(),
-    });
+/// Default statement timeout in milliseconds for bounded ETL queries.
+const DEFAULT_STATEMENT_TIMEOUT: u32 = 30_000;
+/// Default lock timeout in milliseconds for bounded ETL queries.
+const DEFAULT_LOCK_TIMEOUT: u32 = 10_000;
+/// Default idle-in-transaction timeout in milliseconds for bounded ETL queries.
+const DEFAULT_IDLE_IN_TRANSACTION_SESSION_TIMEOUT: u32 = 60_000;
 
 /// Postgres server options for ETL workloads.
 ///
@@ -146,6 +62,26 @@ pub struct PgConnectionOptions {
 }
 
 impl PgConnectionOptions {
+    /// Starts building connection options with common ETL Postgres defaults.
+    ///
+    /// The `application_name` must be provided by each workload so database
+    /// sessions can be identified in Postgres logs and activity views.
+    pub fn builder(application_name: impl Into<String>) -> PgConnectionOptionsBuilder {
+        PgConnectionOptionsBuilder {
+            options: PgConnectionOptions {
+                datestyle: COMMON_DATESTYLE.to_owned(),
+                intervalstyle: COMMON_INTERVALSTYLE.to_owned(),
+                extra_float_digits: COMMON_EXTRA_FLOAT_DIGITS,
+                client_encoding: COMMON_CLIENT_ENCODING.to_owned(),
+                timezone: COMMON_TIMEZONE.to_owned(),
+                statement_timeout: DEFAULT_STATEMENT_TIMEOUT,
+                lock_timeout: DEFAULT_LOCK_TIMEOUT,
+                idle_in_transaction_session_timeout: DEFAULT_IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
+                application_name: application_name.into(),
+            },
+        }
+    }
+
     /// Formats options as a string for tokio-postgres connection.
     ///
     /// Returns space-separated `-c key=value` pairs suitable for the options
@@ -185,6 +121,45 @@ impl PgConnectionOptions {
             ),
             ("application_name".to_owned(), self.application_name.clone()),
         ]
+    }
+}
+
+/// Builder for [`PgConnectionOptions`] with common ETL defaults.
+///
+/// Workload-specific options should prefer this builder over constructing
+/// [`PgConnectionOptions`] directly so shared Postgres session invariants
+/// remain consistent across connection types.
+#[derive(Debug, Clone)]
+pub struct PgConnectionOptionsBuilder {
+    /// Options being configured.
+    options: PgConnectionOptions,
+}
+
+impl PgConnectionOptionsBuilder {
+    /// Overrides the statement timeout in milliseconds.
+    pub fn statement_timeout(mut self, statement_timeout: u32) -> Self {
+        self.options.statement_timeout = statement_timeout;
+        self
+    }
+
+    /// Overrides the lock timeout in milliseconds.
+    pub fn lock_timeout(mut self, lock_timeout: u32) -> Self {
+        self.options.lock_timeout = lock_timeout;
+        self
+    }
+
+    /// Overrides the idle-in-transaction session timeout in milliseconds.
+    pub fn idle_in_transaction_session_timeout(
+        mut self,
+        idle_in_transaction_session_timeout: u32,
+    ) -> Self {
+        self.options.idle_in_transaction_session_timeout = idle_in_transaction_session_timeout;
+        self
+    }
+
+    /// Builds the finalized connection options.
+    pub fn build(self) -> PgConnectionOptions {
+        self.options
     }
 }
 
@@ -442,7 +417,12 @@ mod tests {
 
     #[test]
     fn replication_options_string_format() {
-        let options_string = ETL_REPLICATION_OPTIONS.to_options_string();
+        let options = PgConnectionOptions::builder("supabase_etl_replicator_streaming")
+            .statement_timeout(0)
+            .lock_timeout(0)
+            .idle_in_transaction_session_timeout(0)
+            .build();
+        let options_string = options.to_options_string();
 
         assert_eq!(
             options_string,
@@ -455,7 +435,8 @@ mod tests {
 
     #[test]
     fn out_of_band_options_key_value_pairs() {
-        let pairs = ETL_OUT_OF_BAND_OPTIONS.to_key_value_pairs();
+        let options = PgConnectionOptions::builder("supabase_etl_replicator_out_of_band").build();
+        let pairs = options.to_key_value_pairs();
 
         assert_eq!(pairs.len(), 9);
         assert!(pairs.contains(&("datestyle".to_owned(), "ISO".to_owned())));
@@ -475,8 +456,21 @@ mod tests {
     }
 
     #[test]
-    fn api_options_application_name() {
-        assert_eq!(ETL_API_OPTIONS.application_name, "supabase_etl_api");
+    fn builder_applies_common_defaults_and_overrides() {
+        let options = PgConnectionOptions::builder("custom_workload")
+            .statement_timeout(45_000)
+            .lock_timeout(6_000)
+            .build();
+
+        assert_eq!(options.datestyle, "ISO");
+        assert_eq!(options.intervalstyle, "postgres");
+        assert_eq!(options.extra_float_digits, 3);
+        assert_eq!(options.client_encoding, "UTF8");
+        assert_eq!(options.timezone, "UTC");
+        assert_eq!(options.statement_timeout, 45_000);
+        assert_eq!(options.lock_timeout, 6_000);
+        assert_eq!(options.idle_in_transaction_session_timeout, 60_000);
+        assert_eq!(options.application_name, "custom_workload");
     }
 
     #[test]

--- a/crates/etl-config/src/shared/mod.rs
+++ b/crates/etl-config/src/shared/mod.rs
@@ -9,9 +9,8 @@ mod validators;
 
 pub use base::ValidationError;
 pub use connection::{
-    ETL_API_OPTIONS, ETL_MIGRATION_OPTIONS, ETL_OUT_OF_BAND_OPTIONS, ETL_REPLICATION_OPTIONS,
     IntoConnectOptions, PgConnectionConfig, PgConnectionConfigWithoutSecrets, PgConnectionOptions,
-    TcpKeepaliveConfig, TlsConfig,
+    PgConnectionOptionsBuilder, TcpKeepaliveConfig, TlsConfig,
 };
 pub use destination::{
     ClickHouseEngine, DestinationConfig, DestinationConfigWithoutSecrets, DestinationKind,

--- a/crates/etl/src/config/mod.rs
+++ b/crates/etl/src/config/mod.rs
@@ -7,12 +7,12 @@ pub use etl_config::{
     Config, Environment, LoadConfigError, ParseDucklakeUrlError, SerializableSecretString,
     load_config, parse_ducklake_s3_data_path, parse_ducklake_url,
     shared::{
-        BatchConfig, DestinationConfig, DestinationConfigWithoutSecrets, ETL_API_OPTIONS,
-        ETL_MIGRATION_OPTIONS, ETL_OUT_OF_BAND_OPTIONS, ETL_REPLICATION_OPTIONS, IcebergConfig,
+        BatchConfig, DestinationConfig, DestinationConfigWithoutSecrets, IcebergConfig,
         IcebergConfigWithoutSecrets, IntoConnectOptions, InvalidatedSlotBehavior,
         MemoryBackpressureConfig, PgConnectionConfig, PgConnectionConfigWithoutSecrets,
-        PgConnectionOptions, PipelineConfig, PipelineConfigWithoutSecrets, ReplicatorConfig,
-        ReplicatorConfigWithoutSecrets, SentryConfig, SupabaseConfig, SupabaseConfigWithoutSecrets,
-        TableSyncCopyConfig, TcpKeepaliveConfig, TlsConfig, ValidationError,
+        PgConnectionOptions, PgConnectionOptionsBuilder, PipelineConfig,
+        PipelineConfigWithoutSecrets, ReplicatorConfig, ReplicatorConfigWithoutSecrets,
+        SentryConfig, SupabaseConfig, SupabaseConfigWithoutSecrets, TableSyncCopyConfig,
+        TcpKeepaliveConfig, TlsConfig, ValidationError,
     },
 };

--- a/crates/etl/src/conversions/time.rs
+++ b/crates/etl/src/conversions/time.rs
@@ -13,10 +13,10 @@ pub(crate) fn parse_postgres_timetz(value: &str) -> Result<PgTimeTz, ParseTimeEr
 
 /// Parses a Postgres `timestamp with time zone` text value.
 ///
-/// Replication connections set the Postgres session timezone to UTC through
-/// `ETL_REPLICATION_OPTIONS`. This parser accepts numeric offsets, but UTC
-/// session output keeps `timestamptz` values deterministic before they are
-/// normalized into [`chrono::Utc`].
+/// Replication connections set the Postgres session timezone to UTC. This
+/// parser accepts numeric offsets, but UTC session output keeps
+/// `timestamptz` values deterministic before they are normalized into
+/// [`chrono::Utc`].
 pub(crate) fn parse_postgres_timestamptz(
     value: &str,
 ) -> Result<DateTime<FixedOffset>, ParseTimeError> {

--- a/crates/etl/src/migrations.rs
+++ b/crates/etl/src/migrations.rs
@@ -19,7 +19,7 @@ const APP_NAME_REPLICATOR_MIGRATIONS: &str = "supabase_etl_replicator_migrations
 /// Uses an extended statement timeout for DDL while keeping bounded lock and
 /// idle-in-transaction timeouts from the common Postgres defaults.
 static MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
-    PgConnectionOptions::builder(APP_NAME_REPLICATOR_MIGRATIONS).statement_timeout(300_000).build()
+    PgConnectionOptions::builder(APP_NAME_REPLICATOR_MIGRATIONS).build()
 });
 
 /// Creates a PostgreSQL connection prepared for ETL migrations.

--- a/crates/etl/src/migrations.rs
+++ b/crates/etl/src/migrations.rs
@@ -18,9 +18,8 @@ const APP_NAME_REPLICATOR_MIGRATIONS: &str = "supabase_etl_replicator_migrations
 ///
 /// Uses an extended statement timeout for DDL while keeping bounded lock and
 /// idle-in-transaction timeouts from the common Postgres defaults.
-static MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
-    PgConnectionOptions::builder(APP_NAME_REPLICATOR_MIGRATIONS).build()
-});
+static MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> =
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_REPLICATOR_MIGRATIONS).build());
 
 /// Creates a PostgreSQL connection prepared for ETL migrations.
 async fn create_migration_connection(

--- a/crates/etl/src/migrations.rs
+++ b/crates/etl/src/migrations.rs
@@ -1,19 +1,32 @@
 //! Database migrations required by ETL.
 
+use std::sync::LazyLock;
+
 use sqlx::{Connection, Executor, PgConnection, migrate::Migrator, postgres::PgConnectOptions};
 use tracing::debug;
 
 use crate::{
-    config::{ETL_MIGRATION_OPTIONS, IntoConnectOptions, PgConnectionConfig},
+    config::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions},
     error::{ErrorKind, EtlResult},
     etl_error,
 };
+
+/// Application name for ETL migration connections.
+const APP_NAME_REPLICATOR_MIGRATIONS: &str = "supabase_etl_replicator_migrations";
+
+/// Connection options for ETL migration queries.
+///
+/// Uses an extended statement timeout for DDL while keeping bounded lock and
+/// idle-in-transaction timeouts from the common Postgres defaults.
+static MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
+    PgConnectionOptions::builder(APP_NAME_REPLICATOR_MIGRATIONS).statement_timeout(300_000).build()
+});
 
 /// Creates a PostgreSQL connection prepared for ETL migrations.
 async fn create_migration_connection(
     connection_config: &PgConnectionConfig,
 ) -> Result<PgConnection, sqlx::Error> {
-    let options: PgConnectOptions = connection_config.with_db(Some(&ETL_MIGRATION_OPTIONS));
+    let options: PgConnectOptions = connection_config.with_db(Some(&MIGRATION_OPTIONS));
 
     let mut conn = PgConnection::connect_with(&options).await?;
 
@@ -36,7 +49,7 @@ async fn create_migration_connection(
 async fn source_database_in_recovery(
     connection_config: &PgConnectionConfig,
 ) -> Result<bool, sqlx::Error> {
-    let options: PgConnectOptions = connection_config.with_db(Some(&ETL_MIGRATION_OPTIONS));
+    let options: PgConnectOptions = connection_config.with_db(Some(&MIGRATION_OPTIONS));
     let mut conn = PgConnection::connect_with(&options).await?;
 
     sqlx::query_scalar("select pg_is_in_recovery()").fetch_one(&mut conn).await

--- a/crates/etl/src/replication/client/raw.rs
+++ b/crates/etl/src/replication/client/raw.rs
@@ -45,7 +45,7 @@ const DELETE_SLOT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Default duration unit used when `pg_settings.unit` is empty.
 const PG_SETTINGS_DEFAULT_DURATION_UNIT: &str = "ms";
 /// Application name for ETL logical replication connections.
-const APP_NAME_REPLICATOR_STREAMING: &str = "supabase_etl_replicator_streaming";
+const APP_NAME_REPLICATOR_REPLICATION: &str = "supabase_etl_replicator_replication";
 
 /// Connection options for logical replication streams.
 ///
@@ -53,7 +53,7 @@ const APP_NAME_REPLICATOR_STREAMING: &str = "supabase_etl_replicator_streaming";
 /// replication streams, slot creation, and initial table synchronization can
 /// legitimately run for a long time.
 static REPLICATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
-    PgConnectionOptions::builder(APP_NAME_REPLICATOR_STREAMING)
+    PgConnectionOptions::builder(APP_NAME_REPLICATOR_REPLICATION)
         .statement_timeout(0)
         .lock_timeout(0)
         .idle_in_transaction_session_timeout(0)

--- a/crates/etl/src/replication/client/raw.rs
+++ b/crates/etl/src/replication/client/raw.rs
@@ -47,7 +47,7 @@ const PG_SETTINGS_DEFAULT_DURATION_UNIT: &str = "ms";
 /// Application name for ETL logical replication connections.
 const APP_NAME_REPLICATOR_REPLICATION: &str = "supabase_etl_replicator_replication";
 
-/// Connection options for logical replication streams.
+/// Connection options for logical replication.
 ///
 /// Disables statement, lock, and idle-in-transaction timeouts because
 /// replication streams, slot creation, and initial table synchronization can

--- a/crates/etl/src/replication/client/raw.rs
+++ b/crates/etl/src/replication/client/raw.rs
@@ -1,4 +1,9 @@
-use std::{fmt, num::NonZeroI32, sync::Arc, time::Duration};
+use std::{
+    fmt,
+    num::NonZeroI32,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use etl_postgres::{replication::extract_server_version, tokio::tls::MakeRustlsConnect};
 use pg_escape::{quote_identifier, quote_literal};
@@ -26,7 +31,7 @@ use super::{
 };
 use crate::{
     bail,
-    config::{ETL_REPLICATION_OPTIONS, IntoConnectOptions, PgConnectionConfig},
+    config::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions},
     error::{ErrorKind, EtlResult},
     etl_error,
     types::{PgLsn, TableId, TableName},
@@ -39,6 +44,21 @@ use crate::{
 const DELETE_SLOT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Default duration unit used when `pg_settings.unit` is empty.
 const PG_SETTINGS_DEFAULT_DURATION_UNIT: &str = "ms";
+/// Application name for ETL logical replication connections.
+const APP_NAME_REPLICATOR_STREAMING: &str = "supabase_etl_replicator_streaming";
+
+/// Connection options for logical replication streams.
+///
+/// Disables statement, lock, and idle-in-transaction timeouts because
+/// replication streams, slot creation, and initial table synchronization can
+/// legitimately run for a long time.
+static REPLICATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
+    PgConnectionOptions::builder(APP_NAME_REPLICATOR_STREAMING)
+        .statement_timeout(0)
+        .lock_timeout(0)
+        .idle_in_transaction_session_timeout(0)
+        .build()
+});
 
 /// The kind of PostgreSQL connection to create.
 #[derive(Debug, Clone, Copy)]
@@ -217,7 +237,7 @@ impl PgReplicationClient {
         kind: ConnectionKind,
     ) -> EtlResult<Self> {
         let mut config: Config =
-            connection_config.pg_connection_config().with_db(Some(&ETL_REPLICATION_OPTIONS));
+            connection_config.pg_connection_config().with_db(Some(&REPLICATION_OPTIONS));
         kind.configure(&mut config);
 
         let (client, connection) = config.connect(NoTls).await?;
@@ -238,7 +258,7 @@ impl PgReplicationClient {
         kind: ConnectionKind,
     ) -> EtlResult<Self> {
         let mut config: Config =
-            connection_config.pg_connection_config().with_db(Some(&ETL_REPLICATION_OPTIONS));
+            connection_config.pg_connection_config().with_db(Some(&REPLICATION_OPTIONS));
         kind.configure(&mut config);
 
         let tls_config = connection_config.tls_client_config().ok_or_else(|| {

--- a/crates/etl/src/replication/out_of_band_pool.rs
+++ b/crates/etl/src/replication/out_of_band_pool.rs
@@ -1,10 +1,10 @@
 //! Shared source database pool for out-of-band ETL queries.
 
-use std::time::Duration;
+use std::{sync::LazyLock, time::Duration};
 
 use sqlx::{PgPool, postgres::PgPoolOptions};
 
-use crate::config::{ETL_OUT_OF_BAND_OPTIONS, IntoConnectOptions, PgConnectionConfig};
+use crate::config::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions};
 
 /// Maximum number of connections in the out-of-band pool.
 const MAX_POOL_CONNECTIONS: u32 = 1;
@@ -12,6 +12,15 @@ const MAX_POOL_CONNECTIONS: u32 = 1;
 const MIN_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Extra idle time kept beyond the configured lag refresh interval.
 const IDLE_TIMEOUT_REFRESH_PADDING: Duration = Duration::from_secs(30);
+/// Application name for ETL out-of-band source database connections.
+const APP_NAME_REPLICATOR_OUT_OF_BAND: &str = "supabase_etl_replicator_out_of_band";
+
+/// Connection options for out-of-band source database queries.
+///
+/// Uses the common bounded-query Postgres defaults because lag sampling queries
+/// should be quick and should not block source database work.
+static OUT_OF_BAND_OPTIONS: LazyLock<PgConnectionOptions> =
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_REPLICATOR_OUT_OF_BAND).build());
 
 /// Shared lazy pool for out-of-band source database queries.
 #[derive(Debug, Clone)]
@@ -25,7 +34,7 @@ impl OutOfBandSourcePool {
         connection_config: &PgConnectionConfig,
         replication_lag_refresh_interval: Duration,
     ) -> Self {
-        let connect_options = connection_config.with_db(Some(&ETL_OUT_OF_BAND_OPTIONS));
+        let connect_options = connection_config.with_db(Some(&OUT_OF_BAND_OPTIONS));
         let idle_timeout = replication_lag_refresh_interval
             .saturating_add(IDLE_TIMEOUT_REFRESH_PADDING)
             .max(MIN_IDLE_TIMEOUT);

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     ops::DerefMut,
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 
@@ -15,7 +15,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, info};
 
 use crate::{
-    config::{ETL_OUT_OF_BAND_OPTIONS, IntoConnectOptions, PgConnectionConfig},
+    config::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions},
     error::{ErrorKind, EtlResult},
     etl_error,
     metrics::{ETL_TABLES_TOTAL, STATE_LABEL},
@@ -39,6 +39,16 @@ const MAX_POOL_CONNECTIONS: u32 = 2;
 /// Duration after which idle connections are closed.
 const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Application name for Postgres state store connections.
+const APP_NAME_REPLICATOR_STORE: &str = "supabase_etl_replicator_store";
+
+/// Connection options for Postgres state store queries.
+///
+/// These settings intentionally mirror out-of-band query timeouts while using a
+/// store-specific application name for clearer database observability.
+static POSTGRES_STORE_OPTIONS: LazyLock<PgConnectionOptions> =
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_REPLICATOR_STORE).build());
+
 /// Maximum number of schema snapshots to keep cached per table.
 ///
 /// This limits memory usage by evicting older snapshots when new ones are
@@ -56,7 +66,7 @@ const MAX_CACHED_SCHEMAS_PER_TABLE: usize = 2;
 /// be open for a while and then closed when it's unnecessary since after the
 /// first table copy state, we don't update the state so often.
 fn create_database_pool(connection_config: &PgConnectionConfig) -> PgPool {
-    let options = connection_config.with_db(Some(&ETL_OUT_OF_BAND_OPTIONS));
+    let options = connection_config.with_db(Some(&POSTGRES_STORE_OPTIONS));
 
     PgPoolOptions::new()
         .min_connections(0)

--- a/crates/etl/tests/migrations.rs
+++ b/crates/etl/tests/migrations.rs
@@ -23,9 +23,8 @@ const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
 const POSTGRES_STORE_BASE_VERSION: i64 = 20250827000000;
 const APP_NAME_TEST_MIGRATIONS: &str = "supabase_etl_test_migrations";
 
-static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
-    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).build()
-});
+static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> =
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).build());
 
 fn local_pg_connection_config() -> PgConnectionConfig {
     PgConnectionConfig {

--- a/crates/etl/tests/migrations.rs
+++ b/crates/etl/tests/migrations.rs
@@ -24,7 +24,7 @@ const POSTGRES_STORE_BASE_VERSION: i64 = 20250827000000;
 const APP_NAME_TEST_MIGRATIONS: &str = "supabase_etl_test_migrations";
 
 static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
-    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).statement_timeout(300_000).build()
+    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).build()
 });
 
 fn local_pg_connection_config() -> PgConnectionConfig {

--- a/crates/etl/tests/migrations.rs
+++ b/crates/etl/tests/migrations.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, sync::LazyLock};
 
 use etl::{
     config::{
-        BatchConfig, ETL_MIGRATION_OPTIONS, IntoConnectOptions, InvalidatedSlotBehavior,
-        MemoryBackpressureConfig, PgConnectionConfig, PipelineConfig, TableSyncCopyConfig,
+        BatchConfig, IntoConnectOptions, InvalidatedSlotBehavior, MemoryBackpressureConfig,
+        PgConnectionConfig, PgConnectionOptions, PipelineConfig, TableSyncCopyConfig,
     },
     migrations::run_source_migrations,
     pipeline::Pipeline,
@@ -21,6 +21,11 @@ const DEFAULT_DATABASE_PORT: &str = "5430";
 const DEFAULT_DATABASE_USERNAME: &str = "postgres";
 const DEFAULT_DATABASE_PASSWORD: &str = "postgres";
 const POSTGRES_STORE_BASE_VERSION: i64 = 20250827000000;
+const APP_NAME_TEST_MIGRATIONS: &str = "supabase_etl_test_migrations";
+
+static TEST_MIGRATION_OPTIONS: LazyLock<PgConnectionOptions> = LazyLock::new(|| {
+    PgConnectionOptions::builder(APP_NAME_TEST_MIGRATIONS).statement_timeout(300_000).build()
+});
 
 fn local_pg_connection_config() -> PgConnectionConfig {
     PgConnectionConfig {
@@ -82,7 +87,7 @@ async fn applied_migration_versions(database: &PgDatabase<Client>) -> Vec<i64> {
 }
 
 async fn migration_connection(connection_config: &PgConnectionConfig) -> PgConnection {
-    let options: PgConnectOptions = connection_config.with_db(Some(&ETL_MIGRATION_OPTIONS));
+    let options: PgConnectOptions = connection_config.with_db(Some(&TEST_MIGRATION_OPTIONS));
     let mut conn = PgConnection::connect_with(&options).await.unwrap();
 
     conn.execute("set client_min_messages = warning;").await.unwrap();


### PR DESCRIPTION
## Summary

- Add a `PgConnectionOptions` builder that centralizes common Postgres session defaults.
- Move workload-specific connection options next to the code that uses them.
- Give the Postgres state store its own connection application name: `supabase_etl_replicator_store`.
- Keep out-of-band, replication, migration, API, and test connection settings explicit at their call sites.