### PR TITLE
feat(etl-api): label replicator StatefulSets with tenant and pipeline ids

### DIFF
--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -58,6 +58,10 @@ pub struct DuckLakeMaintenanceResourceConfig {
 pub struct ReplicatorStatefulSetConfig {
     /// Existing Kubernetes resource prefix.
     pub prefix: String,
+    /// Tenant id that owns the replicator.
+    pub tenant_id: String,
+    /// Pipeline id that owns the replicator.
+    pub pipeline_id: i64,
     /// Image for the replicator container.
     pub replicator_image: String,
     /// Deployment environment.

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -182,6 +182,8 @@ pub async fn create_or_update_pipeline_resources_in_k8s(
         k8s_client,
         ReplicatorStatefulSetConfig {
             prefix,
+            tenant_id: tenant_id.to_owned(),
+            pipeline_id: pipeline.id,
             replicator_image,
             environment,
             replicator_resources,

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -813,6 +813,8 @@ impl K8sClient for HttpK8sClient {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             prefix,
+            &request.tenant_id,
+            request.pipeline_id,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -1699,6 +1701,8 @@ fn create_snowflake_passphrase_env_var_json(snowflake_secret_name: &str) -> serd
 #[expect(clippy::too_many_arguments)]
 fn create_replicator_stateful_set_json(
     prefix: &str,
+    tenant_id: &str,
+    pipeline_id: i64,
     stateful_set_name: &str,
     replicator_image: &str,
     container_environment: Vec<serde_json::Value>,
@@ -1720,7 +1724,9 @@ fn create_replicator_stateful_set_json(
         "namespace": DATA_PLANE_NAMESPACE,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
-          "etl.supabase.com/app-type": REPLICATOR_APP_LABEL
+          "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
+          "etl.supabase.com/pipeline-id": pipeline_id.to_string(),
+          "etl.supabase.com/tenant-id": tenant_id
         },
       },
       "spec": {
@@ -1811,6 +1817,7 @@ mod tests {
     use crate::configs::pipeline::ReplicatorResourcesConfig;
 
     const TENANT_ID: &str = "abcdefghijklmnopqrst";
+    const PIPELINE_ID: i64 = 24;
     const MAX_TENANT_ID: &str = "abcdefghijklmnopqrst";
     const MAX_BIGINT_ID: i64 = 9_223_372_036_854_775_807;
     const MAX_K8S_LABEL_VALUE_LEN: usize = 63;
@@ -1835,6 +1842,51 @@ mod tests {
 
             assert_snapshot!(serde_json::to_string_pretty(&stateful_set_json).unwrap());
         }};
+    }
+
+    fn assert_stateful_set_has_identity_metadata_labels(
+        stateful_set_json: &serde_json::Value,
+        tenant_id: &str,
+        pipeline_id: i64,
+    ) {
+        let labels = stateful_set_json
+            .pointer("/metadata/labels")
+            .and_then(serde_json::Value::as_object)
+            .expect("stateful set should have metadata labels");
+        let pipeline_id = pipeline_id.to_string();
+
+        assert_eq!(
+            labels.get("etl.supabase.com/tenant-id").and_then(serde_json::Value::as_str),
+            Some(tenant_id)
+        );
+        assert_eq!(
+            labels.get("etl.supabase.com/pipeline-id").and_then(serde_json::Value::as_str),
+            Some(pipeline_id.as_str())
+        );
+        assert!(
+            stateful_set_json
+                .pointer("/spec/selector/matchLabels/etl.supabase.com~1tenant-id")
+                .is_none(),
+            "tenant-id should not be part of the immutable selector"
+        );
+        assert!(
+            stateful_set_json
+                .pointer("/spec/selector/matchLabels/etl.supabase.com~1pipeline-id")
+                .is_none(),
+            "pipeline-id should not be part of the immutable selector"
+        );
+        assert!(
+            stateful_set_json
+                .pointer("/spec/template/metadata/labels/etl.supabase.com~1tenant-id")
+                .is_none(),
+            "tenant-id should not be part of the pod template labels"
+        );
+        assert!(
+            stateful_set_json
+                .pointer("/spec/template/metadata/labels/etl.supabase.com~1pipeline-id")
+                .is_none(),
+            "pipeline-id should not be part of the pod template labels"
+        );
     }
 
     fn container_environment_has_var(
@@ -2081,6 +2133,8 @@ mod tests {
                 "replicator stateful set",
                 create_replicator_stateful_set_json(
                     &prefix,
+                    MAX_TENANT_ID,
+                    MAX_BIGINT_ID,
                     &stateful_set_name,
                     replicator_image,
                     container_environment,
@@ -2721,6 +2775,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2732,6 +2788,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
 
         // Staging env
@@ -2754,6 +2815,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2765,6 +2828,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
 
         // Prod env
@@ -2787,6 +2855,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2798,6 +2868,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
     }
 
@@ -2827,6 +2902,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2838,6 +2915,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
 
         // Staging env
@@ -2860,6 +2942,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2871,6 +2955,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
 
         // Prod env
@@ -2893,6 +2982,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2904,6 +2995,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
     }
 
@@ -2933,6 +3029,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2944,6 +3042,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
 
         // Staging env
@@ -2966,6 +3069,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -2977,6 +3082,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
 
         // Prod env
@@ -2999,6 +3109,8 @@ mod tests {
 
         let stateful_set_json = create_replicator_stateful_set_json(
             &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
             &stateful_set_name,
             replicator_image,
             container_environment,
@@ -3010,6 +3122,11 @@ mod tests {
         );
 
         assert_stateful_set_json_snapshot!(stateful_set_json);
+        assert_stateful_set_has_identity_metadata_labels(
+            &stateful_set_json,
+            TENANT_ID,
+            PIPELINE_ID,
+        );
         let _stateful_set: StatefulSet = serde_json::from_value(stateful_set_json).unwrap();
     }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
@@ -8,7 +8,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
   "metadata": {
     "labels": {
       "etl.supabase.com/app-name": "abcdefghijklmnopqrst-42-replicator-app",
-      "etl.supabase.com/app-type": "etl-replicator-app"
+      "etl.supabase.com/app-type": "etl-replicator-app",
+      "etl.supabase.com/pipeline-id": "24",
+      "etl.supabase.com/tenant-id": "abcdefghijklmnopqrst"
     },
     "name": "abcdefghijklmnopqrst-42-replicator",
     "namespace": "etl-data-plane"


### PR DESCRIPTION
## Summary

Adds stable identity labels to generated replicator StatefulSets:

- `etl.supabase.com/tenant-id`
- `etl.supabase.com/pipeline-id`

These labels let Kubernetes-side controllers identify which ETL pipeline a StatefulSet belongs to without parsing resource names, reading ConfigMaps, or calling ETL API for lookup.

The labels are added only to StatefulSet `metadata.labels`, not to the immutable selector or pod template labels, so this should not alter pod selection or trigger pod-template changes.