### PR TITLE
feat(etl): add deferred destination durability

### DIFF
--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -11,6 +11,7 @@ use tokio_postgres::types::PgLsn;
 use tracing::warn;
 
 use crate::{
+    destination::durability::DestinationBatchId,
     error::{ErrorKind, EtlResult},
     etl_error,
 };
@@ -31,6 +32,13 @@ pub type WriteTableRowsResult<T = ()> = AsyncResult<T>;
 /// metadata and starting a fresh copy.
 pub type DropTableForCopyResult<T = ()> = AsyncResult<T>;
 
+/// Async completion handle used for a deferred table-copy finish barrier.
+///
+/// Immediate destinations do not need this hook. Deferred table-copy
+/// destinations complete this result only after every accepted copy batch for
+/// the current table-copy attempt is durably committed.
+pub type FinishTableCopyResult<T = ()> = AsyncResult<T>;
+
 /// Async completion handle used for
 /// [`crate::destination::Destination::write_events`].
 ///
@@ -44,6 +52,8 @@ pub(crate) type PendingWriteEventsResult<T = ()> =
 /// Completed async completion used for `Destination::write_events`.
 pub(crate) type CompletedWriteEventsResult<T = ()> =
     CompletedAsyncResult<T, ApplyLoopAsyncResultMetadata>;
+/// Pending async completion used for table-copy row writes.
+pub(crate) type PendingWriteTableRowsResult<T = ()> = PendingAsyncResult<T, ()>;
 
 /// Dispatch-time metrics carried through an asynchronous completion result.
 #[derive(Debug, Clone, Copy)]
@@ -57,6 +67,8 @@ pub(crate) struct DispatchMetrics {
 /// Metadata carried by apply-loop event write completions.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ApplyLoopAsyncResultMetadata {
+    /// Deferred destination batch id, if this completion is acceptance-only.
+    pub batch_id: Option<DestinationBatchId>,
     /// Commit end LSN associated with the dispatched batch, if any.
     ///
     /// After the destination acknowledges the batch, this becomes the durable
@@ -174,6 +186,7 @@ mod tests {
     #[tokio::test]
     async fn async_result_round_trips_success() {
         let metadata = ApplyLoopAsyncResultMetadata {
+            batch_id: None,
             commit_end_lsn: Some(PgLsn::from(42)),
             metrics: DispatchMetrics { items_count: 1, dispatched_at: Instant::now() },
         };

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -2,8 +2,13 @@ use std::future::Future;
 
 use crate::{
     data::TableRow,
-    destination::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
-    error::EtlResult,
+    destination::{
+        DropTableForCopyResult, FinishTableCopyResult, StreamingDurabilityMode,
+        TableCopyDurabilityMode, TrackedEventsBatch, TrackedTableRowsBatch, WriteEventsResult,
+        WriteTableRowsResult,
+    },
+    error::{ErrorKind, EtlResult},
+    etl_error,
     event::Event,
     schema::ReplicatedTableSchema,
 };
@@ -19,7 +24,29 @@ use crate::{
 /// own execution model, such as inline writes, actors, queues, or spawned
 /// tasks.
 ///
-/// ETL is at-least-once, so destinations must tolerate duplicate writes. ETL
+/// ETL provides at-least-once delivery from the last durable checkpoint. After
+/// failures, it may replay streaming events or table-copy rows that were
+/// already submitted to the destination.
+///
+/// By default, a successful destination write is also the durable-completion
+/// signal: when [`Destination::write_events`] or
+/// [`Destination::write_table_rows`] completes, ETL may checkpoint or advance
+/// the submitted work.
+///
+/// Destinations that opt into deferred durability split acceptance from durable
+/// completion. For streaming, [`Destination::write_tracked_events`] may
+/// complete when the destination has accepted ownership of the tracked batch,
+/// but the destination must later report durable completion through the batch's
+/// durability reporter. For table copy,
+/// [`Destination::write_tracked_table_rows`] may complete on acceptance, but
+/// [`Destination::finish_table_copy`] must not complete until every accepted
+/// batch for the copy attempt is durable.
+///
+/// Implementations must make write replays safe through idempotent writes,
+/// durable offset or batch filtering, or by resetting destination state before
+/// retrying a table-copy attempt.
+///
+/// A destination must not report buffered but uncommitted data as durable. ETL
 /// may also call destination methods in parallel under some circumstances, so
 /// implementations must be safe for concurrent use.
 pub trait Destination {
@@ -48,6 +75,30 @@ pub trait Destination {
     /// implementation is a no-op.
     fn startup(&self) -> impl Future<Output = EtlResult<()>> + Send {
         async { Ok(()) }
+    }
+
+    /// Returns the destination's streaming durability mode.
+    ///
+    /// The default is immediate durability, which preserves the original ETL
+    /// contract: the async result from [`Destination::write_events`] is the
+    /// point where upstream may treat the batch as durable.
+    ///
+    /// Deferred destinations split write acceptance from durable completion and
+    /// must implement [`Destination::write_tracked_events`].
+    fn streaming_durability_mode(&self) -> StreamingDurabilityMode {
+        StreamingDurabilityMode::Immediate
+    }
+
+    /// Returns the destination's table-copy durability mode.
+    ///
+    /// The default is immediate durability, which preserves the original ETL
+    /// contract: each table-copy async result is both accepted and durable.
+    ///
+    /// Deferred destinations split batch acceptance from table-copy completion
+    /// and must implement [`Destination::write_tracked_table_rows`] plus
+    /// [`Destination::finish_table_copy`].
+    fn table_copy_durability_mode(&self) -> TableCopyDurabilityMode {
+        TableCopyDurabilityMode::Immediate
     }
 
     /// Drops destination objects before restarting a table copy.
@@ -100,6 +151,48 @@ pub trait Destination {
         async_result: WriteTableRowsResult<()>,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 
+    /// Writes table-copy rows with ETL-assigned tracking metadata.
+    ///
+    /// Immediate destinations do not need to override this method. The default
+    /// implementation delegates to [`Destination::write_table_rows`]. Deferred
+    /// table-copy destinations can override this method and treat the async
+    /// result as acceptance for the current copy attempt rather than durable
+    /// completion.
+    fn write_tracked_table_rows(
+        &self,
+        batch: TrackedTableRowsBatch,
+        async_result: WriteTableRowsResult<()>,
+    ) -> impl Future<Output = EtlResult<()>> + Send
+    where
+        Self: Sync,
+    {
+        async move {
+            self.write_table_rows(&batch.replicated_table_schema, batch.table_rows, async_result)
+                .await
+        }
+    }
+
+    /// Finishes a deferred table-copy attempt.
+    ///
+    /// ETL calls this method only when
+    /// [`Destination::table_copy_durability_mode`] returns
+    /// [`TableCopyDurabilityMode::Deferred`]. The async result must be
+    /// completed only after every accepted row for the current copy attempt is
+    /// durable. The default fails closed so a destination cannot opt into
+    /// deferred copy semantics without a completion barrier.
+    fn finish_table_copy(
+        &self,
+        _replicated_table_schema: &ReplicatedTableSchema,
+        _async_result: FinishTableCopyResult<()>,
+    ) -> impl Future<Output = EtlResult<()>> + Send {
+        async {
+            Err(etl_error!(
+                ErrorKind::DestinationError,
+                "Deferred table-copy durability requested but no finish barrier was implemented"
+            ))
+        }
+    }
+
     /// Writes streaming replication events to the destination.
     ///
     /// This method handles real-time changes from the Postgres replication
@@ -151,4 +244,21 @@ pub trait Destination {
         events: Vec<Event>,
         async_result: WriteEventsResult<()>,
     ) -> impl Future<Output = EtlResult<()>> + Send;
+
+    /// Writes streaming events with ETL-assigned tracking metadata.
+    ///
+    /// Immediate destinations do not need to override this method. The default
+    /// implementation delegates to [`Destination::write_events`]. Deferred
+    /// streaming destinations override this method so they can later report the
+    /// batch id through the reporter carried by [`TrackedEventsBatch`].
+    fn write_tracked_events(
+        &self,
+        batch: TrackedEventsBatch,
+        async_result: WriteEventsResult<()>,
+    ) -> impl Future<Output = EtlResult<()>> + Send
+    where
+        Self: Sync,
+    {
+        async move { self.write_events(batch.events, async_result).await }
+    }
 }

--- a/crates/etl/src/destination/durability.rs
+++ b/crates/etl/src/destination/durability.rs
@@ -1,0 +1,245 @@
+//! Destination APIs for splitting write acceptance from durable completion.
+//!
+//! Immediate destinations complete each write's async result only after the
+//! submitted data is durable; that remains the default contract. Deferred
+//! destinations may complete tracked write results after they have accepted
+//! ownership of the batch, then prove durability through a separate signal.
+//!
+//! Streaming durability is reported per ETL-assigned [`DestinationBatchId`]
+//! with [`DestinationDurabilityReporter`]. Table-copy durability is proven by
+//! [`crate::destination::Destination::finish_table_copy`], which acts as the
+//! durable-completion barrier for all accepted rows in a copy attempt.
+//!
+//! Deferred destinations still participate in at-least-once replication: after
+//! a failure, ETL may replay accepted work that was not proven durable.
+
+use std::num::NonZeroUsize;
+
+use tokio::sync::mpsc;
+
+use crate::{
+    data::TableRow,
+    error::{ErrorKind, EtlError, EtlResult},
+    etl_error,
+    event::Event,
+    schema::ReplicatedTableSchema,
+};
+
+/// Identifier assigned by ETL to a streaming destination batch.
+///
+/// The identifier is unique within one apply loop and correlates a tracked
+/// streaming write acceptance with a later [`DestinationDurabilityEvent`]. It
+/// is not persisted across process restarts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DestinationBatchId(u64);
+
+impl DestinationBatchId {
+    /// Creates a new destination batch identifier.
+    pub(crate) fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw identifier.
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+}
+
+/// Identifier assigned by ETL to a table-copy destination batch.
+///
+/// The identifier is unique within one table-copy attempt and exists for
+/// destination-side diagnostics and correlation. It is not a source-order
+/// cursor and does not prove durability; table-copy durability is proven by
+/// [`crate::destination::Destination::finish_table_copy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TableCopyBatchId(u64);
+
+impl TableCopyBatchId {
+    /// Creates a new table-copy batch identifier.
+    pub(crate) fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw identifier.
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+}
+
+/// Streaming durability mode advertised by a destination.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum StreamingDurabilityMode {
+    /// Write completion means durable completion.
+    #[default]
+    Immediate,
+    /// Write completion means acceptance; durable completion is reported later.
+    Deferred(DeferredStreamingConfig),
+}
+
+/// Table-copy durability mode advertised by a destination.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum TableCopyDurabilityMode {
+    /// Batch completion means durable completion.
+    #[default]
+    Immediate,
+    /// Batch completion means acceptance; table-copy completion is proven by a
+    /// finish barrier after all accepted copy batches have completed.
+    Deferred(DeferredTableCopyConfig),
+}
+
+/// Backpressure limits for deferred streaming durability.
+///
+/// When streaming durability is deferred, ETL may dispatch another streaming
+/// batch after the destination accepts the previous one, before that previous
+/// batch is proven durable. These limits bound the accepted-but-not-yet-retired
+/// streaming backlog that ETL may allow for one apply loop.
+///
+/// A deferred streaming batch remains in the backlog until the destination
+/// reports durable completion for its [`DestinationBatchId`] and all older
+/// accepted batches have also become durable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeferredStreamingConfig {
+    /// Maximum number of accepted but not yet retired streaming batches.
+    pub max_inflight_batches: NonZeroUsize,
+    /// Maximum estimated bytes across accepted but not yet retired streaming
+    /// batches.
+    pub max_inflight_bytes: usize,
+}
+
+impl DeferredStreamingConfig {
+    /// Creates deferred streaming limits.
+    pub fn new(max_inflight_batches: NonZeroUsize, max_inflight_bytes: usize) -> Self {
+        Self { max_inflight_batches, max_inflight_bytes }
+    }
+}
+
+/// Backpressure limits for deferred table-copy durability.
+///
+/// When table-copy durability is deferred, ETL may dispatch additional copy
+/// batches after the destination accepts earlier batches, before those rows are
+/// proven durable. These limits bound the accepted-but-unfinished copy backlog
+/// for one table-copy stream.
+///
+/// Accepted copy batches remain in the backlog until their async acceptance
+/// results complete and the table-copy finish barrier later proves durable
+/// completion for the whole copy attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeferredTableCopyConfig {
+    /// Maximum number of accepted but not yet finished table-copy batches.
+    pub max_inflight_batches: NonZeroUsize,
+    /// Maximum estimated bytes across accepted but not yet finished table-copy
+    /// batches.
+    pub max_inflight_bytes: usize,
+}
+
+impl DeferredTableCopyConfig {
+    /// Creates deferred table-copy limits.
+    pub fn new(max_inflight_batches: NonZeroUsize, max_inflight_bytes: usize) -> Self {
+        Self { max_inflight_batches, max_inflight_bytes }
+    }
+}
+
+/// Streaming events plus ETL-assigned durability tracking metadata.
+#[derive(Debug)]
+pub struct TrackedEventsBatch {
+    /// Identifier used by deferred destinations to report durability.
+    pub id: DestinationBatchId,
+    /// Reporter that sends durability events back to the owning apply loop.
+    pub durability_reporter: DestinationDurabilityReporter,
+    /// Streaming events in source order.
+    pub events: Vec<Event>,
+    /// Approximate byte size used for upstream deferred-durability
+    /// backpressure.
+    pub estimated_bytes: usize,
+}
+
+impl TrackedEventsBatch {
+    /// Creates tracked streaming events.
+    pub(crate) fn new(
+        id: DestinationBatchId,
+        durability_reporter: DestinationDurabilityReporter,
+        events: Vec<Event>,
+        estimated_bytes: usize,
+    ) -> Self {
+        Self { id, durability_reporter, events, estimated_bytes }
+    }
+}
+
+/// Table-copy rows plus ETL-assigned copy tracking metadata.
+#[derive(Debug)]
+pub struct TrackedTableRowsBatch {
+    /// Identifier used for diagnostics and table-copy acceptance tracking.
+    pub id: TableCopyBatchId,
+    /// Destination schema for the copied table.
+    pub replicated_table_schema: ReplicatedTableSchema,
+    /// Copied source rows.
+    pub table_rows: Vec<TableRow>,
+    /// Approximate byte size used for upstream copy backpressure.
+    pub estimated_bytes: usize,
+}
+
+impl TrackedTableRowsBatch {
+    /// Creates tracked table-copy rows.
+    pub(crate) fn new(
+        id: TableCopyBatchId,
+        replicated_table_schema: ReplicatedTableSchema,
+        table_rows: Vec<TableRow>,
+        estimated_bytes: usize,
+    ) -> Self {
+        Self { id, replicated_table_schema, table_rows, estimated_bytes }
+    }
+}
+
+/// Durability event sent by a deferred streaming destination.
+#[derive(Debug)]
+pub enum DestinationDurabilityEvent {
+    /// The streaming batch is durably committed by the destination.
+    Durable {
+        /// Identifier of the durable batch.
+        batch_id: DestinationBatchId,
+    },
+    /// The destination can no longer prove durability for the batch.
+    Failed {
+        /// Identifier of the failed batch.
+        batch_id: DestinationBatchId,
+        /// Destination failure that should stop the apply loop.
+        error: EtlError,
+    },
+}
+
+/// Reporting handle used by deferred streaming destinations.
+#[derive(Debug, Clone)]
+pub struct DestinationDurabilityReporter {
+    tx: mpsc::UnboundedSender<DestinationDurabilityEvent>,
+}
+
+impl DestinationDurabilityReporter {
+    /// Creates a reporter and its receiving side.
+    pub(crate) fn channel() -> (Self, DestinationDurabilityEvents) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Self { tx }, DestinationDurabilityEvents { rx })
+    }
+
+    /// Reports a deferred streaming durability event.
+    pub fn report(&self, event: DestinationDurabilityEvent) -> EtlResult<()> {
+        self.tx.send(event).map_err(|_| {
+            etl_error!(
+                ErrorKind::DestinationError,
+                "Deferred durability reporter closed before receiving event"
+            )
+        })
+    }
+}
+
+/// Receiver for deferred streaming durability events.
+#[derive(Debug)]
+pub(crate) struct DestinationDurabilityEvents {
+    rx: mpsc::UnboundedReceiver<DestinationDurabilityEvent>,
+}
+
+impl DestinationDurabilityEvents {
+    /// Receives the next durability event.
+    pub(crate) async fn recv(&mut self) -> Option<DestinationDurabilityEvent> {
+        self.rx.recv().await
+    }
+}

--- a/crates/etl/src/destination/mod.rs
+++ b/crates/etl/src/destination/mod.rs
@@ -11,15 +11,24 @@
 mod async_result;
 mod base;
 mod capabilities;
+pub(crate) mod durability;
 mod metadata;
 
 pub(crate) use async_result::{
     ApplyLoopAsyncResultMetadata, CompletedWriteEventsResult, DispatchMetrics,
-    PendingWriteEventsResult,
+    PendingWriteEventsResult, PendingWriteTableRowsResult,
 };
-pub use async_result::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult};
+pub use async_result::{
+    DropTableForCopyResult, FinishTableCopyResult, WriteEventsResult, WriteTableRowsResult,
+};
 pub use base::Destination;
 pub use capabilities::PipelineDestination;
+pub(crate) use durability::DestinationDurabilityEvents;
+pub use durability::{
+    DeferredStreamingConfig, DeferredTableCopyConfig, DestinationBatchId,
+    DestinationDurabilityEvent, DestinationDurabilityReporter, StreamingDurabilityMode,
+    TableCopyBatchId, TableCopyDurabilityMode, TrackedEventsBatch, TrackedTableRowsBatch,
+};
 pub use metadata::{
     AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationTableSchemaStatus,
 };

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -8,7 +8,7 @@
 //! cycle.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     future::Future,
     pin::Pin,
     str::FromStr,
@@ -43,8 +43,10 @@ use crate::{
     bail,
     data::SizeHint,
     destination::{
-        ApplyLoopAsyncResultMetadata, CompletedWriteEventsResult, DispatchMetrics,
-        PendingWriteEventsResult, PipelineDestination, WriteEventsResult,
+        ApplyLoopAsyncResultMetadata, CompletedWriteEventsResult, DeferredStreamingConfig,
+        DestinationBatchId, DestinationDurabilityEvent, DestinationDurabilityEvents,
+        DestinationDurabilityReporter, DispatchMetrics, PendingWriteEventsResult,
+        PipelineDestination, StreamingDurabilityMode, TrackedEventsBatch, WriteEventsResult,
     },
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
@@ -617,6 +619,177 @@ impl ApplyLoopTasks {
     }
 }
 
+/// State kept for a streaming batch after it is dispatched to a deferred
+/// durability destination.
+///
+/// The state does not own the event payload. It tracks the ETL-assigned batch
+/// id, the commit boundary and metrics needed when the batch retires, and the
+/// two independent signals required before retirement: destination acceptance
+/// and destination durability.
+#[derive(Debug)]
+struct DeferredStreamingBatchState {
+    /// ETL-assigned batch id.
+    batch_id: DestinationBatchId,
+    /// Commit end LSN associated with the batch, if any.
+    commit_end_lsn: Option<PgLsn>,
+    /// Dispatch-time metrics recorded once the batch is retired as durable.
+    metrics: DispatchMetrics,
+    /// Estimated bytes held against deferred-durability backpressure.
+    estimated_bytes: usize,
+    /// Whether the destination accepted ownership of the batch.
+    accepted: bool,
+    /// Whether the destination has proven the batch durable.
+    durable: bool,
+}
+
+impl DeferredStreamingBatchState {
+    /// Creates a new deferred streaming batch state.
+    fn new(
+        batch_id: DestinationBatchId,
+        commit_end_lsn: Option<PgLsn>,
+        metrics: DispatchMetrics,
+        estimated_bytes: usize,
+    ) -> Self {
+        Self { batch_id, commit_end_lsn, metrics, estimated_bytes, accepted: false, durable: false }
+    }
+
+    /// Returns metadata used by existing progress/metrics handling.
+    fn metadata(&self) -> ApplyLoopAsyncResultMetadata {
+        ApplyLoopAsyncResultMetadata {
+            batch_id: Some(self.batch_id),
+            commit_end_lsn: self.commit_end_lsn,
+            metrics: self.metrics,
+        }
+    }
+}
+
+/// Bounded retirement window for deferred streaming batches.
+///
+/// The window contains dispatched streaming batch states that have not yet
+/// retired. Acceptance and durability may arrive out of order, but ETL retires
+/// only the contiguous front of the window so checkpoints and table-sync
+/// progress never advance past an older unresolved batch.
+#[derive(Debug)]
+struct DeferredStreamingRetirementWindow {
+    /// Destination-provided backpressure limits.
+    config: DeferredStreamingConfig,
+    /// Next ETL-assigned batch id.
+    next_batch_id: u64,
+    /// Streaming batch states that have been dispatched but not retired.
+    batch_states: VecDeque<DeferredStreamingBatchState>,
+    /// Estimated bytes across all unretired batch states.
+    unretired_bytes: usize,
+}
+
+impl DeferredStreamingRetirementWindow {
+    /// Creates a deferred streaming retirement window.
+    fn new(config: DeferredStreamingConfig) -> Self {
+        Self { config, next_batch_id: 0, batch_states: VecDeque::new(), unretired_bytes: 0 }
+    }
+
+    /// Returns whether there are unretired deferred batches.
+    fn has_unretired_batches(&self) -> bool {
+        !self.batch_states.is_empty()
+    }
+
+    /// Returns a new batch id.
+    fn next_batch_id(&mut self) -> DestinationBatchId {
+        let batch_id = DestinationBatchId::new(self.next_batch_id);
+        self.next_batch_id = self.next_batch_id.checked_add(1).unwrap_or_else(|| {
+            warn!(
+                current_batch_id = self.next_batch_id,
+                "deferred streaming batch id overflow detected; reusing last id"
+            );
+
+            self.next_batch_id
+        });
+
+        batch_id
+    }
+
+    /// Returns whether another batch with the provided size may be dispatched.
+    fn has_capacity_for(&self, estimated_bytes: usize) -> bool {
+        let max_batches = self.config.max_inflight_batches.get();
+        if self.batch_states.len() >= max_batches {
+            return false;
+        }
+
+        let max_bytes = self.config.max_inflight_bytes;
+        if max_bytes == 0 || self.batch_states.is_empty() {
+            return true;
+        }
+
+        self.unretired_bytes.saturating_add(estimated_bytes) <= max_bytes
+    }
+
+    /// Records a newly dispatched batch state.
+    fn push(&mut self, batch_state: DeferredStreamingBatchState) {
+        self.unretired_bytes = self.unretired_bytes.saturating_add(batch_state.estimated_bytes);
+        self.batch_states.push_back(batch_state);
+    }
+
+    /// Marks a dispatched batch as accepted by the destination.
+    fn mark_accepted(&mut self, batch_id: DestinationBatchId) -> EtlResult<()> {
+        let Some(batch_state) =
+            self.batch_states.iter_mut().find(|batch_state| batch_state.batch_id == batch_id)
+        else {
+            return Err(etl_error!(
+                ErrorKind::InvalidState,
+                "Deferred streaming acceptance received for unknown batch",
+                format!("batch_id={}", batch_id.into_inner())
+            ));
+        };
+
+        batch_state.accepted = true;
+
+        Ok(())
+    }
+
+    /// Marks a dispatched batch as durable.
+    fn mark_durable(&mut self, batch_id: DestinationBatchId) -> EtlResult<()> {
+        let Some(batch_state) =
+            self.batch_states.iter_mut().find(|batch_state| batch_state.batch_id == batch_id)
+        else {
+            return Err(etl_error!(
+                ErrorKind::InvalidState,
+                "Deferred streaming durability received for unknown batch",
+                format!("batch_id={}", batch_id.into_inner())
+            ));
+        };
+
+        batch_state.durable = true;
+
+        Ok(())
+    }
+
+    /// Removes and returns the next contiguous accepted and durable batch
+    /// state.
+    fn pop(&mut self) -> Option<DeferredStreamingBatchState> {
+        if !self
+            .batch_states
+            .front()
+            .is_some_and(|batch_state| batch_state.accepted && batch_state.durable)
+        {
+            return None;
+        }
+
+        let batch_state = self.batch_states.pop_front()?;
+        self.unretired_bytes = self.unretired_bytes.saturating_sub(batch_state.estimated_bytes);
+
+        Some(batch_state)
+    }
+}
+
+/// Reason the apply loop can resume a queued batch.
+#[derive(Debug, Clone, Copy)]
+enum ProcessingResumeMode {
+    /// A destination async result completed, the pending flush result can be
+    /// cleared.
+    FlushResultCompleted,
+    /// Deferred streaming retirement freed capacity for the queued batch.
+    DeferredStreamingCapacityAvailable,
+}
+
 /// Mutable runtime state that evolves throughout the apply loop.
 #[derive(Debug)]
 struct ApplyLoopState {
@@ -650,6 +823,8 @@ struct ApplyLoopState {
     keep_alive_deadline: Instant,
     /// Destination write result waiting to be applied to replication progress.
     pending_flush_result: Option<PendingWriteEventsResult<()>>,
+    /// Deferred streaming durability state, when enabled by the destination.
+    deferred_streaming: Option<DeferredStreamingRetirementWindow>,
     /// The strongest exit that this apply loop invocation should eventually
     /// return.
     ///
@@ -688,6 +863,7 @@ impl ApplyLoopState {
         keep_alive_deadline_duration: Duration,
         bootstrap_snapshot_id: SnapshotId,
         slot_name: String,
+        deferred_streaming_config: Option<DeferredStreamingConfig>,
     ) -> Self {
         Self {
             last_commit_end_lsn: None,
@@ -703,6 +879,8 @@ impl ApplyLoopState {
             flush_deadline: None,
             keep_alive_deadline: Instant::now() + keep_alive_deadline_duration,
             pending_flush_result: None,
+            deferred_streaming: deferred_streaming_config
+                .map(DeferredStreamingRetirementWindow::new),
             exit_intent: None,
             processing_paused: false,
             bootstrap_snapshot_id,
@@ -904,10 +1082,19 @@ impl ApplyLoopState {
         self.pending_flush_result.is_some()
     }
 
+    /// Returns `true` if the destination has unretired batches.
+    fn has_unretired_deferred_streaming_batches(&self) -> bool {
+        self.deferred_streaming
+            .as_ref()
+            .is_some_and(DeferredStreamingRetirementWindow::has_unretired_batches)
+    }
+
     /// Returns `true` if any buffered or in-flight destination batch work is
     /// still unresolved.
     fn has_unresolved_batch_work(&self) -> bool {
-        self.has_pending_batch() || self.has_pending_flush_result()
+        self.has_pending_batch()
+            || self.has_pending_flush_result()
+            || self.has_unretired_deferred_streaming_batches()
     }
 
     /// Records a new exit intent if one was produced.
@@ -934,21 +1121,52 @@ impl ApplyLoopState {
         !self.processing_paused && self.has_pending_batch()
     }
 
-    /// Marks the current pending batch as paused behind an in-flight flush.
+    /// Returns whether deferred streaming is active and blocks the queued
+    /// batch.
+    ///
+    /// Immediate streaming has no deferred window, so it is not blocking here.
+    fn deferred_streaming_blocks_pending_batch(&self) -> bool {
+        self.deferred_streaming
+            .as_ref()
+            .is_some_and(|window| !window.has_capacity_for(self.events_batch_bytes))
+    }
+
+    /// Returns whether deferred streaming is active and can dispatch the queued
+    /// batch.
+    ///
+    /// Immediate streaming has no deferred window, so it does not satisfy this
+    /// deferred-capacity predicate either.
+    fn deferred_streaming_has_capacity_for_pending_batch(&self) -> bool {
+        self.deferred_streaming
+            .as_ref()
+            .is_some_and(|window| window.has_capacity_for(self.events_batch_bytes))
+    }
+
+    /// Marks the current pending batch as paused behind an in-flight flush or
+    /// a full deferred streaming retirement window.
     fn pause_processing(&mut self) {
-        debug_assert!(self.has_pending_flush_result());
+        debug_assert!(
+            self.has_pending_flush_result() || self.deferred_streaming_blocks_pending_batch()
+        );
         debug_assert!(self.has_pending_batch());
 
         self.processing_paused = true;
     }
 
-    /// Resumes processing by clearing the existing pending flush result and
-    /// enabling processing.
-    fn resume_processing(&mut self) -> bool {
-        debug_assert!(self.has_pending_flush_result());
+    /// Resumes processing after the provided pause reason is cleared.
+    fn resume_processing(&mut self, mode: ProcessingResumeMode) -> bool {
+        match mode {
+            ProcessingResumeMode::FlushResultCompleted => {
+                debug_assert!(self.has_pending_flush_result());
+                self.pending_flush_result = None;
+            }
+            ProcessingResumeMode::DeferredStreamingCapacityAvailable => {
+                debug_assert!(!self.has_pending_flush_result());
+                debug_assert!(self.deferred_streaming_has_capacity_for_pending_batch());
+            }
+        }
 
         let prev_processing_paused = std::mem::replace(&mut self.processing_paused, false);
-        self.pending_flush_result = None;
 
         debug_assert!(!prev_processing_paused || self.has_pending_batch());
 
@@ -993,6 +1211,10 @@ pub(crate) struct ApplyLoop<S, D> {
     memory_monitor: MemoryMonitor,
     /// Cached dynamic batch budget used to decide flushes by bytes.
     cached_batch_budget: CachedBatchBudget,
+    /// Reporter cloned into deferred streaming batches for this apply loop.
+    deferred_durability_reporter: Option<DestinationDurabilityReporter>,
+    /// Receiver for deferred streaming durability events for this apply loop.
+    deferred_durability_events: Option<DestinationDurabilityEvents>,
     /// Maximum duration to wait before forcibly flushing a batch.
     max_batch_fill_duration: Duration,
     /// Deadline duration used before proactively sending a periodic status
@@ -1072,6 +1294,14 @@ where
             worker_type,
             replication_lag_refresh_interval,
         );
+        let (deferred_streaming_config, deferred_durability_reporter, deferred_durability_events) =
+            match destination.streaming_durability_mode() {
+                StreamingDurabilityMode::Immediate => (None, None, None),
+                StreamingDurabilityMode::Deferred(config) => {
+                    let (reporter, events) = DestinationDurabilityReporter::channel();
+                    (Some(config), Some(reporter), Some(events))
+                }
+            };
 
         let state = ApplyLoopState::new(
             replication_progress,
@@ -1079,6 +1309,7 @@ where
             keep_alive_deadline_duration,
             bootstrap_snapshot_id,
             slot_name,
+            deferred_streaming_config,
         );
 
         let mut apply_loop = Self {
@@ -1090,6 +1321,8 @@ where
             worker_context,
             memory_monitor,
             cached_batch_budget: batch_budget.cached(),
+            deferred_durability_reporter,
+            deferred_durability_events,
             max_batch_fill_duration: Duration::from_millis(config.batch.max_fill_ms),
             keep_alive_deadline_duration,
             tasks,
@@ -1229,13 +1462,20 @@ where
                     .await?;
             }
 
-            // PRIORITY 4: Handle batch flush timer expiry.
+            // PRIORITY 4: Handle deferred destination durability events.
+            // Deferred destinations advance durable progress only through this branch.
+            durability_event = Self::wait_for_durability_event(self.deferred_durability_events.as_mut()), if self.deferred_durability_events.is_some() => {
+                self.handle_durability_event(durability_event)
+                    .await?;
+            }
+
+            // PRIORITY 5: Handle batch flush timer expiry.
             // This prevents buffered work from waiting forever when traffic is low.
             _ = Self::wait_for_batch_deadline(self.state.flush_deadline), if self.state.can_wait_for_deadline() => {
                 self.flush_batch("flush deadline reached").await?;
             }
 
-            // PRIORITY 5: Process incoming replication messages from PostgreSQL.
+            // PRIORITY 6: Process incoming replication messages from PostgreSQL.
             // New WAL messages are only accepted while the loop is still actively ingesting.
             maybe_message = events_stream.next(), if self.state.can_process_messages() => {
                 self.handle_stream_message(
@@ -1246,7 +1486,7 @@ where
                 .await?;
             }
 
-            // PRIORITY 6: Emit a periodic status update once the computed keep alive deadline
+            // PRIORITY 7: Emit a periodic status update once the computed keep alive deadline
             // expires. This intentionally resends the same effective flush LSN so PostgreSQL keeps
             // the standby connection open during long stalls, including cases where the loop is
             // paused behind an in-flight flush and therefore not making visible progress yet. This
@@ -1313,12 +1553,18 @@ where
                     .await?;
             }
 
-            // PRIORITY 3: Handle batch flush timer expiry.
+            // PRIORITY 3: Handle deferred destination durability events.
+            durability_event = Self::wait_for_durability_event(self.deferred_durability_events.as_mut()), if self.deferred_durability_events.is_some() => {
+                self.handle_durability_event(durability_event)
+                    .await?;
+            }
+
+            // PRIORITY 4: Handle batch flush timer expiry.
             _ = Self::wait_for_batch_deadline(self.state.flush_deadline), if self.state.can_wait_for_deadline() => {
                 self.flush_batch("flush deadline reached during shutdown drain").await?;
             }
 
-            // PRIORITY 4: Emit a periodic status update while shutdown is draining.
+            // PRIORITY 5: Emit a periodic status update while shutdown is draining.
             _ = Self::wait_for_keep_alive_deadline(self.state.keep_alive_deadline) => {
                 self.send_status_update(
                     events_stream.as_mut(),
@@ -1683,13 +1929,125 @@ where
         }
     }
 
+    /// Waits for a deferred streaming durability event.
+    async fn wait_for_durability_event(
+        durability_events: Option<&mut DestinationDurabilityEvents>,
+    ) -> Option<DestinationDurabilityEvent> {
+        match durability_events {
+            Some(durability_events) => durability_events.recv().await,
+            None => std::future::pending().await,
+        }
+    }
+
+    /// Records metrics and advances table-sync coordination for a durable
+    /// streaming batch.
+    async fn handle_durable_streaming_batch(
+        &mut self,
+        metadata: ApplyLoopAsyncResultMetadata,
+    ) -> EtlResult<()> {
+        counter!(
+            ETL_EVENTS_PROCESSED_TOTAL,
+            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+            ACTION_LABEL => "table_streaming",
+        )
+        .increment(metadata.metrics.items_count as u64);
+
+        histogram!(
+            ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
+            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+            ACTION_LABEL => "table_streaming",
+        )
+        .record(metadata.metrics.dispatched_at.elapsed().as_secs_f64());
+
+        // Process syncing tables at the last commit boundary included in this
+        // durable batch.
+        //
+        // A flushed batch can contain only part of a large transaction. In that
+        // case it has no commit `end_lsn`, so ETL cannot advance durable
+        // replication progress or table-sync state for it yet. Those updates
+        // are commit-boundary based and will run when a later durable batch
+        // includes the transaction's COMMIT message.
+        if let Some(commit_end_lsn) = metadata.commit_end_lsn {
+            self.process_syncing_tables_after_flush(commit_end_lsn).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Retires all contiguous deferred streaming batches that are both accepted
+    /// and durable.
+    async fn retire_deferred_streaming_batches(&mut self) -> EtlResult<()> {
+        while let Some(batch) =
+            self.state.deferred_streaming.as_mut().and_then(DeferredStreamingRetirementWindow::pop)
+        {
+            self.handle_durable_streaming_batch(batch.metadata()).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Handles a deferred streaming durability event.
+    async fn handle_durability_event(
+        &mut self,
+        durability_event: Option<DestinationDurabilityEvent>,
+    ) -> EtlResult<()> {
+        let Some(durability_event) = durability_event else {
+            if self.state.has_unretired_deferred_streaming_batches() {
+                return Err(etl_error!(
+                    ErrorKind::DestinationError,
+                    "Deferred streaming durability channel closed with unresolved batches"
+                ));
+            }
+
+            return Ok(());
+        };
+
+        match durability_event {
+            DestinationDurabilityEvent::Durable { batch_id } => {
+                let Some(deferred_streaming) = self.state.deferred_streaming.as_mut() else {
+                    return Err(etl_error!(
+                        ErrorKind::InvalidState,
+                        "Deferred streaming durability received while immediate mode is active",
+                        format!("batch_id={}", batch_id.into_inner())
+                    ));
+                };
+
+                deferred_streaming.mark_durable(batch_id)?;
+                self.retire_deferred_streaming_batches().await?;
+
+                if self.state.processing_paused
+                    && self.state.has_pending_batch()
+                    && !self.state.has_pending_flush_result()
+                    && self.state.deferred_streaming_has_capacity_for_pending_batch()
+                {
+                    self.state.resume_processing(
+                        ProcessingResumeMode::DeferredStreamingCapacityAvailable,
+                    );
+                    self.flush_batch("deferred durability event received").await?;
+                }
+
+                Ok(())
+            }
+            DestinationDurabilityEvent::Failed { batch_id, error } => {
+                error!(
+                    batch_id = batch_id.into_inner(),
+                    error = %error,
+                    "deferred streaming durability failed"
+                );
+
+                Err(error)
+            }
+        }
+    }
+
     /// Handles a completed batch flush result.
     async fn handle_flush_result(
         &mut self,
         flush_result: CompletedWriteEventsResult<()>,
     ) -> EtlResult<()> {
         // We clear the state up front because this flush is no longer in flight.
-        let processing_paused = self.state.resume_processing();
+        let processing_paused =
+            self.state.resume_processing(ProcessingResumeMode::FlushResultCompleted);
 
         // Explode the result into parts which are used for handling the flush result.
         let (metadata, result) = flush_result.into_parts();
@@ -1698,29 +2056,19 @@ where
         result?;
 
         if let Some(metadata) = metadata {
-            counter!(
-                ETL_EVENTS_PROCESSED_TOTAL,
-                WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-                ACTION_LABEL => "table_streaming",
-            )
-            .increment(metadata.metrics.items_count as u64);
+            if let Some(batch_id) = metadata.batch_id {
+                let Some(deferred_streaming) = self.state.deferred_streaming.as_mut() else {
+                    return Err(etl_error!(
+                        ErrorKind::InvalidState,
+                        "Deferred streaming acceptance received while immediate mode is active",
+                        format!("batch_id={}", batch_id.into_inner())
+                    ));
+                };
 
-            histogram!(
-                ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
-                WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-                ACTION_LABEL => "table_streaming",
-            )
-            .record(metadata.metrics.dispatched_at.elapsed().as_secs_f64());
-
-            // We process the syncing tables with the last end lsn that the batch contains.
-            //
-            // Note that it could be that there is no end lsn for a specific batch, which
-            // could happen if we process a huge transaction, and we don't reach the
-            // commit before flushing. In that case, we don't process syncing
-            // tables, meaning that progress it not tracked, since it's not going to
-            // do anything because we can only track progress at commit boundaries.
-            if let Some(commit_end_lsn) = metadata.commit_end_lsn {
-                self.process_syncing_tables_after_flush(commit_end_lsn).await?;
+                deferred_streaming.mark_accepted(batch_id)?;
+                self.retire_deferred_streaming_batches().await?;
+            } else {
+                self.handle_durable_streaming_batch(metadata).await?;
             }
         }
 
@@ -1824,10 +2172,9 @@ where
 
     /// Flushes the current batch of events to the destination.
     ///
-    /// If a flush is already in flight, this pauses the loop and leaves the
-    /// current batch queued until the pending flush result has been
-    /// processed. The queued batch is then retried from
-    /// [`Self::handle_flush_result`] when that in-flight flush resolves.
+    /// If a flush is already in flight or deferred streaming has no dispatch
+    /// capacity, this pauses the loop and leaves the current batch queued until
+    /// dispatch can be retried.
     async fn flush_batch(&mut self, reason: &str) -> EtlResult<()> {
         // If the batch is empty, we don't need to do anything.
         if !self.state.has_pending_batch() {
@@ -1837,6 +2184,14 @@ where
         // A flush is already in flight. Pause processing until the result resolves, at
         // which point the loop will resume and dispatch this batch.
         if self.state.has_pending_flush_result() {
+            self.state.pause_processing();
+            return Ok(());
+        }
+
+        // Deferred streaming keeps accepted-but-unretired batches in a bounded
+        // window. If the queued batch would exceed that window, wait until
+        // durability events retire enough older batches.
+        if self.state.deferred_streaming_blocks_pending_batch() {
             self.state.pause_processing();
             return Ok(());
         }
@@ -1854,6 +2209,7 @@ where
         // Capture dispatch-time metrics; they are carried through the result channel
         // and recorded once the destination acknowledges the batch.
         let metadata = ApplyLoopAsyncResultMetadata {
+            batch_id: None,
             commit_end_lsn: self.state.last_commit_end_lsn.take(),
             metrics: DispatchMetrics {
                 items_count: events_batch_size,
@@ -1864,8 +2220,45 @@ where
         // Create the flush result channel: the sender is handed to the destination and
         // the pending receiver is stored on the loop state until the
         // destination signals completion.
-        let (flush_result, pending_flush_result) = WriteEventsResult::new(metadata);
-        self.destination.write_events(events_batch, flush_result).await?;
+        let pending_flush_result =
+            if let Some(deferred_streaming) = self.state.deferred_streaming.as_mut() {
+                let batch_id = deferred_streaming.next_batch_id();
+                let metadata = ApplyLoopAsyncResultMetadata {
+                    batch_id: Some(batch_id),
+                    commit_end_lsn: metadata.commit_end_lsn,
+                    metrics: metadata.metrics,
+                };
+                let (flush_result, pending_flush_result) = WriteEventsResult::new(metadata);
+                let Some(durability_reporter) = self.deferred_durability_reporter.clone() else {
+                    return Err(etl_error!(
+                        ErrorKind::InvalidState,
+                        "Deferred streaming mode is active without a durability reporter"
+                    ));
+                };
+                let batch_state = DeferredStreamingBatchState::new(
+                    batch_id,
+                    metadata.commit_end_lsn,
+                    metadata.metrics,
+                    events_batch_bytes,
+                );
+                let write_batch = TrackedEventsBatch::new(
+                    batch_id,
+                    durability_reporter,
+                    events_batch,
+                    events_batch_bytes,
+                );
+
+                deferred_streaming.push(batch_state);
+                self.destination.write_tracked_events(write_batch, flush_result).await?;
+
+                pending_flush_result
+            } else {
+                let metadata = ApplyLoopAsyncResultMetadata { batch_id: None, ..metadata };
+                let (flush_result, pending_flush_result) = WriteEventsResult::new(metadata);
+                self.destination.write_events(events_batch, flush_result).await?;
+
+                pending_flush_result
+            };
         self.state.pending_flush_result = Some(pending_flush_result);
 
         // We reset the deadline for the batch, since we are now flushing a new batch.
@@ -3552,5 +3945,55 @@ async fn get_replicated_table_schema(
                 )
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use super::*;
+
+    fn deferred_config() -> DeferredStreamingConfig {
+        DeferredStreamingConfig::new(NonZeroUsize::new(8).expect("test limit should be nonzero"), 0)
+    }
+
+    fn dispatch_metrics() -> DispatchMetrics {
+        DispatchMetrics { items_count: 1, dispatched_at: Instant::now() }
+    }
+
+    #[test]
+    fn deferred_streaming_retirement_requires_contiguous_accepted_and_durable_prefix() {
+        // This is an upstream checkpoint-safety test, not a destination mock.
+        // It protects the invariant that an out-of-order durability event can
+        // be remembered, but cannot retire or advance progress past an older
+        // batch that is not yet both accepted and durable.
+        let mut state = DeferredStreamingRetirementWindow::new(deferred_config());
+        let first = state.next_batch_id();
+        let second = state.next_batch_id();
+
+        state.push(DeferredStreamingBatchState::new(
+            first,
+            Some(PgLsn::from(10)),
+            dispatch_metrics(),
+            10,
+        ));
+        state.push(DeferredStreamingBatchState::new(
+            second,
+            Some(PgLsn::from(20)),
+            dispatch_metrics(),
+            10,
+        ));
+
+        state.mark_accepted(first).unwrap();
+        state.mark_accepted(second).unwrap();
+        state.mark_durable(second).unwrap();
+
+        assert!(state.pop().is_none());
+
+        state.mark_durable(first).unwrap();
+        assert_eq!(state.pop().unwrap().batch_id, first);
+        assert_eq!(state.pop().unwrap().batch_id, second);
+        assert!(state.pop().is_none());
     }
 }

--- a/crates/etl/src/replication/table_sync/copy.rs
+++ b/crates/etl/src/replication/table_sync/copy.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::VecDeque,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -20,8 +23,11 @@ use tracing::{debug, info, warn};
 #[cfg(feature = "failpoints")]
 use crate::failpoints::{START_TABLE_SYNC_DURING_DATA_SYNC_FP, etl_fail_point};
 use crate::{
-    data::TableRow,
-    destination::{Destination, WriteTableRowsResult},
+    data::{SizeHint, TableRow},
+    destination::{
+        Destination, FinishTableCopyResult, PendingWriteTableRowsResult, TableCopyBatchId,
+        TableCopyDurabilityMode, TrackedTableRowsBatch, WriteTableRowsResult,
+    },
     error::{ErrorKind, EtlResult},
     etl_error,
     observability::{
@@ -89,6 +95,185 @@ enum CopyWorkerOutcome {
     Completed(CompletedCopyWorker),
     /// The worker observed shutdown before committing its transaction.
     Shutdown,
+}
+
+/// Allocates table-copy batch identifiers for one copy attempt.
+///
+/// A table copy may read from multiple CTID partitions concurrently, so copy
+/// batches are not produced by a single stream-local counter. The shared
+/// allocator gives every accepted batch in the attempt a unique diagnostic id
+/// without encoding source order or durability state.
+#[derive(Debug, Clone, Default)]
+struct TableCopyBatchIdAllocator {
+    /// Next table-copy batch id to hand out.
+    next_batch_id: Arc<AtomicU64>,
+}
+
+impl TableCopyBatchIdAllocator {
+    /// Returns the next attempt-local table-copy batch id.
+    fn next_batch_id(&self) -> EtlResult<TableCopyBatchId> {
+        let batch_id = self
+            .next_batch_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |batch_id| batch_id.checked_add(1))
+            .map_err(|current_batch_id| {
+                etl_error!(
+                    ErrorKind::InvalidState,
+                    "Deferred table-copy batch id overflowed",
+                    format!("current_batch_id={current_batch_id}")
+                )
+            })?;
+
+        Ok(TableCopyBatchId::new(batch_id))
+    }
+}
+
+/// State kept for a table-copy batch after it is dispatched to the destination.
+///
+/// Immediate table copy waits for this state before reading the next source
+/// batch. Deferred table copy queues these states so ETL can continue reading
+/// source rows after the destination accepts ownership of earlier batches.
+/// Until the async result completes, the state still counts against the
+/// per-stream acceptance window because the batch may still be buffered by the
+/// destination.
+#[derive(Debug)]
+struct PendingBatchState {
+    /// Destination async result.
+    pending_result: PendingWriteTableRowsResult<()>,
+    /// Approximate bytes held against deferred copy backpressure.
+    estimated_bytes: usize,
+    /// Instant at which the batch was handed to the destination.
+    dispatched_at: Instant,
+}
+
+impl PendingBatchState {
+    /// Waits for the destination async result and records send metrics.
+    async fn wait(self) -> EtlResult<()> {
+        self.pending_result.await.into_result()?;
+        record_table_copy_batch_metrics(self.dispatched_at);
+
+        #[cfg(feature = "failpoints")]
+        etl_fail_point(START_TABLE_SYNC_DURING_DATA_SYNC_FP)?;
+
+        Ok(())
+    }
+}
+
+/// Per-stream window of table-copy batches waiting for async-result completion.
+///
+/// This window tracks state for copy batches dispatched to the destination but
+/// not yet accepted by their async results. It bounds how far one table-copy
+/// stream can run ahead of destination acceptance; durable completion for all
+/// accepted batches is still proven later by
+/// [`Destination::finish_table_copy`].
+#[derive(Debug)]
+struct PendingBatchWindow {
+    /// Destination-provided copy durability mode.
+    mode: TableCopyDurabilityMode,
+    /// State for dispatched batches waiting on async-result completion.
+    batch_states: VecDeque<PendingBatchState>,
+    /// Estimated bytes held by states in the window.
+    pending_bytes: usize,
+}
+
+impl PendingBatchWindow {
+    /// Creates a pending batch window for the destination mode.
+    fn new(mode: TableCopyDurabilityMode) -> Self {
+        Self { mode, batch_states: VecDeque::new(), pending_bytes: 0 }
+    }
+
+    /// Returns whether deferred table-copy behavior is enabled.
+    fn is_deferred(&self) -> bool {
+        matches!(self.mode, TableCopyDurabilityMode::Deferred(_))
+    }
+
+    /// Returns whether another batch with the provided size may be dispatched.
+    fn has_capacity_for(&self, estimated_bytes: usize) -> bool {
+        let TableCopyDurabilityMode::Deferred(config) = self.mode else {
+            return false;
+        };
+
+        let max_batches = config.max_inflight_batches.get();
+        if self.batch_states.len() >= max_batches {
+            return false;
+        }
+
+        let max_bytes = config.max_inflight_bytes;
+        if max_bytes == 0 || self.batch_states.is_empty() {
+            return true;
+        }
+
+        self.pending_bytes.saturating_add(estimated_bytes) <= max_bytes
+    }
+
+    /// Adds state for one dispatched batch.
+    fn push(&mut self, batch_state: PendingBatchState) {
+        self.pending_bytes = self.pending_bytes.saturating_add(batch_state.estimated_bytes);
+        self.batch_states.push_back(batch_state);
+    }
+
+    /// Removes the oldest pending batch state.
+    fn pop(&mut self) -> Option<PendingBatchState> {
+        let batch_state = self.batch_states.pop_front()?;
+        self.pending_bytes = self.pending_bytes.saturating_sub(batch_state.estimated_bytes);
+
+        Some(batch_state)
+    }
+
+    /// Returns whether the window has no pending batch states.
+    fn is_empty(&self) -> bool {
+        self.batch_states.is_empty()
+    }
+
+    /// Waits for the oldest pending batch state, if any.
+    async fn wait_for_one(&mut self) -> EtlResult<()> {
+        let Some(batch_state) = self.pop() else {
+            return Ok(());
+        };
+
+        batch_state.wait().await
+    }
+
+    /// Waits for every pending batch state.
+    async fn wait_for_all(&mut self) -> EtlResult<()> {
+        while !self.is_empty() {
+            self.wait_for_one().await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Estimates the memory footprint of a copied row batch.
+fn estimate_table_rows_bytes(table_rows: &[TableRow]) -> usize {
+    table_rows.iter().fold(0_usize, |total, table_row| total.saturating_add(table_row.size_hint()))
+}
+
+/// Records table-copy send metrics after destination acceptance.
+fn record_table_copy_batch_metrics(dispatched_at: Instant) {
+    let send_duration_seconds = dispatched_at.elapsed().as_secs_f64();
+    histogram!(
+        ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
+        WORKER_TYPE_LABEL => "table_sync",
+        ACTION_LABEL => "table_copy",
+    )
+    .record(send_duration_seconds);
+}
+
+/// Runs the destination finish barrier for deferred table copy.
+async fn finish_deferred_table_copy<D>(
+    destination: &D,
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> EtlResult<()>
+where
+    D: Destination + Clone + Send + Sync + 'static,
+{
+    if !matches!(destination.table_copy_durability_mode(), TableCopyDurabilityMode::Deferred(_)) {
+        return Ok(());
+    }
+
+    let (finish_result, pending_finish_result) = FinishTableCopyResult::new(());
+    destination.finish_table_copy(replicated_table_schema, finish_result).await?;
+    pending_finish_result.await.into_result()
 }
 
 /// Returns `numerator / denominator`, rounded up.
@@ -237,7 +422,7 @@ async fn stop_table_copy_lag_reporter(lag_reporter: &mut Option<JoinHandle<()>>)
 
 /// Copies a table through ctid work items, using worker child connections.
 #[expect(clippy::too_many_arguments)]
-pub(crate) async fn table_copy<D: Destination + Clone + Send + 'static>(
+pub(crate) async fn table_copy<D: Destination + Clone + Send + Sync + 'static>(
     replication_transaction: &PgReplicationTransaction<'_>,
     table_id: TableId,
     replicated_table_schema: ReplicatedTableSchema,
@@ -273,7 +458,7 @@ pub(crate) async fn table_copy<D: Destination + Clone + Send + 'static>(
 /// Copies a table by assigning physical ctid ranges to child-connection
 /// workers.
 #[expect(clippy::too_many_arguments)]
-async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
+async fn worker_table_copy<D: Destination + Clone + Send + Sync + 'static>(
     replication_transaction: &PgReplicationTransaction<'_>,
     table_id: TableId,
     replicated_table_schema: ReplicatedTableSchema,
@@ -314,6 +499,7 @@ async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
     // CTID ranges for this table copy see a consistent source view.
     let snapshot_id = replication_transaction.export_snapshot().await?;
     let work_queue = Arc::new(Mutex::new(VecDeque::from(copy_partitions)));
+    let batch_id_allocator = TableCopyBatchIdAllocator::default();
     let publication_name = publication_name.map(str::to_owned);
     let mut join_set = JoinSet::new();
     let mut lag_reporter = Some(spawn_table_copy_lag_reporter(
@@ -342,6 +528,7 @@ async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
         // them avoids extra shared ownership machinery in the hot path.
         let snapshot_id = snapshot_id.clone();
         let work_queue = Arc::clone(&work_queue);
+        let batch_id_allocator = batch_id_allocator.clone();
         let replicated_table_schema = replicated_table_schema.clone();
         let publication_name = publication_name.clone();
         let batch_config = batch_config.clone();
@@ -356,6 +543,7 @@ async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
                 child_replication_client,
                 snapshot_id,
                 work_queue,
+                batch_id_allocator,
                 table_id,
                 replicated_table_schema,
                 publication_name,
@@ -410,6 +598,7 @@ async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
     }
 
     stop_table_copy_lag_reporter(&mut lag_reporter).await;
+    finish_deferred_table_copy(&destination, &replicated_table_schema).await?;
 
     let total_duration_secs = start_time.elapsed().as_secs_f64();
     counter!(ETL_TABLE_COPY_ROWS_TOTAL).increment(total_rows);
@@ -515,6 +704,7 @@ async fn copy_worker<D>(
     mut child_replication_client: ChildPgReplicationClient,
     snapshot_id: String,
     work_queue: Arc<Mutex<VecDeque<CopyPartition>>>,
+    batch_id_allocator: TableCopyBatchIdAllocator,
     table_id: TableId,
     replicated_table_schema: ReplicatedTableSchema,
     publication_name: Option<String>,
@@ -525,7 +715,7 @@ async fn copy_worker<D>(
     batch_budget: BatchBudgetController,
 ) -> EtlResult<CopyWorkerOutcome>
 where
-    D: Destination + Clone + Send + 'static,
+    D: Destination + Clone + Send + Sync + 'static,
 {
     let child_replication_transaction =
         child_replication_client.begin_transaction(&snapshot_id).await?;
@@ -553,6 +743,7 @@ where
             replicated_table_schema.clone(),
             publication_name.clone(),
             copy_partition,
+            batch_id_allocator.clone(),
             batch_config.clone(),
             shutdown_rx.clone(),
             destination.clone(),
@@ -577,6 +768,7 @@ async fn copy_partition_rows<D>(
     replicated_table_schema: ReplicatedTableSchema,
     publication_name: Option<String>,
     partition: CopyPartition,
+    batch_id_allocator: TableCopyBatchIdAllocator,
     batch_config: BatchConfig,
     shutdown_rx: ShutdownRx,
     destination: D,
@@ -584,7 +776,7 @@ async fn copy_partition_rows<D>(
     batch_budget: BatchBudgetController,
 ) -> EtlResult<TableCopyResult>
 where
-    D: Destination + Clone + Send + 'static,
+    D: Destination + Clone + Send + Sync + 'static,
 {
     if is_shutdown_requested(&shutdown_rx) {
         return Ok(TableCopyResult::Shutdown);
@@ -629,6 +821,7 @@ where
         shutdown_rx,
         connection_updates_rx,
         replicated_table_schema,
+        batch_id_allocator,
         destination,
     )
     .await?
@@ -662,15 +855,26 @@ async fn copy_table_rows_from_stream<D, S>(
     mut shutdown_rx: ShutdownRx,
     mut connection_updates_rx: watch::Receiver<PostgresConnectionUpdate>,
     replicated_table_schema: ReplicatedTableSchema,
+    batch_id_allocator: TableCopyBatchIdAllocator,
     destination: D,
 ) -> EtlResult<ShutdownResult<u64, u64>>
 where
-    D: Destination + Clone + Send + 'static,
+    D: Destination + Clone + Send + Sync + 'static,
     S: Stream<Item = EtlResult<Vec<TableRow>>>,
 {
     let mut total_rows = 0;
+    let mut pending_batch_window =
+        PendingBatchWindow::new(destination.table_copy_durability_mode());
 
     loop {
+        // If the deferred window is full by batch count, wait before polling the source
+        // again. The next batch size is not known yet, so `0` checks only whether
+        // another batch may be admitted at all.
+        if pending_batch_window.is_deferred() && !pending_batch_window.has_capacity_for(0) {
+            pending_batch_window.wait_for_one().await?;
+            continue;
+        }
+
         tokio::select! {
             biased;
 
@@ -707,6 +911,10 @@ where
 
             maybe_batch = table_copy_stream.next() => {
                 let Some(table_rows) = maybe_batch else {
+                    if pending_batch_window.is_deferred() {
+                        pending_batch_window.wait_for_all().await?;
+                    }
+
                     return Ok(ShutdownResult::Ok(total_rows));
                 };
 
@@ -714,25 +922,41 @@ where
                 let batch_size = table_rows.len() as u64;
 
                 let before_sending = Instant::now();
-                let (flush_result, pending_flush_result) = WriteTableRowsResult::new(());
+                if pending_batch_window.is_deferred() {
+                    let estimated_bytes = estimate_table_rows_bytes(&table_rows);
+                    while !pending_batch_window.has_capacity_for(estimated_bytes) {
+                        pending_batch_window.wait_for_one().await?;
+                    }
 
-                destination
-                    .write_table_rows(&replicated_table_schema, table_rows, flush_result)
+                    let batch_id = batch_id_allocator.next_batch_id()?;
+                    let (flush_result, pending_flush_result) = WriteTableRowsResult::new(());
+                    let batch = TrackedTableRowsBatch::new(
+                        batch_id,
+                        replicated_table_schema.clone(),
+                        table_rows,
+                        estimated_bytes,
+                    );
+                    destination.write_tracked_table_rows(batch, flush_result).await?;
+                    pending_batch_window.push(PendingBatchState {
+                        pending_result: pending_flush_result,
+                        estimated_bytes,
+                        dispatched_at: before_sending,
+                    });
+                } else {
+                    let (flush_result, pending_flush_result) = WriteTableRowsResult::new(());
+                    destination
+                        .write_table_rows(&replicated_table_schema, table_rows, flush_result)
+                        .await?;
+                    PendingBatchState {
+                        pending_result: pending_flush_result,
+                        estimated_bytes: 0,
+                        dispatched_at: before_sending,
+                    }
+                    .wait()
                     .await?;
-                pending_flush_result.await.into_result()?;
+                }
 
                 total_rows += batch_size;
-
-                let send_duration_seconds = before_sending.elapsed().as_secs_f64();
-                histogram!(
-                    ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
-                    WORKER_TYPE_LABEL => "table_sync",
-                    ACTION_LABEL => "table_copy",
-                )
-                .record(send_duration_seconds);
-
-                #[cfg(feature = "failpoints")]
-                etl_fail_point(START_TABLE_SYNC_DURING_DATA_SYNC_FP)?;
             }
         }
     }
@@ -740,9 +964,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        MAX_CTID_COPY_PARTITIONS, partitions_for_table_weight, target_ctid_partition_count,
-    };
+    use super::*;
 
     #[test]
     fn target_ctid_partition_count_matches_workers() {
@@ -783,5 +1005,15 @@ mod tests {
     #[test]
     fn partitions_for_table_weight_does_not_exceed_table_blocks() {
         assert_eq!(partitions_for_table_weight(1000, 1000, 3, 128), 3);
+    }
+
+    #[test]
+    fn table_copy_batch_id_allocator_is_shared_across_clones() {
+        let allocator = TableCopyBatchIdAllocator::default();
+        let cloned_allocator = allocator.clone();
+
+        assert_eq!(allocator.next_batch_id().unwrap().into_inner(), 0);
+        assert_eq!(cloned_allocator.next_batch_id().unwrap().into_inner(), 1);
+        assert_eq!(allocator.next_batch_id().unwrap().into_inner(), 2);
     }
 }

--- a/crates/etl/src/runtime/apply/worker.rs
+++ b/crates/etl/src/runtime/apply/worker.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use etl_config::shared::{InvalidatedSlotBehavior, PipelineConfig};
 use etl_postgres::slots::EtlReplicationSlot;
@@ -221,8 +221,9 @@ where
             pipeline_id = self.pipeline_id,
             publication_name = self.config.publication_name
         );
-        let apply_worker =
-            self.guarded_run_apply_worker().instrument(apply_worker_span.or_current());
+        let apply_worker: Pin<Box<dyn Future<Output = EtlResult<()>> + Send>> =
+            Box::pin(self.guarded_run_apply_worker());
+        let apply_worker = apply_worker.instrument(apply_worker_span.or_current());
 
         let handle = tokio::spawn(apply_worker);
 

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -329,6 +329,7 @@ where
 
         let (wrapped_flush_result, pending_flush_result) =
             WriteEventsResult::new(ApplyLoopAsyncResultMetadata {
+                batch_id: None,
                 commit_end_lsn: None,
                 metrics: DispatchMetrics {
                     items_count: events.len(),


### PR DESCRIPTION
## Summary

- add destination durability modes, tracked batch types, and streaming durability reporting APIs
- track deferred streaming acceptance and durable retirement in the apply loop
- add deferred table-copy acceptance, finish barrier, and attempt-local copy batch IDs
