### PR TITLE
feat: Persist destination write stream state

### DIFF
--- a/crates/etl-postgres/src/store/destination_write_stream.rs
+++ b/crates/etl-postgres/src/store/destination_write_stream.rs
@@ -1,0 +1,157 @@
+//! SQL accessors for durable destination write stream state.
+
+use sqlx::{PgExecutor, PgPool, Row, postgres::types::Oid as SqlxTableId};
+
+use crate::schema::TableId;
+
+/// Database row representation of destination write stream state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredDestinationWriteStreamRow {
+    /// Source table identifier.
+    pub table_id: TableId,
+    /// Destination-specific physical table identifier.
+    pub destination_table_id: String,
+    /// Fully-qualified BigQuery Storage Write API stream name.
+    pub stream_name: String,
+    /// Next contiguous row offset to append.
+    pub next_offset: i64,
+}
+
+/// Gets write stream state for a physical destination table.
+pub async fn get_destination_write_stream(
+    pool: &PgPool,
+    pipeline_id: i64,
+    table_id: TableId,
+    destination_table_id: &str,
+) -> Result<Option<StoredDestinationWriteStreamRow>, sqlx::Error> {
+    let row = sqlx::query(
+        r#"
+        select table_id, destination_table_id, stream_name, next_offset
+        from etl.destination_write_streams
+        where pipeline_id = $1 and table_id = $2 and destination_table_id = $3
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(destination_table_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|row| {
+        let table_id: SqlxTableId = row.get("table_id");
+        StoredDestinationWriteStreamRow {
+            table_id: TableId::new(table_id.0),
+            destination_table_id: row.get("destination_table_id"),
+            stream_name: row.get("stream_name"),
+            next_offset: row.get("next_offset"),
+        }
+    }))
+}
+
+/// Stores write stream state for a physical destination table.
+pub async fn store_destination_write_stream(
+    pool: &PgPool,
+    pipeline_id: i64,
+    table_id: TableId,
+    destination_table_id: &str,
+    stream_name: &str,
+    next_offset: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        insert into etl.destination_write_streams
+            (pipeline_id, table_id, destination_table_id, stream_name, next_offset)
+        values ($1, $2, $3, $4, $5)
+        on conflict (pipeline_id, table_id, destination_table_id)
+        do update set
+            stream_name = excluded.stream_name,
+            next_offset = excluded.next_offset,
+            updated_at = now()
+        where etl.destination_write_streams.next_offset < excluded.next_offset
+            or (
+                etl.destination_write_streams.next_offset = excluded.next_offset
+                and etl.destination_write_streams.stream_name = excluded.stream_name
+            )
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(destination_table_id)
+    .bind(stream_name)
+    .bind(next_offset)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Deletes write stream state for a single source table.
+pub async fn delete_destination_write_streams_for_table<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+    table_id: TableId,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    let result = sqlx::query(
+        r#"
+        delete from etl.destination_write_streams
+        where pipeline_id = $1 and table_id = $2
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+/// Deletes write stream state for one physical destination table.
+pub async fn delete_destination_write_stream<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+    table_id: TableId,
+    destination_table_id: &str,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    let result = sqlx::query(
+        r#"
+        delete from etl.destination_write_streams
+        where pipeline_id = $1
+          and table_id = $2
+          and destination_table_id = $3
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(destination_table_id)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+/// Deletes all write stream state for a pipeline.
+pub async fn delete_destination_write_streams_for_all_tables<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    let result = sqlx::query(
+        r#"
+        delete from etl.destination_write_streams
+        where pipeline_id = $1
+        "#,
+    )
+    .bind(pipeline_id)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}

--- a/crates/etl-postgres/src/store/mod.rs
+++ b/crates/etl-postgres/src/store/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod catalog;
 pub mod destination_table_metadata;
+pub mod destination_write_stream;
 pub mod health;
 pub mod progress;
 pub mod schema;

--- a/crates/etl-replicator/src/error_reporting.rs
+++ b/crates/etl-replicator/src/error_reporting.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, sync::Arc};
 
 use etl::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::{EtlError, EtlResult},
     schema::{PgLsn, SnapshotId, TableId, TableSchema},
     store::{
@@ -146,6 +148,30 @@ where
         metadata: DestinationTableMetadata,
     ) -> EtlResult<()> {
         self.inner.store_destination_table_metadata(table_id, metadata).await
+    }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        self.inner.get_destination_write_stream_state(table_id, destination_table_id).await
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        self.inner.store_destination_write_stream_state(table_id, state).await
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        self.inner.delete_destination_write_stream_state(table_id, destination_table_id).await
     }
 }
 

--- a/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.down.sql
+++ b/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.down.sql
@@ -1,0 +1,1 @@
+drop table if exists etl.destination_write_streams;

--- a/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.up.sql
+++ b/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.up.sql
@@ -1,0 +1,21 @@
+-- Durable destination write stream state.
+--
+-- Append-only BigQuery writes use explicitly-created committed streams and
+-- offsets. Persisting the stream name and next offset lets retries reuse the
+-- same stream position after an unknown append result.
+
+create table etl.destination_write_streams (
+    id bigint generated always as identity primary key,
+    pipeline_id bigint not null,
+    table_id oid not null,
+    destination_table_id text not null,
+    stream_name text not null,
+    next_offset bigint not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint destination_write_streams_next_offset_check check (next_offset >= 0),
+    unique (pipeline_id, table_id, destination_table_id)
+);
+
+create index idx_destination_write_streams_pipeline_table
+    on etl.destination_write_streams (pipeline_id, table_id);

--- a/crates/etl/src/destination/metadata.rs
+++ b/crates/etl/src/destination/metadata.rs
@@ -163,3 +163,35 @@ pub struct AppliedDestinationTableMetadata {
     /// The replication mask indicating which columns are replicated.
     pub replication_mask: ReplicationMask,
 }
+
+/// Durable Storage Write API stream position for an append-only destination
+/// table.
+///
+/// Destinations that use explicitly-created write streams need both the stream
+/// name and the next contiguous offset to retry appends without duplicating
+/// rows after an unknown write outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DestinationWriteStreamState {
+    /// Destination-specific physical table identifier.
+    pub destination_table_id: String,
+    /// Fully-qualified Storage Write API stream name.
+    pub stream_name: String,
+    /// Next contiguous row offset to append.
+    pub next_offset: i64,
+}
+
+impl DestinationWriteStreamState {
+    /// Creates durable stream state for a destination table.
+    pub fn new(destination_table_id: String, stream_name: String, next_offset: i64) -> Self {
+        Self { destination_table_id, stream_name, next_offset }
+    }
+
+    /// Returns this stream state advanced by `row_count` rows.
+    pub fn advanced_by(&self, row_count: usize) -> Self {
+        Self {
+            destination_table_id: self.destination_table_id.clone(),
+            stream_name: self.stream_name.clone(),
+            next_offset: self.next_offset + row_count as i64,
+        }
+    }
+}

--- a/crates/etl/src/destination/mod.rs
+++ b/crates/etl/src/destination/mod.rs
@@ -22,6 +22,7 @@ pub use base::Destination;
 pub use capabilities::PipelineDestination;
 pub use metadata::{
     AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationTableSchemaStatus,
+    DestinationWriteStreamState,
 };
 
 pub use crate::runtime::concurrency::TaskSet;

--- a/crates/etl/src/store/both/memory.rs
+++ b/crates/etl/src/store/both/memory.rs
@@ -7,14 +7,17 @@ use tokio::sync::Mutex;
 use tokio_postgres::types::PgLsn;
 
 use crate::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::{ErrorKind, EtlResult},
     etl_error,
     replication::{WorkerType, state::TableState},
     schema::{SnapshotId, TableId, TableSchema},
     store::{
-        DestinationTablesMetadata, SchemaStore, StateStore, TableSchemaRetention,
-        TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation, TableStates,
+        DestinationTablesMetadata, DestinationWriteStreamStates, SchemaStore, StateStore,
+        TableSchemaRetention, TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation,
+        TableStates,
     },
 };
 
@@ -34,6 +37,8 @@ struct Inner {
     table_schemas: Arc<TableSchemaSnapshots>,
     /// Cached destination table metadata indexed by table ID.
     destination_tables_metadata: DestinationTablesMetadata,
+    /// Durable write stream state indexed by source table and destination table.
+    destination_write_stream_states: DestinationWriteStreamStates,
     /// Durable replication progress indexed by worker type and optional table.
     replication_progress: HashMap<WorkerType, PgLsn>,
 }
@@ -65,6 +70,7 @@ impl MemoryStore {
             table_state_history: HashMap::new(),
             table_schemas: Arc::new(TableSchemaSnapshots::default()),
             destination_tables_metadata: Arc::new(BTreeMap::new()),
+            destination_write_stream_states: Arc::new(BTreeMap::new()),
             replication_progress: HashMap::new(),
         };
 
@@ -209,6 +215,59 @@ impl StateStore for MemoryStore {
 
         Ok(())
     }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        let inner = self.inner.lock().await;
+
+        Ok(inner.destination_write_stream_states.get(&(table_id, destination_table_id)).cloned())
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
+        let key = (table_id, state.destination_table_id.clone());
+        if should_store_destination_write_stream_state(
+            inner.destination_write_stream_states.get(&key),
+            &state,
+        ) {
+            Arc::make_mut(&mut inner.destination_write_stream_states).insert(key, state);
+        }
+
+        Ok(())
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
+        Arc::make_mut(&mut inner.destination_write_stream_states)
+            .remove(&(table_id, destination_table_id));
+
+        Ok(())
+    }
+}
+
+fn should_store_destination_write_stream_state(
+    current: Option<&DestinationWriteStreamState>,
+    next: &DestinationWriteStreamState,
+) -> bool {
+    match current {
+        None => true,
+        Some(current) => {
+            current.next_offset < next.next_offset
+                || (current.next_offset == next.next_offset
+                    && current.stream_name == next.stream_name)
+        }
+    }
 }
 
 impl SchemaStore for MemoryStore {
@@ -266,6 +325,8 @@ impl TableStateLifecycleStore for MemoryStore {
                 let mut inner = self.inner.lock().await;
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
 
                 Ok(0)
@@ -291,6 +352,7 @@ impl TableStateLifecycleStore for MemoryStore {
                 }
 
                 inner.replication_progress.remove(&WorkerType::Apply);
+                Arc::make_mut(&mut inner.destination_write_stream_states).clear();
 
                 Ok(reset_count)
             }
@@ -302,6 +364,8 @@ impl TableStateLifecycleStore for MemoryStore {
                 inner.table_state_history.remove(&table_id);
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
 
                 Ok(affected_table_count)

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use etl_postgres::store::{
-    destination_table_metadata as pg_destination_table_metadata, progress, schema,
+    destination_table_metadata as pg_destination_table_metadata,
+    destination_write_stream as pg_destination_write_stream, progress, schema,
     table_state as pg_table_state,
 };
 use metrics::gauge;
@@ -19,6 +20,7 @@ use crate::{
     config::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions},
     destination::{
         AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationTableSchemaStatus,
+        DestinationWriteStreamState,
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -487,6 +489,81 @@ impl StateStore for PostgresStore {
 
         Ok(())
     }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        pg_destination_write_stream::get_destination_write_stream(
+            &self.pool,
+            self.pipeline_id as i64,
+            table_id,
+            &destination_table_id,
+        )
+        .await
+        .map(|row| {
+            row.map(|row| {
+                DestinationWriteStreamState::new(
+                    row.destination_table_id,
+                    row.stream_name,
+                    row.next_offset,
+                )
+            })
+        })
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination write stream state loading failed",
+                source: err
+            )
+        })
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        pg_destination_write_stream::store_destination_write_stream(
+            &self.pool,
+            self.pipeline_id as i64,
+            table_id,
+            &state.destination_table_id,
+            &state.stream_name,
+            state.next_offset,
+        )
+        .await
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination write stream state storage failed",
+                source: err
+            )
+        })
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        pg_destination_write_stream::delete_destination_write_stream(
+            &self.pool,
+            self.pipeline_id as i64,
+            table_id,
+            &destination_table_id,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination write stream state deletion failed",
+                source: err
+            )
+        })
+    }
 }
 
 impl SchemaStore for PostgresStore {
@@ -666,6 +743,20 @@ impl TableStateLifecycleStore for PostgresStore {
                     )
                 })?;
 
+                pg_destination_write_stream::delete_destination_write_streams_for_table(
+                    &mut *tx,
+                    self.pipeline_id as i64,
+                    table_id,
+                )
+                .await
+                .map_err(|err| {
+                    etl_error!(
+                        ErrorKind::SourceQueryFailed,
+                        "Destination write stream state deletion failed",
+                        source: err
+                    )
+                })?;
+
                 schema::delete_table_schema_for_table(&mut *tx, self.pipeline_id as i64, table_id)
                     .await
                     .map_err(|err| {
@@ -730,6 +821,19 @@ impl TableStateLifecycleStore for PostgresStore {
                     )
                 })?;
 
+                pg_destination_write_stream::delete_destination_write_streams_for_all_tables(
+                    &mut *tx,
+                    self.pipeline_id as i64,
+                )
+                .await
+                .map_err(|err| {
+                    etl_error!(
+                        ErrorKind::SourceQueryFailed,
+                        "Destination write stream state deletion failed",
+                        source: err
+                    )
+                })?;
+
                 tx.commit().await?;
 
                 for table_id in table_ids {
@@ -754,6 +858,20 @@ impl TableStateLifecycleStore for PostgresStore {
                     etl_error!(
                         ErrorKind::SourceQueryFailed,
                         "Destination table metadata deletion failed",
+                        source: err
+                    )
+                })?;
+
+                pg_destination_write_stream::delete_destination_write_streams_for_table(
+                    &mut *tx,
+                    self.pipeline_id as i64,
+                    table_id,
+                )
+                .await
+                .map_err(|err| {
+                    etl_error!(
+                        ErrorKind::SourceQueryFailed,
+                        "Destination write stream state deletion failed",
                         source: err
                     )
                 })?;

--- a/crates/etl/src/store/mod.rs
+++ b/crates/etl/src/store/mod.rs
@@ -28,7 +28,7 @@ pub use capabilities::{DestinationStore, PipelineStore, SharedStateStore};
 pub use lifecycle::{TableStateLifecycleStore, TableStateOperation};
 pub(crate) use schema::TableSchemaSnapshots;
 pub use schema::{SchemaStore, TableSchemaRetention};
-pub(crate) use state::DestinationTablesMetadata;
+pub(crate) use state::{DestinationTablesMetadata, DestinationWriteStreamStates};
 pub use state::{StateStore, TableStates};
 
 pub use crate::replication::{

--- a/crates/etl/src/store/state/base.rs
+++ b/crates/etl/src/store/state/base.rs
@@ -1,7 +1,9 @@
 use std::{collections::BTreeMap, future::Future, sync::Arc};
 
 use crate::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::EtlResult,
     schema::{PgLsn, TableId},
     store::{TableState, WorkerType},
@@ -12,6 +14,10 @@ pub type TableStates = Arc<BTreeMap<TableId, TableState>>;
 
 /// Arc-wrapped dictionary of destination table metadata.
 pub(crate) type DestinationTablesMetadata = Arc<BTreeMap<TableId, DestinationTableMetadata>>;
+
+/// Arc-wrapped dictionary of destination write stream states.
+pub(crate) type DestinationWriteStreamStates =
+    Arc<BTreeMap<(TableId, String), DestinationWriteStreamState>>;
 
 /// Trait for storing and retrieving table states, durable replication progress,
 /// and destination metadata.
@@ -135,5 +141,26 @@ pub trait StateStore {
         &self,
         table_id: TableId,
         metadata: DestinationTableMetadata,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
+
+    /// Returns durable write stream state for a physical destination table.
+    fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> impl Future<Output = EtlResult<Option<DestinationWriteStreamState>>> + Send;
+
+    /// Stores durable write stream state for a physical destination table.
+    fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
+
+    /// Deletes durable write stream state for a physical destination table.
+    fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 }

--- a/crates/etl/src/store/state/mod.rs
+++ b/crates/etl/src/store/state/mod.rs
@@ -1,4 +1,4 @@
 mod base;
 
-pub(crate) use base::DestinationTablesMetadata;
+pub(crate) use base::{DestinationTablesMetadata, DestinationWriteStreamStates};
 pub use base::{StateStore, TableStates};

--- a/crates/etl/src/test_utils/notifying_store.rs
+++ b/crates/etl/src/test_utils/notifying_store.rs
@@ -8,7 +8,9 @@ use tokio::sync::{Notify, RwLock};
 use tokio_postgres::types::PgLsn;
 
 use crate::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::{ErrorKind, EtlResult},
     etl_error,
     replication::{
@@ -17,8 +19,9 @@ use crate::{
     },
     schema::{SnapshotId, TableId, TableSchema},
     store::{
-        DestinationTablesMetadata, SchemaStore, StateStore, TableSchemaRetention,
-        TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation, TableStates,
+        DestinationTablesMetadata, DestinationWriteStreamStates, SchemaStore, StateStore,
+        TableSchemaRetention, TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation,
+        TableStates,
     },
     test_utils::notify::TimedNotify,
 };
@@ -42,6 +45,7 @@ struct Inner {
     table_state_history: HashMap<TableId, Vec<TableState>>,
     table_schemas: Arc<TableSchemaSnapshots>,
     destination_tables_metadata: DestinationTablesMetadata,
+    destination_write_stream_states: DestinationWriteStreamStates,
     replication_progress: HashMap<WorkerType, PgLsn>,
     table_state_type_conditions: Vec<TableStateTypeCondition>,
     table_state_conditions: Vec<TableStateCondition>,
@@ -114,6 +118,7 @@ impl NotifyingStore {
             table_state_history: HashMap::new(),
             table_schemas: Arc::new(TableSchemaSnapshots::default()),
             destination_tables_metadata: Arc::new(BTreeMap::new()),
+            destination_write_stream_states: Arc::new(BTreeMap::new()),
             replication_progress: HashMap::new(),
             table_state_type_conditions: Vec::new(),
             table_state_conditions: Vec::new(),
@@ -388,6 +393,61 @@ impl StateStore for NotifyingStore {
         Arc::make_mut(&mut inner.destination_tables_metadata).insert(table_id, metadata);
         Ok(())
     }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        let inner = self.inner.read().await;
+
+        Ok(inner.destination_write_stream_states.get(&(table_id, destination_table_id)).cloned())
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.write().await;
+        let key = (table_id, state.destination_table_id.clone());
+        if should_store_destination_write_stream_state(
+            inner.destination_write_stream_states.get(&key),
+            &state,
+        ) {
+            Arc::make_mut(&mut inner.destination_write_stream_states).insert(key, state);
+        }
+        inner.check_conditions();
+
+        Ok(())
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.write().await;
+        Arc::make_mut(&mut inner.destination_write_stream_states)
+            .remove(&(table_id, destination_table_id));
+        inner.check_conditions();
+
+        Ok(())
+    }
+}
+
+fn should_store_destination_write_stream_state(
+    current: Option<&DestinationWriteStreamState>,
+    next: &DestinationWriteStreamState,
+) -> bool {
+    match current {
+        None => true,
+        Some(current) => {
+            current.next_offset < next.next_offset
+                || (current.next_offset == next.next_offset
+                    && current.stream_name == next.stream_name)
+        }
+    }
 }
 
 impl SchemaStore for NotifyingStore {
@@ -450,6 +510,8 @@ impl TableStateLifecycleStore for NotifyingStore {
                 let mut inner = self.inner.write().await;
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
                 inner.check_conditions();
 
@@ -476,6 +538,7 @@ impl TableStateLifecycleStore for NotifyingStore {
                 }
 
                 inner.replication_progress.remove(&WorkerType::Apply);
+                Arc::make_mut(&mut inner.destination_write_stream_states).clear();
                 inner.check_conditions();
 
                 Ok(reset_count)
@@ -488,6 +551,8 @@ impl TableStateLifecycleStore for NotifyingStore {
                 inner.table_state_history.remove(&table_id);
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
                 inner.check_conditions();
 

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -3,15 +3,15 @@
 use std::collections::HashMap;
 
 use etl::{
-    destination::DestinationTableMetadata,
+    destination::{DestinationTableMetadata, DestinationWriteStreamState},
     error::ErrorKind,
     etl_error,
     schema::{ColumnSchema, ReplicationMask, SnapshotId, TableId, TableName, TableSchema},
     store::{
-        PostgresStore, SchemaStore, StateStore, TableRetryPolicy, TableSchemaRetention, TableState,
-        TableStateLifecycleStore, WorkerType,
+        MemoryStore, PostgresStore, SchemaStore, StateStore, TableRetryPolicy,
+        TableSchemaRetention, TableState, TableStateLifecycleStore, WorkerType,
     },
-    test_utils::database::spawn_source_database,
+    test_utils::{database::spawn_source_database, notifying_store::NotifyingStore},
 };
 use etl_postgres::source::connect_to_source_database;
 use etl_telemetry::tracing::init_test_tracing;
@@ -252,6 +252,208 @@ async fn state_store_replication_progress_is_monotonic() {
     store.delete_replication_progress(table_sync_worker).await.unwrap();
     assert_eq!(store.get_replication_progress(table_sync_worker).await.unwrap(), None);
     assert_eq!(store.get_replication_progress(apply_worker).await.unwrap(), Some(later_lsn));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn state_store_destination_write_stream_state_persists_and_clears() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let pipeline_id = 1;
+    let table_id = TableId::new(12345);
+    let other_table_id = TableId::new(67890);
+
+    let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    let stream_state = DestinationWriteStreamState::new(
+        "dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/s1".to_owned(),
+        42,
+    );
+    let other_stream_state = DestinationWriteStreamState::new(
+        "other_dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/other_dest_table_0001/streams/s2".to_owned(),
+        7,
+    );
+
+    assert!(
+        store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id.clone())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    store.store_destination_write_stream_state(table_id, stream_state.clone()).await.unwrap();
+    store
+        .store_destination_write_stream_state(other_table_id, other_stream_state.clone())
+        .await
+        .unwrap();
+
+    let loaded = store
+        .get_destination_write_stream_state(table_id, stream_state.destination_table_id.clone())
+        .await
+        .unwrap()
+        .expect("stream state should be stored");
+    assert_eq!(loaded, stream_state);
+
+    let advanced = stream_state.advanced_by(3);
+    store.store_destination_write_stream_state(table_id, advanced.clone()).await.unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let stale = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/stale".to_owned(),
+        advanced.next_offset - 1,
+    );
+    store.store_destination_write_stream_state(table_id, stale).await.unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let same_offset_different_stream = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/same_offset_stale".to_owned(),
+        advanced.next_offset,
+    );
+    store
+        .store_destination_write_stream_state(table_id, same_offset_different_stream)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let new_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    assert_eq!(
+        new_store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced)
+    );
+
+    new_store.prepare_table_state_for_copy(table_id).await.unwrap();
+    assert!(
+        new_store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        new_store
+            .get_destination_write_stream_state(
+                other_table_id,
+                other_stream_state.destination_table_id.clone()
+            )
+            .await
+            .unwrap(),
+        Some(other_stream_state)
+    );
+}
+
+async fn assert_destination_write_stream_state_is_monotonic<S>(store: S)
+where
+    S: StateStore,
+{
+    let table_id = TableId::new(12345);
+    let stream_state = DestinationWriteStreamState::new(
+        "dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/s1".to_owned(),
+        42,
+    );
+    let advanced = stream_state.advanced_by(3);
+
+    store.store_destination_write_stream_state(table_id, advanced.clone()).await.unwrap();
+    store.store_destination_write_stream_state(table_id, stream_state).await.unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let same_offset_different_stream = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/same_offset_stale".to_owned(),
+        advanced.next_offset,
+    );
+    store
+        .store_destination_write_stream_state(table_id, same_offset_different_stream)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced)
+    );
+}
+
+#[tokio::test]
+async fn memory_store_destination_write_stream_state_is_monotonic() {
+    assert_destination_write_stream_state_is_monotonic(MemoryStore::new()).await;
+}
+
+#[tokio::test]
+async fn notifying_store_destination_write_stream_state_is_monotonic() {
+    assert_destination_write_stream_state_is_monotonic(NotifyingStore::new()).await;
+}
+
+async fn assert_reset_for_resync_clears_destination_write_stream_state<S>(store: S)
+where
+    S: StateStore + TableStateLifecycleStore,
+{
+    let table_id = TableId::new(12345);
+    let stream_state = DestinationWriteStreamState::new(
+        "dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/s1".to_owned(),
+        42,
+    );
+
+    store.store_destination_write_stream_state(table_id, stream_state.clone()).await.unwrap();
+    assert!(
+        store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id.clone())
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    store.reset_table_states_for_resync().await.unwrap();
+    assert!(
+        store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn memory_store_reset_for_resync_clears_destination_write_stream_state() {
+    assert_reset_for_resync_clears_destination_write_stream_state(MemoryStore::new()).await;
+}
+
+#[tokio::test]
+async fn notifying_store_reset_for_resync_clears_destination_write_stream_state() {
+    assert_reset_for_resync_clears_destination_write_stream_state(NotifyingStore::new()).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

Adds durable destination write stream state to the replication store.

This PR introduces a small store-level foundation that lets a destination persist the state of an external write stream, including:

- the destination stream name
- the next offset to use
- creation and update timestamps

The implementation is wired through:

- the Postgres-backed store
- the in-memory store
- the notifying test store wrapper
- the error-reporting state store wrapper
- a Postgres migration for the new `destination_write_streams` table
- store-level tests for create/read/update/reset behavior

## Why

BigQuery Storage Write API committed streams need a stable stream name and durable offsets to make retries safe.

Without persisted offsets, a destination can append the same logical rows again after a retry or process restart. This state store is the foundation needed by #875 to use BigQuery committed streams safely for append-only history writes.

## Relationship to the follow-up PR

This is the first PR in the split for #873.

- #874: generic destination write stream state foundation
- #875: BigQuery append-only history mode using this state with Storage Write committed streams

Keeping this as a separate PR makes the storage contract reviewable without the larger BigQuery append-only implementation in the same diff.

## Behavior and compatibility

- This PR does not change existing destination write behavior by itself.
- Existing destinations are not required to use the new state API.
- The new Postgres table is additive.
- In-memory and notifying stores are updated so existing tests and future destination tests can use the same store contract.
- Reset-for-resync clears in-memory destination write stream state, matching the Postgres store behavior.

## Tests

- `cargo check -p etl --features test-utils`
- `cargo check -p etl-replicator --no-default-features`
- `cargo test -p etl --features test-utils reset_for_resync_clears_destination_write_stream_state --test main`

Refs #873
