### PR TITLE
ref(scripts): remove fmt shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run Cargo Fmt
         if: matrix.check == 'fmt'
-        run: ./scripts/bin/fmt-check.sh
+        run: cargo x fmt --check
 
       - name: Run Cargo Clippy
         if: matrix.check == 'clippy'

--- a/crates/xtask/src/commands/fmt.rs
+++ b/crates/xtask/src/commands/fmt.rs
@@ -1,29 +1,105 @@
+use std::ffi::{OsStr, OsString};
+
 use anyhow::Result;
 use clap::Args;
 use xshell::{Shell, cmd};
 
 use crate::utils::NIGHTLY_TOOLCHAIN;
 
+/// Name of the formatter subcommand in the raw process arguments.
+const FMT_COMMAND: &str = "fmt";
+/// Separator used by Cargo to forward trailing arguments to rustfmt.
+const ARG_SEPARATOR: &str = "--";
+/// Rustfmt check-mode argument.
+const CHECK_ARG: &str = "--check";
+
+/// Arguments for formatting the workspace with the pinned nightly rustfmt.
 #[derive(Args)]
 pub(crate) struct FmtArgs {
-    /// Check formatting without modifying files
+    /// Check formatting without modifying files.
     #[arg(long)]
     check: bool,
+
+    /// Arguments passed through to `cargo fmt`.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    args: Vec<OsString>,
 }
 
 impl FmtArgs {
+    /// Runs `cargo fmt --all` with the pinned nightly formatter toolchain.
     pub(crate) fn run(self) -> Result<()> {
         let sh = Shell::new()?;
+        let FmtArgs { check, args: _ } = self;
+        // Clap gives us typed access to `--check`, but it does not preserve the literal
+        // `--` separator after parsing. Re-read the raw arguments so calls like `cargo
+        // x fmt -- --config max_width=100` keep matching the deleted shell scripts'
+        // passthrough behavior.
+        let (cargo_fmt_args, rustfmt_args) = split_raw_passthrough_args(raw_fmt_args(), check);
         let toolchain = format!(
             "+{}",
             std::env::var("RUSTFMT_NIGHTLY_TOOLCHAIN")
                 .unwrap_or_else(|_| NIGHTLY_TOOLCHAIN.to_owned())
         );
-        if self.check {
-            cmd!(sh, "cargo {toolchain} fmt --all -- --check").run()?;
-        } else {
-            cmd!(sh, "cargo {toolchain} fmt --all").run()?;
+
+        let mut fmt = cmd!(sh, "cargo {toolchain} fmt --all").args(&cargo_fmt_args);
+        if !rustfmt_args.is_empty() {
+            // Rustfmt arguments must stay behind Cargo's `--` separator.
+            fmt = fmt.arg(ARG_SEPARATOR).args(&rustfmt_args);
         }
+        fmt.run()?;
+
         Ok(())
     }
+}
+
+/// Splits raw arguments into `cargo fmt` arguments and rustfmt arguments.
+fn split_raw_passthrough_args(
+    raw_args: Vec<OsString>,
+    check: bool,
+) -> (Vec<OsString>, Vec<OsString>) {
+    let mut cargo_fmt_args = Vec::new();
+    let mut rustfmt_args = Vec::new();
+    let mut rustfmt_separator_seen = false;
+    let mut check_arg_removed = false;
+
+    for arg in raw_args {
+        // Everything after `--` belongs to rustfmt, not `cargo fmt`.
+        if !rustfmt_separator_seen && arg == OsStr::new(ARG_SEPARATOR) {
+            rustfmt_separator_seen = true;
+            continue;
+        }
+
+        // `cargo x fmt --check` is an xtask convenience flag, so remove it
+        // from the Cargo side and inject it into the rustfmt side below.
+        if !rustfmt_separator_seen && check && !check_arg_removed && arg == OsStr::new(CHECK_ARG) {
+            check_arg_removed = true;
+            continue;
+        }
+
+        if rustfmt_separator_seen {
+            rustfmt_args.push(arg);
+        } else {
+            cargo_fmt_args.push(arg);
+        }
+    }
+
+    if check {
+        // Put `--check` first so user-provided rustfmt args keep their order.
+        rustfmt_args.insert(0, OsString::from(CHECK_ARG));
+    }
+
+    (cargo_fmt_args, rustfmt_args)
+}
+
+/// Returns the raw process arguments after the `fmt` subcommand.
+fn raw_fmt_args() -> Vec<OsString> {
+    let mut args = std::env::args_os().skip(1);
+
+    for arg in args.by_ref() {
+        if arg == OsStr::new(FMT_COMMAND) {
+            return args.collect();
+        }
+    }
+
+    Vec::new()
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts
 
-Legacy shell scripts for development workflows. All scripts are accessible through the `cargo x` task runner (see `cargo x --help`).
+Legacy shell scripts for development workflows. Remaining scripts are accessible through the `cargo x` task runner (see `cargo x --help`).
 
 New development commands should be added as xtask commands in `crates/xtask/src/commands/` rather than as shell scripts here. Existing scripts will be ported to native xtask commands over time.
 
@@ -8,7 +8,6 @@ New development commands should be added as xtask commands in `crates/xtask/src/
 
 | Script                                | xtask command             |
 | ------------------------------------- | ------------------------- |
-| `bin/fmt.sh` / `bin/fmt-check.sh`     | `cargo x fmt [--check]`   |
 | `bin/check-msrv-sync.sh`              | `cargo x msrv`            |
 | `bin/init.sh`                         | `cargo x init`            |
 | `bin/run-migrations.sh`               | `cargo x migrate`         |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,13 @@
 # Scripts
 
-Legacy shell scripts for development workflows. Remaining scripts are accessible through the `cargo x` task runner (see `cargo x --help`).
+Development workflows should be exposed through the `cargo x` task runner (see
+`cargo x --help`). Shell scripts in `scripts/bin` are legacy entrypoints kept
+only until their implementation is moved into native xtask commands and the
+scripts can be removed.
 
-New development commands should be added as xtask commands in `crates/xtask/src/commands/` rather than as shell scripts here. Existing scripts will be ported to native xtask commands over time.
+New development commands should be added as xtask commands in
+`crates/xtask/src/commands/` rather than as shell scripts here. Existing shell
+scripts are being removed over time as their logic moves into xtask.
 
 ## Script to xtask mapping
 

--- a/scripts/bin/fmt-check.sh
+++ b/scripts/bin/fmt-check.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-TOOLCHAIN="${RUSTFMT_NIGHTLY_TOOLCHAIN:-nightly-2026-04-15}"
-
-exec cargo +"${TOOLCHAIN}" fmt --all -- --check "$@"

--- a/scripts/bin/fmt.sh
+++ b/scripts/bin/fmt.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-TOOLCHAIN="${RUSTFMT_NIGHTLY_TOOLCHAIN:-nightly-2026-04-15}"
-
-exec cargo +"${TOOLCHAIN}" fmt --all "$@"


### PR DESCRIPTION
## Summary

- remove standalone `fmt.sh` and `fmt-check.sh`
- switch CI formatting to `cargo x fmt --check`
- keep `cargo x fmt` semantics compatible with the removed scripts, including rustfmt passthrough args

## Verification

- `cargo x fmt --check`
- `cargo x fmt -- --check`
- `cargo x fmt -- --config max_width=100 --check`
- `cargo check -p xtask`