### PR TITLE
fix(ducklake): don't use raw catalog_url for sqlx connection because of ipv6

### DIFF
--- a/crates/etl-config/src/ducklake.rs
+++ b/crates/etl-config/src/ducklake.rs
@@ -1,8 +1,10 @@
 //! DuckLake-specific configuration helpers.
 
-use std::{io, path::PathBuf};
+use std::{io, path::PathBuf, str::FromStr};
 
+use sqlx::postgres::{PgConnectOptions, PgSslMode};
 use thiserror::Error;
+use tokio_postgres::{Config as PgConfig, config::SslMode};
 use url::Url;
 
 /// Errors returned by [`parse_ducklake_url`].
@@ -23,6 +25,22 @@ pub enum ParseDucklakeUrlError {
     /// DuckLake data path did not use S3 storage.
     #[error("DuckLake data path must use the s3:// scheme, got {0}://")]
     UnsupportedDataPathScheme(String),
+}
+
+/// Errors returned by [`ducklake_catalog_metadata_connect_options`].
+#[derive(Debug, Error)]
+pub enum DuckLakeCatalogConnectOptionsError {
+    /// The catalog URL could not be parsed as a tokio-postgres connection.
+    #[error("Invalid DuckLake PostgreSQL catalog URL")]
+    TokioPostgres(#[source] tokio_postgres::Error),
+
+    /// The catalog URL could not be parsed as a sqlx Postgres connection.
+    #[error("Invalid DuckLake PostgreSQL catalog URL")]
+    Sqlx(#[source] sqlx::Error),
+
+    /// The catalog URL uses an SSL mode that cannot be represented for sqlx.
+    #[error("DuckLake PostgreSQL catalog URL uses an unsupported sslmode")]
+    UnsupportedSslMode,
 }
 
 /// Parses a DuckLake URL or local path into a normalized [`Url`].
@@ -60,6 +78,45 @@ pub fn libpq_tcp_host(host: &str) -> &str {
     }
 }
 
+/// Builds sqlx connection options for DuckLake metadata catalog queries.
+pub fn ducklake_catalog_metadata_connect_options(
+    catalog_url: &Url,
+) -> Result<PgConnectOptions, DuckLakeCatalogConnectOptionsError> {
+    let config = PgConfig::from_str(catalog_url.as_str())
+        .map_err(DuckLakeCatalogConnectOptionsError::TokioPostgres)?;
+    let mut options = PgConnectOptions::from_str(catalog_url.as_str())
+        .map_err(DuckLakeCatalogConnectOptionsError::Sqlx)?;
+
+    if let Some(hostaddr) = config.get_hostaddrs().first() {
+        options = options.host(&hostaddr.to_string());
+    } else if let Some(host) = catalog_url.host_str() {
+        options = options.host(libpq_tcp_host(host));
+    }
+
+    options = options.ssl_mode(sqlx_ssl_mode(config.get_ssl_mode(), config.get_hostaddrs())?);
+
+    Ok(options)
+}
+
+/// Maps libpq-style SSL modes onto sqlx's Postgres SSL modes.
+fn sqlx_ssl_mode(
+    ssl_mode: SslMode,
+    hostaddrs: &[std::net::IpAddr],
+) -> Result<PgSslMode, DuckLakeCatalogConnectOptionsError> {
+    match ssl_mode {
+        SslMode::Disable => Ok(PgSslMode::Disable),
+        SslMode::Prefer => Ok(PgSslMode::Prefer),
+        SslMode::Require => Ok(PgSslMode::Require),
+        SslMode::VerifyCa => Ok(PgSslMode::VerifyCa),
+        SslMode::VerifyFull if hostaddrs.is_empty() => Ok(PgSslMode::VerifyFull),
+        // sqlx does not expose libpq's separate hostaddr field. When dialing a
+        // numeric address, verify the CA but avoid hostname verification
+        // against the IP literal.
+        SslMode::VerifyFull => Ok(PgSslMode::VerifyCa),
+        _ => Err(DuckLakeCatalogConnectOptionsError::UnsupportedSslMode),
+    }
+}
+
 /// Parses a DuckLake data path and requires an `s3://` URL.
 pub fn parse_ducklake_s3_data_path(value: &str) -> Result<Url, ParseDucklakeUrlError> {
     let url = parse_ducklake_url(value)?;
@@ -75,6 +132,7 @@ pub fn parse_ducklake_s3_data_path(value: &str) -> Result<Url, ParseDucklakeUrlE
 mod tests {
     use std::sync::{Mutex, OnceLock};
 
+    use sqlx::postgres::PgSslMode;
     use tempfile::TempDir;
 
     use super::*;
@@ -146,5 +204,60 @@ mod tests {
             error,
             ParseDucklakeUrlError::UnsupportedDataPathScheme(scheme) if scheme == "file"
         ));
+    }
+
+    #[test]
+    fn ducklake_catalog_metadata_connect_options_uses_catalog_host_without_hostaddr() {
+        let catalog_url = Url::parse(
+            "postgres://user:password@catalog.example.test:5432/ducklake?sslmode=verify-full",
+        )
+        .unwrap();
+
+        let options = ducklake_catalog_metadata_connect_options(&catalog_url).unwrap();
+
+        assert_eq!(options.get_host(), "catalog.example.test");
+        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyFull));
+    }
+
+    #[test]
+    fn ducklake_catalog_metadata_connect_options_uses_ipv4_hostaddr_as_network_target() {
+        let catalog_url = Url::parse(
+            "postgres://user:password@catalog.example.test:5432/ducklake?hostaddr=192.0.2.10&\
+             sslmode=verify-full",
+        )
+        .unwrap();
+
+        let options = ducklake_catalog_metadata_connect_options(&catalog_url).unwrap();
+
+        assert_eq!(options.get_host(), "192.0.2.10");
+        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyCa));
+    }
+
+    #[test]
+    fn ducklake_catalog_metadata_connect_options_uses_ipv6_hostaddr_as_network_target() {
+        let catalog_url = Url::parse(
+            "postgres://user:password@catalog.example.test:5432/ducklake?hostaddr=2001:db8::10&\
+             sslmode=verify-full",
+        )
+        .unwrap();
+
+        let options = ducklake_catalog_metadata_connect_options(&catalog_url).unwrap();
+
+        assert_eq!(options.get_host(), "2001:db8::10");
+        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyCa));
+    }
+
+    #[test]
+    fn ducklake_catalog_metadata_connect_options_supports_ipv6_literal_host() {
+        let catalog_url = Url::parse(
+            "postgres://postgres:FAKE_SECRET@[2a05:dddd:c3c:b703:e52f:e170:4155:c8dd]:5432/\
+             postgres?sslmode=prefer",
+        )
+        .unwrap();
+
+        let options = ducklake_catalog_metadata_connect_options(&catalog_url).unwrap();
+
+        assert_eq!(options.get_host(), "2a05:dddd:c3c:b703:e52f:e170:4155:c8dd");
+        assert!(matches!(options.get_ssl_mode(), PgSslMode::Prefer));
     }
 }

--- a/crates/etl-config/src/lib.rs
+++ b/crates/etl-config/src/lib.rs
@@ -11,7 +11,9 @@ mod secret;
 pub mod shared;
 
 pub use ducklake::{
-    ParseDucklakeUrlError, libpq_tcp_host, parse_ducklake_s3_data_path, parse_ducklake_url,
+    DuckLakeCatalogConnectOptionsError, ParseDucklakeUrlError,
+    ducklake_catalog_metadata_connect_options, libpq_tcp_host, parse_ducklake_s3_data_path,
+    parse_ducklake_url,
 };
 pub use environment::Environment;
 pub use load::{Config, LoadConfigError, load_config};

--- a/crates/etl-destinations/src/ducklake/config.rs
+++ b/crates/etl-destinations/src/ducklake/config.rs
@@ -801,6 +801,37 @@ mod tests {
     }
 
     #[test]
+    fn catalog_conninfo_from_postgres_ipv6_url_with_password_matches_expected_shape() {
+        let url = Url::parse(
+            "postgres://postgres:debug-password@[2406:da18:1d63:9b01:7f24:6b65:7aa:cac8]:5432/\
+             postgres?sslmode=prefer",
+        )
+        .unwrap();
+        let conninfo = catalog_conninfo_from_url(&url).unwrap();
+
+        assert_eq!(
+            conninfo,
+            "postgres:host='2406:da18:1d63:9b01:7f24:6b65:7aa:cac8' port='5432' dbname='postgres' \
+             user='postgres' password='debug-password' sslmode=prefer"
+        );
+    }
+
+    #[test]
+    fn sqlx_connect_options_from_postgres_ipv6_url_keeps_bracketed_host() {
+        let options = sqlx::postgres::PgConnectOptions::from_str(
+            "postgres://postgres:debug-password@[2406:da18:1d63:9b01:7f24:6b65:7aa:cac8]:5432/\
+             postgres?sslmode=prefer",
+        )
+        .unwrap();
+
+        assert_eq!(options.get_host(), "[2406:da18:1d63:9b01:7f24:6b65:7aa:cac8]");
+        assert_eq!(options.get_port(), 5432);
+        assert_eq!(options.get_database(), Some("postgres"));
+        assert_eq!(options.get_username(), "postgres");
+        assert!(matches!(options.get_ssl_mode(), sqlx::postgres::PgSslMode::Prefer));
+    }
+
+    #[test]
     fn catalog_conninfo_from_postgres_url_with_password_and_query_params_round_trip() {
         let url = Url::parse(
             "postgres://user:pa%27ss%5Cword@localhost:5433/mydb?sslmode=disable&\

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -21,6 +21,7 @@ use etl::{
     },
     store::DestinationStore,
 };
+use etl_config::ducklake_catalog_metadata_connect_options;
 use metrics::gauge;
 use parking_lot::Mutex;
 use pg_escape::{quote_identifier as quote_postgres_identifier, quote_literal};
@@ -87,19 +88,20 @@ pub(super) const DUCKLAKE_DROPPED_COLUMN_PREFIX: &str = "__etl_ducklake_dropped_
 
 /// Builds the shared Postgres metadata pool used by background samplers.
 fn build_ducklake_metadata_pg_pool(catalog_url: &Url) -> EtlResult<PgPool> {
-    PgPoolOptions::new()
+    let options = ducklake_catalog_metadata_connect_options(catalog_url).map_err(|source| {
+        etl_error!(
+            ErrorKind::ConfigError,
+            "DuckLake metadata pool configuration failed",
+            source: source
+        )
+    })?;
+
+    Ok(PgPoolOptions::new()
         .max_connections(DUCKLAKE_METADATA_PG_POOL_SIZE)
         .min_connections(0)
         .acquire_timeout(std::time::Duration::from_secs(5))
         .idle_timeout(Some(std::time::Duration::from_secs(30)))
-        .connect_lazy(catalog_url.as_str())
-        .map_err(|source| {
-            etl_error!(
-                ErrorKind::ConfigError,
-                "DuckLake metadata pool configuration failed",
-                source: source
-            )
-        })
+        .connect_lazy_with(options))
 }
 
 /// Returns whether a DuckLake DDL error indicates another transaction already

--- a/crates/etl-maintenance/src/ducklake/runner.rs
+++ b/crates/etl-maintenance/src/ducklake/runner.rs
@@ -17,14 +17,11 @@ use etl::{
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
 };
-use etl_config::libpq_tcp_host;
+use etl_config::{ducklake_catalog_metadata_connect_options, libpq_tcp_host};
 use metrics::{gauge, histogram};
 use pg_escape::{quote_identifier, quote_literal};
 use regex::Regex;
-use sqlx::{
-    AssertSqlSafe, PgPool,
-    postgres::{PgConnectOptions, PgPoolOptions, PgSslMode},
-};
+use sqlx::{AssertSqlSafe, PgPool, postgres::PgPoolOptions};
 use tokio::{
     sync::{Semaphore, oneshot},
     task::JoinHandle,
@@ -499,58 +496,6 @@ fn catalog_attach_target(catalog_url: &Url) -> EtlResult<String> {
             ErrorKind::ConfigError,
             "Unsupported DuckLake catalog URL scheme",
             format!("catalog URL scheme `{scheme}` is not supported")
-        )),
-    }
-}
-
-/// Builds sqlx connection options for DuckLake metadata catalog queries.
-fn catalog_metadata_connect_options(catalog_url: &Url) -> EtlResult<PgConnectOptions> {
-    let config = PgConfig::from_str(catalog_url.as_str()).map_err(|source| {
-        etl_error!(
-            ErrorKind::ConfigError,
-            "Invalid DuckLake PostgreSQL catalog URL",
-            source: source
-        )
-    })?;
-    let mut options = PgConnectOptions::from_str(catalog_url.as_str()).map_err(|source| {
-        etl_error!(
-            ErrorKind::ConfigError,
-            "Invalid DuckLake PostgreSQL catalog URL",
-            source: source
-        )
-    })?;
-
-    if let Some(hostaddr) = config.get_hostaddrs().first() {
-        options = options.host(&hostaddr.to_string());
-    } else if let Some(host) = catalog_url.host_str() {
-        options = options.host(unbracket_ipv6_literal(host));
-    }
-
-    options = options.ssl_mode(sqlx_ssl_mode(config.get_ssl_mode(), config.get_hostaddrs())?);
-
-    Ok(options)
-}
-
-/// Removes URL brackets from an IPv6 literal host.
-fn unbracket_ipv6_literal(host: &str) -> &str {
-    host.strip_prefix('[').and_then(|host| host.strip_suffix(']')).unwrap_or(host)
-}
-
-/// Maps libpq-style SSL modes onto sqlx's Postgres SSL modes.
-fn sqlx_ssl_mode(ssl_mode: SslMode, hostaddrs: &[std::net::IpAddr]) -> EtlResult<PgSslMode> {
-    match ssl_mode {
-        SslMode::Disable => Ok(PgSslMode::Disable),
-        SslMode::Prefer => Ok(PgSslMode::Prefer),
-        SslMode::Require => Ok(PgSslMode::Require),
-        SslMode::VerifyCa => Ok(PgSslMode::VerifyCa),
-        SslMode::VerifyFull if hostaddrs.is_empty() => Ok(PgSslMode::VerifyFull),
-        // sqlx does not expose libpq's separate hostaddr field. When dialing a
-        // numeric address, verify the CA but avoid hostname verification
-        // against the IP literal.
-        SslMode::VerifyFull => Ok(PgSslMode::VerifyCa),
-        _ => Err(etl_error!(
-            ErrorKind::ConfigError,
-            "DuckLake PostgreSQL catalog URL uses an unsupported sslmode"
         )),
     }
 }
@@ -1658,9 +1603,15 @@ pub async fn run_maintenance_once(
         metadata_schema = %metadata_schema,
         "ducklake external maintenance metadata schema resolved"
     );
-    let metadata_pg_pool = PgPoolOptions::new()
-        .max_connections(1)
-        .connect_lazy_with(catalog_metadata_connect_options(&config.catalog_url)?);
+    let metadata_pg_pool = PgPoolOptions::new().max_connections(1).connect_lazy_with(
+        ducklake_catalog_metadata_connect_options(&config.catalog_url).map_err(|source| {
+            etl_error!(
+                ErrorKind::ConfigError,
+                "Invalid DuckLake PostgreSQL catalog URL",
+                source: source
+            )
+        })?,
+    );
     let table_names = list_ducklake_tables(&metadata_pg_pool, &metadata_schema).await?;
     info!(
         table_count = table_names.len(),
@@ -2739,61 +2690,6 @@ mod tests {
             "CALL ducklake_cleanup_old_files('lake', older_than => CAST(now() AS TIMESTAMP) - \
              CAST('1 hour' AS INTERVAL));"
         );
-    }
-
-    #[test]
-    fn catalog_metadata_connect_options_uses_catalog_host_without_hostaddr() {
-        let catalog_url = Url::parse(
-            "postgres://user:password@catalog.example.test:5432/ducklake?sslmode=verify-full",
-        )
-        .unwrap();
-
-        let options = catalog_metadata_connect_options(&catalog_url).unwrap();
-
-        assert_eq!(options.get_host(), "catalog.example.test");
-        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyFull));
-    }
-
-    #[test]
-    fn catalog_metadata_connect_options_uses_ipv4_hostaddr_as_network_target() {
-        let catalog_url = Url::parse(
-            "postgres://user:password@catalog.example.test:5432/ducklake?hostaddr=192.0.2.10&\
-             sslmode=verify-full",
-        )
-        .unwrap();
-
-        let options = catalog_metadata_connect_options(&catalog_url).unwrap();
-
-        assert_eq!(options.get_host(), "192.0.2.10");
-        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyCa));
-    }
-
-    #[test]
-    fn catalog_metadata_connect_options_uses_ipv6_hostaddr_as_network_target() {
-        let catalog_url = Url::parse(
-            "postgres://user:password@catalog.example.test:5432/ducklake?hostaddr=2001:db8::10&\
-             sslmode=verify-full",
-        )
-        .unwrap();
-
-        let options = catalog_metadata_connect_options(&catalog_url).unwrap();
-
-        assert_eq!(options.get_host(), "2001:db8::10");
-        assert!(matches!(options.get_ssl_mode(), PgSslMode::VerifyCa));
-    }
-
-    #[test]
-    fn catalog_metadata_connect_options_supports_ipv6_literal_host() {
-        let catalog_url = Url::parse(
-            "postgres://postgres:FAKE_SECRET@[2a05:dddd:c3c:b703:e52f:e170:4155:c8dd]:5432/\
-             postgres?sslmode=prefer",
-        )
-        .unwrap();
-
-        let options = catalog_metadata_connect_options(&catalog_url).unwrap();
-
-        assert_eq!(options.get_host(), "2a05:dddd:c3c:b703:e52f:e170:4155:c8dd");
-        assert!(matches!(options.get_ssl_mode(), PgSslMode::Prefer));
     }
 
     #[test]


### PR DESCRIPTION
The syntax for the catalog url for ducklake when we have an ipv6 is like this (with brackets) `postgres://postgres:debug-password@[2405:da18:1d63:9b01:7f24:6b65:7aa:cac8]:5432/postgres?sslmode=prefer` but when using sqlx we have to get rid of brackets. This PR fixes this behavior.

It reuses an existing function to parse it.