### PR TITLE
refactor(ducklake): change the table naming convention when replicated in ducklake

### DIFF
--- a/crates/etl-destinations/src/ducklake/batches.rs
+++ b/crates/etl-destinations/src/ducklake/batches.rs
@@ -335,7 +335,7 @@ pub(super) struct PreparedDuckLakeTableBatch {
 
 impl PreparedDuckLakeTableBatch {
     /// Returns the destination table this batch targets.
-    pub(super) fn table_name(&self) -> &str {
+    pub(super) fn table_name(&self) -> &DuckLakeTableName {
         &self.table_name
     }
 
@@ -724,13 +724,14 @@ pub(super) fn prepare_truncate_table_batch(
 /// Deletes persisted markers for one table and batch kind.
 pub(super) fn clear_applied_batch_markers_for_kind(
     conn: &duckdb::Connection,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     batch_kind: DuckLakeTableBatchKind,
 ) -> EtlResult<()> {
+    let table_id = table_name.id();
     let sql = format!(
         r#"DELETE FROM {LAKE_CATALOG}."{APPLIED_BATCHES_TABLE}"
          WHERE table_name = {} AND batch_kind = {};"#,
-        quote_literal(table_name),
+        quote_literal(&table_id),
         quote_literal(batch_kind.as_str())
     );
     conn.execute_batch(&sql).map_err(|err| {
@@ -747,12 +748,13 @@ pub(super) fn clear_applied_batch_markers_for_kind(
 /// Deletes the persisted streaming replay watermark for one table.
 pub(super) fn clear_table_streaming_progress(
     conn: &duckdb::Connection,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> EtlResult<()> {
+    let table_id = table_name.id();
     let sql = format!(
         r#"DELETE FROM {LAKE_CATALOG}."{STREAMING_PROGRESS_TABLE}"
          WHERE table_name = {};"#,
-        quote_literal(table_name),
+        quote_literal(&table_id),
     );
     conn.execute_batch(&sql).map_err(|err| {
         etl_error!(
@@ -796,13 +798,14 @@ fn record_replayed_batch_skip(batch: &PreparedDuckLakeTableBatch) {
 /// Reads the steady-state streaming replay watermark for one table.
 fn read_table_streaming_progress(
     conn: &duckdb::Connection,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> EtlResult<Option<TableStreamingProgress>> {
+    let table_id = table_name.id();
     let sql = format!(
         r#"SELECT last_commit_lsn, last_tx_ordinal
          FROM {LAKE_CATALOG}."{STREAMING_PROGRESS_TABLE}"
          WHERE table_name = {} LIMIT 1;"#,
-        quote_literal(table_name),
+        quote_literal(&table_id),
     );
     let mut statement = conn.prepare(&sql).map_err(|err| {
         etl_error!(
@@ -858,7 +861,7 @@ fn read_table_streaming_progress(
 /// Reads the last applied streaming sequence key for one table.
 pub(super) fn read_table_streaming_progress_sequence_key(
     conn: &duckdb::Connection,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> EtlResult<Option<EventSequenceKey>> {
     Ok(read_table_streaming_progress(conn, table_name)?.map(|progress| progress.last_sequence_key))
 }
@@ -1026,7 +1029,7 @@ fn apply_table_batches(
 fn push_prepared_mutation_batch(
     prepared_batches: &mut Vec<PreparedDuckLakeTableBatch>,
     replicated_table_schema: &ReplicatedTableSchema,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     tracked_mutations: Vec<TrackedTableMutation>,
 ) -> EtlResult<()> {
     if tracked_mutations.is_empty() {
@@ -1040,7 +1043,7 @@ fn push_prepared_mutation_batch(
     let mutations = tracked_mutations.into_iter().map(|tracked| tracked.mutation).collect();
 
     prepared_batches.push(PreparedDuckLakeTableBatch {
-        table_name: table_name.to_owned(),
+        table_name: table_name.clone(),
         batch_id: identity.batch_id,
         batch_kind: DuckLakeTableBatchKind::Mutation,
         first_start_lsn: identity.first_start_lsn,
@@ -1333,13 +1336,13 @@ fn update_assignments_from_partial_row(
 
 /// Builds a deterministic identity for one ordered mutation batch.
 fn build_mutation_batch_identity(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     replicated_table_schema: &ReplicatedTableSchema,
     tracked_mutations: &[TrackedTableMutation],
 ) -> EtlResult<DuckLakeBatchIdentity> {
     let mut hasher = BatchIdHasher::new();
     "mutation".hash(&mut hasher);
-    table_name.hash(&mut hasher);
+    table_name.id().hash(&mut hasher);
 
     for tracked_mutation in tracked_mutations {
         u64::from(tracked_mutation.start_lsn).hash(&mut hasher);
@@ -1380,13 +1383,13 @@ fn build_mutation_batch_identity(
 
 /// Builds a deterministic identity for one ordered table-copy batch.
 fn build_copy_batch_identity(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     replicated_table_schema: &ReplicatedTableSchema,
     table_rows: &[TableRow],
 ) -> EtlResult<DuckLakeBatchIdentity> {
     let mut hasher = BatchIdHasher::new();
     "copy".hash(&mut hasher);
-    table_name.hash(&mut hasher);
+    table_name.id().hash(&mut hasher);
 
     for row in table_rows {
         delete_predicate_from_copy_row(replicated_table_schema, row)?.hash(&mut hasher);
@@ -1435,12 +1438,12 @@ fn delete_predicate_from_copy_row(
 
 /// Builds a deterministic identity for one ordered truncate batch.
 fn build_truncate_batch_identity(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     tracked_truncates: &[TrackedTruncateEvent],
 ) -> DuckLakeBatchIdentity {
     let mut hasher = BatchIdHasher::new();
     "truncate".hash(&mut hasher);
-    table_name.hash(&mut hasher);
+    table_name.id().hash(&mut hasher);
 
     for tracked_truncate in tracked_truncates {
         u64::from(tracked_truncate.start_lsn).hash(&mut hasher);
@@ -1522,10 +1525,11 @@ fn applied_batch_marker_exists(
     conn: &duckdb::Connection,
     batch: &PreparedDuckLakeTableBatch,
 ) -> EtlResult<bool> {
+    let table_id = batch.table_name.id();
     let sql = format!(
         r#"SELECT 1 FROM {LAKE_CATALOG}."{APPLIED_BATCHES_TABLE}"
          WHERE table_name = {} AND batch_id = {} LIMIT 1;"#,
-        quote_literal(&batch.table_name),
+        quote_literal(&table_id),
         quote_literal(&batch.batch_id)
     );
     let mut statement = conn.prepare(&sql).map_err(|err| {
@@ -1560,10 +1564,11 @@ fn insert_applied_batch_marker(
     conn: &duckdb::Connection,
     batch: &PreparedDuckLakeTableBatch,
 ) -> EtlResult<()> {
+    let table_id = batch.table_name.id();
     let sql = format!(
         r#"INSERT INTO {LAKE_CATALOG}."{APPLIED_BATCHES_TABLE}"
          (table_name, batch_id, batch_kind, first_start_lsn, last_commit_lsn, applied_at) VALUES ({}, {}, {}, {}, {}, current_timestamp);"#,
-        quote_literal(&batch.table_name),
+        quote_literal(&table_id),
         quote_literal(&batch.batch_id),
         quote_literal(batch.batch_kind.as_str()),
         optional_lsn_to_sql_literal(batch.first_start_lsn),
@@ -1593,14 +1598,15 @@ fn update_table_streaming_progress(
             format!("table={}, batch_kind={}", batch.table_name, batch.batch_kind.as_str())
         )
     })?;
+    let table_id = batch.table_name.id();
     let sql = format!(
         r#"DELETE FROM {LAKE_CATALOG}."{STREAMING_PROGRESS_TABLE}"
          WHERE table_name = {};
          INSERT INTO {LAKE_CATALOG}."{STREAMING_PROGRESS_TABLE}"
          (table_name, last_commit_lsn, last_tx_ordinal, updated_at)
          VALUES ({}, {}, {}, current_timestamp);"#,
-        quote_literal(&batch.table_name),
-        quote_literal(&batch.table_name),
+        quote_literal(&table_id),
+        quote_literal(&table_id),
         u64::from(last_sequence_key.commit_lsn),
         last_sequence_key.tx_ordinal,
     );
@@ -1634,10 +1640,10 @@ struct ReusableStagingTable {
 
 impl ReusableStagingTable {
     /// Creates a fresh staging-table manager for one destination table.
-    fn new(table_name: &str, insert_column_names: Vec<String>) -> Self {
+    fn new(table_name: &DuckLakeTableName, insert_column_names: Vec<String>) -> Self {
         Self {
-            table_name: table_name.to_owned(),
-            staging_name: format!("__staging_{table_name}"),
+            table_name: table_name.clone(),
+            staging_name: format!("__staging_{}", table_name.id()),
             created: false,
             insert_column_names,
         }
@@ -1702,7 +1708,7 @@ impl ReusableStagingTable {
         #[cfg(feature = "test-utils")]
         {
             let mut counts = STAGING_TABLE_CREATIONS_BY_TABLE.lock();
-            *counts.entry(self.table_name.clone()).or_default() += 1;
+            *counts.entry(self.table_name.id()).or_default() += 1;
         }
 
         let column_list = quoted_column_list(&self.insert_column_names);
@@ -1867,7 +1873,10 @@ fn apply_table_batch(
 }
 
 /// Applies the truncate action inside an open transaction.
-fn apply_truncate_batch_action(conn: &duckdb::Connection, table_name: &str) -> EtlResult<()> {
+fn apply_truncate_batch_action(
+    conn: &duckdb::Connection,
+    table_name: &DuckLakeTableName,
+) -> EtlResult<()> {
     let target_table = qualified_lake_table_name(table_name);
     let sql = format!("TRUNCATE TABLE {target_table};");
     conn.execute_batch(&sql).map_err(|error| {
@@ -2004,7 +2013,7 @@ fn apply_delete_mutation(
 /// Applies one update statement inside an open DuckLake transaction.
 fn apply_update_mutation(
     conn: &duckdb::Connection,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     assignments: &[String],
     predicate: &str,
 ) -> EtlResult<()> {
@@ -2156,7 +2165,7 @@ pub fn ducklake_staging_table_creations_for_tests(table_name: &str) -> usize {
 #[cfg(feature = "test-utils")]
 fn maybe_fail_after_committed_batch_for_tests(
     batch_kind: DuckLakeTableBatchKind,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> EtlResult<()> {
     match batch_kind {
         DuckLakeTableBatchKind::Copy => maybe_fail_after_copy_batch_commit_for_tests(table_name),
@@ -2169,9 +2178,9 @@ fn maybe_fail_after_committed_batch_for_tests(
 /// Injects a synthetic failure after commit so retries must rely on the
 /// progress row.
 #[cfg(feature = "test-utils")]
-fn maybe_fail_after_atomic_batch_commit_for_tests(table_name: &str) -> EtlResult<()> {
+fn maybe_fail_after_atomic_batch_commit_for_tests(table_name: &DuckLakeTableName) -> EtlResult<()> {
     let mut fail_table = FAIL_AFTER_ATOMIC_BATCH_COMMIT_TABLE.lock();
-    if fail_table.as_deref() == Some(table_name) {
+    if fail_table.as_deref() == Some(table_name.id().as_str()) {
         *fail_table = None;
         return Err(etl_error!(
             ErrorKind::DestinationQueryFailed,
@@ -2185,9 +2194,9 @@ fn maybe_fail_after_atomic_batch_commit_for_tests(table_name: &str) -> EtlResult
 /// Injects a synthetic failure after commit so copy retries must rely on the
 /// marker table.
 #[cfg(feature = "test-utils")]
-fn maybe_fail_after_copy_batch_commit_for_tests(table_name: &str) -> EtlResult<()> {
+fn maybe_fail_after_copy_batch_commit_for_tests(table_name: &DuckLakeTableName) -> EtlResult<()> {
     let mut fail_table = FAIL_AFTER_COPY_BATCH_COMMIT_TABLE.lock();
-    if fail_table.as_deref() == Some(table_name) {
+    if fail_table.as_deref() == Some(table_name.id().as_str()) {
         *fail_table = None;
         return Err(etl_error!(
             ErrorKind::DestinationQueryFailed,
@@ -2224,9 +2233,13 @@ mod tests {
         ReplicatedTableSchema::all(Arc::new(make_schema()))
     }
 
-    fn make_prepared_batch(table_name: &str) -> PreparedDuckLakeTableBatch {
+    fn ducklake_table_name() -> DuckLakeTableName {
+        DuckLakeTableName::new("public", "users")
+    }
+
+    fn make_prepared_batch(table_name: DuckLakeTableName) -> PreparedDuckLakeTableBatch {
         PreparedDuckLakeTableBatch {
-            table_name: table_name.to_owned(),
+            table_name,
             batch_id: "test-batch".to_owned(),
             batch_kind: DuckLakeTableBatchKind::Mutation,
             first_start_lsn: None,
@@ -2255,7 +2268,7 @@ mod tests {
     #[test]
     fn apply_delete_mutation_failure_omits_row_values_from_detail() {
         let conn = duckdb::Connection::open_in_memory().unwrap();
-        let batch = make_prepared_batch("users");
+        let batch = make_prepared_batch(ducklake_table_name());
         let operation_context = DuckLakeBlockingOperationContext::for_tests();
         let sensitive_value = "alice@example.com";
         let predicates = vec![format!("\"email\" = '{sensitive_value}'")];
@@ -2283,8 +2296,13 @@ mod tests {
         let assignments = vec![format!("\"token\" = '{sensitive_value}'")];
         let predicate = format!("\"token\" = '{sensitive_value}'");
 
-        let error =
-            apply_update_mutation(&conn, "users", assignments.as_slice(), &predicate).unwrap_err();
+        let error = apply_update_mutation(
+            &conn,
+            &ducklake_table_name(),
+            assignments.as_slice(),
+            &predicate,
+        )
+        .unwrap_err();
 
         assert_query_failure_omits_sensitive_value(
             &error,
@@ -2573,7 +2591,7 @@ mod tests {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
-            "public_users".to_owned(),
+            ducklake_table_name(),
             vec![
                 TrackedTableMutation::new(
                     PgLsn::from(10),
@@ -2623,7 +2641,7 @@ mod tests {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
-            "public_users".to_owned(),
+            ducklake_table_name(),
             vec![
                 TrackedTableMutation::new(
                     PgLsn::from(100),
@@ -2680,7 +2698,7 @@ mod tests {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
-            "public_users".to_owned(),
+            ducklake_table_name(),
             vec![
                 TrackedTableMutation::new(
                     PgLsn::from(100),
@@ -2730,7 +2748,7 @@ mod tests {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
-            "public_users".to_owned(),
+            ducklake_table_name(),
             vec![
                 TrackedTableMutation::new(
                     PgLsn::from(100),
@@ -2803,7 +2821,7 @@ mod tests {
             .collect();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
-            "public_users".to_owned(),
+            ducklake_table_name(),
             tracked,
         )
         .unwrap();
@@ -2840,7 +2858,7 @@ mod tests {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
             &replicated_table_schema,
-            "public_users".to_owned(),
+            ducklake_table_name(),
             vec![
                 TrackedTableMutation::new(
                     PgLsn::from(100),
@@ -2981,12 +2999,11 @@ mod tests {
             ),
         ];
 
+        let table_name = ducklake_table_name();
         let first =
-            build_mutation_batch_identity("public_users", &replicated_table_schema, &tracked)
-                .unwrap();
+            build_mutation_batch_identity(&table_name, &replicated_table_schema, &tracked).unwrap();
         let second =
-            build_mutation_batch_identity("public_users", &replicated_table_schema, &tracked)
-                .unwrap();
+            build_mutation_batch_identity(&table_name, &replicated_table_schema, &tracked).unwrap();
 
         assert_eq!(first.batch_id, second.batch_id);
         assert_eq!(first.first_start_lsn, Some(PgLsn::from(100)));
@@ -2996,8 +3013,9 @@ mod tests {
     #[test]
     fn build_mutation_batch_identity_changes_with_order_and_lsn() {
         let replicated_table_schema = make_replicated_schema();
+        let table_name = ducklake_table_name();
         let original = build_mutation_batch_identity(
-            "public_users",
+            &table_name,
             &replicated_table_schema,
             &[
                 TrackedTableMutation::new(
@@ -3022,7 +3040,7 @@ mod tests {
         )
         .unwrap();
         let reordered = build_mutation_batch_identity(
-            "public_users",
+            &table_name,
             &replicated_table_schema,
             &[
                 TrackedTableMutation::new(
@@ -3047,7 +3065,7 @@ mod tests {
         )
         .unwrap();
         let changed_lsn = build_mutation_batch_identity(
-            "public_users",
+            &table_name,
             &replicated_table_schema,
             &[TrackedTableMutation::new(
                 PgLsn::from(101),
@@ -3067,12 +3085,13 @@ mod tests {
 
     #[test]
     fn build_truncate_batch_identity_changes_with_lsn() {
+        let table_name = ducklake_table_name();
         let first = build_truncate_batch_identity(
-            "public_users",
+            &table_name,
             &[TrackedTruncateEvent::new(PgLsn::from(300), PgLsn::from(400), 0, 0)],
         );
         let second = build_truncate_batch_identity(
-            "public_users",
+            &table_name,
             &[TrackedTruncateEvent::new(PgLsn::from(301), PgLsn::from(401), 0, 0)],
         );
 

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -2515,11 +2515,9 @@ where
     /// Lists active DuckLake table names from the metadata catalog.
     async fn list_active_ducklake_tables(&self) -> EtlResult<Vec<DuckLakeTableName>> {
         let sql = format!(
-            "SELECT s.schema_name, t.table_name \
-             FROM {}.{} AS t \
-             JOIN {}.{} AS s ON s.schema_id = t.schema_id \
-             WHERE t.end_snapshot IS NULL AND s.end_snapshot IS NULL \
-             ORDER BY s.schema_name, t.table_name",
+            "SELECT s.schema_name, t.table_name FROM {}.{} AS t JOIN {}.{} AS s ON s.schema_id = \
+             t.schema_id WHERE t.end_snapshot IS NULL AND s.end_snapshot IS NULL ORDER BY \
+             s.schema_name, t.table_name",
             quote_postgres_identifier(self.metadata_schema.as_ref()),
             quote_postgres_identifier("ducklake_table"),
             quote_postgres_identifier(self.metadata_schema.as_ref()),

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -40,43 +40,40 @@ use tokio::{
 use tracing::{debug, info, warn};
 use url::Url;
 
-use crate::{
-    ducklake::{
-        DuckLakeTableName, LAKE_CATALOG, S3Config,
-        batches::{
-            DuckLakeTableBatchKind, TableMutation, TrackedTableMutation, TrackedTruncateEvent,
-            apply_table_batch_with_retry, apply_table_batches_with_retry,
-            clear_applied_batch_markers_for_kind, clear_table_streaming_progress,
-            ensure_applied_batches_table_exists, ensure_streaming_progress_table_exists,
-            prepare_copy_table_batch, prepare_mutation_table_batches, prepare_truncate_table_batch,
-            read_table_streaming_progress_sequence_key, retain_mutations_after_sequence_key,
-            retain_truncates_after_sequence_key,
-        },
-        client::{
-            DuckLakeConnectionManager, DuckLakeInterruptRegistry, build_warm_ducklake_pool,
-            format_query_error_detail, run_duckdb_blocking,
-        },
-        config::{
-            MAINTENANCE_TARGET_FILE_SIZE, MIN_EXPIRE_SNAPSHOTS_OLDER_THAN, build_setup_plan,
-            current_duckdb_extension_strategy, maintenance_target_file_size_sql,
-            resolve_expire_snapshots_older_than, validate_expire_snapshots_older_than_sql,
-        },
-        external_maintenance::ExternalMaintenanceOperations,
-        inline_size::DuckLakePendingInlineSizeSampler,
-        metrics::{
-            DuckLakeMetricsSampler, ETL_DUCKLAKE_POOL_SIZE, query_catalog_maintenance_metrics,
-            query_table_storage_metrics, register_metrics,
-            resolve_ducklake_metadata_schema_blocking, spawn_ducklake_metrics_sampler,
-        },
-        schema::{
-            build_add_column_sql_ducklake, build_create_table_sql_ducklake,
-            build_drop_column_sql_ducklake, build_drop_default_sql_ducklake,
-            build_rename_column_sql_ducklake, build_set_default_sql_ducklake,
-            supports_column_default_ducklake,
-        },
-        sql::qualified_lake_table_name,
+use crate::ducklake::{
+    DuckLakeTableName, LAKE_CATALOG, S3Config,
+    batches::{
+        DuckLakeTableBatchKind, TableMutation, TrackedTableMutation, TrackedTruncateEvent,
+        apply_table_batch_with_retry, apply_table_batches_with_retry,
+        clear_applied_batch_markers_for_kind, clear_table_streaming_progress,
+        ensure_applied_batches_table_exists, ensure_streaming_progress_table_exists,
+        prepare_copy_table_batch, prepare_mutation_table_batches, prepare_truncate_table_batch,
+        read_table_streaming_progress_sequence_key, retain_mutations_after_sequence_key,
+        retain_truncates_after_sequence_key,
     },
-    table_name::try_stringify_table_name,
+    client::{
+        DuckLakeConnectionManager, DuckLakeInterruptRegistry, build_warm_ducklake_pool,
+        format_query_error_detail, run_duckdb_blocking,
+    },
+    config::{
+        MAINTENANCE_TARGET_FILE_SIZE, MIN_EXPIRE_SNAPSHOTS_OLDER_THAN, build_setup_plan,
+        current_duckdb_extension_strategy, maintenance_target_file_size_sql,
+        resolve_expire_snapshots_older_than, validate_expire_snapshots_older_than_sql,
+    },
+    external_maintenance::ExternalMaintenanceOperations,
+    inline_size::DuckLakePendingInlineSizeSampler,
+    metrics::{
+        DuckLakeMetricsSampler, ETL_DUCKLAKE_POOL_SIZE, query_catalog_maintenance_metrics,
+        query_table_storage_metrics, register_metrics, resolve_ducklake_metadata_schema_blocking,
+        spawn_ducklake_metrics_sampler,
+    },
+    schema::{
+        build_add_column_sql_ducklake, build_create_table_sql_ducklake,
+        build_drop_column_sql_ducklake, build_drop_default_sql_ducklake,
+        build_rename_column_sql_ducklake, build_set_default_sql_ducklake,
+        supports_column_default_ducklake,
+    },
+    sql::qualified_lake_table_name,
 };
 
 /// Shared Postgres metadata pool size for DuckLake background samplers.
@@ -111,7 +108,7 @@ fn build_ducklake_metadata_pg_pool(catalog_url: &Url) -> EtlResult<PgPool> {
 pub(super) fn is_create_table_conflict(error: &duckdb::Error, table_name: &str) -> bool {
     let message = error.to_string();
     message.contains("has been created by another transaction already")
-        && message.contains(&format!(r#"attempting to create table "{table_name}""#))
+        && message.contains(table_name)
 }
 
 /// Parses `expire_snapshots_older_than` into seconds for cheap metadata-only
@@ -206,10 +203,10 @@ impl Default for DuckLakeExternalMaintenanceConfig {
 /// Returns the table-local semaphore shared by concurrent foreground writes.
 fn table_write_slot(
     table_write_slots: &Arc<Mutex<HashMap<DuckLakeTableName, Arc<Semaphore>>>>,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> Arc<Semaphore> {
     let mut slots = table_write_slots.lock();
-    let slot = slots.entry(table_name.to_owned()).or_insert_with(|| Arc::new(Semaphore::new(1)));
+    let slot = slots.entry(table_name.clone()).or_insert_with(|| Arc::new(Semaphore::new(1)));
     Arc::clone(slot)
 }
 
@@ -350,13 +347,13 @@ fn validate_ducklake_replica_identity(
 }
 
 /// Builds the query used to inspect a DuckLake table shape.
-fn ducklake_table_columns_sql(table_name: &str) -> String {
+fn ducklake_table_columns_sql(table_name: &DuckLakeTableName) -> String {
     format!(
         "select column_name from information_schema.columns where table_catalog = {} and \
          table_schema = {} and table_name = {} order by ordinal_position",
         quote_literal(LAKE_CATALOG),
-        quote_literal("main"),
-        quote_literal(table_name)
+        quote_literal(table_name.schema()),
+        quote_literal(table_name.table())
     )
 }
 
@@ -365,7 +362,7 @@ fn ducklake_table_columns_sql(table_name: &str) -> String {
 /// Call only from a [`run_duckdb_blocking`] closure.
 fn read_ducklake_table_column_names_blocking(
     conn: &duckdb::Connection,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> EtlResult<Vec<String>> {
     let sql = ducklake_table_columns_sql(table_name);
     let mut statement = conn.prepare(&sql).map_err(|source| {
@@ -506,7 +503,7 @@ fn tombstone_columns_to_cleanup_ducklake(
 
 /// Plans idempotent DuckLake schema DDL for the current destination columns.
 fn plan_schema_diff_sql_ducklake(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     mut column_names: Vec<String>,
     diff: &SchemaDiff,
 ) -> EtlResult<DuckLakeSchemaDiffPlan> {
@@ -1439,7 +1436,7 @@ where
                     )
                 )
             })?;
-        let table_name = metadata.destination_table_id.clone();
+        let table_name = DuckLakeTableName::from_metadata_id(&metadata.destination_table_id)?;
         let metadata = if metadata.is_applying() {
             self.recover_applying_metadata(
                 table_id,
@@ -1493,7 +1490,7 @@ where
         self.cleanup_tombstone_columns_after_applied(&table_name, &current_schema).await;
 
         let updated_metadata = DestinationTableMetadata::new_applied(
-            table_name.clone(),
+            table_name.to_metadata_id()?,
             current_snapshot_id,
             current_replication_mask,
         )
@@ -1534,7 +1531,11 @@ where
 
     /// Applies a schema diff while serializing with table-local writes and
     /// external maintenance.
-    async fn apply_schema_diff(&self, table_name: &str, diff: &SchemaDiff) -> EtlResult<()> {
+    async fn apply_schema_diff(
+        &self,
+        table_name: &DuckLakeTableName,
+        diff: &SchemaDiff,
+    ) -> EtlResult<()> {
         if diff.is_empty() {
             debug!(table = %table_name, "ducklake schema diff is empty");
             return Ok(());
@@ -1550,7 +1551,7 @@ where
 
         let _table_write_permit = self.acquire_table_write_slot(table_name).await?;
         let _checkpoint_guard = self.acquire_mutation_guard().await;
-        let table_name = table_name.to_owned();
+        let table_name = table_name.clone();
         let diff = diff.clone();
 
         run_duckdb_blocking(Arc::clone(&self.pool), Arc::clone(&self.blocking_slots), move |conn| {
@@ -1598,10 +1599,10 @@ where
     /// Adds target replicated columns missing from the physical DuckLake table.
     async fn reconcile_missing_replicated_columns(
         &self,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
         target_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
-        let table_name_for_read = table_name.to_owned();
+        let table_name_for_read = table_name.clone();
         let ducklake_columns = run_duckdb_blocking(
             Arc::clone(&self.pool),
             Arc::clone(&self.blocking_slots),
@@ -1632,12 +1633,12 @@ where
     /// Drops ETL tombstone columns after schema metadata is durably `Applied`.
     async fn cleanup_tombstone_columns(
         &self,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
         target_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         let _table_write_permit = self.acquire_table_write_slot(table_name).await?;
         let _checkpoint_guard = self.acquire_mutation_guard().await;
-        let table_name = table_name.to_owned();
+        let table_name = table_name.clone();
         let target_schema = target_schema.clone();
 
         run_duckdb_blocking(Arc::clone(&self.pool), Arc::clone(&self.blocking_slots), move |conn| {
@@ -1695,7 +1696,7 @@ where
     /// Best-effort wrapper for post-`Applied` tombstone cleanup.
     async fn cleanup_tombstone_columns_after_applied(
         &self,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
         target_schema: &ReplicatedTableSchema,
     ) {
         if let Err(error) = self.cleanup_tombstone_columns(table_name, target_schema).await {
@@ -1726,7 +1727,7 @@ where
                 continue;
             };
 
-            let table_name = metadata.destination_table_id.clone();
+            let table_name = DuckLakeTableName::from_metadata_id(&metadata.destination_table_id)?;
             if metadata.is_applying() {
                 self.recover_applying_metadata(table_id, &table_name, metadata, None).await?;
                 continue;
@@ -2062,11 +2063,11 @@ where
     async fn create_table_with_metadata(
         &self,
         table_id: TableId,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         let metadata = DestinationTableMetadata::new_applying(
-            table_name.to_owned(),
+            table_name.to_metadata_id()?,
             replicated_table_schema.inner().snapshot_id,
             replicated_table_schema.replication_mask().clone(),
         );
@@ -2081,13 +2082,13 @@ where
     /// Issues DuckLake's idempotent `create table if not exists` statement.
     async fn issue_create_table_stmt(
         &self,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         let column_schemas: Vec<_> = replicated_table_schema.column_schemas().cloned().collect();
         let ddl = build_create_table_sql_ducklake(table_name, &column_schemas);
         let created_tables = Arc::clone(&self.created_tables);
-        let table_name = table_name.to_owned();
+        let table_name = table_name.clone();
         let _checkpoint_guard = self.acquire_mutation_guard().await;
 
         run_duckdb_blocking(
@@ -2099,7 +2100,7 @@ where
                     Ok(()) => {
                         created_tables.lock().insert(table_name.clone());
                     }
-                    Err(error) if is_create_table_conflict(&error, &table_name) => {
+                    Err(error) if is_create_table_conflict(&error, table_name.table()) => {
                         created_tables.lock().insert(table_name.clone());
                     }
                     Err(error) => {
@@ -2215,7 +2216,7 @@ where
     async fn recover_applying_metadata(
         &self,
         table_id: TableId,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
         metadata: DestinationTableMetadata,
         target_schema: Option<&ReplicatedTableSchema>,
     ) -> EtlResult<DestinationTableMetadata> {
@@ -2254,7 +2255,7 @@ where
         let metadata = metadata.to_applied();
         self.store.store_destination_table_metadata(table_id, metadata.clone()).await?;
         self.cleanup_tombstone_columns_after_applied(table_name, &target_schema).await;
-        self.created_tables.lock().insert(table_name.to_owned());
+        self.created_tables.lock().insert(table_name.clone());
 
         Ok(metadata)
     }
@@ -2268,7 +2269,7 @@ where
         let metadata = self.store.get_destination_table_metadata(table_id).await?;
         let table_name = metadata.as_ref().map_or_else(
             || table_name_to_ducklake_table_name(replicated_table_schema.name()),
-            |metadata| Ok(metadata.destination_table_id.clone()),
+            |metadata| DuckLakeTableName::from_metadata_id(&metadata.destination_table_id),
         )?;
 
         if !metadata.as_ref().is_some_and(DestinationTableMetadata::is_applying)
@@ -2291,7 +2292,7 @@ where
         let metadata = self.store.get_destination_table_metadata(table_id).await?;
         let table_name = metadata.as_ref().map_or_else(
             || table_name_to_ducklake_table_name(replicated_table_schema.name()),
-            |metadata| Ok(metadata.destination_table_id.clone()),
+            |metadata| DuckLakeTableName::from_metadata_id(&metadata.destination_table_id),
         )?;
 
         if !metadata.as_ref().is_some_and(DestinationTableMetadata::is_applying)
@@ -2375,14 +2376,17 @@ where
         let table_id = replicated_table_schema.id();
 
         if let Some(existing) = self.store.get_destination_table_metadata(table_id).await? {
-            return Ok(existing.destination_table_id);
+            return DuckLakeTableName::from_metadata_id(&existing.destination_table_id);
         }
 
         table_name_to_ducklake_table_name(replicated_table_schema.name())
     }
 
     /// Serializes table-local truncate and CDC mutation writes.
-    async fn acquire_table_write_slot(&self, table_name: &str) -> EtlResult<OwnedSemaphorePermit> {
+    async fn acquire_table_write_slot(
+        &self,
+        table_name: &DuckLakeTableName,
+    ) -> EtlResult<OwnedSemaphorePermit> {
         let table_slot = table_write_slot(&self.table_write_slots, table_name);
         match Arc::clone(&table_slot).try_acquire_owned() {
             Ok(permit) => Ok(permit),
@@ -2475,7 +2479,7 @@ where
         }
 
         for table_name in table_names {
-            if table_name.starts_with("__etl_") {
+            if table_name.is_internal_helper() {
                 continue;
             }
 
@@ -2509,13 +2513,19 @@ where
     }
 
     /// Lists active DuckLake table names from the metadata catalog.
-    async fn list_active_ducklake_tables(&self) -> EtlResult<Vec<String>> {
+    async fn list_active_ducklake_tables(&self) -> EtlResult<Vec<DuckLakeTableName>> {
         let sql = format!(
-            "SELECT table_name FROM {}.{} WHERE end_snapshot IS NULL ORDER BY table_name",
+            "SELECT s.schema_name, t.table_name \
+             FROM {}.{} AS t \
+             JOIN {}.{} AS s ON s.schema_id = t.schema_id \
+             WHERE t.end_snapshot IS NULL AND s.end_snapshot IS NULL \
+             ORDER BY s.schema_name, t.table_name",
             quote_postgres_identifier(self.metadata_schema.as_ref()),
-            quote_postgres_identifier("ducklake_table")
+            quote_postgres_identifier("ducklake_table"),
+            quote_postgres_identifier(self.metadata_schema.as_ref()),
+            quote_postgres_identifier("ducklake_schema")
         );
-        let rows: Vec<(String,)> = sqlx::query_as(AssertSqlSafe(sql))
+        let rows: Vec<(String, String)> = sqlx::query_as(AssertSqlSafe(sql))
             .fetch_all(&self.metadata_pg_pool)
             .await
             .map_err(|source| {
@@ -2526,7 +2536,10 @@ where
                     source: source
                 )
             })?;
-        Ok(rows.into_iter().map(|(table_name,)| table_name).collect())
+        Ok(rows
+            .into_iter()
+            .map(|(schema_name, table_name)| DuckLakeTableName::new(schema_name, table_name))
+            .collect())
     }
 
     /// Runs one DuckDB operation on Tokio's blocking pool after acquiring a
@@ -2632,19 +2645,12 @@ async fn wait_if_streaming_write_paused_for_tests() {
     let _ = resume_rx.await;
 }
 
-/// Converts a Postgres [`TableName`] to a DuckLake table name string.
+/// Converts a Postgres [`TableName`] to the matching DuckLake schema/table.
 ///
-/// Escapes underscores in schema and table name components by doubling them,
-/// then joins the two parts with a single `_`. This matches the convention
-/// used by other destinations in this crate.
-///
-/// # Example
-/// - `public.my_table` → `public_my__table`
-/// - `my_schema.orders` → `my__schema_orders`
-///
-/// Returns an error if the table name cannot be converted.
+/// Source schemas are preserved in DuckLake. For example, `public.my_table`
+/// becomes the DuckLake table `lake.public.my_table`.
 pub fn table_name_to_ducklake_table_name(table_name: &TableName) -> EtlResult<DuckLakeTableName> {
-    try_stringify_table_name(table_name)
+    Ok(DuckLakeTableName::from_source(table_name))
 }
 
 #[cfg(test)]
@@ -2697,6 +2703,10 @@ mod tests {
                 ColumnSchema::new("name".to_owned(), PgType::TEXT, -1, 2, true),
             ],
         )
+    }
+
+    fn ducklake_table_name() -> DuckLakeTableName {
+        DuckLakeTableName::new("public", "users")
     }
 
     fn make_alternative_identity_schema() -> ReplicatedTableSchema {
@@ -2820,17 +2830,20 @@ mod tests {
             columns_to_change: vec![rename_change("name", "full_name", 2)],
         };
 
-        let plan =
-            plan_schema_diff_sql_ducklake("users", vec!["id".to_owned(), "name".to_owned()], &diff)
-                .expect("schema diff should plan");
+        let plan = plan_schema_diff_sql_ducklake(
+            &ducklake_table_name(),
+            vec!["id".to_owned(), "name".to_owned()],
+            &diff,
+        )
+        .expect("schema diff should plan");
         let statement_sql: Vec<_> =
             plan.statements.iter().map(|statement| statement.sql.clone()).collect();
 
         assert_eq!(
             statement_sql,
             vec![
-                r#"alter table "lake"."users" rename column "name" to "full_name""#,
-                r#"alter table "lake"."users" add column "name" varchar"#,
+                r#"alter table "lake"."public"."users" rename column "name" to "full_name""#,
+                r#"alter table "lake"."public"."users" add column "name" varchar"#,
             ]
         );
         assert_eq!(plan.column_names, vec!["id", "full_name", "name"]);
@@ -2847,15 +2860,20 @@ mod tests {
             columns_to_change: Vec::new(),
         };
 
-        let plan =
-            plan_schema_diff_sql_ducklake("users", vec!["id".to_owned(), "name".to_owned()], &diff)
-                .expect("schema diff should plan");
+        let plan = plan_schema_diff_sql_ducklake(
+            &ducklake_table_name(),
+            vec!["id".to_owned(), "name".to_owned()],
+            &diff,
+        )
+        .expect("schema diff should plan");
         let statement_sql: Vec<_> =
             plan.statements.iter().map(|statement| statement.sql.clone()).collect();
 
         assert_eq!(
             statement_sql,
-            vec![r#"alter table "lake"."users" add column "status" varchar default 'pending'"#]
+            vec![
+                r#"alter table "lake"."public"."users" add column "status" varchar default 'pending'"#
+            ]
         );
         assert_eq!(plan.column_names, vec!["id", "name", "status"]);
     }
@@ -2874,7 +2892,7 @@ mod tests {
         };
 
         let plan = plan_schema_diff_sql_ducklake(
-            "users",
+            &ducklake_table_name(),
             vec!["id".to_owned(), "name".to_owned(), "status".to_owned()],
             &diff,
         )
@@ -2893,7 +2911,7 @@ mod tests {
         };
 
         let plan = plan_schema_diff_sql_ducklake(
-            "users",
+            &ducklake_table_name(),
             vec!["id".to_owned(), "full_name".to_owned(), "name".to_owned()],
             &diff,
         )
@@ -2915,7 +2933,7 @@ mod tests {
         };
 
         let plan = plan_schema_diff_sql_ducklake(
-            "users",
+            &ducklake_table_name(),
             vec!["id".to_owned(), "full_name".to_owned(), "name".to_owned()],
             &diff,
         )
@@ -2934,7 +2952,7 @@ mod tests {
         };
 
         let plan = plan_schema_diff_sql_ducklake(
-            "users",
+            &ducklake_table_name(),
             vec!["id".to_owned(), "ddl_col_4_1".to_owned(), "ddl_col_4_0".to_owned()],
             &diff,
         )
@@ -2942,7 +2960,10 @@ mod tests {
         let statement_sql: Vec<_> =
             plan.statements.iter().map(|statement| statement.sql.as_str()).collect();
 
-        assert_eq!(statement_sql, vec![r#"alter table "lake"."users" drop column "ddl_col_4_1""#]);
+        assert_eq!(
+            statement_sql,
+            vec![r#"alter table "lake"."public"."users" drop column "ddl_col_4_1""#]
+        );
         assert_eq!(plan.column_names, vec!["id", "ddl_col_4_0"]);
     }
 
@@ -2957,7 +2978,7 @@ mod tests {
         };
 
         let plan = plan_schema_diff_sql_ducklake(
-            "users",
+            &ducklake_table_name(),
             vec!["id".to_owned(), "name".to_owned(), "status".to_owned()],
             &diff,
         )
@@ -2969,9 +2990,10 @@ mod tests {
             statement_sql,
             vec![
                 format!(
-                    r#"alter table "lake"."users" rename column "status" to "{tombstone_name}""#
+                    r#"alter table "lake"."public"."users" rename column "status" to "{tombstone_name}""#
                 ),
-                r#"alter table "lake"."users" rename column "name" to "status""#.to_owned(),
+                r#"alter table "lake"."public"."users" rename column "name" to "status""#
+                    .to_owned(),
             ]
         );
         assert_eq!(plan.column_names, vec!["id", "status", tombstone_name.as_str()]);
@@ -2987,17 +3009,22 @@ mod tests {
             columns_to_change: Vec::new(),
         };
 
-        let plan =
-            plan_schema_diff_sql_ducklake("users", vec!["id".to_owned(), "name".to_owned()], &diff)
-                .expect("schema diff should tombstone reused removed name");
+        let plan = plan_schema_diff_sql_ducklake(
+            &ducklake_table_name(),
+            vec!["id".to_owned(), "name".to_owned()],
+            &diff,
+        )
+        .expect("schema diff should tombstone reused removed name");
         let statement_sql: Vec<_> =
             plan.statements.iter().map(|statement| statement.sql.as_str()).collect();
 
         assert_eq!(
             statement_sql,
             vec![
-                format!(r#"alter table "lake"."users" rename column "name" to "{tombstone_name}""#),
-                r#"alter table "lake"."users" add column "name" varchar"#.to_owned(),
+                format!(
+                    r#"alter table "lake"."public"."users" rename column "name" to "{tombstone_name}""#
+                ),
+                r#"alter table "lake"."public"."users" add column "name" varchar"#.to_owned(),
             ]
         );
         assert_eq!(plan.column_names, vec!["id", tombstone_name.as_str(), "name"]);
@@ -3014,7 +3041,7 @@ mod tests {
         };
 
         let plan = plan_schema_diff_sql_ducklake(
-            "users",
+            &ducklake_table_name(),
             vec!["id".to_owned(), tombstone_name.clone(), "name".to_owned()],
             &diff,
         )
@@ -3266,14 +3293,14 @@ mod tests {
         conn
     }
 
-    fn lake_table_exists(conn: &Connection, table_name: &str) -> bool {
+    fn lake_table_exists(conn: &Connection, table_name: &DuckLakeTableName) -> bool {
         conn.query_row(
             &format!(
                 "SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog = {} AND \
                  table_schema = {} AND table_name = {}",
                 quote_literal(LAKE_CATALOG),
-                quote_literal("main"),
-                quote_literal(table_name),
+                quote_literal(table_name.schema()),
+                quote_literal(table_name.table()),
             ),
             [],
             |row| row.get::<_, i64>(0),
@@ -3284,7 +3311,7 @@ mod tests {
     async fn open_lake_conn_when_table_visible(
         catalog: &Url,
         data: &Url,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
     ) -> Connection {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         loop {
@@ -3303,14 +3330,14 @@ mod tests {
     }
 
     #[test]
-    fn table_name_escaping() {
+    fn table_name_to_ducklake_table_name_preserves_schema() {
         assert_eq!(
             table_name_to_ducklake_table_name(&TableName {
                 schema: "public".to_owned(),
                 name: "orders".to_owned(),
             })
             .unwrap(),
-            "public_orders"
+            DuckLakeTableName::new("public", "orders")
         );
         assert_eq!(
             table_name_to_ducklake_table_name(&TableName {
@@ -3318,7 +3345,7 @@ mod tests {
                 name: "my_table".to_owned(),
             })
             .unwrap(),
-            "my__schema_my__table"
+            DuckLakeTableName::new("my_schema", "my_table")
         );
     }
 
@@ -3383,8 +3410,9 @@ mod tests {
                 .expect("failed to resolve metadata schema");
             let metadata_pg_pool =
                 build_ducklake_metadata_pg_pool(&catalog).expect("failed to create metadata pool");
-            let _rows_flushed = flush_table_inlined_data(&conn, &table_name)
-                .expect("failed to materialize inlined rows for storage metrics test");
+            let _rows_flushed =
+                flush_table_inlined_data(&conn, table_name.schema(), table_name.table())
+                    .expect("failed to materialize inlined rows for storage metrics test");
             let deadline = Instant::now() + Duration::from_secs(10);
             let metrics = loop {
                 let metrics =
@@ -3448,8 +3476,9 @@ mod tests {
                 .expect("failed to resolve metadata schema");
             let metadata_pg_pool =
                 build_ducklake_metadata_pg_pool(&catalog).expect("failed to create metadata pool");
-            let _rows_flushed = flush_table_inlined_data(&conn, &table_name)
-                .expect("failed to materialize inlined rows for catalog metrics test");
+            let _rows_flushed =
+                flush_table_inlined_data(&conn, table_name.schema(), table_name.table())
+                    .expect("failed to materialize inlined rows for catalog metrics test");
             let deadline = Instant::now() + Duration::from_secs(10);
             let metrics = loop {
                 let metrics =

--- a/crates/etl-destinations/src/ducklake/inline_size.rs
+++ b/crates/etl-destinations/src/ducklake/inline_size.rs
@@ -6,7 +6,10 @@ use metrics::gauge;
 use pg_escape::{quote_identifier, quote_literal};
 use sqlx::{AssertSqlSafe, PgPool};
 
-use crate::ducklake::metrics::{ETL_DUCKLAKE_TABLE_ACTIVE_INLINED_DATA_BYTES, TABLE_LABEL};
+use crate::ducklake::{
+    DuckLakeTableName,
+    metrics::{ETL_DUCKLAKE_TABLE_ACTIVE_INLINED_DATA_BYTES, TABLE_LABEL},
+};
 
 /// Pending inlined bytes sampled from the Postgres DuckLake catalog.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -30,11 +33,12 @@ impl DuckLakePendingInlineSizeSampler {
     /// Samples pending inlined bytes for one DuckLake table.
     pub(super) async fn sample_table(
         &self,
-        table_name: &str,
+        table_name: &DuckLakeTableName,
     ) -> EtlResult<DuckLakePendingInlineDataSizes> {
         let sql = pending_inline_data_bytes_query(&self.metadata_schema);
         let inlined_bytes: i64 = sqlx::query_scalar(AssertSqlSafe(sql))
-            .bind(table_name)
+            .bind(table_name.schema())
+            .bind(table_name.table())
             .fetch_one(&self.pool)
             .await
             .map_err(|source| {
@@ -44,7 +48,7 @@ impl DuckLakePendingInlineSizeSampler {
                     source: source
                 )
             })?;
-        Ok(record_pending_inline_data_sizes(inlined_bytes, table_name))
+        Ok(record_pending_inline_data_sizes(inlined_bytes, &table_name.id()))
     }
 }
 
@@ -63,6 +67,7 @@ fn record_pending_inline_data_sizes(
 fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
     let metadata_schema_literal = quote_literal(metadata_schema);
     let metadata_schema = quote_identifier(metadata_schema);
+    let ducklake_schema = quote_identifier("ducklake_schema");
     let ducklake_table = quote_identifier("ducklake_table");
     let ducklake_inlined_data_tables = quote_identifier("ducklake_inlined_data_tables");
 
@@ -72,9 +77,13 @@ fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
     // deterministic delete-table relation size.
     format!(
         r"WITH target_table AS (
-             SELECT table_id
-             FROM {metadata_schema}.{ducklake_table}
-             WHERE end_snapshot IS NULL AND table_name = $1
+             SELECT t.table_id
+             FROM {metadata_schema}.{ducklake_table} AS t
+             JOIN {metadata_schema}.{ducklake_schema} AS s ON s.schema_id = t.schema_id
+             WHERE t.end_snapshot IS NULL
+               AND s.end_snapshot IS NULL
+               AND s.schema_name = $1
+               AND t.table_name = $2
              LIMIT 1
          ),
          target_inline_tables AS (

--- a/crates/etl-destinations/src/ducklake/metrics.rs
+++ b/crates/etl-destinations/src/ducklake/metrics.rs
@@ -473,7 +473,7 @@ async fn record_catalog_maintenance_metrics(
 pub(super) async fn query_table_storage_metrics(
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> EtlResult<DuckLakeTableStorageMetrics> {
     let sql = table_storage_metrics_query(metadata_schema);
     let (
@@ -485,7 +485,8 @@ pub(super) async fn query_table_storage_metrics(
         active_delete_bytes,
         deleted_rows,
     ): (i64, i64, i64, i64, i64, i64, i64) = sqlx::query_as(AssertSqlSafe(sql))
-        .bind(table_name)
+        .bind(table_name.schema())
+        .bind(table_name.table())
         .fetch_one(metadata_pg_pool)
         .await
         .map_err(|source| {
@@ -549,15 +550,20 @@ pub(super) async fn query_catalog_maintenance_metrics(
 /// Returns the SQL query used to sample table-level storage health.
 fn table_storage_metrics_query(metadata_schema: &str) -> String {
     let metadata_schema = quote_identifier(metadata_schema);
+    let ducklake_schema = quote_identifier("ducklake_schema");
     let ducklake_table = quote_identifier("ducklake_table");
     let ducklake_data_file = quote_identifier("ducklake_data_file");
     let ducklake_delete_file = quote_identifier("ducklake_delete_file");
 
     format!(
         r#"WITH target_table AS (
-             SELECT table_id
-             FROM {metadata_schema}.{ducklake_table}
-             WHERE end_snapshot IS NULL AND table_name = $1
+             SELECT t.table_id
+             FROM {metadata_schema}.{ducklake_table} AS t
+             JOIN {metadata_schema}.{ducklake_schema} AS s ON s.schema_id = t.schema_id
+             WHERE t.end_snapshot IS NULL
+               AND s.end_snapshot IS NULL
+               AND s.schema_name = $1
+               AND t.table_name = $2
              LIMIT 1
          ),
          data_stats AS (

--- a/crates/etl-destinations/src/ducklake/metrics.rs
+++ b/crates/etl-destinations/src/ducklake/metrics.rs
@@ -682,7 +682,8 @@ mod tests {
         assert!(sql.contains("ducklake_data_file"));
         assert!(sql.contains("ducklake_delete_file"));
         assert!(sql.contains(r#""duck'lake""#));
-        assert!(sql.contains("table_name = $1"));
+        assert!(sql.contains("s.schema_name = $1"));
+        assert!(sql.contains("t.table_name = $2"));
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/mod.rs
+++ b/crates/etl-destinations/src/ducklake/mod.rs
@@ -9,11 +9,86 @@ mod metrics;
 mod schema;
 mod sql;
 
+use std::fmt;
+
+use etl::{
+    error::{ErrorKind, EtlResult},
+    etl_error,
+    types::TableName,
+};
+use serde::{Deserialize, Serialize};
+
 /// The DuckDB catalog alias used in every `lake.<table>` qualified name.
 pub(super) const LAKE_CATALOG: &str = "lake";
 
-/// Alias for DuckLake table names.
-pub(super) type DuckLakeTableName = String;
+/// A table reference inside the DuckLake catalog.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+pub struct DuckLakeTableName {
+    schema: String,
+    table: String,
+}
+
+impl DuckLakeTableName {
+    /// Creates a DuckLake table reference from explicit schema and table names.
+    pub fn new(schema: impl Into<String>, table: impl Into<String>) -> Self {
+        Self { schema: schema.into(), table: table.into() }
+    }
+
+    /// Creates a DuckLake table reference for ETL internal helper tables.
+    /// Creates a DuckLake table reference that mirrors a source Postgres table.
+    pub fn from_source(table_name: &TableName) -> Self {
+        Self::new(table_name.schema.clone(), table_name.name.clone())
+    }
+
+    /// Returns the DuckLake schema name.
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    /// Returns the DuckLake table name.
+    pub fn table(&self) -> &str {
+        &self.table
+    }
+
+    /// Returns a stable ID for logs, metrics, and replay marker rows.
+    pub fn id(&self) -> String {
+        format!("{}.{}", self.schema, self.table)
+    }
+
+    /// Serializes this reference for durable destination metadata.
+    pub fn to_metadata_id(&self) -> EtlResult<String> {
+        serde_json::to_string(self).map_err(|source| {
+            etl_error!(
+                ErrorKind::InvalidState,
+                "DuckLake destination table metadata serialization failed",
+                source: source
+            )
+        })
+    }
+
+    /// Parses a durable destination metadata table reference.
+    pub(super) fn from_metadata_id(value: &str) -> EtlResult<Self> {
+        serde_json::from_str(value).map_err(|source| {
+            etl_error!(
+                ErrorKind::InvalidState,
+                "DuckLake destination table metadata is invalid",
+                format!("destination_table_id={value}"),
+                source: source
+            )
+        })
+    }
+
+    /// Returns whether this is an internal ETL helper table.
+    pub(super) fn is_internal_helper(&self) -> bool {
+        self.table.starts_with("__etl_")
+    }
+}
+
+impl fmt::Display for DuckLakeTableName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.id())
+    }
+}
 
 /// Attach-level DuckLake data inlining limit for ETL-managed connections.
 ///

--- a/crates/etl-destinations/src/ducklake/schema.rs
+++ b/crates/etl-destinations/src/ducklake/schema.rs
@@ -320,7 +320,8 @@ mod tests {
         );
 
         assert!(sql.starts_with(
-            "create schema if not exists \"lake\".\"public\";\ncreate table if not exists \"lake\".\"public\".\"odd\"\"table\""
+            "create schema if not exists \"lake\".\"public\";\ncreate table if not exists \
+             \"lake\".\"public\".\"odd\"\"table\""
         ));
         assert!(sql.contains("  \"select\" integer not null"));
     }

--- a/crates/etl-destinations/src/ducklake/schema.rs
+++ b/crates/etl-destinations/src/ducklake/schema.rs
@@ -1,7 +1,10 @@
 use etl::types::{ColumnSchema, DefaultExpression, Type, is_array_type, parse_default_expression};
 use tracing::warn;
 
-use crate::ducklake::sql::{qualified_lake_table_name, quote_identifier};
+use crate::ducklake::{
+    DuckLakeTableName,
+    sql::{qualified_lake_schema_name, qualified_lake_table_name, quote_identifier},
+};
 
 /// Returns the DuckLake SQL type string for a given Postgres scalar type.
 fn postgres_scalar_type_to_ducklake_sql(typ: &Type) -> &'static str {
@@ -185,16 +188,20 @@ fn ducklake_default_expression(default_expression: &str, typ: &Type) -> Option<S
 /// The supplied columns are the destination-visible replicated columns in
 /// write order.
 pub(super) fn build_create_table_sql_ducklake(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     column_schemas: &[ColumnSchema],
 ) -> String {
+    let schema_name = qualified_lake_schema_name(table_name.schema());
     let table_name = qualified_lake_table_name(table_name);
     let col_defs: Vec<String> = column_schemas
         .iter()
         .map(|col| format!("  {}", ducklake_column_definition(col, true, true)))
         .collect();
 
-    format!("create table if not exists {table_name} ({})", col_defs.join(",\n"))
+    format!(
+        "create schema if not exists {schema_name};\ncreate table if not exists {table_name} ({})",
+        col_defs.join(",\n")
+    )
 }
 
 /// Builds a DuckLake `alter table add column` statement.
@@ -202,7 +209,7 @@ pub(super) fn build_create_table_sql_ducklake(
 /// DuckLake stores add-time defaults as metadata and does not rewrite data
 /// files during schema evolution.
 pub(super) fn build_add_column_sql_ducklake(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     column_schema: &ColumnSchema,
 ) -> String {
     let table_name = qualified_lake_table_name(table_name);
@@ -212,7 +219,10 @@ pub(super) fn build_add_column_sql_ducklake(
 }
 
 /// Builds a DuckLake `alter table drop column` statement.
-pub(super) fn build_drop_column_sql_ducklake(table_name: &str, column_name: &str) -> String {
+pub(super) fn build_drop_column_sql_ducklake(
+    table_name: &DuckLakeTableName,
+    column_name: &str,
+) -> String {
     let table_name = qualified_lake_table_name(table_name);
     let column_name = quote_identifier(column_name);
 
@@ -221,7 +231,7 @@ pub(super) fn build_drop_column_sql_ducklake(table_name: &str, column_name: &str
 
 /// Builds a DuckLake `alter table rename column` statement.
 pub(super) fn build_rename_column_sql_ducklake(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     old_name: &str,
     new_name: &str,
 ) -> String {
@@ -234,7 +244,7 @@ pub(super) fn build_rename_column_sql_ducklake(
 
 /// Builds a DuckLake `alter table alter column set default` statement.
 pub(super) fn build_set_default_sql_ducklake(
-    table_name: &str,
+    table_name: &DuckLakeTableName,
     column_name: &str,
     typ: &Type,
     default_expression: &str,
@@ -250,7 +260,10 @@ pub(super) fn build_set_default_sql_ducklake(
 }
 
 /// Builds a DuckLake `alter table alter column drop default` statement.
-pub(super) fn build_drop_default_sql_ducklake(table_name: &str, column_name: &str) -> String {
+pub(super) fn build_drop_default_sql_ducklake(
+    table_name: &DuckLakeTableName,
+    column_name: &str,
+) -> String {
     let table_name = qualified_lake_table_name(table_name);
     let column_name = quote_identifier(column_name);
 
@@ -260,6 +273,10 @@ pub(super) fn build_drop_default_sql_ducklake(table_name: &str, column_name: &st
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn table_name(table: &str) -> DuckLakeTableName {
+        DuckLakeTableName::new("public", table)
+    }
 
     #[test]
     fn scalar_type_mapping() {
@@ -298,33 +315,35 @@ mod tests {
     #[test]
     fn build_create_table_sql_qualifies_lake_catalog() {
         let sql = build_create_table_sql_ducklake(
-            "odd\"table",
+            &table_name("odd\"table"),
             &[ColumnSchema::new("select".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1)],
         );
 
-        assert!(sql.starts_with("create table if not exists \"lake\".\"odd\"\"table\""));
+        assert!(sql.starts_with(
+            "create schema if not exists \"lake\".\"public\";\ncreate table if not exists \"lake\".\"public\".\"odd\"\"table\""
+        ));
         assert!(sql.contains("  \"select\" integer not null"));
     }
 
     #[test]
     fn build_add_column_sql_keeps_added_columns_nullable() {
         let sql = build_add_column_sql_ducklake(
-            "test_table",
+            &table_name("test_table"),
             &ColumnSchema::new("score".to_owned(), Type::INT4, -1, 4, false),
         );
 
-        assert_eq!(sql, r#"alter table "lake"."test_table" add column "score" integer"#);
+        assert_eq!(sql, r#"alter table "lake"."public"."test_table" add column "score" integer"#);
     }
 
     #[test]
     fn build_add_column_sql_includes_supported_default() {
         let column = ColumnSchema::new("status".to_owned(), Type::TEXT, -1, 4, true)
             .with_default_expression("'pending'::text".to_owned());
-        let sql = build_add_column_sql_ducklake("test_table", &column);
+        let sql = build_add_column_sql_ducklake(&table_name("test_table"), &column);
 
         assert_eq!(
             sql,
-            r#"alter table "lake"."test_table" add column "status" varchar default 'pending'"#
+            r#"alter table "lake"."public"."test_table" add column "status" varchar default 'pending'"#
         );
     }
 
@@ -379,18 +398,22 @@ mod tests {
 
     #[test]
     fn build_drop_column_sql_quotes_identifiers() {
-        let sql = build_drop_column_sql_ducklake("table\"name", "old\"column");
+        let sql = build_drop_column_sql_ducklake(&table_name("table\"name"), "old\"column");
 
-        assert_eq!(sql, r#"alter table "lake"."table""name" drop column "old""column""#);
+        assert_eq!(sql, r#"alter table "lake"."public"."table""name" drop column "old""column""#);
     }
 
     #[test]
     fn build_rename_column_sql_quotes_identifiers() {
-        let sql = build_rename_column_sql_ducklake("table\"name", "old\"column", "new\"column");
+        let sql = build_rename_column_sql_ducklake(
+            &table_name("table\"name"),
+            "old\"column",
+            "new\"column",
+        );
 
         assert_eq!(
             sql,
-            r#"alter table "lake"."table""name" rename column "old""column" to "new""column""#
+            r#"alter table "lake"."public"."table""name" rename column "old""column" to "new""column""#
         );
     }
 
@@ -401,19 +424,19 @@ mod tests {
 
         assert_eq!(
             build_set_default_sql_ducklake(
-                "table\"name",
+                &table_name("table\"name"),
                 &column.name,
                 &column.typ,
                 column.default_expression.as_deref().expect("test default")
             ),
             Some(
-                r#"alter table "lake"."table""name" alter column "status""value" set default 'pending'"#
+                r#"alter table "lake"."public"."table""name" alter column "status""value" set default 'pending'"#
                     .to_owned()
             )
         );
         assert_eq!(
-            build_drop_default_sql_ducklake("table\"name", "status\"value"),
-            r#"alter table "lake"."table""name" alter column "status""value" drop default"#
+            build_drop_default_sql_ducklake(&table_name("table\"name"), "status\"value"),
+            r#"alter table "lake"."public"."table""name" alter column "status""value" drop default"#
         );
     }
 }

--- a/crates/etl-destinations/src/ducklake/sql.rs
+++ b/crates/etl-destinations/src/ducklake/sql.rs
@@ -11,7 +11,8 @@ pub(super) fn quote_identifier(identifier: &str) -> String {
     quote_double_identifier(identifier)
 }
 
-/// Quotes a DuckLake schema reference and qualifies it with the DuckLake catalog.
+/// Quotes a DuckLake schema reference and qualifies it with the DuckLake
+/// catalog.
 ///
 /// Each identifier part is quoted separately so names containing dots remain
 /// one identifier, not extra path components.
@@ -19,7 +20,8 @@ pub(super) fn qualified_lake_schema_name(schema_name: &str) -> String {
     format!("{}.{}", quote_identifier(LAKE_CATALOG), quote_identifier(schema_name))
 }
 
-/// Quotes a DuckLake table reference and qualifies it with the DuckLake catalog.
+/// Quotes a DuckLake table reference and qualifies it with the DuckLake
+/// catalog.
 ///
 /// Each identifier part is quoted separately so names containing dots are
 /// treated as one identifier, not as extra path components.

--- a/crates/etl-destinations/src/ducklake/sql.rs
+++ b/crates/etl-destinations/src/ducklake/sql.rs
@@ -1,4 +1,7 @@
-use crate::{ducklake::LAKE_CATALOG, sql::quote_double_identifier};
+use crate::{
+    ducklake::{DuckLakeTableName, LAKE_CATALOG},
+    sql::quote_double_identifier,
+};
 
 /// Quotes a DuckDB SQL identifier for DuckLake SQL.
 ///
@@ -8,12 +11,24 @@ pub(super) fn quote_identifier(identifier: &str) -> String {
     quote_double_identifier(identifier)
 }
 
-/// Quotes a DuckLake table name and qualifies it with the DuckLake catalog.
+/// Quotes a DuckLake schema reference and qualifies it with the DuckLake catalog.
 ///
-/// Each identifier part is quoted separately so table names containing dots are
-/// treated as a single table identifier, not as extra path components.
-pub(super) fn qualified_lake_table_name(table_name: &str) -> String {
-    format!("{}.{}", quote_identifier(LAKE_CATALOG), quote_identifier(table_name))
+/// Each identifier part is quoted separately so names containing dots remain
+/// one identifier, not extra path components.
+pub(super) fn qualified_lake_schema_name(schema_name: &str) -> String {
+    format!("{}.{}", quote_identifier(LAKE_CATALOG), quote_identifier(schema_name))
+}
+
+/// Quotes a DuckLake table reference and qualifies it with the DuckLake catalog.
+///
+/// Each identifier part is quoted separately so names containing dots are
+/// treated as one identifier, not as extra path components.
+pub(super) fn qualified_lake_table_name(table_name: &DuckLakeTableName) -> String {
+    format!(
+        "{}.{}",
+        qualified_lake_schema_name(table_name.schema()),
+        quote_identifier(table_name.table())
+    )
 }
 
 #[cfg(test)]
@@ -31,9 +46,10 @@ mod tests {
 
     #[test]
     fn qualified_lake_table_name_quotes_each_identifier_part() {
+        let table_name = DuckLakeTableName::new("schema.name", r#"users"; DROP TABLE other; --"#);
         assert_eq!(
-            qualified_lake_table_name(r#"users"; DROP TABLE other; --"#),
-            r#""lake"."users""; DROP TABLE other; --""#
+            qualified_lake_table_name(&table_name),
+            r#""lake"."schema.name"."users""; DROP TABLE other; --""#
         );
     }
 }

--- a/crates/etl-destinations/tests/ducklake/destination.rs
+++ b/crates/etl-destinations/tests/ducklake/destination.rs
@@ -289,7 +289,7 @@ fn count_internal_table_files(data: &Path, table_name: &str) -> usize {
 }
 
 fn count_files_in_dir(table_dir: &Path) -> usize {
-    match std::fs::read_dir(&table_dir) {
+    match std::fs::read_dir(table_dir) {
         Ok(entries) => {
             entries.filter_map(Result::ok).filter(|entry| entry.path().is_file()).count()
         }

--- a/crates/etl-destinations/tests/ducklake/destination.rs
+++ b/crates/etl-destinations/tests/ducklake/destination.rs
@@ -16,7 +16,7 @@
 //!   LOAD '/absolute/path/to/ducklake.duckdb_extension';
 //!   ATTACH 'ducklake:postgres:host=... dbname=... user=...' AS lake
 //!     (DATA_PATH 'file:///path/printed/data');
-//!   SELECT * FROM lake.public_users;
+//!   SELECT * FROM lake.public.users;
 //! "
 //! ```
 
@@ -37,7 +37,9 @@ use etl::{
         TableSchema, Type as PgType, UpdatedTableRow,
     },
 };
-use etl_destinations::ducklake::{DuckLakeDestination, table_name_to_ducklake_table_name};
+use etl_destinations::ducklake::{
+    DuckLakeDestination, DuckLakeTableName, table_name_to_ducklake_table_name,
+};
 #[cfg(feature = "test-utils")]
 use etl_destinations::ducklake::{
     arm_fail_after_atomic_batch_commit_once_for_tests,
@@ -134,14 +136,14 @@ fn open_lake_conn(catalog: &Url, data: &Url) -> Connection {
     try_open_lake_conn(catalog, data).expect("failed to attach DuckLake catalog")
 }
 
-fn lake_table_exists(conn: &Connection, table_name: &str) -> bool {
+fn lake_table_exists(conn: &Connection, table_name: &DuckLakeTableName) -> bool {
     conn.query_row(
         &format!(
             "SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog = {} AND \
              table_schema = {} AND table_name = {}",
             quote_literal("lake"),
-            quote_literal("main"),
-            quote_literal(table_name)
+            quote_literal(table_name.schema()),
+            quote_literal(table_name.table())
         ),
         [],
         |row| row.get::<_, i64>(0),
@@ -152,7 +154,7 @@ fn lake_table_exists(conn: &Connection, table_name: &str) -> bool {
 async fn open_lake_conn_when_tables_visible(
     catalog: &Url,
     data: &Url,
-    table_names: &[&str],
+    table_names: &[&DuckLakeTableName],
 ) -> Connection {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
@@ -193,26 +195,31 @@ async fn new_test_destination(
     .expect("failed to create DuckLake destination")
 }
 
-fn count_rows(conn: &Connection, table_name: &str) -> i64 {
+fn qualified_lake_table_name(table_name: &DuckLakeTableName) -> String {
+    format!(
+        "{}.{}.{}",
+        quote_identifier("lake"),
+        quote_identifier(table_name.schema()),
+        quote_identifier(table_name.table())
+    )
+}
+
+fn count_rows(conn: &Connection, table_name: &DuckLakeTableName) -> i64 {
     conn.query_row(
-        &format!(
-            "SELECT COUNT(*) FROM {}.{}",
-            quote_identifier("lake"),
-            quote_identifier(table_name)
-        ),
+        &format!("SELECT COUNT(*) FROM {}", qualified_lake_table_name(table_name)),
         [],
         |r| r.get(0),
     )
     .expect("count query failed")
 }
 
-fn table_column_names(conn: &Connection, table_name: &str) -> Vec<String> {
+fn table_column_names(conn: &Connection, table_name: &DuckLakeTableName) -> Vec<String> {
     conn.prepare(&format!(
         "select column_name from information_schema.columns where table_catalog = {} and \
          table_schema = {} and table_name = {} order by ordinal_position",
         quote_literal("lake"),
-        quote_literal("main"),
-        quote_literal(table_name),
+        quote_literal(table_name.schema()),
+        quote_literal(table_name.table()),
     ))
     .expect("failed to prepare column query")
     .query_map([], |row| row.get::<_, String>(0))
@@ -221,13 +228,17 @@ fn table_column_names(conn: &Connection, table_name: &str) -> Vec<String> {
     .expect("failed to read table columns")
 }
 
-fn count_applied_batches(conn: &Connection, table_name: &str, batch_kind: &str) -> i64 {
+fn count_applied_batches(
+    conn: &Connection,
+    table_name: &DuckLakeTableName,
+    batch_kind: &str,
+) -> i64 {
     conn.query_row(
         &format!(
             "SELECT COUNT(*) FROM {}.{} WHERE table_name = {} AND batch_kind = {}",
             quote_identifier("lake"),
             quote_identifier("__etl_applied_table_batches"),
-            quote_literal(table_name),
+            quote_literal(&table_name.id()),
             quote_literal(batch_kind)
         ),
         [],
@@ -236,13 +247,13 @@ fn count_applied_batches(conn: &Connection, table_name: &str, batch_kind: &str) 
     .expect("batch marker count query failed")
 }
 
-fn count_streaming_progress_rows(conn: &Connection, table_name: &str) -> i64 {
+fn count_streaming_progress_rows(conn: &Connection, table_name: &DuckLakeTableName) -> i64 {
     conn.query_row(
         &format!(
             "SELECT COUNT(*) FROM {}.{} WHERE table_name = {}",
             quote_identifier("lake"),
             quote_identifier("__etl_streaming_progress"),
-            quote_literal(table_name),
+            quote_literal(&table_name.id()),
         ),
         [],
         |r| r.get(0),
@@ -250,13 +261,16 @@ fn count_streaming_progress_rows(conn: &Connection, table_name: &str) -> i64 {
     .expect("streaming progress count query failed")
 }
 
-fn read_streaming_progress(conn: &Connection, table_name: &str) -> Option<(u64, u64)> {
+fn read_streaming_progress(
+    conn: &Connection,
+    table_name: &DuckLakeTableName,
+) -> Option<(u64, u64)> {
     conn.query_row(
         &format!(
             "SELECT last_commit_lsn, last_tx_ordinal FROM {}.{} WHERE table_name = {}",
             quote_identifier("lake"),
             quote_identifier("__etl_streaming_progress"),
-            quote_literal(table_name),
+            quote_literal(&table_name.id()),
         ),
         [],
         |r| Ok((r.get(0)?, r.get(1)?)),
@@ -264,8 +278,17 @@ fn read_streaming_progress(conn: &Connection, table_name: &str) -> Option<(u64, 
     .ok()
 }
 
-fn count_table_files(data: &Path, table_name: &str) -> usize {
+fn count_table_files(data: &Path, table_name: &DuckLakeTableName) -> usize {
+    let table_dir = data.join(table_name.schema()).join(table_name.table());
+    count_files_in_dir(&table_dir)
+}
+
+fn count_internal_table_files(data: &Path, table_name: &str) -> usize {
     let table_dir = data.join("main").join(table_name);
+    count_files_in_dir(&table_dir)
+}
+
+fn count_files_in_dir(table_dir: &Path) -> usize {
     match std::fs::read_dir(&table_dir) {
         Ok(entries) => {
             entries.filter_map(Result::ok).filter(|entry| entry.path().is_file()).count()
@@ -275,13 +298,14 @@ fn count_table_files(data: &Path, table_name: &str) -> usize {
     }
 }
 
-fn flush_inlined_rows(conn: &Connection, table_name: &str) -> i64 {
+fn flush_inlined_rows(conn: &Connection, table_name: &DuckLakeTableName) -> i64 {
     conn.query_row(
         &format!(
             "SELECT COALESCE(SUM(rows_flushed), 0) FROM ducklake_flush_inlined_data({}, \
-             table_name => {})",
+             schema_name => {}, table_name => {})",
             quote_literal("lake"),
-            quote_literal(table_name),
+            quote_literal(table_name.schema()),
+            quote_literal(table_name.table()),
         ),
         [],
         |r| r.get(0),
@@ -351,9 +375,8 @@ async fn write_table_rows_basic() {
     let (id, name): (i32, Option<String>) = conn
         .query_row(
             &format!(
-                "SELECT id, name FROM {}.{} WHERE id = 1",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
+                "SELECT id, name FROM {} WHERE id = 1",
+                qualified_lake_table_name(&table_name)
             ),
             [],
             |r| Ok((r.get(0)?, r.get(1)?)),
@@ -619,7 +642,7 @@ async fn write_table_rows_replaces_broken_pooled_connection_after_retry() {
 
     assert_eq!(destination.connection_open_count_for_tests(), 1);
 
-    arm_fail_after_copy_batch_commit_once_for_tests(&table_name);
+    arm_fail_after_copy_batch_commit_once_for_tests(&table_name.id());
     destination
         .write_table_rows(
             &replicated_table_schema,
@@ -676,7 +699,7 @@ async fn write_table_rows_retry_after_post_commit_failure_is_idempotent() {
     .await
     .unwrap();
 
-    arm_fail_after_copy_batch_commit_once_for_tests(&table_name);
+    arm_fail_after_copy_batch_commit_once_for_tests(&table_name.id());
     destination
         .write_table_rows(
             &replicated_table_schema,
@@ -793,7 +816,7 @@ async fn concurrent_same_table_copy_batches_complete() {
              AND batch_kind = {}",
             quote_identifier("lake"),
             quote_identifier("__etl_applied_table_batches"),
-            quote_literal(&table_name),
+            quote_literal(&table_name.id()),
             quote_literal("copy"),
         );
         let mut stmt = conn.prepare(&sql).expect("marker detail prepare failed");
@@ -909,8 +932,8 @@ async fn truncate_clears_rows() {
                 "SELECT COUNT(*) FROM information_schema.columns WHERE table_catalog = {} AND \
                  table_schema = {} AND table_name = {}",
                 quote_literal("lake"),
-                quote_literal("main"),
-                quote_literal(&table_name),
+                quote_literal(table_name.schema()),
+                quote_literal(table_name.table()),
             ),
             [],
             |r| r.get(0),
@@ -1038,11 +1061,7 @@ async fn write_events() {
 
     let (id, name): (i32, String) = conn
         .query_row(
-            &format!(
-                "SELECT id, name FROM {}.{}",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT id, name FROM {}", qualified_lake_table_name(&table_name)),
             [],
             |r| Ok((r.get(0)?, r.get(1)?)),
         )
@@ -1111,9 +1130,8 @@ async fn write_events_splits_same_table_batch_by_replicated_schema() {
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     let mut statement = conn
         .prepare(&format!(
-            "select id, name, email from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, name, email from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare segmented schema query");
     let rows = statement
@@ -1184,7 +1202,7 @@ async fn write_events_recovers_applying_metadata_before_relation_event() {
         .unwrap();
 
     let applying_metadata = DestinationTableMetadata::new_applied(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         old_schema.snapshot_id,
         old_replicated_table_schema.replication_mask().clone(),
     )
@@ -1230,9 +1248,8 @@ async fn write_events_recovers_applying_metadata_before_relation_event() {
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     let mut statement = conn
         .prepare(&format!(
-            "select id, name, email from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, name, email from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare state query");
     let rows = statement
@@ -1306,7 +1323,7 @@ async fn write_events_applies_defaulted_schema_change() {
         .unwrap();
 
     let initial_metadata = DestinationTableMetadata::new_applied(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         old_schema.snapshot_id,
         old_replicated_table_schema.replication_mask().clone(),
     );
@@ -1341,9 +1358,8 @@ async fn write_events_applies_defaulted_schema_change() {
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     let mut rows_statement = conn
         .prepare(&format!(
-            "select id, name, status, score, active from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, name, status, score, active from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare defaulted row query");
     let rows = rows_statement
@@ -1423,7 +1439,7 @@ async fn write_events_reconciles_missing_columns_after_applied_metadata() {
         .unwrap();
 
     let applied_metadata = DestinationTableMetadata::new_applied(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         new_schema.snapshot_id,
         new_replicated_table_schema.replication_mask().clone(),
     );
@@ -1464,9 +1480,8 @@ async fn write_events_reconciles_missing_columns_after_applied_metadata() {
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     let mut statement = conn
         .prepare(&format!(
-            "select id, name, email from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, name, email from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare state query");
     let rows = statement
@@ -1567,9 +1582,8 @@ async fn write_events_supports_drop_and_add_same_column_name() {
 
     let mut statement = conn
         .prepare(&format!(
-            "select id, name, status from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, name, status from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare state query");
     let rows = statement
@@ -1686,9 +1700,8 @@ async fn write_events_supports_repeated_drop_and_add_same_column_name() {
 
     let mut statement = conn
         .prepare(&format!(
-            "select id, status from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, status from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare state query");
     let rows = statement
@@ -1741,13 +1754,11 @@ async fn write_events_drops_stale_tombstone_before_reusing_tombstone_name() {
 
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     conn.execute_batch(&format!(
-        "alter table {}.{} add column {} varchar;
-         update {}.{} set {} = {};",
-        quote_identifier("lake"),
-        quote_identifier(&table_name),
+        "alter table {} add column {} varchar;
+         update {} set {} = {};",
+        qualified_lake_table_name(&table_name),
         quote_identifier(stale_tombstone_column),
-        quote_identifier("lake"),
-        quote_identifier(&table_name),
+        qualified_lake_table_name(&table_name),
         quote_identifier(stale_tombstone_column),
         quote_literal("stale"),
     ))
@@ -1783,10 +1794,9 @@ async fn write_events_drops_stale_tombstone_before_reusing_tombstone_name() {
 
     let mut statement = conn
         .prepare(&format!(
-            "select id, name, {} from {}.{} order by id",
+            "select id, name, {} from {} order by id",
             quote_identifier(stale_tombstone_column),
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare reused tombstone query");
     let rows = statement
@@ -1842,10 +1852,9 @@ async fn write_table_rows_preserves_active_column_with_tombstone_prefix() {
     let value: String = conn
         .query_row(
             &format!(
-                "select {} from {}.{} where id = 1",
+                "select {} from {} where id = 1",
                 quote_identifier("__etl_ducklake_dropped_business"),
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
+                qualified_lake_table_name(&table_name)
             ),
             [],
             |row| row.get(0),
@@ -1884,7 +1893,7 @@ async fn startup_after_restart_reconciles_applied_metadata_missing_columns() {
         .unwrap();
 
     let applied_metadata = DestinationTableMetadata::new_applied(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         new_schema.snapshot_id,
         new_replicated_table_schema.replication_mask().clone(),
     );
@@ -1912,9 +1921,8 @@ async fn startup_after_restart_reconciles_applied_metadata_missing_columns() {
 
     let mut statement = conn
         .prepare(&format!(
-            "select id, name, email from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, name, email from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare state query");
     let rows = statement
@@ -1961,7 +1969,7 @@ async fn startup_after_restart_recovers_applying_schema_change() {
         .unwrap();
 
     let applying_metadata = DestinationTableMetadata::new_applied(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         old_schema.snapshot_id,
         old_replicated_table_schema.replication_mask().clone(),
     )
@@ -2036,13 +2044,11 @@ async fn startup_after_restart_drops_stale_rename_source_when_target_exists() {
 
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     conn.execute_batch(&format!(
-        "alter table {}.{} add column {} varchar;
-         update {}.{} set {} = {};",
-        quote_identifier("lake"),
-        quote_identifier(&table_name),
+        "alter table {} add column {} varchar;
+         update {} set {} = {};",
+        qualified_lake_table_name(&table_name),
         quote_identifier("ddl_col_4_0"),
-        quote_identifier("lake"),
-        quote_identifier(&table_name),
+        qualified_lake_table_name(&table_name),
         quote_identifier("ddl_col_4_0"),
         quote_identifier("ddl_col_4_1"),
     ))
@@ -2050,7 +2056,7 @@ async fn startup_after_restart_drops_stale_rename_source_when_target_exists() {
     drop(conn);
 
     let applying_metadata = DestinationTableMetadata::new_applied(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         old_schema.snapshot_id,
         old_replicated_table_schema.replication_mask().clone(),
     )
@@ -2087,9 +2093,8 @@ async fn startup_after_restart_drops_stale_rename_source_when_target_exists() {
 
     let mut statement = conn
         .prepare(&format!(
-            "select id, ddl_col_4_0 from {}.{} order by id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "select id, ddl_col_4_0 from {} order by id",
+            qualified_lake_table_name(&table_name)
         ))
         .expect("failed to prepare state query");
     let rows = statement
@@ -2133,7 +2138,7 @@ async fn startup_after_restart_recovers_applying_schema_change_with_pruned_previ
         .unwrap();
 
     let applying_metadata = DestinationTableMetadata::new_applied(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         missing_previous_snapshot_id,
         old_replicated_table_schema.replication_mask().clone(),
     )
@@ -2177,7 +2182,7 @@ async fn startup_after_restart_recovers_initial_applying_metadata() {
     let store = MemoryStore::new();
     store.store_table_schema(schema.clone()).await.unwrap();
     let applying_metadata = DestinationTableMetadata::new_applying(
-        table_name.clone(),
+        table_name.to_metadata_id().unwrap(),
         schema.snapshot_id,
         replicated_table_schema.replication_mask().clone(),
     );
@@ -2313,11 +2318,7 @@ async fn write_events_with_old_row_update() {
 
     let (id, name): (i32, String) = conn
         .query_row(
-            &format!(
-                "SELECT id, name FROM {}.{}",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT id, name FROM {}", qualified_lake_table_name(&table_name)),
             [],
             |r| Ok((r.get(0)?, r.get(1)?)),
         )
@@ -2402,11 +2403,7 @@ async fn write_events_with_partial_updates() {
 
     let name: String = conn
         .query_row(
-            &format!(
-                "SELECT name FROM {}.{} WHERE id = 1",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT name FROM {} WHERE id = 1", qualified_lake_table_name(&table_name)),
             [],
             |r| r.get(0),
         )
@@ -2492,11 +2489,7 @@ async fn write_events_without_replica_identity_rejects_mutations() {
     assert_eq!(count_rows(&conn, &table_name), 1);
     let name: String = conn
         .query_row(
-            &format!(
-                "SELECT name FROM {}.{} WHERE id = 1",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT name FROM {} WHERE id = 1", qualified_lake_table_name(&table_name)),
             [],
             |r| r.get(0),
         )
@@ -2587,11 +2580,7 @@ async fn write_events_replay_is_idempotent() {
 
     let (id, name): (i32, String) = conn
         .query_row(
-            &format!(
-                "SELECT id, name FROM {}.{}",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT id, name FROM {}", qualified_lake_table_name(&table_name)),
             [],
             |r| Ok((r.get(0)?, r.get(1)?)),
         )
@@ -2665,11 +2654,7 @@ async fn write_events_same_commit_lsn_higher_tx_ordinal_still_applies() {
 
     let name: String = conn
         .query_row(
-            &format!(
-                "SELECT name FROM {}.{} WHERE id = 1",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT name FROM {} WHERE id = 1", qualified_lake_table_name(&table_name)),
             [],
             |r| r.get(0),
         )
@@ -2776,9 +2761,8 @@ async fn write_events_restart_overlap_rebatches_only_pending_suffix() {
 
     let names: Vec<String> = conn
         .prepare(&format!(
-            "SELECT name FROM {}.{} ORDER BY id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "SELECT name FROM {} ORDER BY id",
+            qualified_lake_table_name(&table_name)
         ))
         .unwrap()
         .query_map([], |row| row.get(0))
@@ -2859,16 +2843,15 @@ async fn write_events_reuses_one_staging_table_per_atomic_batch() {
         .await
         .unwrap();
 
-    assert_eq!(ducklake_staging_table_creations_for_tests(&table_name), 1);
+    assert_eq!(ducklake_staging_table_creations_for_tests(&table_name.id()), 1);
 
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     assert_eq!(count_rows(&conn, &table_name), 2);
 
     let rows = conn
         .prepare(&format!(
-            "SELECT id, name FROM {}.{} ORDER BY id",
-            quote_identifier("lake"),
-            quote_identifier(&table_name)
+            "SELECT id, name FROM {} ORDER BY id",
+            qualified_lake_table_name(&table_name)
         ))
         .unwrap()
         .query_map([], |row| Ok((row.get::<_, i32>(0)?, row.get::<_, String>(1)?)))
@@ -2921,7 +2904,7 @@ async fn applied_batches_table_uses_data_inlining() {
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     assert_eq!(count_rows(&conn, &table_name), 1);
     assert_eq!(count_applied_batches(&conn, &table_name, "copy"), 1);
-    assert_eq!(count_table_files(&data, "__etl_applied_table_batches"), 0);
+    assert_eq!(count_internal_table_files(&data, "__etl_applied_table_batches"), 0);
 }
 
 /// Mixed table batches remain correct when multiple tables are written in one
@@ -3030,22 +3013,14 @@ async fn write_events_mixed_multi_table_batches() {
 
     let name_a: String = conn
         .query_row(
-            &format!(
-                "SELECT name FROM {}.{} WHERE id = 1",
-                quote_identifier("lake"),
-                quote_identifier(&table_name_a)
-            ),
+            &format!("SELECT name FROM {} WHERE id = 1", qualified_lake_table_name(&table_name_a)),
             [],
             |r| r.get(0),
         )
         .unwrap();
     let name_b: String = conn
         .query_row(
-            &format!(
-                "SELECT name FROM {}.{} WHERE id = 2",
-                quote_identifier("lake"),
-                quote_identifier(&table_name_b)
-            ),
+            &format!("SELECT name FROM {} WHERE id = 2", qualified_lake_table_name(&table_name_b)),
             [],
             |r| r.get(0),
         )
@@ -3102,7 +3077,7 @@ async fn write_events_truncate_retry_after_post_commit_failure_is_idempotent() {
         .await
         .unwrap();
 
-    arm_fail_after_atomic_batch_commit_once_for_tests(&table_name);
+    arm_fail_after_atomic_batch_commit_once_for_tests(&table_name.id());
 
     let lsn = PgLsn::from(800u64);
     destination
@@ -3137,11 +3112,7 @@ async fn write_events_truncate_retry_after_post_commit_failure_is_idempotent() {
 
     let name: String = conn
         .query_row(
-            &format!(
-                "SELECT name FROM {}.{} WHERE id = 3",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT name FROM {} WHERE id = 3", qualified_lake_table_name(&table_name)),
             [],
             |r| r.get(0),
         )
@@ -3185,7 +3156,7 @@ async fn write_events_retry_after_post_commit_failure_is_idempotent() {
     .await
     .unwrap();
 
-    arm_fail_after_atomic_batch_commit_once_for_tests(&table_name);
+    arm_fail_after_atomic_batch_commit_once_for_tests(&table_name.id());
 
     let lsn = PgLsn::from(500u64);
     destination
@@ -3240,11 +3211,7 @@ async fn write_events_retry_after_post_commit_failure_is_idempotent() {
 
     let name: String = conn
         .query_row(
-            &format!(
-                "SELECT name FROM {}.{} WHERE id = 1",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
-            ),
+            &format!("SELECT name FROM {} WHERE id = 1", qualified_lake_table_name(&table_name)),
             [],
             |r| r.get(0),
         )
@@ -3369,9 +3336,8 @@ async fn type_mapping_round_trip() {
     let row: (i32, String, f64, bool, String) = conn
         .query_row(
             &format!(
-                "SELECT id, label, score, active, CAST(birthday AS VARCHAR) FROM {}.{}",
-                quote_identifier("lake"),
-                quote_identifier(&table_name)
+                "SELECT id, label, score, active, CAST(birthday AS VARCHAR) FROM {}",
+                qualified_lake_table_name(&table_name)
             ),
             [],
             |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -16,7 +16,9 @@ use etl::{
     },
     types::{EventType, PipelineId},
 };
-use etl_destinations::ducklake::{DuckLakeDestination, table_name_to_ducklake_table_name};
+use etl_destinations::ducklake::{
+    DuckLakeDestination, DuckLakeTableName, table_name_to_ducklake_table_name,
+};
 use etl_postgres::tokio::test_utils::TableModification;
 use etl_telemetry::tracing::init_test_tracing;
 use pg_escape::{quote_identifier, quote_literal};
@@ -111,16 +113,22 @@ fn checkpoint_lake(catalog: &Url, data: &Url) {
     conn.execute_batch("checkpoint").expect("failed to checkpoint DuckLake catalog");
 }
 
+fn qualified_lake_table_name(table_name: &DuckLakeTableName) -> String {
+    format!(
+        "{}.{}.{}",
+        quote_identifier("lake"),
+        quote_identifier(table_name.schema()),
+        quote_identifier(table_name.table())
+    )
+}
+
 /// Queries replicated user rows using blocking DuckDB APIs.
 ///
 /// Production async code must wrap equivalent DuckDB work in
 /// `run_duckdb_blocking`.
-fn query_user_rows(conn: &Connection, table_name: &str) -> Vec<(i64, String, i32)> {
-    let sql = format!(
-        "select id, name, age from {}.{} order by id",
-        quote_identifier("lake"),
-        quote_identifier(table_name)
-    );
+fn query_user_rows(conn: &Connection, table_name: &DuckLakeTableName) -> Vec<(i64, String, i32)> {
+    let sql =
+        format!("select id, name, age from {} order by id", qualified_lake_table_name(table_name));
     let mut statement = conn.prepare(&sql).expect("failed to prepare users query");
     let mut rows = statement.query([]).expect("failed to run users query");
     let mut result = Vec::new();
@@ -140,11 +148,10 @@ fn query_user_rows(conn: &Connection, table_name: &str) -> Vec<(i64, String, i32
 ///
 /// Production async code must wrap equivalent DuckDB work in
 /// `run_duckdb_blocking`.
-fn query_order_rows(conn: &Connection, table_name: &str) -> Vec<(i64, String)> {
+fn query_order_rows(conn: &Connection, table_name: &DuckLakeTableName) -> Vec<(i64, String)> {
     let sql = format!(
-        "select id, description from {}.{} order by id",
-        quote_identifier("lake"),
-        quote_identifier(table_name)
+        "select id, description from {} order by id",
+        qualified_lake_table_name(table_name)
     );
     let mut statement = conn.prepare(&sql).expect("failed to prepare orders query");
     let mut rows = statement.query([]).expect("failed to run orders query");
@@ -164,13 +171,13 @@ fn query_order_rows(conn: &Connection, table_name: &str) -> Vec<(i64, String)> {
 ///
 /// Production async code must wrap equivalent DuckDB work in
 /// `run_duckdb_blocking`.
-fn query_table_columns(conn: &Connection, table_name: &str) -> Vec<String> {
+fn query_table_columns(conn: &Connection, table_name: &DuckLakeTableName) -> Vec<String> {
     let sql = format!(
         "select column_name from information_schema.columns where table_catalog = {} and \
          table_schema = {} and table_name = {} order by ordinal_position",
         quote_literal("lake"),
-        quote_literal("main"),
-        quote_literal(table_name)
+        quote_literal(table_name.schema()),
+        quote_literal(table_name.table())
     );
     let mut statement = conn.prepare(&sql).expect("failed to prepare columns query");
     let mut rows = statement.query([]).expect("failed to run columns query");
@@ -187,11 +194,10 @@ fn query_table_columns(conn: &Connection, table_name: &str) -> Vec<String> {
 ///
 /// Production async code must wrap equivalent DuckDB work in
 /// `run_duckdb_blocking`.
-fn query_schema_add_rows(conn: &Connection, table_name: &str) -> Vec<SchemaAddRow> {
+fn query_schema_add_rows(conn: &Connection, table_name: &DuckLakeTableName) -> Vec<SchemaAddRow> {
     let sql = format!(
-        "select id, name, age, email, score from {}.{} order by id",
-        quote_identifier("lake"),
-        quote_identifier(table_name)
+        "select id, name, age, email, score from {} order by id",
+        qualified_lake_table_name(table_name)
     );
     let mut statement = conn.prepare(&sql).expect("failed to prepare schema add query");
     let mut rows = statement.query([]).expect("failed to run schema add query");
@@ -215,11 +221,13 @@ fn query_schema_add_rows(conn: &Connection, table_name: &str) -> Vec<SchemaAddRo
 ///
 /// Production async code must wrap equivalent DuckDB work in
 /// `run_duckdb_blocking`.
-fn query_schema_multi_rows(conn: &Connection, table_name: &str) -> Vec<SchemaMultiRow> {
+fn query_schema_multi_rows(
+    conn: &Connection,
+    table_name: &DuckLakeTableName,
+) -> Vec<SchemaMultiRow> {
     let sql = format!(
-        "select id, full_name, status, email from {}.{} order by id",
-        quote_identifier("lake"),
-        quote_identifier(table_name)
+        "select id, full_name, status, email from {} order by id",
+        qualified_lake_table_name(table_name)
     );
     let mut statement = conn.prepare(&sql).expect("failed to prepare schema multi query");
     let mut rows = statement.query([]).expect("failed to run schema multi query");
@@ -242,11 +250,13 @@ fn query_schema_multi_rows(conn: &Connection, table_name: &str) -> Vec<SchemaMul
 ///
 /// Production async code must wrap equivalent DuckDB work in
 /// `run_duckdb_blocking`.
-fn query_schema_mutation_rows(conn: &Connection, table_name: &str) -> Vec<SchemaMutationRow> {
+fn query_schema_mutation_rows(
+    conn: &Connection,
+    table_name: &DuckLakeTableName,
+) -> Vec<SchemaMutationRow> {
     let sql = format!(
-        "select id, full_name, visits, email from {}.{} order by id",
-        quote_identifier("lake"),
-        quote_identifier(table_name)
+        "select id, full_name, visits, email from {} order by id",
+        qualified_lake_table_name(table_name)
     );
     let mut statement = conn.prepare(&sql).expect("failed to prepare schema mutation query");
     let mut rows = statement.query([]).expect("failed to run schema mutation query");
@@ -271,12 +281,11 @@ fn query_schema_mutation_rows(conn: &Connection, table_name: &str) -> Vec<Schema
 /// `run_duckdb_blocking`.
 fn query_simulator_ddl_rotation_rows(
     conn: &Connection,
-    table_name: &str,
+    table_name: &DuckLakeTableName,
 ) -> Vec<SimulatorDdlRotationRow> {
     let sql = format!(
-        "select id, text_col, ddl_col_0_0 from {}.{} order by id",
-        quote_identifier("lake"),
-        quote_identifier(table_name)
+        "select id, text_col, ddl_col_0_0 from {} order by id",
+        qualified_lake_table_name(table_name)
     );
     let mut statement = conn.prepare(&sql).expect("failed to prepare simulator DDL rotation query");
     let mut rows = statement.query([]).expect("failed to run simulator DDL rotation query");
@@ -298,12 +307,14 @@ fn query_simulator_ddl_rotation_rows(
 ///
 /// Production async code must wrap equivalent DuckDB work in
 /// `run_duckdb_blocking`.
-fn query_simulator_ddl_type_row(conn: &Connection, table_name: &str) -> SimulatorDdlTypeRow {
+fn query_simulator_ddl_type_row(
+    conn: &Connection,
+    table_name: &DuckLakeTableName,
+) -> SimulatorDdlTypeRow {
     let sql = format!(
         "select id, text_col, ddl_col_0_0, ddl_col_1_0, ddl_col_2_0, ddl_col_3_0 is not null, \
-         ddl_col_4_0 from {}.{} where id = 5",
-        quote_identifier("lake"),
-        quote_identifier(table_name)
+         ddl_col_4_0 from {} where id = 5",
+        qualified_lake_table_name(table_name)
     );
     let mut statement = conn.prepare(&sql).expect("failed to prepare simulator DDL type query");
     let row = statement.query_row([], |row| {

--- a/crates/etl-maintenance/src/ducklake/runner.rs
+++ b/crates/etl-maintenance/src/ducklake/runner.rs
@@ -1821,11 +1821,9 @@ async fn list_ducklake_tables(
     metadata_schema: &str,
 ) -> EtlResult<Vec<DuckLakeMaintenanceTableName>> {
     let sql = format!(
-        "SELECT s.schema_name, t.table_name \
-         FROM {}.{} AS t \
-         JOIN {}.{} AS s ON s.schema_id = t.schema_id \
-         WHERE t.end_snapshot IS NULL AND s.end_snapshot IS NULL \
-         ORDER BY s.schema_name, t.table_name",
+        "SELECT s.schema_name, t.table_name FROM {}.{} AS t JOIN {}.{} AS s ON s.schema_id = \
+         t.schema_id WHERE t.end_snapshot IS NULL AND s.end_snapshot IS NULL ORDER BY \
+         s.schema_name, t.table_name",
         quote_identifier(metadata_schema),
         quote_identifier("ducklake_table"),
         quote_identifier(metadata_schema),
@@ -2247,8 +2245,8 @@ fn merge_adjacent_files(
     max_compacted_files: u32,
 ) -> EtlResult<u64> {
     let sql = format!(
-        "SELECT COALESCE(SUM(files_created), 0) FROM ducklake_merge_adjacent_files({}, {}, \
-         schema => {}, max_compacted_files => {});",
+        "SELECT COALESCE(SUM(files_created), 0) FROM ducklake_merge_adjacent_files({}, {}, schema \
+         => {}, max_compacted_files => {});",
         quote_literal(LAKE_CATALOG),
         quote_literal(&table_name.table_name),
         quote_literal(&table_name.schema_name),

--- a/crates/etl-maintenance/src/ducklake/runner.rs
+++ b/crates/etl-maintenance/src/ducklake/runner.rs
@@ -71,6 +71,32 @@ const RESULT_LABEL: &str = "result";
 const TABLE_LABEL: &str = "table";
 const SMALL_FILE_SIZE_BYTES: i64 = 5 * 1024 * 1024;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DuckLakeMaintenanceTableName {
+    schema_name: String,
+    table_name: String,
+}
+
+impl DuckLakeMaintenanceTableName {
+    fn new(schema_name: String, table_name: String) -> Self {
+        Self { schema_name, table_name }
+    }
+
+    fn id(&self) -> String {
+        format!("{}.{}", self.schema_name, self.table_name)
+    }
+
+    fn is_etl_internal_table(&self) -> bool {
+        self.table_name.starts_with("__etl_")
+    }
+}
+
+impl fmt::Display for DuckLakeMaintenanceTableName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.id())
+    }
+}
+
 static POSTGRES_PASSWORD_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"password=(?:'([^'\\]|\\.)*'|[^\s,);]+)")
         .expect("postgres password redaction regex should compile")
@@ -1793,13 +1819,19 @@ async fn resolve_metadata_schema(duckdb: &DuckDbMaintenanceExecutor) -> EtlResul
 async fn list_ducklake_tables(
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-) -> EtlResult<Vec<String>> {
+) -> EtlResult<Vec<DuckLakeMaintenanceTableName>> {
     let sql = format!(
-        "SELECT table_name FROM {}.{} WHERE end_snapshot IS NULL ORDER BY table_name",
+        "SELECT s.schema_name, t.table_name \
+         FROM {}.{} AS t \
+         JOIN {}.{} AS s ON s.schema_id = t.schema_id \
+         WHERE t.end_snapshot IS NULL AND s.end_snapshot IS NULL \
+         ORDER BY s.schema_name, t.table_name",
         quote_identifier(metadata_schema),
-        quote_identifier("ducklake_table")
+        quote_identifier("ducklake_table"),
+        quote_identifier(metadata_schema),
+        quote_identifier("ducklake_schema")
     );
-    let rows: Vec<(String,)> =
+    let rows: Vec<(String, String)> =
         sqlx::query_as(AssertSqlSafe(sql)).fetch_all(metadata_pg_pool).await.map_err(|source| {
             etl_error!(
                 ErrorKind::DestinationQueryFailed,
@@ -1808,7 +1840,10 @@ async fn list_ducklake_tables(
                 source: source
             )
         })?;
-    Ok(rows.into_iter().map(|(table_name,)| table_name).collect())
+    Ok(rows
+        .into_iter()
+        .map(|(schema_name, table_name)| DuckLakeMaintenanceTableName::new(schema_name, table_name))
+        .collect())
 }
 
 /// Runs inline flush for tables that crossed the pending-inline threshold.
@@ -1816,7 +1851,7 @@ async fn run_inline_flush(
     duckdb: &DuckDbMaintenanceExecutor,
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-    table_names: &[String],
+    table_names: &[DuckLakeMaintenanceTableName],
     config: InlineFlushMaintenanceConfig,
     outcome: &mut DuckLakeMaintenanceOutcome,
 ) -> EtlResult<()> {
@@ -1845,8 +1880,15 @@ async fn run_inline_flush(
             "ducklake inline flush executing"
         );
         let table_name_for_query = table_name.clone();
-        let rows =
-            duckdb.run(move |conn| flush_table_inlined_data(conn, &table_name_for_query)).await?;
+        let rows = duckdb
+            .run(move |conn| {
+                flush_table_inlined_data(
+                    conn,
+                    &table_name_for_query.schema_name,
+                    &table_name_for_query.table_name,
+                )
+            })
+            .await?;
         outcome.inline_flush_tables = outcome.inline_flush_tables.saturating_add(1);
         outcome.inline_flush_rows = outcome.inline_flush_rows.saturating_add(rows);
         info!(
@@ -1868,7 +1910,7 @@ async fn run_merge_adjacent_files(
     duckdb: &DuckDbMaintenanceExecutor,
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-    table_names: &[String],
+    table_names: &[DuckLakeMaintenanceTableName],
     config: &MergeAdjacentFilesMaintenanceConfig,
     outcome: &mut DuckLakeMaintenanceOutcome,
 ) -> EtlResult<()> {
@@ -1952,7 +1994,7 @@ async fn run_rewrite_data_files(
     duckdb: &DuckDbMaintenanceExecutor,
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-    table_names: &[String],
+    table_names: &[DuckLakeMaintenanceTableName],
     config: RewriteDataFilesMaintenanceConfig,
     outcome: &mut DuckLakeMaintenanceOutcome,
 ) -> EtlResult<()> {
@@ -2035,13 +2077,13 @@ async fn run_cleanup_old_files(
 async fn select_merge_tables(
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-    table_names: &[String],
+    table_names: &[DuckLakeMaintenanceTableName],
     target_file_size_bytes: Option<i64>,
     max_tables_per_run: u32,
-) -> EtlResult<Vec<String>> {
+) -> EtlResult<Vec<DuckLakeMaintenanceTableName>> {
     let mut selected = Vec::new();
     for table_name in table_names {
-        if is_etl_internal_table(table_name) {
+        if table_name.is_etl_internal_table() {
             info!(
                 table = %table_name,
                 "ducklake rewrite-data-files table skipped because it is internal ETL metadata"
@@ -2099,13 +2141,13 @@ fn should_merge(
 async fn select_rewrite_tables(
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-    table_names: &[String],
+    table_names: &[DuckLakeMaintenanceTableName],
     min_active_data_files: i64,
     max_tables_per_run: u32,
-) -> EtlResult<Vec<String>> {
+) -> EtlResult<Vec<DuckLakeMaintenanceTableName>> {
     let mut selected = Vec::new();
     for table_name in table_names {
-        if is_etl_internal_table(table_name) {
+        if table_name.is_etl_internal_table() {
             info!(
                 table = %table_name,
                 "ducklake rewrite-data-files table skipped because it is internal ETL metadata"
@@ -2142,10 +2184,6 @@ async fn select_rewrite_tables(
     Ok(selected)
 }
 
-fn is_etl_internal_table(table_name: &str) -> bool {
-    table_name.starts_with("__etl_")
-}
-
 /// Returns whether a table should be rewritten.
 fn should_rewrite(metrics: &DuckLakeTableStorageMetrics, min_active_data_files: i64) -> bool {
     metrics.active_data_files > min_active_data_files
@@ -2153,12 +2191,17 @@ fn should_rewrite(metrics: &DuckLakeTableStorageMetrics, min_active_data_files: 
 
 /// Flushes inlined user data for one table.
 #[doc(hidden)]
-pub fn flush_table_inlined_data(conn: &duckdb::Connection, table_name: &str) -> EtlResult<u64> {
+pub fn flush_table_inlined_data(
+    conn: &duckdb::Connection,
+    schema_name: &str,
+    table_name: &str,
+) -> EtlResult<u64> {
     let flush_started = std::time::Instant::now();
     let sql = format!(
         r#"SELECT COALESCE(SUM(rows_flushed), 0)
-         FROM ducklake_flush_inlined_data({}, table_name => {});"#,
+         FROM ducklake_flush_inlined_data({}, schema_name => {}, table_name => {});"#,
         quote_literal(LAKE_CATALOG),
+        quote_literal(schema_name),
         quote_literal(table_name),
     );
     let rows_flushed: i64 = conn.query_row(&sql, [], |row| row.get(0)).map_err(|source| {
@@ -2184,13 +2227,13 @@ pub fn flush_table_inlined_data(conn: &duckdb::Connection, table_name: &str) -> 
 
     if rows_flushed > 0 {
         debug!(
-            table = %table_name,
+            table = %format!("{schema_name}.{table_name}"),
             rows_flushed,
             "ducklake inlined data flushed"
         );
     } else {
         debug!(
-            table = %table_name,
+            table = %format!("{schema_name}.{table_name}"),
             "ducklake inlined data already flushed"
         );
     }
@@ -2200,25 +2243,30 @@ pub fn flush_table_inlined_data(conn: &duckdb::Connection, table_name: &str) -> 
 /// Calls DuckLake merge-adjacent-files for one table.
 fn merge_adjacent_files(
     conn: &duckdb::Connection,
-    table_name: &str,
+    table_name: &DuckLakeMaintenanceTableName,
     max_compacted_files: u32,
 ) -> EtlResult<u64> {
     let sql = format!(
         "SELECT COALESCE(SUM(files_created), 0) FROM ducklake_merge_adjacent_files({}, {}, \
-         max_compacted_files => {});",
+         schema => {}, max_compacted_files => {});",
         quote_literal(LAKE_CATALOG),
-        quote_literal(table_name),
+        quote_literal(&table_name.table_name),
+        quote_literal(&table_name.schema_name),
         max_compacted_files
     );
     count_maintenance_files(conn, &sql, "DuckLake merge adjacent files failed")
 }
 
 /// Calls DuckLake rewrite-data-files for one table.
-fn rewrite_data_files(conn: &duckdb::Connection, table_name: &str) -> EtlResult<u64> {
+fn rewrite_data_files(
+    conn: &duckdb::Connection,
+    table_name: &DuckLakeMaintenanceTableName,
+) -> EtlResult<u64> {
     let sql = format!(
-        "CALL ducklake_rewrite_data_files({}, {});",
+        "CALL ducklake_rewrite_data_files({}, {}, schema => {});",
         quote_literal(LAKE_CATALOG),
-        quote_literal(table_name)
+        quote_literal(&table_name.table_name),
+        quote_literal(&table_name.schema_name)
     );
     conn.execute_batch(&sql).map_err(|source| {
         etl_error!(
@@ -2329,10 +2377,14 @@ impl DuckLakePendingInlineSizeSampler {
         Self { metadata_schema, pool }
     }
 
-    async fn sample_table(&self, table_name: &str) -> EtlResult<DuckLakePendingInlineDataSizes> {
+    async fn sample_table(
+        &self,
+        table_name: &DuckLakeMaintenanceTableName,
+    ) -> EtlResult<DuckLakePendingInlineDataSizes> {
         let sql = pending_inline_data_bytes_query(&self.metadata_schema);
         let inlined_bytes: i64 = sqlx::query_scalar(AssertSqlSafe(sql))
-            .bind(table_name)
+            .bind(&table_name.schema_name)
+            .bind(&table_name.table_name)
             .fetch_one(&self.pool)
             .await
             .map_err(|source| {
@@ -2342,7 +2394,7 @@ impl DuckLakePendingInlineSizeSampler {
                     source: source
                 )
             })?;
-        Ok(record_pending_inline_data_sizes(inlined_bytes, table_name))
+        Ok(record_pending_inline_data_sizes(inlined_bytes, &table_name.id()))
     }
 }
 
@@ -2359,14 +2411,19 @@ fn record_pending_inline_data_sizes(
 fn pending_inline_data_bytes_query(metadata_schema: &str) -> String {
     let metadata_schema_literal = quote_literal(metadata_schema);
     let metadata_schema = quote_identifier(metadata_schema);
+    let ducklake_schema = quote_identifier("ducklake_schema");
     let ducklake_table = quote_identifier("ducklake_table");
     let ducklake_inlined_data_tables = quote_identifier("ducklake_inlined_data_tables");
 
     format!(
         r"WITH target_table AS (
-             SELECT table_id
-             FROM {metadata_schema}.{ducklake_table}
-             WHERE end_snapshot IS NULL AND table_name = $1
+             SELECT t.table_id
+             FROM {metadata_schema}.{ducklake_table} AS t
+             JOIN {metadata_schema}.{ducklake_schema} AS s ON s.schema_id = t.schema_id
+             WHERE t.end_snapshot IS NULL
+               AND s.end_snapshot IS NULL
+               AND s.schema_name = $1
+               AND t.table_name = $2
              LIMIT 1
          ),
          target_inline_tables AS (
@@ -2446,7 +2503,7 @@ impl DuckLakeTableStorageMetrics {
 async fn query_table_storage_metrics(
     metadata_pg_pool: &PgPool,
     metadata_schema: &str,
-    table_name: &str,
+    table_name: &DuckLakeMaintenanceTableName,
 ) -> EtlResult<DuckLakeTableStorageMetrics> {
     let sql = table_storage_metrics_query(metadata_schema);
     let (
@@ -2458,7 +2515,8 @@ async fn query_table_storage_metrics(
         _active_delete_bytes,
         deleted_rows,
     ): (i64, i64, i64, i64, i64, i64, i64) = sqlx::query_as(AssertSqlSafe(sql))
-        .bind(table_name)
+        .bind(&table_name.schema_name)
+        .bind(&table_name.table_name)
         .fetch_one(metadata_pg_pool)
         .await
         .map_err(|source| {
@@ -2489,15 +2547,20 @@ fn parse_size_bytes(value: &str) -> Option<i64> {
 
 fn table_storage_metrics_query(metadata_schema: &str) -> String {
     let metadata_schema = quote_identifier(metadata_schema);
+    let ducklake_schema = quote_identifier("ducklake_schema");
     let ducklake_table = quote_identifier("ducklake_table");
     let ducklake_data_file = quote_identifier("ducklake_data_file");
     let ducklake_delete_file = quote_identifier("ducklake_delete_file");
 
     format!(
         r#"WITH target_table AS (
-             SELECT table_id
-             FROM {metadata_schema}.{ducklake_table}
-             WHERE end_snapshot IS NULL AND table_name = $1
+             SELECT t.table_id
+             FROM {metadata_schema}.{ducklake_table} AS t
+             JOIN {metadata_schema}.{ducklake_schema} AS s ON s.schema_id = t.schema_id
+             WHERE t.end_snapshot IS NULL
+               AND s.end_snapshot IS NULL
+               AND s.schema_name = $1
+               AND t.table_name = $2
              LIMIT 1
          ),
          data_stats AS (


### PR DESCRIPTION
This PR is changing the naming convention when replicating data from:
```
source public.test        -> DuckLake main.public_test
source audit.events       -> DuckLake main.audit_events
source my_schema.orders   -> DuckLake main.my__schema_orders
```
TO

```
source public.test      -> DuckLake public.test
source audit.events     -> DuckLake audit.events
source my_schema.orders -> DuckLake my_schema.orders
```