### PR TITLE
fix(clickhouse): serialise first-time table creation across ctid copy workers

### DIFF
--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -16,7 +16,7 @@ use etl::{
     store::{SchemaStore, StateStore},
 };
 use etl_config::shared::ClickHouseEngine;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use tokio::task::JoinSet;
 use tracing::{debug, info, warn};
 use url::Url;
@@ -368,6 +368,19 @@ pub struct ClickHouseDestination<S> {
     /// section is a brief in-memory map op with no `.await` inside, so the
     /// async `tokio::sync::RwLock` would be needless overhead.
     table_cache: Arc<RwLock<HashMap<String, Arc<[bool]>>>>,
+    /// Per-`table_id` locks serialising first-time table creation.
+    ///
+    /// The two ctid copy workers spawned when `max_copy_connections > 1` share
+    /// this destination (it is `Clone` over `Arc` state), so without a guard
+    /// both fall through the cache miss in [`Self::ensure_table_exists`] and
+    /// issue racing `CREATE TABLE` / `CREATE VIEW` statements. On ClickHouse
+    /// Cloud the replicated `... IF NOT EXISTS` is not atomic across replicas,
+    /// so the loser fails with "DDL failed". A `tokio::sync::Mutex` (held
+    /// across the DDL `.await`) per table makes the second worker wait,
+    /// then fall through the post-lock cache re-check. The outer map is
+    /// guarded by a brief, await-free `parking_lot::Mutex` and grows at
+    /// most one entry per replicated table.
+    create_locks: Arc<Mutex<HashMap<TableId, Arc<tokio::sync::Mutex<()>>>>>,
 }
 
 impl<S> ClickHouseDestination<S>
@@ -393,6 +406,7 @@ where
             inserter_config,
             store: Arc::new(store),
             table_cache: Arc::new(RwLock::new(HashMap::new())),
+            create_locks: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -523,13 +537,33 @@ where
             return Ok((clickhouse_table_name, flags));
         }
 
+        let table_id = schema.id();
+
+        // Serialise the first-time create/recover path per `table_id`. When
+        // `max_copy_connections > 1` the two ctid copy workers share this
+        // destination and would otherwise both fall through the cache miss
+        // above and issue racing CREATE TABLE / CREATE VIEW statements; on
+        // ClickHouse Cloud the replicated `... IF NOT EXISTS` is not atomic
+        // across replicas, so the loser fails with "DDL failed". See the
+        // `create_locks` field doc.
+        let table_lock = {
+            let mut guard = self.create_locks.lock();
+            Arc::clone(guard.entry(table_id).or_default())
+        };
+        let _create_guard = table_lock.lock().await;
+
+        // Re-check the cache under the lock: a worker that went ahead of us may
+        // have completed creation and populated it while we were blocked.
+        if let Some(flags) = self.table_cache.read().get(&clickhouse_table_name).cloned() {
+            return Ok((clickhouse_table_name, flags));
+        }
+
         // Engine-mismatch detection runs before any DDL or metadata mutation:
         // a pre-existing table created under a different engine must hard-fail
         // here, not silently get an idempotent CREATE TABLE IF NOT EXISTS that
         // would then mis-align RowBinary on insert.
         self.ensure_engine_matches(&clickhouse_table_name).await?;
 
-        let table_id = schema.id();
         match self.store.get_destination_table_metadata(table_id).await? {
             None => {
                 self.create_table_with_metadata(


### PR DESCRIPTION
## Summary

When `max_copy_connections > 1`, parallel ctid copy workers can race on first-time ClickHouse table creation. On ClickHouse Cloud, replicated `CREATE ... IF NOT EXISTS` DDL is not atomic across replicas, so one worker can lose with `DDL failed` and the table sync worker ends in an errored state.

This serialises the create/recover path with a per-`table_id` async mutex and re-checks the table cache once the lock is held, so the second worker no-ops instead of issuing duplicate DDL.

## Root Cause

`ensure_table_exists` had a read-through cache fast path, but no mutual exclusion after a cache miss. Multiple ctid copy workers share the same `ClickHouseDestination` state via `Arc`, so two workers for the same table could enter the create/recover path concurrently.

The previous code relied on `CREATE ... IF NOT EXISTS` being idempotent. That is generally fine on a single ClickHouse node, but it is not enough for ClickHouse Cloud's replicated DDL path.

## Fix

- Add a per-table `tokio::sync::Mutex`, stored in an await-free `parking_lot::Mutex<HashMap<TableId, Arc<...>>>`.
- Acquire it only after the cache miss fast path.
- Re-check `table_cache` after acquiring the table lock.
- Hold the async table lock across the create/recover DB round trips.

An in-process lock is sufficient here because the race is between copy workers inside one `etl` process sharing one destination instance.

## Testing

Validated locally on the pushed branch:

- `cargo +nightly-2026-04-15 fmt --all -- --check`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="" cargo check -p etl-destinations --features clickhouse`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="" cargo clippy -p etl-destinations --features clickhouse --all-targets -- -D warnings`

Also exercised in the original spike against a ClickHouse Cloud target: repeated full-copy runs of a wide table that previously errored with `DDL failed` reached `sync_done` after adding the guard.