### PR TITLE
fix(api): preserve default image on missing update

### DIFF
--- a/crates/etl-api/src/data/images.rs
+++ b/crates/etl-api/src/data/images.rs
@@ -96,8 +96,25 @@ pub async fn update_image(
 ) -> Result<Option<i64>, ImagesDbError> {
     let mut txn = pool.begin().await?;
 
-    // If this is to be the new default image, first unset any existing default
+    // If this is to be the new default image, first unset any existing default.
     if is_default {
+        // Check the target image first, so missing updates cannot change defaults.
+        if sqlx::query(
+            r#"
+        select id
+        from app.images
+        where id = $1
+        for update
+        "#,
+        )
+        .bind(image_id)
+        .fetch_optional(&mut *txn)
+        .await?
+        .is_none()
+        {
+            return Ok(None);
+        }
+
         sqlx::query!(
             r#"
             update app.images

--- a/crates/etl-api/tests/images.rs
+++ b/crates/etl-api/tests/images.rs
@@ -99,6 +99,12 @@ async fn non_existing_image_cannot_be_updated() {
     // Arrange
     let app = spawn_test_app().await;
 
+    let image = CreateImageRequest { name: "default-image".to_owned(), is_default: true };
+    let response = app.create_image(&image).await;
+    let response: CreateImageResponse =
+        response.json().await.expect("failed to deserialize response");
+    let image_id = response.id;
+
     // Act
     let name = "some/image".to_owned();
     let is_default = true;
@@ -107,6 +113,10 @@ async fn non_existing_image_cannot_be_updated() {
 
     // Assert
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let response = app.read_image(image_id).await;
+    let image: ReadImageResponse = response.json().await.expect("failed to deserialize response");
+    assert!(image.is_default);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Check image existence before clearing the current default.


## Tests
- `cargo nextest run -p etl-api --all-features non_existing_image_cannot_be_updated`