### PR TITLE
fix(api): Improve tenant deletion reliability

### DIFF
--- a/crates/etl-api/src/data/mod.rs
+++ b/crates/etl-api/src/data/mod.rs
@@ -1,49 +1,12 @@
-use std::sync::LazyLock;
-
-use etl_config::shared::{PgConnectionConfig, PgConnectionOptions};
-use etl_postgres::replication::connect_to_source_database;
-use sqlx::PgPool;
-
 pub mod destinations;
 pub mod destinations_pipelines;
 pub mod images;
 pub mod pipelines;
 pub mod publications;
 pub mod replicators;
+pub mod source_database;
 pub mod sources;
 pub mod tables;
 pub mod tenants;
 pub mod tenants_sources;
 pub mod utils;
-
-/// Minimum number of connections for the source Postgres connection pool.
-const MIN_POOL_CONNECTIONS: u32 = 1;
-/// Maximum number of connections for the source Postgres connection pool.
-const MAX_POOL_CONNECTIONS: u32 = 1;
-/// Application name for ETL API source database connections.
-const APP_NAME_API: &str = "supabase_etl_api";
-
-/// Connection options for API source database queries.
-///
-/// Uses strict timeouts to keep API requests responsive under contention.
-static API_OPTIONS: LazyLock<PgConnectionOptions> =
-    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_API).build());
-
-/// Connects to the source database with the specified configuration and default
-/// connection pool size.
-///
-/// Uses state management options with moderate timeouts suitable for
-/// administrative queries like listing tables and reading publications. If
-/// configured, the source connection uses `hostaddr` as the TCP target and
-/// preserves `host` as the canonical database hostname in stored API state.
-pub async fn connect_to_source_database_from_api(
-    config: &PgConnectionConfig,
-) -> Result<PgPool, sqlx::Error> {
-    connect_to_source_database(
-        config,
-        MIN_POOL_CONNECTIONS,
-        MAX_POOL_CONNECTIONS,
-        Some(&API_OPTIONS),
-    )
-    .await
-}

--- a/crates/etl-api/src/data/source_database.rs
+++ b/crates/etl-api/src/data/source_database.rs
@@ -1,0 +1,197 @@
+use std::{io::ErrorKind, sync::LazyLock};
+
+use etl_config::shared::{PgConnectionConfig, PgConnectionOptions};
+use etl_postgres::replication::connect_to_source_database;
+use sqlx::{PgPool, error::DatabaseError};
+
+/// Classification for source database errors exposed by API routes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceDatabaseErrorKind {
+    /// The source database did not respond before the request timeout.
+    TimedOut,
+    /// The source database is unavailable or the existing connection was lost.
+    Unavailable,
+    /// The source database returned an error that is not a connection lifecycle
+    /// failure.
+    Failed,
+}
+
+/// Minimum number of connections for the source Postgres connection pool.
+const MIN_POOL_CONNECTIONS: u32 = 1;
+
+/// Maximum number of connections for the source Postgres connection pool.
+const MAX_POOL_CONNECTIONS: u32 = 1;
+/// Application name for ETL API source database connections.
+const APP_NAME_API: &str = "supabase_etl_api";
+
+/// Connection options for API source database queries.
+///
+/// Uses strict timeouts to keep API requests responsive under contention.
+static API_OPTIONS: LazyLock<PgConnectionOptions> =
+    LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_API).build());
+
+/// Connects to the source database with API route defaults.
+///
+/// Uses state management options with moderate timeouts suitable for
+/// administrative queries like listing tables and reading publications. If
+/// configured, the source connection uses `hostaddr` as the TCP target and
+/// preserves `host` as the canonical database hostname in stored API state.
+pub(crate) async fn connect(config: &PgConnectionConfig) -> Result<PgPool, sqlx::Error> {
+    connect_to_source_database(
+        config,
+        MIN_POOL_CONNECTIONS,
+        MAX_POOL_CONNECTIONS,
+        Some(&API_OPTIONS),
+    )
+    .await
+}
+
+/// Classifies a source database error using stable SQLSTATE and IO categories.
+pub(crate) fn classify_error(error: &sqlx::Error) -> SourceDatabaseErrorKind {
+    match error {
+        sqlx::Error::Io(error) if error.kind() == ErrorKind::TimedOut => {
+            SourceDatabaseErrorKind::TimedOut
+        }
+        error if error_is_unavailable(error) => SourceDatabaseErrorKind::Unavailable,
+        _ => SourceDatabaseErrorKind::Failed,
+    }
+}
+
+/// Returns true when a source database error means the source is unavailable.
+pub(crate) fn error_is_unavailable(error: &sqlx::Error) -> bool {
+    match error {
+        sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed | sqlx::Error::WorkerCrashed => true,
+        sqlx::Error::Io(error) => io_error_is_unavailable(error.kind()),
+        sqlx::Error::Database(error) => database_error_is_unavailable(error.as_ref()),
+        _ => false,
+    }
+}
+
+/// Returns true when an IO error means the source connection cannot be used.
+fn io_error_is_unavailable(error_kind: ErrorKind) -> bool {
+    matches!(
+        error_kind,
+        ErrorKind::ConnectionRefused
+            | ErrorKind::ConnectionReset
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::NotConnected
+            | ErrorKind::BrokenPipe
+            | ErrorKind::TimedOut
+            | ErrorKind::UnexpectedEof
+    )
+}
+
+/// Returns true when a database SQLSTATE means the source connection cannot be
+/// used.
+fn database_error_is_unavailable(error: &dyn DatabaseError) -> bool {
+    let Some(code) = error.code() else {
+        return false;
+    };
+
+    // PostgreSQL recommends matching on SQLSTATE codes rather than localized
+    // message text. Class 08 covers connection exceptions; 53300 covers server
+    // connection exhaustion; 57P01-57P05 cover shutdown/crash/database-dropped
+    // and idle-session lifecycle failures.
+    code.starts_with("08")
+        || matches!(code.as_ref(), "53300" | "57P01" | "57P02" | "57P03" | "57P04" | "57P05")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, error::Error as StdError, fmt};
+
+    use super::*;
+
+    /// Test database error that lets tests exercise SQLSTATE classification.
+    #[derive(Debug)]
+    struct TestDatabaseError {
+        /// SQLSTATE exposed by this test error.
+        code: &'static str,
+    }
+
+    impl TestDatabaseError {
+        /// Creates a new test database error with the provided SQLSTATE.
+        fn new(code: &'static str) -> Self {
+            Self { code }
+        }
+    }
+
+    impl fmt::Display for TestDatabaseError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "test database error {}", self.code)
+        }
+    }
+
+    impl StdError for TestDatabaseError {}
+
+    impl DatabaseError for TestDatabaseError {
+        fn message(&self) -> &str {
+            "test database error"
+        }
+
+        fn code(&self) -> Option<Cow<'_, str>> {
+            Some(Cow::Borrowed(self.code))
+        }
+
+        fn as_error(&self) -> &(dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn StdError + Send + Sync + 'static> {
+            self
+        }
+
+        fn kind(&self) -> sqlx::error::ErrorKind {
+            sqlx::error::ErrorKind::Other
+        }
+    }
+
+    #[test]
+    fn pool_timeout_is_reported_as_service_unavailable() {
+        let error = sqlx::Error::PoolTimedOut;
+
+        assert_eq!(classify_error(&error), SourceDatabaseErrorKind::Unavailable);
+    }
+
+    #[test]
+    fn io_timeout_is_reported_as_gateway_timeout() {
+        let error = sqlx::Error::Io(std::io::Error::new(ErrorKind::TimedOut, "timed out"));
+
+        assert_eq!(classify_error(&error), SourceDatabaseErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn connection_io_errors_are_reported_as_service_unavailable() {
+        let error =
+            sqlx::Error::Io(std::io::Error::new(ErrorKind::ConnectionReset, "connection reset"));
+
+        assert_eq!(classify_error(&error), SourceDatabaseErrorKind::Unavailable);
+    }
+
+    #[test]
+    fn connection_sqlstate_errors_are_reported_as_service_unavailable() {
+        for code in ["08006", "53300", "57P01", "57P02", "57P03", "57P04", "57P05"] {
+            let error = sqlx::Error::Database(Box::new(TestDatabaseError::new(code)));
+
+            assert_eq!(classify_error(&error), SourceDatabaseErrorKind::Unavailable);
+        }
+    }
+
+    #[test]
+    fn non_connection_sqlstate_errors_are_reported_as_upstream_failures() {
+        let error = sqlx::Error::Database(Box::new(TestDatabaseError::new("42501")));
+
+        assert_eq!(classify_error(&error), SourceDatabaseErrorKind::Failed);
+    }
+
+    #[test]
+    fn protocol_errors_are_reported_as_upstream_failures() {
+        let error = sqlx::Error::Protocol("bad source response".to_owned());
+
+        assert_eq!(classify_error(&error), SourceDatabaseErrorKind::Failed);
+    }
+}

--- a/crates/etl-api/src/data/source_database.rs
+++ b/crates/etl-api/src/data/source_database.rs
@@ -17,8 +17,10 @@ pub(crate) enum SourceDatabaseErrorKind {
 }
 
 /// Minimum number of connections for the source Postgres connection pool.
-const MIN_POOL_CONNECTIONS: u32 = 1;
-
+///
+/// API source pools are request-scoped administrative pools, so they should not
+/// keep customer database connections open after their work is done.
+const MIN_POOL_CONNECTIONS: u32 = 0;
 /// Maximum number of connections for the source Postgres connection pool.
 const MAX_POOL_CONNECTIONS: u32 = 1;
 /// Application name for ETL API source database connections.

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -23,7 +23,6 @@ use crate::{
     },
     data,
     data::{
-        connect_to_source_database_from_api,
         destinations::{DestinationsDbError, destination_exists},
         destinations_pipelines::DestinationPipelinesDbError,
         images::ImagesDbError,
@@ -33,6 +32,7 @@ use crate::{
             delete_pipeline_source_state, read_pipeline, read_pipeline_for_deletion,
             read_pipelines_for_destination_for_deletion,
         },
+        source_database,
         sources::SourcesDbError,
     },
     feature_flags::{FeatureFlagsClient, get_max_pipelines_per_tenant},
@@ -140,7 +140,7 @@ impl DestinationPipelineError {
             | DestinationPipelineError::K8sCore(_) => "Internal server error".to_owned(),
             DestinationPipelineError::SourceDatabase(_)
             | DestinationPipelineError::SourcePipelineState(_) => {
-                "Could not query your source database".to_owned()
+                utils::source_database_query_error_message().to_owned()
             }
             DestinationPipelineError::Validation(error) => {
                 utils::validation_error_message(error).to_owned()
@@ -458,7 +458,7 @@ pub(crate) async fn delete_destination_and_pipeline(
     )
     .await?
     .ok_or(DestinationPipelineError::SourceNotFound(pipeline.source_id))?;
-    let source_pool = match connect_to_source_database_from_api(
+    let source_pool = match source_database::connect(
         &source.config.into_connection_config(tls_config),
     )
     .await

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -21,7 +21,6 @@ use crate::{
     configs::{encryption::EncryptionKeyring, pipeline::FullApiPipelineConfig},
     data,
     data::{
-        connect_to_source_database_from_api,
         destinations::{DestinationsDbError, destination_exists},
         images::ImagesDbError,
         pipelines::{
@@ -30,6 +29,7 @@ use crate::{
             read_pipeline_components, read_pipeline_for_deletion,
         },
         replicators::ReplicatorsDbError,
+        source_database,
         sources::SourcesDbError,
     },
     feature_flags::{FeatureFlagsClient, get_max_pipelines_per_tenant},
@@ -203,7 +203,9 @@ impl PipelineError {
             ) => "Internal server error".to_owned(),
             PipelineError::SourceDatabase(_)
             | PipelineError::SourcePipelineState(_)
-            | PipelineError::TableLookup(_) => "Could not query your source database".to_owned(),
+            | PipelineError::TableLookup(_) => {
+                route_utils::source_database_query_error_message().to_owned()
+            }
             PipelineError::Validation(error) => {
                 route_utils::validation_error_message(error).to_owned()
             }
@@ -212,6 +214,7 @@ impl PipelineError {
         }
     }
 }
+
 impl IntoResponse for PipelineError {
     fn into_response(self) -> Response {
         let status_code = match &self {
@@ -856,7 +859,7 @@ pub(crate) async fn delete_pipeline(
     .await?
     .ok_or(PipelineError::SourceNotFound(pipeline.source_id))?;
 
-    let source_pool = match connect_to_source_database_from_api(
+    let source_pool = match source_database::connect(
         &source.config.into_connection_config(tls_config),
     )
     .await
@@ -1213,10 +1216,9 @@ pub(crate) async fn get_pipeline_replication_status(
 
     // Connect to the source database to read the necessary state
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
-    let source_pool =
-        connect_to_source_database_from_api(&source.config.into_connection_config(tls_config))
-            .await
-            .map_err(PipelineError::SourceDatabase)?;
+    let source_pool = source_database::connect(&source.config.into_connection_config(tls_config))
+        .await
+        .map_err(PipelineError::SourceDatabase)?;
 
     // Start transaction for all source database operations
     let mut source_txn = source_pool.begin().await.map_err(PipelineError::SourceDatabase)?;
@@ -1321,10 +1323,9 @@ pub(crate) async fn rollback_tables(
 
     // Connect to the source database to perform rollback
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
-    let source_pool =
-        connect_to_source_database_from_api(&source.config.into_connection_config(tls_config))
-            .await
-            .map_err(PipelineError::SourceDatabase)?;
+    let source_pool = source_database::connect(&source.config.into_connection_config(tls_config))
+        .await
+        .map_err(PipelineError::SourceDatabase)?;
 
     // Start transaction for all source database operations
     let mut source_txn = source_pool.begin().await.map_err(PipelineError::SourceDatabase)?;

--- a/crates/etl-api/src/routes/sources/publications.rs
+++ b/crates/etl-api/src/routes/sources/publications.rs
@@ -15,8 +15,9 @@ use crate::{
     config::ApiConfig,
     configs::encryption::EncryptionKeyring,
     data::{
-        self, connect_to_source_database_from_api,
+        self,
         publications::{Publication, PublicationsDbError},
+        source_database,
         sources::SourcesDbError,
         tables::Table,
     },
@@ -59,7 +60,9 @@ impl PublicationError {
                 "Internal server error".to_owned()
             }
             PublicationError::PublicationsDb(PublicationsDbError::Database(_))
-            | PublicationError::Database(_) => "Could not query your source database".to_owned(),
+            | PublicationError::Database(_) => {
+                utils::source_database_query_error_message().to_owned()
+            }
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
         }
@@ -144,8 +147,7 @@ pub(crate) async fn create_publication(
 
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
     let publication = publication.0;
     let publication = Publication { name: publication.name, tables: publication.tables };
     data::publications::create_publication(&publication, &source_pool).await?;
@@ -192,8 +194,7 @@ pub(crate) async fn read_publication(
 
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
     let publications = data::publications::read_publication(&publication_name, &source_pool)
         .await?
         .ok_or(PublicationError::PublicationNotFound(publication_name))?;
@@ -242,8 +243,7 @@ pub(crate) async fn update_publication(
 
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
 
     if data::publications::read_publication(&publication_name, &source_pool).await?.is_none() {
         return Err(PublicationError::PublicationNotFound(publication_name));
@@ -295,8 +295,7 @@ pub(crate) async fn delete_publication(
 
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
     data::publications::drop_publication(&publication_name, &source_pool).await?;
 
     Ok(StatusCode::OK)
@@ -340,8 +339,7 @@ pub(crate) async fn read_all_publications(
 
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
     let publications = data::publications::read_all_publications(&source_pool).await?;
     let response = ReadPublicationsResponse { publications };
 
@@ -387,8 +385,7 @@ pub(crate) async fn add_tables_to_publication(
         .ok_or(PublicationError::SourceNotFound(source_id))?;
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
 
     if data::publications::read_publication(&publication_name, &source_pool).await?.is_none() {
         return Err(PublicationError::PublicationNotFound(publication_name));
@@ -440,8 +437,7 @@ pub(crate) async fn drop_tables_from_publication(
         .ok_or(PublicationError::SourceNotFound(source_id))?;
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
 
     if data::publications::read_publication(&publication_name, &source_pool).await?.is_none() {
         return Err(PublicationError::PublicationNotFound(publication_name));
@@ -493,8 +489,7 @@ pub(crate) async fn set_publication_tables(
         .ok_or(PublicationError::SourceNotFound(source_id))?;
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
 
     if data::publications::read_publication(&publication_name, &source_pool).await?.is_none() {
         return Err(PublicationError::PublicationNotFound(publication_name));

--- a/crates/etl-api/src/routes/sources/tables.rs
+++ b/crates/etl-api/src/routes/sources/tables.rs
@@ -15,7 +15,7 @@ use crate::{
     config::ApiConfig,
     configs::encryption::EncryptionKeyring,
     data::{
-        self, connect_to_source_database_from_api,
+        self, source_database,
         sources::SourcesDbError,
         tables::{Table, TablesDbError},
     },
@@ -55,7 +55,7 @@ impl TableError {
                 "Internal server error".to_owned()
             }
             TableError::TablesDb(TablesDbError::Database(_)) | TableError::Database(_) => {
-                "Could not query your source database".to_owned()
+                utils::source_database_query_error_message().to_owned()
             }
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
@@ -124,8 +124,7 @@ pub(crate) async fn read_table_names(
 
     let tls_config = trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
     let source_pool =
-        connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-            .await?;
+        source_database::connect(&source_config.into_connection_config(tls_config)).await?;
     let tables = data::tables::get_tables(&source_pool).await?;
     let response = ReadTablesResponse { tables };
 

--- a/crates/etl-api/src/routes/tenants.rs
+++ b/crates/etl-api/src/routes/tenants.rs
@@ -17,11 +17,11 @@ use crate::{
     configs::encryption::EncryptionKeyring,
     data,
     data::{
-        connect_to_source_database_from_api,
         pipelines::{
             PipelinesDbError, delete_pipeline_replication_slots, delete_pipelines_source_state,
             read_all_pipelines_for_deletion,
         },
+        source_database::{self, SourceDatabaseErrorKind},
         sources::SourcesDbError,
         tenants::TenantsDbError,
     },
@@ -72,17 +72,6 @@ pub enum TenantError {
 }
 
 impl TenantError {
-    /// Returns true when the error means source cleanup cannot continue.
-    fn is_source_database_unavailable(&self) -> bool {
-        match self {
-            Self::SourceDatabase(error) => utils::source_database_error_is_unavailable(error),
-            Self::SourcePipelineState(PipelinesDbError::Database(error)) => {
-                utils::source_database_error_is_unavailable(error)
-            }
-            _ => false,
-        }
-    }
-
     pub fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
@@ -93,10 +82,21 @@ impl TenantError {
             | TenantError::TrustedRootCerts(_)
             | TenantError::K8sCore(_) => "Internal server error".to_owned(),
             TenantError::SourceDatabase(_) | TenantError::SourcePipelineState(_) => {
-                "Could not query your source database".to_owned()
+                utils::source_database_query_error_message().to_owned()
             }
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
+        }
+    }
+
+    fn allows_best_effort_source_cleanup_to_continue(&self) -> bool {
+        match self {
+            TenantError::SourceDatabase(error)
+            | TenantError::SourcePipelineState(PipelinesDbError::Database(error)) => matches!(
+                source_database::classify_error(error),
+                SourceDatabaseErrorKind::TimedOut | SourceDatabaseErrorKind::Unavailable
+            ),
+            _ => false,
         }
     }
 }
@@ -363,7 +363,7 @@ pub(crate) async fn delete_tenant(
         // If the source database is already unreachable during tenant teardown, we
         // treat it as effectively deleted and keep removing the tenant's
         // API-side state.
-        let source_pool = match connect_to_source_database_from_api(
+        let source_pool = match source_database::connect(
             &source.config.into_connection_config(tls_config.clone()),
         )
         .await
@@ -380,7 +380,7 @@ pub(crate) async fn delete_tenant(
                 continue;
             }
         };
-        
+
         let source_cleanup_result = async {
             let mut source_txn = source_pool.begin().await.map_err(TenantError::SourceDatabase)?;
 
@@ -392,16 +392,16 @@ pub(crate) async fn delete_tenant(
             data::sources::uninstall_source_installation(source_txn.deref_mut())
                 .await
                 .map_err(TenantError::SourceDatabase)?;
-            
+
             source_txn.commit().await.map_err(TenantError::SourceDatabase)?;
 
             Ok::<_, TenantError>(deleted_pipeline_ids)
         }
         .await;
-        
+
         let deleted_pipeline_ids = match source_cleanup_result {
             Ok(deleted_pipeline_ids) => deleted_pipeline_ids,
-            Err(error) if error.is_source_database_unavailable() => {
+            Err(error) if error.allows_best_effort_source_cleanup_to_continue() => {
                 warn!(
                     tenant_id = %tenant_id,
                     source_id = source.id,
@@ -413,14 +413,13 @@ pub(crate) async fn delete_tenant(
             }
             Err(error) => return Err(error),
         };
-        
         for pipeline_id in deleted_pipeline_ids {
             let slot_cleanup_result = delete_pipeline_replication_slots(&source_pool, pipeline_id)
                 .await
                 .map_err(TenantError::SourcePipelineState);
-            
-            if let Err(error) = slot_cleanup_result && error.is_source_database_unavailable() {
-                if error.is_source_database_unavailable() {
+
+            if let Err(error) = slot_cleanup_result {
+                if error.allows_best_effort_source_cleanup_to_continue() {
                     warn!(
                         tenant_id = %tenant_id,
                         source_id = source.id,

--- a/crates/etl-api/src/routes/tenants.rs
+++ b/crates/etl-api/src/routes/tenants.rs
@@ -9,6 +9,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use thiserror::Error;
+use tracing::warn;
 use utoipa::ToSchema;
 
 use crate::{
@@ -71,6 +72,17 @@ pub enum TenantError {
 }
 
 impl TenantError {
+    /// Returns true when the error means source cleanup cannot continue.
+    fn is_source_database_unavailable(&self) -> bool {
+        match self {
+            Self::SourceDatabase(error) => utils::source_database_error_is_unavailable(error),
+            Self::SourcePipelineState(PipelinesDbError::Database(error)) => {
+                utils::source_database_error_is_unavailable(error)
+            }
+            _ => false,
+        }
+    }
+
     pub fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
@@ -348,7 +360,6 @@ pub(crate) async fn delete_tenant(
     // cleanup stays idempotent, so repeated passes are still safe without
     // deduplicating connection configs.
     for source in sources {
-        let source_pipelines = pipelines_by_source.remove(&source.id).unwrap_or_default();
         // If the source database is already unreachable during tenant teardown, we
         // treat it as effectively deleted and keep removing the tenant's
         // API-side state.
@@ -359,7 +370,7 @@ pub(crate) async fn delete_tenant(
         {
             Ok(source_pool) => source_pool,
             Err(error) => {
-                tracing::warn!(
+                warn!(
                     tenant_id = %tenant_id,
                     source_id = source.id,
                     error = %error,
@@ -369,19 +380,60 @@ pub(crate) async fn delete_tenant(
                 continue;
             }
         };
-        let mut source_txn = source_pool.begin().await.map_err(TenantError::SourceDatabase)?;
-        let deleted_pipeline_ids =
-            delete_pipelines_source_state(source_txn.deref_mut(), &source_pipelines)
+        
+        let source_cleanup_result = async {
+            let mut source_txn = source_pool.begin().await.map_err(TenantError::SourceDatabase)?;
+
+            let source_pipelines = pipelines_by_source.remove(&source.id).unwrap_or_default();
+            let deleted_pipeline_ids =
+                delete_pipelines_source_state(source_txn.deref_mut(), &source_pipelines)
+                    .await
+                    .map_err(TenantError::SourcePipelineState)?;
+            data::sources::uninstall_source_installation(source_txn.deref_mut())
                 .await
-                .map_err(TenantError::SourcePipelineState)?;
-        data::sources::uninstall_source_installation(source_txn.deref_mut())
-            .await
-            .map_err(TenantError::SourceDatabase)?;
-        source_txn.commit().await.map_err(TenantError::SourceDatabase)?;
+                .map_err(TenantError::SourceDatabase)?;
+            
+            source_txn.commit().await.map_err(TenantError::SourceDatabase)?;
+
+            Ok::<_, TenantError>(deleted_pipeline_ids)
+        }
+        .await;
+        
+        let deleted_pipeline_ids = match source_cleanup_result {
+            Ok(deleted_pipeline_ids) => deleted_pipeline_ids,
+            Err(error) if error.is_source_database_unavailable() => {
+                warn!(
+                    tenant_id = %tenant_id,
+                    source_id = source.id,
+                    error = %error,
+                    "source database became unavailable during tenant deletion, skipping source cleanup",
+                );
+
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        
         for pipeline_id in deleted_pipeline_ids {
-            delete_pipeline_replication_slots(&source_pool, pipeline_id)
+            let slot_cleanup_result = delete_pipeline_replication_slots(&source_pool, pipeline_id)
                 .await
-                .map_err(TenantError::SourcePipelineState)?;
+                .map_err(TenantError::SourcePipelineState);
+            
+            if let Err(error) = slot_cleanup_result && error.is_source_database_unavailable() {
+                if error.is_source_database_unavailable() {
+                    warn!(
+                        tenant_id = %tenant_id,
+                        source_id = source.id,
+                        pipeline_id,
+                        error = %error,
+                        "source database became unavailable during replication slot cleanup, skipping remaining slot cleanup",
+                    );
+
+                    break;
+                }
+
+                return Err(error);
+            }
         }
     }
 

--- a/crates/etl-api/src/routes/utils.rs
+++ b/crates/etl-api/src/routes/utils.rs
@@ -19,19 +19,44 @@ pub fn validation_error_status_code(error: &ValidationError) -> StatusCode {
 /// Returns the public HTTP status code for source database execution errors.
 pub fn source_database_error_status_code(error: &sqlx::Error) -> StatusCode {
     match error {
-        sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed => StatusCode::SERVICE_UNAVAILABLE,
-        sqlx::Error::Database(error) if source_database_unavailable_error(error.as_ref()) => {
-            StatusCode::SERVICE_UNAVAILABLE
-        }
         sqlx::Error::Io(error) if error.kind() == ErrorKind::TimedOut => {
             StatusCode::GATEWAY_TIMEOUT
         }
+        error if source_database_error_is_unavailable(error) => StatusCode::SERVICE_UNAVAILABLE,
         _ => StatusCode::BAD_GATEWAY,
     }
 }
 
+/// Returns true when a source database error means the source is unavailable.
+pub fn source_database_error_is_unavailable(error: &sqlx::Error) -> bool {
+    match error {
+        sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed | sqlx::Error::WorkerCrashed => true,
+        sqlx::Error::Io(error) => source_database_io_error_is_unavailable(error.kind()),
+        sqlx::Error::Database(error) => source_database_unavailable_error(error.as_ref()),
+        _ => false,
+    }
+}
+
+fn source_database_io_error_is_unavailable(error_kind: ErrorKind) -> bool {
+    matches!(
+        error_kind,
+        ErrorKind::ConnectionRefused
+            | ErrorKind::ConnectionReset
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::NotConnected
+            | ErrorKind::BrokenPipe
+            | ErrorKind::TimedOut
+            | ErrorKind::UnexpectedEof
+    )
+}
+
 fn source_database_unavailable_error(error: &dyn DatabaseError) -> bool {
-    matches!(error.code().as_deref(), Some("57P01" | "57P02" | "57P03"))
+    let Some(code) = error.code() else {
+        return false;
+    };
+
+    code.starts_with("08")
+        || matches!(code.as_ref(), "53300" | "57P01" | "57P02" | "57P03" | "57P04" | "57P05")
 }
 
 /// Returns the public error message for a validation execution error.
@@ -64,7 +89,54 @@ pub fn format_validation_failures(failures: Vec<ValidationFailure>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::{borrow::Cow, error::Error as StdError, fmt};
+
     use super::*;
+
+    #[derive(Debug)]
+    struct TestDatabaseError {
+        code: &'static str,
+    }
+
+    impl TestDatabaseError {
+        fn new(code: &'static str) -> Self {
+            Self { code }
+        }
+    }
+
+    impl fmt::Display for TestDatabaseError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "test database error {}", self.code)
+        }
+    }
+
+    impl StdError for TestDatabaseError {}
+
+    impl DatabaseError for TestDatabaseError {
+        fn message(&self) -> &str {
+            "test database error"
+        }
+
+        fn code(&self) -> Option<Cow<'_, str>> {
+            Some(Cow::Borrowed(self.code))
+        }
+
+        fn as_error(&self) -> &(dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn StdError + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn StdError + Send + Sync + 'static> {
+            self
+        }
+
+        fn kind(&self) -> sqlx::error::ErrorKind {
+            sqlx::error::ErrorKind::Other
+        }
+    }
 
     #[test]
     fn source_database_pool_timeout_is_reported_as_service_unavailable() {
@@ -91,6 +163,33 @@ mod tests {
             "Could not reach your source database in time"
         );
         assert_eq!(error.to_string(), "Database query failed");
+    }
+
+    #[test]
+    fn source_database_connection_io_errors_are_reported_as_service_unavailable() {
+        let error =
+            sqlx::Error::Io(std::io::Error::new(ErrorKind::ConnectionReset, "connection reset"));
+
+        assert_eq!(source_database_error_status_code(&error), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(source_database_error_is_unavailable(&error));
+    }
+
+    #[test]
+    fn source_database_connection_sqlstate_errors_are_reported_as_service_unavailable() {
+        for code in ["08006", "53300", "57P01", "57P02", "57P03", "57P04", "57P05"] {
+            let error = sqlx::Error::Database(Box::new(TestDatabaseError::new(code)));
+
+            assert_eq!(source_database_error_status_code(&error), StatusCode::SERVICE_UNAVAILABLE);
+            assert!(source_database_error_is_unavailable(&error));
+        }
+    }
+
+    #[test]
+    fn source_database_non_connection_sqlstate_errors_are_reported_as_upstream_failures() {
+        let error = sqlx::Error::Database(Box::new(TestDatabaseError::new("42501")));
+
+        assert_eq!(source_database_error_status_code(&error), StatusCode::BAD_GATEWAY);
+        assert!(!source_database_error_is_unavailable(&error));
     }
 
     #[test]

--- a/crates/etl-api/src/routes/utils.rs
+++ b/crates/etl-api/src/routes/utils.rs
@@ -1,9 +1,9 @@
-use std::io::ErrorKind;
-
 use axum::http::StatusCode;
-use sqlx::error::DatabaseError;
 
-use crate::validation::{ValidationError, ValidationFailure};
+use crate::{
+    data::source_database::{self, SourceDatabaseErrorKind},
+    validation::{ValidationError, ValidationFailure},
+};
 
 /// Returns the public HTTP status code for a validation execution error.
 pub fn validation_error_status_code(error: &ValidationError) -> StatusCode {
@@ -16,68 +16,43 @@ pub fn validation_error_status_code(error: &ValidationError) -> StatusCode {
     }
 }
 
-/// Returns the public HTTP status code for source database execution errors.
+/// Returns the public HTTP status code for a source database error.
 pub fn source_database_error_status_code(error: &sqlx::Error) -> StatusCode {
-    match error {
-        sqlx::Error::Io(error) if error.kind() == ErrorKind::TimedOut => {
-            StatusCode::GATEWAY_TIMEOUT
-        }
-        error if source_database_error_is_unavailable(error) => StatusCode::SERVICE_UNAVAILABLE,
-        _ => StatusCode::BAD_GATEWAY,
+    match source_database::classify_error(error) {
+        SourceDatabaseErrorKind::TimedOut => StatusCode::GATEWAY_TIMEOUT,
+        SourceDatabaseErrorKind::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        SourceDatabaseErrorKind::Failed => StatusCode::BAD_GATEWAY,
     }
 }
 
-/// Returns true when a source database error means the source is unavailable.
-pub fn source_database_error_is_unavailable(error: &sqlx::Error) -> bool {
-    match error {
-        sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed | sqlx::Error::WorkerCrashed => true,
-        sqlx::Error::Io(error) => source_database_io_error_is_unavailable(error.kind()),
-        sqlx::Error::Database(error) => source_database_unavailable_error(error.as_ref()),
-        _ => false,
-    }
-}
-
-fn source_database_io_error_is_unavailable(error_kind: ErrorKind) -> bool {
-    matches!(
-        error_kind,
-        ErrorKind::ConnectionRefused
-            | ErrorKind::ConnectionReset
-            | ErrorKind::ConnectionAborted
-            | ErrorKind::NotConnected
-            | ErrorKind::BrokenPipe
-            | ErrorKind::TimedOut
-            | ErrorKind::UnexpectedEof
-    )
-}
-
-fn source_database_unavailable_error(error: &dyn DatabaseError) -> bool {
-    let Some(code) = error.code() else {
-        return false;
-    };
-
-    code.starts_with("08")
-        || matches!(code.as_ref(), "53300" | "57P01" | "57P02" | "57P03" | "57P04" | "57P05")
+/// Returns the public error message for source database query failures.
+pub fn source_database_query_error_message() -> &'static str {
+    "Could not query your source database"
 }
 
 /// Returns the public error message for a validation execution error.
 pub fn validation_error_message(error: &ValidationError) -> &'static str {
     match error {
-        ValidationError::Database { source: sqlx::Error::PoolTimedOut } => {
-            "Could not reach your source database in time"
-        }
-        ValidationError::Database { source: sqlx::Error::PoolClosed } => {
-            "Your source database is currently unavailable"
-        }
-        ValidationError::Database { source: sqlx::Error::Io(error) }
-            if error.kind() == ErrorKind::TimedOut =>
-        {
-            "Could not reach your source database in time"
-        }
-        ValidationError::Database { .. } => "Could not validate your source database connection",
+        ValidationError::Database { source } => source_database_validation_error_message(source),
         ValidationError::BigQuery(_) => "Could not connect to BigQuery",
         ValidationError::Iceberg(_) => "Could not connect to the Iceberg endpoint",
         ValidationError::TrustedRootCerts(_) | ValidationError::Environment(_) => {
             "Internal server error"
+        }
+    }
+}
+
+/// Returns the public validation message for source database failures.
+fn source_database_validation_error_message(error: &sqlx::Error) -> &'static str {
+    match (error, source_database::classify_error(error)) {
+        (sqlx::Error::PoolTimedOut, _) | (_, SourceDatabaseErrorKind::TimedOut) => {
+            "Could not reach your source database in time"
+        }
+        (_, SourceDatabaseErrorKind::Unavailable) => {
+            "Your source database is currently unavailable"
+        }
+        (_, SourceDatabaseErrorKind::Failed) => {
+            "Could not validate your source database connection"
         }
     }
 }
@@ -89,54 +64,9 @@ pub fn format_validation_failures(failures: Vec<ValidationFailure>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{borrow::Cow, error::Error as StdError, fmt};
+    use std::io::ErrorKind;
 
     use super::*;
-
-    #[derive(Debug)]
-    struct TestDatabaseError {
-        code: &'static str,
-    }
-
-    impl TestDatabaseError {
-        fn new(code: &'static str) -> Self {
-            Self { code }
-        }
-    }
-
-    impl fmt::Display for TestDatabaseError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "test database error {}", self.code)
-        }
-    }
-
-    impl StdError for TestDatabaseError {}
-
-    impl DatabaseError for TestDatabaseError {
-        fn message(&self) -> &str {
-            "test database error"
-        }
-
-        fn code(&self) -> Option<Cow<'_, str>> {
-            Some(Cow::Borrowed(self.code))
-        }
-
-        fn as_error(&self) -> &(dyn StdError + Send + Sync + 'static) {
-            self
-        }
-
-        fn as_error_mut(&mut self) -> &mut (dyn StdError + Send + Sync + 'static) {
-            self
-        }
-
-        fn into_error(self: Box<Self>) -> Box<dyn StdError + Send + Sync + 'static> {
-            self
-        }
-
-        fn kind(&self) -> sqlx::error::ErrorKind {
-            sqlx::error::ErrorKind::Other
-        }
-    }
 
     #[test]
     fn source_database_pool_timeout_is_reported_as_service_unavailable() {
@@ -166,36 +96,12 @@ mod tests {
     }
 
     #[test]
-    fn source_database_connection_io_errors_are_reported_as_service_unavailable() {
-        let error =
-            sqlx::Error::Io(std::io::Error::new(ErrorKind::ConnectionReset, "connection reset"));
-
-        assert_eq!(source_database_error_status_code(&error), StatusCode::SERVICE_UNAVAILABLE);
-        assert!(source_database_error_is_unavailable(&error));
-    }
-
-    #[test]
-    fn source_database_connection_sqlstate_errors_are_reported_as_service_unavailable() {
-        for code in ["08006", "53300", "57P01", "57P02", "57P03", "57P04", "57P05"] {
-            let error = sqlx::Error::Database(Box::new(TestDatabaseError::new(code)));
-
-            assert_eq!(source_database_error_status_code(&error), StatusCode::SERVICE_UNAVAILABLE);
-            assert!(source_database_error_is_unavailable(&error));
-        }
-    }
-
-    #[test]
-    fn source_database_non_connection_sqlstate_errors_are_reported_as_upstream_failures() {
-        let error = sqlx::Error::Database(Box::new(TestDatabaseError::new("42501")));
-
-        assert_eq!(source_database_error_status_code(&error), StatusCode::BAD_GATEWAY);
-        assert!(!source_database_error_is_unavailable(&error));
-    }
-
-    #[test]
     fn source_database_errors_are_reported_as_upstream_failures() {
         let error = sqlx::Error::Protocol("bad source response".to_owned());
 
-        assert_eq!(source_database_error_status_code(&error), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            validation_error_status_code(&ValidationError::from(error)),
+            StatusCode::BAD_GATEWAY
+        );
     }
 }

--- a/crates/etl-api/src/startup.rs
+++ b/crates/etl-api/src/startup.rs
@@ -88,6 +88,12 @@ use crate::{
 /// Running API server task.
 pub type Server = tokio::task::JoinHandle<io::Result<()>>;
 
+/// Minimum number of connections for the API metadata database pool.
+///
+/// The API pool is lazy and should not keep metadata database connections open
+/// while the server is idle.
+const MIN_DATABASE_POOL_CONNECTIONS: u32 = 0;
+
 /// ETL API application server wrapper.
 ///
 /// Manages the HTTP server lifecycle including startup, migration, and
@@ -252,7 +258,9 @@ fn decode_encryption_key(
 /// Connects to the API's own metadata database using server defaults (no custom
 /// options).
 pub fn get_connection_pool(config: &PgConnectionConfig) -> PgPool {
-    PgPoolOptions::new().connect_lazy_with(config.with_db(None))
+    PgPoolOptions::new()
+        .min_connections(MIN_DATABASE_POOL_CONNECTIONS)
+        .connect_lazy_with(config.with_db(None))
 }
 
 /// Creates and configures the HTTP server with all routes and middleware.

--- a/crates/etl-api/src/validation/mod.rs
+++ b/crates/etl-api/src/validation/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         destination::FullApiDestinationConfig, pipeline::FullApiPipelineConfig,
         source::StoredSourceConfig,
     },
-    data::connect_to_source_database_from_api,
+    data::source_database,
     k8s::{TrustedRootCertsCache, TrustedRootCertsError},
     validation::validators::{DestinationValidator, PipelineValidator, SourceValidator},
 };
@@ -53,8 +53,7 @@ impl ValidationContext {
         let tls_config =
             trusted_root_certs_cache.get_tls_config(api_config.source.tls_enabled).await?;
         let source_pool =
-            connect_to_source_database_from_api(&source_config.into_connection_config(tls_config))
-                .await?;
+            source_database::connect(&source_config.into_connection_config(tls_config)).await?;
         let environment = Environment::load()?;
 
         Ok(Self::builder(environment)

--- a/crates/etl-api/tests/tenants.rs
+++ b/crates/etl-api/tests/tenants.rs
@@ -408,6 +408,81 @@ async fn tenant_with_unreachable_source_can_still_be_deleted() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn tenant_with_source_terminated_during_cleanup_can_still_be_deleted() {
+    init_test_tracing();
+
+    let trusted_source = create_trusted_source_database().await;
+    let app =
+        spawn_test_app_with_trusted_username(Some(trusted_source.trusted_username.clone())).await;
+    let tenant_id = &create_tenant(&app).await;
+
+    let source = CreateSourceRequest {
+        name: "Test Source".to_owned(),
+        config: FullApiSourceConfig {
+            host: trusted_source.trusted_config.host.clone(),
+            hostaddr: trusted_source.trusted_config.hostaddr,
+            port: trusted_source.trusted_config.port,
+            name: trusted_source.trusted_config.name.clone(),
+            username: trusted_source.trusted_config.username.clone(),
+            password: trusted_source.trusted_config.password.as_ref().map(|password| {
+                SerializableSecretString::from(password.expose_secret().to_owned())
+            }),
+        },
+    };
+    let response = app.create_source(tenant_id, &source).await;
+    assert!(response.status().is_success());
+    let response: etl_api::routes::sources::CreateSourceResponse =
+        response.json().await.expect("failed to deserialize response");
+    let source_id = response.id;
+
+    run_etl_migrations_on_source_database(&trusted_source.trusted_config).await;
+
+    sqlx::query(
+        r#"
+        create or replace function public.kill_tenant_delete_backend()
+        returns event_trigger
+        language plpgsql
+        as $$
+        begin
+            perform pg_terminate_backend(pg_backend_pid());
+        end;
+        $$;
+        "#,
+    )
+    .execute(&trusted_source.admin_pool)
+    .await
+    .expect("failed to install backend termination function");
+    sqlx::query(
+        r#"
+        create event trigger tenant_delete_kill_backend
+        on ddl_command_start
+        when tag in ('DROP SCHEMA')
+        execute function public.kill_tenant_delete_backend();
+        "#,
+    )
+    .execute(&trusted_source.admin_pool)
+    .await
+    .expect("failed to install backend termination trigger");
+
+    create_default_image(&app).await;
+    let destination_id = create_destination(&app, tenant_id).await;
+    let pipeline_id = create_pipeline_for_source(&app, tenant_id, source_id, destination_id).await;
+
+    app.k8s_state.set_pod_status(PodStatus::Stopped).await;
+
+    let response = app.delete_tenant(tenant_id).await;
+    assert!(response.status().is_success());
+
+    let tenant_response = app.read_tenant(tenant_id).await;
+    assert_eq!(tenant_response.status(), StatusCode::NOT_FOUND);
+
+    let pipeline_response = app.read_pipeline(tenant_id, pipeline_id).await;
+    assert_eq!(pipeline_response.status(), StatusCode::NOT_FOUND);
+
+    drop_trusted_source_database(trusted_source).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn all_tenants_can_be_read() {
     init_test_tracing();
     // Arrange

--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -757,10 +757,16 @@ fn pg_connect_options(args: &PgConnectionArgs) -> PgConnectOptions {
     options
 }
 
+/// Minimum number of connections for benchmark helper Postgres pools.
+const MIN_POSTGRES_POOL_CONNECTIONS: u32 = 0;
+/// Maximum number of connections for benchmark helper Postgres pools.
+const MAX_POSTGRES_POOL_CONNECTIONS: u32 = 16;
+
 /// Opens a Postgres pool for benchmark helpers.
 pub async fn pg_pool(args: &PgConnectionArgs) -> Result<PgPool> {
     PgPoolOptions::new()
-        .max_connections(16)
+        .min_connections(MIN_POSTGRES_POOL_CONNECTIONS)
+        .max_connections(MAX_POSTGRES_POOL_CONNECTIONS)
         .connect_with(pg_connect_options(args))
         .await
         .context("failed to connect to Postgres")

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -134,7 +134,7 @@ async fn state_store_rollback() {
     store.update_table_state(table_id, data_sync_state.clone()).await.unwrap();
 
     // Verify two rows exist before rollback (init + data_sync)
-    let pool = connect_to_source_database(&database.config, 1, 1, None)
+    let pool = connect_to_source_database(&database.config, 0, 1, None)
         .await
         .expect("Failed to connect to source database with sqlx");
     let count_before: i64 = sqlx::query_scalar(
@@ -562,7 +562,7 @@ async fn schema_store_prunes_obsolete_versions_from_database_and_cache() {
         store.store_table_schema(table_schema).await.unwrap();
     }
 
-    let pool = connect_to_source_database(&database.config, 1, 1, None).await.unwrap();
+    let pool = connect_to_source_database(&database.config, 0, 1, None).await.unwrap();
     let obsolete_schema_ids: Vec<i64> = sqlx::query_scalar(
         r#"
         select id
@@ -1139,7 +1139,7 @@ async fn replication_mask_loads_correctly_from_string_bytea() {
     let table_id = TableId::new(12345);
     let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
 
-    let pool = connect_to_source_database(&database.config, 1, 1, None)
+    let pool = connect_to_source_database(&database.config, 0, 1, None)
         .await
         .expect("Failed to connect to source database with sqlx");
 
@@ -1188,7 +1188,7 @@ async fn replication_mask_various_patterns() {
     let pipeline_id = 1;
     let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
 
-    let pool = connect_to_source_database(&database.config, 1, 1, None)
+    let pool = connect_to_source_database(&database.config, 0, 1, None)
         .await
         .expect("Failed to connect to source database with sqlx");
 


### PR DESCRIPTION
## Summary

- Centralize API source Postgres connection setup and source database error classification in `data::source_database`.
- Route source database failures through one shared HTTP status/message mapping across validation, source table/publication routes, pipelines, destination+pipeline routes, and tenant deletion.
- Make tenant deletion best-effort when the customer/source database is unreachable, removed, shutting down, or terminates the connection during cleanup.
- Preserve normal failures for non-lifecycle source database errors instead of swallowing unexpected query problems.
- Add regression coverage for source cleanup where PostgreSQL terminates the active backend during tenant deletion.

## Source database error handling

- `504 Gateway Timeout` for IO timeouts.
- `503 Service Unavailable` for unavailable/lifecycle failures, including SQLx pool closure/timeouts, worker crashes, connection reset/refused/aborted/not connected/broken pipe/EOF, PostgreSQL connection exception class `08`, `53300`, and `57P01`-`57P05`.
- `502 Bad Gateway` for other source database/query failures.