### PR TITLE
feat: Add BigQuery append-only history mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,6 +2099,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-stream",
  "tonic",
  "tracing",
  "url",

--- a/crates/etl-api/src/configs/destination.rs
+++ b/crates/etl-api/src/configs/destination.rs
@@ -1,6 +1,9 @@
 use etl_config::{
     SerializableSecretString,
-    shared::{ClickHouseEngine, DestinationConfig, DuckLakeMaintenanceMode, IcebergConfig},
+    shared::{
+        BigQueryWriteMode, ClickHouseEngine, DestinationConfig, DuckLakeMaintenanceMode,
+        IcebergConfig,
+    },
 };
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -44,6 +47,9 @@ pub enum FullApiDestinationConfig {
         #[schema(example = 8)]
         #[serde(skip_serializing_if = "Option::is_none")]
         connection_pool_size: Option<usize>,
+        #[schema(value_type = String, example = "append_only")]
+        #[serde(default)]
+        write_mode: BigQueryWriteMode,
     },
     #[serde(rename = "clickhouse")]
     ClickHouse {
@@ -174,6 +180,11 @@ pub enum FullApiDestinationConfig {
 pub enum DestinationConfigUpdateError {
     #[error("Missing required secret field `{field}` for {destination} destination")]
     MissingRequiredSecret { destination: &'static str, field: &'static str },
+    #[error(
+        "Changing `write_mode` for an existing {destination} destination is not supported because \
+         destination tables were created with the stored write mode's layout"
+    )]
+    WriteModeChangeNotSupported { destination: &'static str },
 }
 
 /// Represents an update field where the API must distinguish an omitted field
@@ -277,6 +288,9 @@ pub enum UpdateApiDestinationConfig {
         #[schema(example = 8)]
         #[serde(skip_serializing_if = "Option::is_none")]
         connection_pool_size: Option<usize>,
+        #[schema(value_type = Option<String>, example = "append_only")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        write_mode: Option<BigQueryWriteMode>,
     },
     #[serde(rename = "clickhouse")]
     ClickHouse {
@@ -422,16 +436,33 @@ impl UpdateApiDestinationConfig {
                     service_account_key,
                     max_staleness_mins,
                     connection_pool_size,
+                    write_mode,
                 },
-                StoredDestinationConfig::BigQuery { service_account_key: stored_key, .. },
-            ) => Ok(StoredDestinationConfig::BigQuery {
-                project_id,
-                dataset_id,
-                service_account_key: service_account_key.unwrap_or(stored_key),
-                max_staleness_mins,
-                connection_pool_size: connection_pool_size
-                    .unwrap_or(DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE),
-            }),
+                StoredDestinationConfig::BigQuery {
+                    service_account_key: stored_key,
+                    write_mode: stored_write_mode,
+                    ..
+                },
+            ) => {
+                // Existing destination tables were created with the stored
+                // write mode's physical layout, so flipping the mode would
+                // write incompatible rows into them.
+                if write_mode.is_some_and(|write_mode| write_mode != stored_write_mode) {
+                    return Err(DestinationConfigUpdateError::WriteModeChangeNotSupported {
+                        destination: "BigQuery",
+                    });
+                }
+
+                Ok(StoredDestinationConfig::BigQuery {
+                    project_id,
+                    dataset_id,
+                    service_account_key: service_account_key.unwrap_or(stored_key),
+                    max_staleness_mins,
+                    connection_pool_size: connection_pool_size
+                        .unwrap_or(DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE),
+                    write_mode: stored_write_mode,
+                })
+            }
             (
                 Self::ClickHouse { url, user, password, database, engine },
                 StoredDestinationConfig::ClickHouse { password: stored_password, .. },
@@ -524,6 +555,7 @@ impl UpdateApiDestinationConfig {
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => Ok(StoredDestinationConfig::BigQuery {
                 project_id,
                 dataset_id,
@@ -535,6 +567,7 @@ impl UpdateApiDestinationConfig {
                 max_staleness_mins,
                 connection_pool_size: connection_pool_size
                     .unwrap_or(DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE),
+                write_mode: write_mode.unwrap_or_default(),
             }),
             Self::ClickHouse { url, user, password, database, engine } => {
                 Ok(StoredDestinationConfig::ClickHouse { url, user, password, database, engine })
@@ -609,12 +642,14 @@ impl From<StoredDestinationConfig> for FullApiDestinationConfig {
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => Self::BigQuery {
                 project_id,
                 dataset_id,
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size: Some(connection_pool_size),
+                write_mode,
             },
             StoredDestinationConfig::ClickHouse { url, user, password, database, engine } => {
                 Self::ClickHouse { url, user, password, database, engine }
@@ -715,6 +750,7 @@ pub enum StoredDestinationConfig {
         service_account_key: SerializableSecretString,
         max_staleness_mins: Option<u16>,
         connection_pool_size: usize,
+        write_mode: BigQueryWriteMode,
     },
     ClickHouse {
         url: Url,
@@ -761,12 +797,14 @@ impl StoredDestinationConfig {
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => DestinationConfig::BigQuery {
                 project_id,
                 dataset_id,
                 service_account_key: service_account_key.into(),
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             },
             Self::ClickHouse { url, user, password, database, engine } => {
                 DestinationConfig::ClickHouse {
@@ -874,6 +912,7 @@ impl From<FullApiDestinationConfig> for StoredDestinationConfig {
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => Self::BigQuery {
                 project_id,
                 dataset_id,
@@ -881,6 +920,7 @@ impl From<FullApiDestinationConfig> for StoredDestinationConfig {
                 max_staleness_mins,
                 connection_pool_size: connection_pool_size
                     .unwrap_or(DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE),
+                write_mode,
             },
             FullApiDestinationConfig::ClickHouse { url, user, password, database, engine } => {
                 Self::ClickHouse { url, user, password, database, engine }
@@ -982,12 +1022,14 @@ impl From<FullApiDestinationConfig> for UpdateApiDestinationConfig {
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => Self::BigQuery {
                 project_id,
                 dataset_id,
                 service_account_key: Some(service_account_key),
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode: Some(write_mode),
             },
             FullApiDestinationConfig::ClickHouse { url, user, password, database, engine } => {
                 Self::ClickHouse { url, user, password, database, engine }
@@ -1094,6 +1136,7 @@ impl Encrypt<EncryptedStoredDestinationConfig> for StoredDestinationConfig {
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => {
                 let encrypted_service_account_key =
                     encrypt_text(service_account_key.expose_secret().to_owned(), encryption_key)?;
@@ -1104,6 +1147,7 @@ impl Encrypt<EncryptedStoredDestinationConfig> for StoredDestinationConfig {
                     service_account_key: encrypted_service_account_key,
                     max_staleness_mins,
                     connection_pool_size,
+                    write_mode,
                 })
             }
             Self::ClickHouse { url, user, password, database, engine } => {
@@ -1304,6 +1348,8 @@ pub enum EncryptedStoredDestinationConfig {
         max_staleness_mins: Option<u16>,
         #[serde(default = "default_connection_pool_size")]
         connection_pool_size: usize,
+        #[serde(default)]
+        write_mode: BigQueryWriteMode,
     },
     ClickHouse {
         url: Url,
@@ -1359,6 +1405,7 @@ impl Decrypt<StoredDestinationConfig> for EncryptedStoredDestinationConfig {
                 service_account_key: encrypted_service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => {
                 let service_account_key = SerializableSecretString::from(decrypt_text(
                     encrypted_service_account_key,
@@ -1371,6 +1418,7 @@ impl Decrypt<StoredDestinationConfig> for EncryptedStoredDestinationConfig {
                     service_account_key,
                     max_staleness_mins,
                     connection_pool_size,
+                    write_mode,
                 })
             }
             Self::Iceberg { config } => match config {
@@ -1790,6 +1838,7 @@ mod tests {
             ),
             max_staleness_mins: Some(15),
             connection_pool_size: 8,
+            write_mode: BigQueryWriteMode::AppendOnly,
         };
 
         let key = EncryptionKeyring::from(EncryptionKey {
@@ -1816,6 +1865,7 @@ mod tests {
                     service_account_key: key1,
                     max_staleness_mins: staleness1,
                     connection_pool_size: connection_pool_size1,
+                    write_mode: write_mode1,
                 },
                 StoredDestinationConfig::BigQuery {
                     project_id: p2,
@@ -1823,12 +1873,14 @@ mod tests {
                     service_account_key: key2,
                     max_staleness_mins: staleness2,
                     connection_pool_size: connection_pool_size2,
+                    write_mode: write_mode2,
                 },
             ) => {
                 assert_eq!(p1, p2);
                 assert_eq!(d1, d2);
                 assert_eq!(staleness1, staleness2);
                 assert_eq!(connection_pool_size1, connection_pool_size2);
+                assert_eq!(write_mode1, write_mode2);
                 // Assert that service account key was encrypted and decrypted correctly
                 assert_eq!(key1.expose_secret(), key2.expose_secret());
             }
@@ -2172,6 +2224,7 @@ mod tests {
             service_account_key: SerializableSecretString::from("{\"test\": \"key\"}".to_owned()),
             max_staleness_mins: Some(15),
             connection_pool_size: None,
+            write_mode: BigQueryWriteMode::AppendOnly,
         };
 
         let stored: StoredDestinationConfig = full_config.clone().into();
@@ -2185,6 +2238,7 @@ mod tests {
                     service_account_key: p1_service_account_key,
                     max_staleness_mins: p1_max_staleness_mins,
                     connection_pool_size: p1_connection_pool_size,
+                    write_mode: p1_write_mode,
                 },
                 FullApiDestinationConfig::BigQuery {
                     project_id: p2_project_id,
@@ -2192,6 +2246,7 @@ mod tests {
                     service_account_key: p2_service_account_key,
                     max_staleness_mins: p2_max_staleness_mins,
                     connection_pool_size: p2_connection_pool_size,
+                    write_mode: p2_write_mode,
                 },
             ) => {
                 assert_eq!(p1_project_id, p2_project_id);
@@ -2207,6 +2262,29 @@ mod tests {
                     p2_connection_pool_size,
                     Some(DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE)
                 );
+                assert_eq!(p1_write_mode, BigQueryWriteMode::AppendOnly);
+                assert_eq!(p2_write_mode, BigQueryWriteMode::AppendOnly);
+            }
+            _ => panic!("Config types don't match"),
+        }
+    }
+
+    #[test]
+    fn stored_destination_config_into_etl_config_preserves_bigquery_write_mode() {
+        let config = StoredDestinationConfig::BigQuery {
+            project_id: "test-project".to_owned(),
+            dataset_id: "test_dataset".to_owned(),
+            service_account_key: SerializableSecretString::from("{\"test\": \"key\"}".to_owned()),
+            max_staleness_mins: Some(15),
+            connection_pool_size: 8,
+            write_mode: BigQueryWriteMode::AppendOnly,
+        };
+
+        let etl_config = config.into_etl_config();
+
+        match etl_config {
+            DestinationConfig::BigQuery { write_mode, .. } => {
+                assert_eq!(write_mode, BigQueryWriteMode::AppendOnly);
             }
             _ => panic!("Config types don't match"),
         }
@@ -2220,6 +2298,7 @@ mod tests {
             service_account_key: SerializableSecretString::from("existing-key".to_owned()),
             max_staleness_mins: Some(15),
             connection_pool_size: 8,
+            write_mode: BigQueryWriteMode::AppendOnly,
         };
         let update_config = UpdateApiDestinationConfig::BigQuery {
             project_id: "updated-project".to_owned(),
@@ -2227,6 +2306,7 @@ mod tests {
             service_account_key: None,
             max_staleness_mins: None,
             connection_pool_size: None,
+            write_mode: None,
         };
 
         let updated_config = update_config.merge_into_stored(stored_config).unwrap();
@@ -2238,12 +2318,14 @@ mod tests {
                 service_account_key,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => {
                 assert_eq!(project_id, "updated-project");
                 assert_eq!(dataset_id, "updated_dataset");
                 assert_eq!(service_account_key.expose_secret(), "existing-key");
                 assert_eq!(max_staleness_mins, None);
                 assert_eq!(connection_pool_size, DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE);
+                assert_eq!(write_mode, BigQueryWriteMode::AppendOnly);
             }
             _ => panic!("Config types don't match"),
         }
@@ -2257,6 +2339,7 @@ mod tests {
             service_account_key: SerializableSecretString::from("existing-key".to_owned()),
             max_staleness_mins: Some(15),
             connection_pool_size: 8,
+            write_mode: BigQueryWriteMode::CurrentState,
         };
         let update_config = UpdateApiDestinationConfig::BigQuery {
             project_id: "updated-project".to_owned(),
@@ -2264,16 +2347,45 @@ mod tests {
             service_account_key: Some(SerializableSecretString::from("new-key".to_owned())),
             max_staleness_mins: None,
             connection_pool_size: None,
+            write_mode: Some(BigQueryWriteMode::CurrentState),
         };
 
         let updated_config = update_config.merge_into_stored(stored_config).unwrap();
 
         match updated_config {
-            StoredDestinationConfig::BigQuery { service_account_key, .. } => {
+            StoredDestinationConfig::BigQuery { service_account_key, write_mode, .. } => {
                 assert_eq!(service_account_key.expose_secret(), "new-key");
+                assert_eq!(write_mode, BigQueryWriteMode::CurrentState);
             }
             _ => panic!("Config types don't match"),
         }
+    }
+
+    #[test]
+    fn update_api_destination_config_rejects_bigquery_write_mode_change() {
+        let stored_config = StoredDestinationConfig::BigQuery {
+            project_id: "test-project".to_owned(),
+            dataset_id: "test_dataset".to_owned(),
+            service_account_key: SerializableSecretString::from("existing-key".to_owned()),
+            max_staleness_mins: Some(15),
+            connection_pool_size: 8,
+            write_mode: BigQueryWriteMode::CurrentState,
+        };
+        let update_config = UpdateApiDestinationConfig::BigQuery {
+            project_id: "test-project".to_owned(),
+            dataset_id: "test_dataset".to_owned(),
+            service_account_key: None,
+            max_staleness_mins: Some(15),
+            connection_pool_size: None,
+            write_mode: Some(BigQueryWriteMode::AppendOnly),
+        };
+
+        let err = update_config.merge_into_stored(stored_config).unwrap_err();
+
+        assert!(matches!(
+            err,
+            DestinationConfigUpdateError::WriteModeChangeNotSupported { destination: "BigQuery" }
+        ));
     }
 
     #[test]
@@ -2437,6 +2549,7 @@ mod tests {
             service_account_key: None,
             max_staleness_mins: None,
             connection_pool_size: None,
+            write_mode: None,
         };
 
         let error = update_config.merge_into_stored(stored_config).unwrap_err();

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -1807,9 +1807,9 @@ fn get_restarted_at_annotation_value() -> String {
 #[allow(clippy::redundant_test_prefix)]
 mod tests {
     use etl_config::shared::{
-        BatchConfig, DestinationConfig, InvalidatedSlotBehavior, MemoryBackpressureConfig,
-        PgConnectionConfig, PipelineConfig, ReplicatorConfig, ReplicatorConfigWithoutSecrets,
-        TableSyncCopyConfig, TcpKeepaliveConfig, TlsConfig,
+        BatchConfig, BigQueryWriteMode, DestinationConfig, InvalidatedSlotBehavior,
+        MemoryBackpressureConfig, PgConnectionConfig, PipelineConfig, ReplicatorConfig,
+        ReplicatorConfigWithoutSecrets, TableSyncCopyConfig, TcpKeepaliveConfig, TlsConfig,
     };
     use insta::{assert_json_snapshot, assert_snapshot};
 
@@ -2272,6 +2272,7 @@ mod tests {
                 service_account_key: "sa-key".into(),
                 max_staleness_mins: None,
                 connection_pool_size: 4,
+                write_mode: BigQueryWriteMode::CurrentState,
             },
             pipeline: PipelineConfig {
                 id: 42,

--- a/crates/etl-api/tests/support/mocks.rs
+++ b/crates/etl-api/tests/support/mocks.rs
@@ -12,7 +12,10 @@ use etl_api::{
         sources::{CreateSourceRequest, CreateSourceResponse},
     },
 };
-use etl_config::{SerializableSecretString, shared::DuckLakeMaintenanceMode};
+use etl_config::{
+    SerializableSecretString,
+    shared::{BigQueryWriteMode, DuckLakeMaintenanceMode},
+};
 
 use crate::support::test_app::TestApp;
 
@@ -55,6 +58,7 @@ pub(crate) mod destinations {
             ),
             max_staleness_mins: Some(10),
             connection_pool_size: Some(1),
+            write_mode: BigQueryWriteMode::CurrentState,
         }
     }
 
@@ -66,6 +70,7 @@ pub(crate) mod destinations {
             service_account_key: SerializableSecretString::from("service-account-key".to_owned()),
             max_staleness_mins: None,
             connection_pool_size: Some(1),
+            write_mode: BigQueryWriteMode::CurrentState,
         }
     }
 

--- a/crates/etl-api/tests/validators/bigquery.rs
+++ b/crates/etl-api/tests/validators/bigquery.rs
@@ -2,7 +2,7 @@ use etl_api::{
     configs::destination::FullApiDestinationConfig,
     validation::{FailureType, ValidationContext, validate_destination, validate_pipeline},
 };
-use etl_config::{Environment, SerializableSecretString};
+use etl_config::{Environment, SerializableSecretString, shared::BigQueryWriteMode};
 use etl_destinations::bigquery::test_utils::{
     setup_bigquery_database, setup_bigquery_database_without_dataset,
     skip_if_missing_bigquery_env_vars,
@@ -24,6 +24,7 @@ fn create_bigquery_config(
         service_account_key: SerializableSecretString::from(sa_key.to_owned()),
         max_staleness_mins: None,
         connection_pool_size: None,
+        write_mode: BigQueryWriteMode::CurrentState,
     }
 }
 

--- a/crates/etl-api/tests/validators/destination.rs
+++ b/crates/etl-api/tests/validators/destination.rs
@@ -2,7 +2,10 @@ use etl_api::{
     configs::destination::FullApiDestinationConfig,
     validation::{FailureType, validate_destination},
 };
-use etl_config::{SerializableSecretString, shared::ClickHouseEngine};
+use etl_config::{
+    SerializableSecretString,
+    shared::{BigQueryWriteMode, ClickHouseEngine},
+};
 use etl_postgres::{sqlx::test_utils::drop_pg_database, version::POSTGRES_15};
 use sqlx::Executor;
 use url::Url;
@@ -16,6 +19,7 @@ fn create_bigquery_config() -> FullApiDestinationConfig {
         service_account_key: SerializableSecretString::from("service-account-key".to_owned()),
         max_staleness_mins: None,
         connection_pool_size: Some(1),
+        write_mode: BigQueryWriteMode::CurrentState,
     }
 }
 

--- a/crates/etl-config/src/shared/destination.rs
+++ b/crates/etl-config/src/shared/destination.rs
@@ -12,6 +12,10 @@ const fn default_ducklake_pool_size() -> u32 {
     DestinationConfig::DEFAULT_DUCKLAKE_POOL_SIZE
 }
 
+fn is_default_bigquery_write_mode(write_mode: &BigQueryWriteMode) -> bool {
+    *write_mode == BigQueryWriteMode::default()
+}
+
 /// Table engine used by the ClickHouse destination when creating replicated
 /// tables.
 ///
@@ -60,6 +64,18 @@ pub enum DuckLakeMaintenanceMode {
     Disabled,
     Kubernetes,
     Postgres,
+}
+
+/// Write layout used by the BigQuery destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum BigQueryWriteMode {
+    /// Maintain a current-state table using BigQuery CDC.
+    #[default]
+    CurrentState,
+    /// Preserve each source change as an append-only history row.
+    AppendOnly,
 }
 
 /// Supported product destination kind.
@@ -127,6 +143,9 @@ pub enum DestinationConfig {
         /// consumes more resources.
         #[serde(default = "default_connection_pool_size")]
         connection_pool_size: usize,
+        /// BigQuery table write layout.
+        #[serde(default)]
+        write_mode: BigQueryWriteMode,
     },
     #[serde(rename = "clickhouse")]
     ClickHouse {
@@ -356,6 +375,9 @@ pub enum DestinationConfigWithoutSecrets {
         /// consumes more resources.
         #[serde(default = "default_connection_pool_size")]
         connection_pool_size: usize,
+        /// BigQuery table write layout.
+        #[serde(default, skip_serializing_if = "is_default_bigquery_write_mode")]
+        write_mode: BigQueryWriteMode,
     },
     #[serde(rename = "clickhouse")]
     ClickHouse {
@@ -423,11 +445,13 @@ impl From<DestinationConfig> for DestinationConfigWithoutSecrets {
                 service_account_key: _,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             } => DestinationConfigWithoutSecrets::BigQuery {
                 project_id,
                 dataset_id,
                 max_staleness_mins,
                 connection_pool_size,
+                write_mode,
             },
             DestinationConfig::ClickHouse { url, user, password: _, database, engine } => {
                 DestinationConfigWithoutSecrets::ClickHouse { url, user, database, engine }
@@ -517,5 +541,56 @@ mod tests {
         assert_eq!(DestinationKind::Ducklake.as_str(), "ducklake");
         assert_eq!(DestinationKind::Iceberg.as_str(), "iceberg");
         assert_eq!(DestinationKind::Snowflake.as_str(), "snowflake");
+    }
+
+    #[test]
+    fn bigquery_write_mode_deserializes_append_only() {
+        let config: DestinationConfig = serde_json::from_value(serde_json::json!({
+            "big_query": {
+                "project_id": "project",
+                "dataset_id": "dataset",
+                "service_account_key": "{}",
+                "max_staleness_mins": null,
+                "write_mode": "append_only"
+            }
+        }))
+        .unwrap();
+
+        let DestinationConfig::BigQuery { write_mode, connection_pool_size, .. } = config else {
+            panic!("expected BigQuery destination config");
+        };
+
+        assert_eq!(write_mode, BigQueryWriteMode::AppendOnly);
+        assert_eq!(connection_pool_size, DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE);
+    }
+
+    #[test]
+    fn bigquery_write_mode_omits_default_current_state_without_secrets() {
+        let config = DestinationConfigWithoutSecrets::BigQuery {
+            project_id: "project".to_owned(),
+            dataset_id: "dataset".to_owned(),
+            max_staleness_mins: None,
+            connection_pool_size: DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE,
+            write_mode: BigQueryWriteMode::CurrentState,
+        };
+
+        let json = serde_json::to_value(config).unwrap();
+
+        assert!(json["big_query"].get("write_mode").is_none());
+    }
+
+    #[test]
+    fn bigquery_write_mode_serializes_append_only_without_secrets() {
+        let config = DestinationConfigWithoutSecrets::BigQuery {
+            project_id: "project".to_owned(),
+            dataset_id: "dataset".to_owned(),
+            max_staleness_mins: None,
+            connection_pool_size: DestinationConfig::DEFAULT_CONNECTION_POOL_SIZE,
+            write_mode: BigQueryWriteMode::AppendOnly,
+        };
+
+        let json = serde_json::to_value(config).unwrap();
+
+        assert_eq!(json["big_query"]["write_mode"], "append_only");
     }
 }

--- a/crates/etl-config/src/shared/mod.rs
+++ b/crates/etl-config/src/shared/mod.rs
@@ -13,8 +13,8 @@ pub use connection::{
     PgConnectionOptionsBuilder, TcpKeepaliveConfig, TlsConfig,
 };
 pub use destination::{
-    ClickHouseEngine, DestinationConfig, DestinationConfigWithoutSecrets, DestinationKind,
-    DuckLakeMaintenanceMode, IcebergConfig, IcebergConfigWithoutSecrets,
+    BigQueryWriteMode, ClickHouseEngine, DestinationConfig, DestinationConfigWithoutSecrets,
+    DestinationKind, DuckLakeMaintenanceMode, IcebergConfig, IcebergConfigWithoutSecrets,
 };
 pub use pipeline::{
     BatchConfig, InvalidatedSlotBehavior, MemoryBackpressureConfig, PipelineConfig,

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -33,10 +33,15 @@ ducklake = [
     "dep:url",
 ]
 bigquery = [
+    "dep:async-trait",
+    "dep:base64",
     "dep:gcp-bigquery-client",
+    "dep:serde",
     "dep:serde_json",
+    "dep:sha2",
     "dep:prost",
     "dep:rand",
+    "dep:tokio-stream",
     "dep:tonic",
     "dep:tracing",
     "dep:tokio",
@@ -123,7 +128,8 @@ serde_json = { workspace = true, optional = true, features = ["arbitrary_precisi
 sha2 = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true, features = ["runtime-tokio", "tls-rustls", "postgres"] }
 thiserror = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["rt", "sync", "time"] }
+tokio = { workspace = true, optional = true, features = ["fs", "rt", "sync", "time"] }
+tokio-stream = { workspace = true, optional = true }
 tokio-postgres = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true, default-features = true }

--- a/crates/etl-destinations/src/bigquery/append_only.rs
+++ b/crates/etl-destinations/src/bigquery/append_only.rs
@@ -14,9 +14,7 @@ use etl::{
 };
 use sha2::{Digest, Sha256};
 
-use super::core::{
-    bigquery_delete_old_row, bigquery_update_new_row, ensure_bigquery_key_image_matches_primary_key,
-};
+use super::core::{bigquery_delete_old_row, bigquery_update_new_row};
 use crate::bigquery::encoding::BigQueryTableRow;
 
 const BIGQUERY_SEQUENCE_ORDINAL_FIRST: u64 = 0;
@@ -330,23 +328,26 @@ pub(super) fn append_only_delete_old_row(
     }
 }
 
-/// Expands a dense primary-key row into a sparse table row.
+/// Expands a dense replica-identity key row into a sparse table row.
 fn key_row_to_sparse_table_row(
     replicated_table_schema: &ReplicatedTableSchema,
     key_row: TableRow,
 ) -> EtlResult<TableRow> {
-    ensure_bigquery_key_image_matches_primary_key(replicated_table_schema)?;
-
     let mut key_values = key_row.into_values().into_iter();
+    let mut identity_column_schemas = replicated_table_schema.identity_column_schemas().peekable();
     let mut values = Vec::with_capacity(replicated_table_schema.column_schemas().len());
     for column_schema in replicated_table_schema.column_schemas() {
-        if column_schema.primary_key() {
+        if identity_column_schemas
+            .peek()
+            .is_some_and(|identity_column_schema| identity_column_schema.name == column_schema.name)
+        {
+            identity_column_schemas.next();
             let Some(value) = key_values.next() else {
                 bail!(
                     ErrorKind::InvalidState,
                     "Append-only key image shape is inconsistent",
                     format!(
-                        "Table '{}' key image ended before all primary key values",
+                        "Table '{}' key image ended before all replica identity values",
                         replicated_table_schema.name()
                     )
                 );
@@ -362,7 +363,7 @@ fn key_row_to_sparse_table_row(
             ErrorKind::InvalidState,
             "Append-only key image has leftover values",
             format!(
-                "Table '{}' key image contained more values than its primary key",
+                "Table '{}' key image contained more values than its replica identity",
                 replicated_table_schema.name()
             )
         );

--- a/crates/etl-destinations/src/bigquery/append_only.rs
+++ b/crates/etl-destinations/src/bigquery/append_only.rs
@@ -1,0 +1,385 @@
+use std::{
+    collections::HashSet,
+    fmt::Write as _,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use etl::{
+    bail,
+    data::{ArrayCell, Cell, OldTableRow, TableRow, UpdatedTableRow},
+    error::{ErrorKind, EtlResult},
+    etl_error,
+    event::EventSequenceKey,
+    schema::{ColumnModification, ColumnSchema, ReplicatedTableSchema, SchemaDiff},
+};
+use sha2::{Digest, Sha256};
+
+use super::core::{
+    bigquery_delete_old_row, bigquery_update_new_row, ensure_bigquery_key_image_matches_primary_key,
+};
+use crate::bigquery::encoding::BigQueryTableRow;
+
+const BIGQUERY_SEQUENCE_ORDINAL_FIRST: u64 = 0;
+const BIGQUERY_SEQUENCE_ORDINAL_SECOND: u64 = 1;
+const APPEND_ONLY_COPY_SORT_TIMESTAMP: i64 = i64::MIN;
+const POSTGRES_EPOCH_UNIX_SECONDS: i64 = 946_684_800;
+const MICROS_PER_SECOND: i64 = 1_000_000;
+
+/// Append-only change operation.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum AppendOnlyChangeType {
+    Insert,
+    UpdateDelete,
+    UpdateInsert,
+    Delete,
+}
+
+impl AppendOnlyChangeType {
+    /// Returns the stored change type string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Insert => "INSERT",
+            Self::UpdateDelete => "UPDATE-DELETE",
+            Self::UpdateInsert => "UPDATE-INSERT",
+            Self::Delete => "DELETE",
+        }
+    }
+}
+
+/// Metadata stored alongside every append-only row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AppendOnlyMetadata {
+    pub(super) uuid: String,
+    pub(super) source_timestamp: i64,
+    pub(super) change_sequence_number: String,
+    pub(super) sort_keys: Vec<String>,
+}
+
+/// Builds an append-only sequence number for copied rows.
+pub(super) fn append_only_copy_sequence_number(row_index: u64) -> String {
+    format!("0000000000000000/0000000000000000/{row_index:016x}")
+}
+
+/// Returns a process-local timestamp for initial-copy metadata in Postgres
+/// timestamp wire format.
+pub(super) fn append_only_backfill_timestamp() -> EtlResult<i64> {
+    let duration = SystemTime::now().duration_since(UNIX_EPOCH).map_err(|err| {
+        etl_error!(
+            ErrorKind::InvalidState,
+            "System clock is before the Unix epoch",
+            err.to_string()
+        )
+    })?;
+
+    let unix_micros = duration
+        .as_secs()
+        .checked_mul(MICROS_PER_SECOND as u64)
+        .and_then(|micros| micros.checked_add(u64::from(duration.subsec_micros())))
+        .ok_or_else(|| {
+            etl_error!(
+                ErrorKind::InvalidState,
+                "Current timestamp exceeded supported range",
+                "Initial-copy metadata timestamp overflowed"
+            )
+        })?;
+    let postgres_epoch_micros = POSTGRES_EPOCH_UNIX_SECONDS * MICROS_PER_SECOND;
+
+    i64::try_from(unix_micros)
+        .ok()
+        .and_then(|micros| micros.checked_sub(postgres_epoch_micros))
+        .ok_or_else(|| {
+            etl_error!(
+                ErrorKind::InvalidState,
+                "Current timestamp exceeded supported range",
+                "Initial-copy metadata timestamp overflowed"
+            )
+        })
+}
+
+/// Builds an append-only sequence number for streamed rows.
+pub(super) fn append_only_sequence_number(
+    sequence_key: EventSequenceKey,
+    internal_ordinal: u64,
+) -> String {
+    format!("{sequence_key}/{internal_ordinal:016x}")
+}
+
+/// Builds metadata for an initial-copy row.
+pub(super) fn append_only_copy_metadata(
+    replicated_table_schema: &ReplicatedTableSchema,
+    table_row: &TableRow,
+    source_timestamp: i64,
+    row_index: u64,
+) -> AppendOnlyMetadata {
+    let row_hash = append_only_copy_row_hash(replicated_table_schema, table_row);
+    let sequence_number = append_only_copy_sequence_number(row_index);
+    let uuid = format!("copy/{sequence_number}/{row_hash}");
+    AppendOnlyMetadata {
+        uuid: uuid.clone(),
+        source_timestamp,
+        change_sequence_number: sequence_number.clone(),
+        sort_keys: vec![
+            append_only_timestamp_sort_key(APPEND_ONLY_COPY_SORT_TIMESTAMP),
+            sequence_number,
+            uuid,
+        ],
+    }
+}
+
+/// Builds metadata for a CDC-derived append-only row.
+pub(super) fn append_only_event_metadata(
+    sequence_key: EventSequenceKey,
+    internal_ordinal: u64,
+    source_timestamp: i64,
+) -> AppendOnlyMetadata {
+    let sequence_number = append_only_sequence_number(sequence_key, internal_ordinal);
+    AppendOnlyMetadata {
+        uuid: sequence_number.clone(),
+        source_timestamp,
+        change_sequence_number: sequence_number.clone(),
+        sort_keys: vec![
+            append_only_timestamp_sort_key(source_timestamp),
+            sequence_key.to_string(),
+            format!("{internal_ordinal:016x}"),
+        ],
+    }
+}
+
+/// Converts an `i64` into a lexicographically sortable hexadecimal key.
+pub(super) fn append_only_timestamp_sort_key(timestamp: i64) -> String {
+    format!("{:016x}", (timestamp as u64) ^ (1_u64 << 63))
+}
+
+/// Builds a deterministic row identity for initial-copy rows.
+fn append_only_copy_row_hash(
+    replicated_table_schema: &ReplicatedTableSchema,
+    table_row: &TableRow,
+) -> String {
+    let mut identity = String::new();
+    let _ = write!(
+        &mut identity,
+        "table_id={};table_name={};snapshot={};",
+        replicated_table_schema.id(),
+        replicated_table_schema.name(),
+        replicated_table_schema.inner().snapshot_id
+    );
+
+    let use_primary_key_identity = replicated_table_schema.all_primary_key_columns_replicated()
+        && replicated_table_schema.primary_key_column_schemas().len() > 0;
+    let _ = write!(&mut identity, "identity=primary_key:{use_primary_key_identity};");
+
+    for (column_schema, cell) in replicated_table_schema.column_schemas().zip(table_row.values()) {
+        if use_primary_key_identity && !column_schema.primary_key() {
+            continue;
+        }
+
+        let _ = write!(
+            &mut identity,
+            "column={}#{}:{};",
+            column_schema.name,
+            column_schema.ordinal_position,
+            stable_cell_identity(cell)
+        );
+    }
+
+    let digest = Sha256::digest(identity.as_bytes());
+    let mut hash = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(&mut hash, "{byte:02x}");
+    }
+    hash
+}
+
+/// Produces a length-prefixed representation to avoid simple delimiter
+/// collisions in initial-copy row hashing.
+fn stable_cell_identity(cell: &Cell) -> String {
+    let value = format!("{cell:?}");
+    format!("{}:{value}", value.len())
+}
+
+/// Returns physical columns that must be added for append-only schema changes.
+pub(super) fn append_only_schema_columns_to_add(diff: &SchemaDiff) -> Vec<&ColumnSchema> {
+    let mut seen_column_names = HashSet::new();
+    let mut columns = Vec::new();
+
+    for column in &diff.columns_to_add {
+        if seen_column_names.insert(column.name.clone()) {
+            columns.push(column);
+        }
+    }
+
+    for change in &diff.columns_to_change {
+        if change
+            .modifications
+            .iter()
+            .any(|modification| matches!(modification, ColumnModification::Rename { .. }))
+            && seen_column_names.insert(change.new_column.name.clone())
+        {
+            columns.push(&change.new_column);
+        }
+    }
+
+    columns
+}
+
+/// Builds one or two append-only rows for an update event.
+pub(super) fn append_only_update_rows(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: Option<OldTableRow>,
+    updated_table_row: UpdatedTableRow,
+    sequence_key: EventSequenceKey,
+    source_timestamp: i64,
+) -> EtlResult<Vec<BigQueryTableRow>> {
+    let new_table_row = bigquery_update_new_row(replicated_table_schema, updated_table_row)?;
+    // Postgres sends a key-only old image when the replica identity key
+    // changed, so expand it to record the old key's removal in the history.
+    let old_table_row = match old_table_row {
+        Some(OldTableRow::Full(row)) => Some(row),
+        Some(OldTableRow::Key(row)) => {
+            Some(key_row_to_sparse_table_row(replicated_table_schema, row)?)
+        }
+        None => None,
+    };
+    let mut rows = Vec::with_capacity(2);
+
+    if let Some(old_table_row) = old_table_row {
+        rows.push(append_only_row(
+            replicated_table_schema,
+            old_table_row,
+            AppendOnlyChangeType::UpdateDelete,
+            append_only_event_metadata(
+                sequence_key,
+                BIGQUERY_SEQUENCE_ORDINAL_FIRST,
+                source_timestamp,
+            ),
+        )?);
+        rows.push(append_only_row(
+            replicated_table_schema,
+            new_table_row,
+            AppendOnlyChangeType::UpdateInsert,
+            append_only_event_metadata(
+                sequence_key,
+                BIGQUERY_SEQUENCE_ORDINAL_SECOND,
+                source_timestamp,
+            ),
+        )?);
+    } else {
+        rows.push(append_only_row(
+            replicated_table_schema,
+            new_table_row,
+            AppendOnlyChangeType::UpdateInsert,
+            append_only_event_metadata(
+                sequence_key,
+                BIGQUERY_SEQUENCE_ORDINAL_FIRST,
+                source_timestamp,
+            ),
+        )?);
+    }
+
+    Ok(rows)
+}
+
+/// Returns the old row required for append-only delete events.
+pub(super) fn append_only_delete_old_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    old_table_row: Option<OldTableRow>,
+) -> EtlResult<TableRow> {
+    let old_table_row = bigquery_delete_old_row(replicated_table_schema, old_table_row)?;
+    match old_table_row {
+        OldTableRow::Full(row) => Ok(row),
+        OldTableRow::Key(row) => key_row_to_sparse_table_row(replicated_table_schema, row),
+    }
+}
+
+/// Expands a dense primary-key row into a sparse table row.
+fn key_row_to_sparse_table_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    key_row: TableRow,
+) -> EtlResult<TableRow> {
+    ensure_bigquery_key_image_matches_primary_key(replicated_table_schema)?;
+
+    let mut key_values = key_row.into_values().into_iter();
+    let mut values = Vec::with_capacity(replicated_table_schema.column_schemas().len());
+    for column_schema in replicated_table_schema.column_schemas() {
+        if column_schema.primary_key() {
+            let Some(value) = key_values.next() else {
+                bail!(
+                    ErrorKind::InvalidState,
+                    "Append-only key image shape is inconsistent",
+                    format!(
+                        "Table '{}' key image ended before all primary key values",
+                        replicated_table_schema.name()
+                    )
+                );
+            };
+            values.push(value);
+        } else {
+            values.push(Cell::Null);
+        }
+    }
+
+    if key_values.next().is_some() {
+        bail!(
+            ErrorKind::InvalidState,
+            "Append-only key image has leftover values",
+            format!(
+                "Table '{}' key image contained more values than its primary key",
+                replicated_table_schema.name()
+            )
+        );
+    }
+
+    Ok(TableRow::new(values))
+}
+
+/// Builds an append-only JSON row with ETL metadata.
+pub(super) fn append_only_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    table_row: TableRow,
+    change_type: AppendOnlyChangeType,
+    metadata: AppendOnlyMetadata,
+) -> EtlResult<BigQueryTableRow> {
+    let column_count = replicated_table_schema.column_schemas().len();
+    if table_row.values().len() != column_count {
+        bail!(
+            ErrorKind::InvalidState,
+            "Append-only row image does not match the replicated schema",
+            format!(
+                "Expected {} values for table '{}', got {}",
+                column_count,
+                replicated_table_schema.name(),
+                table_row.values().len()
+            )
+        );
+    }
+
+    let mut tagged_cells = table_row
+        .into_values()
+        .into_iter()
+        .enumerate()
+        .map(|(index, cell)| (index + 1, cell))
+        .collect::<Vec<_>>();
+
+    tagged_cells.extend(append_only_metadata_tagged_cells(column_count, change_type, metadata));
+
+    BigQueryTableRow::try_from_tagged_cells(tagged_cells)
+}
+
+/// Builds flat append-only metadata cells using descriptor field numbers after
+/// the source columns.
+fn append_only_metadata_tagged_cells(
+    source_column_count: usize,
+    change_type: AppendOnlyChangeType,
+    metadata: AppendOnlyMetadata,
+) -> Vec<(usize, Cell)> {
+    vec![
+        (source_column_count + 1, Cell::String(metadata.uuid)),
+        (source_column_count + 2, Cell::I64(metadata.source_timestamp)),
+        (source_column_count + 3, Cell::String(metadata.change_sequence_number)),
+        (source_column_count + 4, Cell::String(change_type.as_str().to_owned())),
+        (
+            source_column_count + 5,
+            Cell::Array(ArrayCell::String(metadata.sort_keys.into_iter().map(Some).collect())),
+        ),
+    ]
+}

--- a/crates/etl-destinations/src/bigquery/append_only.rs
+++ b/crates/etl-destinations/src/bigquery/append_only.rs
@@ -84,6 +84,10 @@ pub(super) fn append_only_copy_sequence_number(row_index: u64) -> String {
     format!("0000000000000000/0000000000000000/{row_index:016x}")
 }
 
+fn append_only_copy_stable_sequence_number(row_hash: &str) -> String {
+    format!("0000000000000000/0000000000000000/{row_hash}")
+}
+
 /// Returns a process-local timestamp for initial-copy metadata in Postgres
 /// timestamp wire format.
 pub(super) fn append_only_backfill_timestamp() -> EtlResult<i64> {
@@ -136,7 +140,11 @@ pub(super) fn append_only_copy_metadata(
     row_index: u64,
 ) -> AppendOnlyMetadata {
     let row_hash = append_only_copy_row_hash(replicated_table_schema, table_row);
-    let sequence_number = append_only_copy_sequence_number(row_index);
+    let sequence_number = if append_only_copy_uses_primary_key_identity(replicated_table_schema) {
+        append_only_copy_stable_sequence_number(&row_hash)
+    } else {
+        append_only_copy_sequence_number(row_index)
+    };
     let uuid = format!("copy/{sequence_number}/{row_hash}");
     AppendOnlyMetadata {
         uuid: uuid.clone(),
@@ -188,8 +196,8 @@ fn append_only_copy_row_hash(
         replicated_table_schema.inner().snapshot_id
     );
 
-    let use_primary_key_identity = replicated_table_schema.all_primary_key_columns_replicated()
-        && replicated_table_schema.primary_key_column_schemas().len() > 0;
+    let use_primary_key_identity =
+        append_only_copy_uses_primary_key_identity(replicated_table_schema);
     let _ = write!(&mut identity, "identity=primary_key:{use_primary_key_identity};");
 
     for (column_schema, cell) in replicated_table_schema.column_schemas().zip(table_row.values()) {
@@ -212,6 +220,13 @@ fn append_only_copy_row_hash(
         let _ = write!(&mut hash, "{byte:02x}");
     }
     hash
+}
+
+fn append_only_copy_uses_primary_key_identity(
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> bool {
+    replicated_table_schema.all_primary_key_columns_replicated()
+        && replicated_table_schema.primary_key_column_schemas().len() > 0
 }
 
 /// Produces a length-prefixed representation to avoid simple delimiter

--- a/crates/etl-destinations/src/bigquery/append_only.rs
+++ b/crates/etl-destinations/src/bigquery/append_only.rs
@@ -55,6 +55,30 @@ pub(super) struct AppendOnlyMetadata {
     pub(super) sort_keys: Vec<String>,
 }
 
+/// Append-only row paired with its durable replay sequence number.
+pub(super) struct AppendOnlyTableRow {
+    row: BigQueryTableRow,
+    sequence_number: String,
+}
+
+impl AppendOnlyTableRow {
+    pub(super) fn new(row: BigQueryTableRow, sequence_number: String) -> Self {
+        Self { row, sequence_number }
+    }
+
+    pub(super) fn row(&self) -> &BigQueryTableRow {
+        &self.row
+    }
+
+    pub(super) fn sequence_number(&self) -> &str {
+        &self.sequence_number
+    }
+
+    pub(super) fn into_parts(self) -> (BigQueryTableRow, String) {
+        (self.row, self.sequence_number)
+    }
+}
+
 /// Builds an append-only sequence number for copied rows.
 pub(super) fn append_only_copy_sequence_number(row_index: u64) -> String {
     format!("0000000000000000/0000000000000000/{row_index:016x}")
@@ -229,7 +253,7 @@ pub(super) fn append_only_update_rows(
     updated_table_row: UpdatedTableRow,
     sequence_key: EventSequenceKey,
     source_timestamp: i64,
-) -> EtlResult<Vec<BigQueryTableRow>> {
+) -> EtlResult<Vec<AppendOnlyTableRow>> {
     let new_table_row = bigquery_update_new_row(replicated_table_schema, updated_table_row)?;
     // Postgres sends a key-only old image when the replica identity key
     // changed, so expand it to record the old key's removal in the history.
@@ -243,7 +267,7 @@ pub(super) fn append_only_update_rows(
     let mut rows = Vec::with_capacity(2);
 
     if let Some(old_table_row) = old_table_row {
-        rows.push(append_only_row(
+        rows.push(append_only_tracked_row(
             replicated_table_schema,
             old_table_row,
             AppendOnlyChangeType::UpdateDelete,
@@ -253,7 +277,7 @@ pub(super) fn append_only_update_rows(
                 source_timestamp,
             ),
         )?);
-        rows.push(append_only_row(
+        rows.push(append_only_tracked_row(
             replicated_table_schema,
             new_table_row,
             AppendOnlyChangeType::UpdateInsert,
@@ -264,7 +288,7 @@ pub(super) fn append_only_update_rows(
             ),
         )?);
     } else {
-        rows.push(append_only_row(
+        rows.push(append_only_tracked_row(
             replicated_table_schema,
             new_table_row,
             AppendOnlyChangeType::UpdateInsert,
@@ -363,6 +387,18 @@ pub(super) fn append_only_row(
     tagged_cells.extend(append_only_metadata_tagged_cells(column_count, change_type, metadata));
 
     BigQueryTableRow::try_from_tagged_cells(tagged_cells)
+}
+
+/// Builds an append-only row and keeps its sequence number next to it.
+pub(super) fn append_only_tracked_row(
+    replicated_table_schema: &ReplicatedTableSchema,
+    table_row: TableRow,
+    change_type: AppendOnlyChangeType,
+    metadata: AppendOnlyMetadata,
+) -> EtlResult<AppendOnlyTableRow> {
+    let sequence_number = metadata.change_sequence_number.clone();
+    let row = append_only_row(replicated_table_schema, table_row, change_type, metadata)?;
+    Ok(AppendOnlyTableRow::new(row, sequence_number))
 }
 
 /// Builds flat append-only metadata cells using descriptor field numbers after

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -45,7 +45,10 @@ use metrics::counter;
 use prost::Message;
 use rand::random;
 use serde::Deserialize;
-use tokio::time::{Duration, Instant, sleep};
+use tokio::{
+    sync::Semaphore,
+    time::{Duration, Instant, sleep},
+};
 use tonic::{
     Code, Request, Status,
     codec::CompressionEncoding,
@@ -122,6 +125,13 @@ const COMMITTED_STREAM_RETRY_POLICY: RetryPolicy = RetryPolicy {
     initial_delay: Duration::from_secs(1),
     max_delay: Duration::from_secs(30),
 };
+
+/// Result of one committed-stream append request.
+pub(super) struct CommittedStreamAppendResult {
+    pub(super) row_count: usize,
+    pub(super) bytes_sent: usize,
+    pub(super) bytes_received: usize,
+}
 /// BigQuery project identifier.
 pub type BigQueryProjectId = String;
 /// BigQuery dataset identifier.
@@ -463,6 +473,10 @@ fn compute_max_inflight_requests(connection_pool_size: usize) -> usize {
         .checked_mul(MAX_INFLIGHT_REQUESTS_PER_CONNECTION)
         .unwrap_or(MAX_SAFE_INFLIGHT_REQUESTS)
         .min(MAX_SAFE_INFLIGHT_REQUESTS)
+}
+
+fn compute_committed_stream_max_inflight_requests(connection_pool_size: usize) -> usize {
+    connection_pool_size.clamp(1, MAX_SAFE_INFLIGHT_REQUESTS)
 }
 
 /// Adds equal jitter to a retry delay.
@@ -846,6 +860,7 @@ pub struct BigQueryClient {
     client: Client,
     auth: Arc<dyn Authenticator>,
     storage_write_client: BigQueryWriteClient<Channel>,
+    committed_stream_append_permits: Arc<Semaphore>,
 }
 
 impl BigQueryClient {
@@ -878,8 +893,17 @@ impl BigQueryClient {
             .map_err(bq_error_to_etl_error)?;
         let storage_write_client =
             create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
+        let committed_stream_append_permits = Arc::new(Semaphore::new(
+            compute_committed_stream_max_inflight_requests(connection_pool_size),
+        ));
 
-        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
+        Ok(BigQueryClient {
+            project_id,
+            client,
+            auth,
+            storage_write_client,
+            committed_stream_append_permits,
+        })
     }
 
     /// Creates a new [`BigQueryClient`] from a service account key JSON string.
@@ -908,8 +932,17 @@ impl BigQueryClient {
             .map_err(bq_error_to_etl_error)?;
         let storage_write_client =
             create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
+        let committed_stream_append_permits = Arc::new(Semaphore::new(
+            compute_committed_stream_max_inflight_requests(connection_pool_size),
+        ));
 
-        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
+        Ok(BigQueryClient {
+            project_id,
+            client,
+            auth,
+            storage_write_client,
+            committed_stream_append_permits,
+        })
     }
 
     /// Creates a new [`BigQueryClient`] using Application Default Credentials.
@@ -935,8 +968,17 @@ impl BigQueryClient {
             .map_err(bq_error_to_etl_error)?;
         let storage_write_client =
             create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
+        let committed_stream_append_permits = Arc::new(Semaphore::new(
+            compute_committed_stream_max_inflight_requests(connection_pool_size),
+        ));
 
-        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
+        Ok(BigQueryClient {
+            project_id,
+            client,
+            auth,
+            storage_write_client,
+            committed_stream_append_permits,
+        })
     }
 
     /// Creates a new [`BigQueryClient`] using OAuth2 installed flow
@@ -965,8 +1007,17 @@ impl BigQueryClient {
             .map_err(bq_error_to_etl_error)?;
         let storage_write_client =
             create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
+        let committed_stream_append_permits = Arc::new(Semaphore::new(
+            compute_committed_stream_max_inflight_requests(connection_pool_size),
+        ));
 
-        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
+        Ok(BigQueryClient {
+            project_id,
+            client,
+            auth,
+            storage_write_client,
+            committed_stream_append_permits,
+        })
     }
 
     /// Returns the fully qualified BigQuery table name.
@@ -1436,78 +1487,66 @@ impl BigQueryClient {
         rows: &[BigQueryTableRow],
         start_offset: i64,
         trace_id: String,
-    ) -> EtlResult<(usize, usize)> {
+    ) -> EtlResult<CommittedStreamAppendResult> {
         if rows.is_empty() {
-            return Ok((0, 0));
+            return Ok(CommittedStreamAppendResult {
+                row_count: 0,
+                bytes_sent: 0,
+                bytes_received: 0,
+            });
         }
 
-        let mut current_index = 0;
-        let mut current_offset = start_offset;
-        let mut total_bytes_sent = 0;
-        let mut total_bytes_received = 0;
-
-        while current_index < rows.len() {
-            let (encoded_rows, processed_count) = StorageApi::create_rows(
-                &table_descriptor,
-                &rows[current_index..],
-                MAX_BATCH_SIZE_BYTES,
-            );
-            if processed_count == 0 {
-                return Err(etl_error!(
-                    ErrorKind::DestinationError,
-                    "BigQuery committed stream row is too large",
-                    "A single encoded row exceeded the Storage Write API request size limit"
-                ));
-            }
-
-            let request = AppendRowsRequest {
-                write_stream: stream_name.to_owned(),
-                offset: Some(current_offset),
-                trace_id: trace_id.clone(),
-                missing_value_interpretations: HashMap::new(),
-                default_missing_value_interpretation:
-                    append_rows_request::MissingValueInterpretation::Unspecified as i32,
-                rows: Some(encoded_rows),
-            };
-            let request_bytes = request.encoded_len();
-
-            let response_bytes = retry_with_backoff(
-                COMMITTED_STREAM_RETRY_POLICY,
-                |err: &EtlError| {
-                    if err.kind() == ErrorKind::DestinationAtomicBatchRetryable {
-                        RetryDecision::Retry
-                    } else {
-                        RetryDecision::Stop
-                    }
-                },
-                storage_write_retry_delay_with_jitter,
-                |attempt| {
-                    warn!(
-                        retry_index = attempt.retry_index,
-                        max_retries = attempt.max_retries,
-                        sleep_ms = attempt.sleep_delay.as_millis(),
-                        error = %attempt.error,
-                        "retrying retryable bigquery committed stream append error"
-                    );
-                },
-                || {
-                    let request = request.clone();
-                    async move {
-                        self.append_committed_stream_request(stream_name, request, current_offset)
-                            .await
-                    }
-                },
-            )
-            .await
-            .map_err(|failure| failure.last_error)?;
-
-            total_bytes_sent += request_bytes;
-            total_bytes_received += response_bytes;
-            current_index += processed_count;
-            current_offset += processed_count as i64;
+        let (encoded_rows, row_count) =
+            StorageApi::create_rows(&table_descriptor, rows, MAX_BATCH_SIZE_BYTES);
+        if row_count == 0 {
+            return Err(etl_error!(
+                ErrorKind::DestinationError,
+                "BigQuery committed stream row is too large",
+                "A single encoded row exceeded the Storage Write API request size limit"
+            ));
         }
 
-        Ok((total_bytes_sent, total_bytes_received))
+        let request = AppendRowsRequest {
+            write_stream: stream_name.to_owned(),
+            offset: Some(start_offset),
+            trace_id,
+            missing_value_interpretations: HashMap::new(),
+            default_missing_value_interpretation:
+                append_rows_request::MissingValueInterpretation::Unspecified as i32,
+            rows: Some(encoded_rows),
+        };
+        let bytes_sent = request.encoded_len();
+
+        let bytes_received = retry_with_backoff(
+            COMMITTED_STREAM_RETRY_POLICY,
+            |err: &EtlError| {
+                if err.kind() == ErrorKind::DestinationAtomicBatchRetryable {
+                    RetryDecision::Retry
+                } else {
+                    RetryDecision::Stop
+                }
+            },
+            storage_write_retry_delay_with_jitter,
+            |attempt| {
+                warn!(
+                    retry_index = attempt.retry_index,
+                    max_retries = attempt.max_retries,
+                    sleep_ms = attempt.sleep_delay.as_millis(),
+                    error = %attempt.error,
+                    "retrying retryable bigquery committed stream append error"
+                );
+            },
+            || {
+                let request = request.clone();
+                async move {
+                    self.append_committed_stream_request(stream_name, request, start_offset).await
+                }
+            },
+        )
+        .await
+        .map_err(|failure| failure.last_error)?;
+
+        Ok(CommittedStreamAppendResult { row_count, bytes_sent, bytes_received })
     }
 
     async fn append_committed_stream_request(
@@ -1516,6 +1555,18 @@ impl BigQueryClient {
         request: AppendRowsRequest,
         expected_offset: i64,
     ) -> EtlResult<usize> {
+        let _permit = self
+            .committed_stream_append_permits
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| {
+                etl_error!(
+                    ErrorKind::DestinationError,
+                    "BigQuery committed stream append limiter closed",
+                    "The committed stream append limiter was closed before a permit could be acquired"
+                )
+            })?;
         let request =
             new_authorized_storage_request(self.auth.clone(), tokio_stream::iter(vec![request]))
                 .await
@@ -1906,6 +1957,12 @@ mod tests {
                 append_rows_response::AppendResult { offset: None },
             )),
         }
+    }
+
+    #[test]
+    fn committed_stream_max_inflight_uses_connection_pool_size_as_proactive_limit() {
+        assert_eq!(compute_committed_stream_max_inflight_requests(0), 1);
+        assert_eq!(compute_committed_stream_max_inflight_requests(3), 3);
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -419,9 +419,12 @@ fn is_retryable_committed_stream_status(status: &Status) -> bool {
         // stream appends created immediately after a table schema change while
         // the Storage Write schema metadata catches up with the DDL.
         Code::Aborted
+            | Code::Cancelled
+            | Code::DeadlineExceeded
             | Code::Internal
             | Code::InvalidArgument
             | Code::ResourceExhausted
+            | Code::Unknown
             | Code::Unavailable
     )
 }
@@ -433,9 +436,12 @@ fn is_retryable_committed_stream_response_status(status: &GoogleRpcStatus) -> bo
         // See `is_retryable_committed_stream_status` for why INVALID_ARGUMENT
         // is retried on committed stream append responses.
         Code::Aborted
+            | Code::Cancelled
+            | Code::DeadlineExceeded
             | Code::Internal
             | Code::InvalidArgument
             | Code::ResourceExhausted
+            | Code::Unknown
             | Code::Unavailable
     )
 }
@@ -2019,6 +2025,38 @@ mod tests {
         assert!(is_retryable_committed_stream_response_status(&GoogleRpcStatus {
             code: Code::InvalidArgument as i32,
             message: "schema metadata is not ready".to_owned(),
+            details: Vec::new(),
+        }));
+    }
+
+    #[test]
+    fn committed_stream_cancelled_is_retryable() {
+        assert!(is_retryable_committed_stream_status(&Status::cancelled(
+            "append operation was cancelled"
+        )));
+        assert!(is_retryable_committed_stream_response_status(&GoogleRpcStatus {
+            code: Code::Cancelled as i32,
+            message: "append operation was cancelled".to_owned(),
+            details: Vec::new(),
+        }));
+    }
+
+    #[test]
+    fn committed_stream_transport_uncertainty_is_retryable() {
+        assert!(is_retryable_committed_stream_status(&Status::deadline_exceeded(
+            "append deadline exceeded"
+        )));
+        assert!(is_retryable_committed_stream_status(&Status::unknown(
+            "append acknowledgement was lost"
+        )));
+        assert!(is_retryable_committed_stream_response_status(&GoogleRpcStatus {
+            code: Code::DeadlineExceeded as i32,
+            message: "append deadline exceeded".to_owned(),
+            details: Vec::new(),
+        }));
+        assert!(is_retryable_committed_stream_response_status(&GoogleRpcStatus {
+            code: Code::Unknown as i32,
+            message: "append acknowledgement was lost".to_owned(),
             details: Vec::new(),
         }));
     }

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -1,5 +1,6 @@
-use std::fmt;
+use std::{collections::HashMap, fmt, path::PathBuf, sync::Arc};
 
+use async_trait::async_trait;
 use etl::{
     data::Cell,
     error::{ErrorKind, EtlError, EtlResult},
@@ -9,11 +10,14 @@ use etl::{
 };
 use gcp_bigquery_client::{
     Client,
+    auth::Authenticator,
     client_builder::ClientBuilder,
     error::BQError,
     google::{
         cloud::bigquery::storage::v1::{
-            RowError, StorageError, row_error::RowErrorCode, storage_error::StorageErrorCode,
+            AppendRowsRequest, CreateWriteStreamRequest, RowError, StorageError, WriteStream,
+            append_rows_request, append_rows_response, big_query_write_client::BigQueryWriteClient,
+            row_error::RowErrorCode, storage_error::StorageErrorCode, write_stream,
         },
         rpc::Status as GoogleRpcStatus,
     },
@@ -23,16 +27,30 @@ use gcp_bigquery_client::{
         query_response::ResultSet,
     },
     storage::{
-        BatchAppendRequest, BatchAppendResult, StorageApiConfig, StreamName, TableBatch,
-        TableDescriptor,
+        BatchAppendRequest, BatchAppendResult, MAX_BATCH_SIZE_BYTES, StorageApi, StorageApiConfig,
+        StreamName, TableBatch, TableDescriptor,
     },
-    yup_oauth2::parse_service_account_key,
+    yup_oauth2::{
+        ApplicationDefaultCredentialsAuthenticator as YupApplicationDefaultCredentialsAuthenticator,
+        ApplicationDefaultCredentialsFlowOpts, ApplicationSecret,
+        AuthorizedUserAuthenticator as YupAuthorizedUserAuthenticator,
+        InstalledFlowAuthenticator as YupInstalledFlowAuthenticator, InstalledFlowReturnMethod,
+        ServiceAccountKey,
+        authenticator::{ApplicationDefaultCredentialsTypes, DefaultAuthenticator},
+        authorized_user::AuthorizedUserSecret,
+        parse_application_secret, parse_service_account_key,
+    },
 };
 use metrics::counter;
 use prost::Message;
 use rand::random;
+use serde::Deserialize;
 use tokio::time::{Duration, Instant, sleep};
-use tonic::Code;
+use tonic::{
+    Code, Request, Status,
+    codec::CompressionEncoding,
+    transport::{Channel, ClientTlsConfig},
+};
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -41,7 +59,10 @@ use crate::{
         metrics::{
             ETL_BQ_APPEND_BATCHES_BATCH_ERRORS_TOTAL, ETL_BQ_APPEND_BATCHES_BATCH_ROW_ERRORS_TOTAL,
         },
-        schema::{create_columns_spec, default_expression_sql, postgres_to_bigquery_type},
+        schema::{
+            create_append_only_columns_spec, create_columns_spec, default_expression_sql,
+            postgres_to_bigquery_type,
+        },
         sql::{quote_identifier, quote_information_schema_tables_path, quote_table_path},
     },
     retry::{RetryDecision, RetryPolicy, retry_with_backoff},
@@ -83,13 +104,163 @@ const TRANSIENT_BIGQUERY_QUERY_REASONS: &[&str] =
 /// Protobuf type name for BigQuery storage errors embedded in gRPC status
 /// details.
 const BIGQUERY_STORAGE_ERROR_TYPE_NAME: &str = "google.cloud.bigquery.storage.v1.StorageError";
-
+/// BigQuery OAuth scope used by the upstream BigQuery client.
+const BIG_QUERY_AUTH_URL: &str = "https://www.googleapis.com/auth/bigquery";
+/// Base URL for the BigQuery Storage Write API endpoint.
+const BIG_QUERY_STORAGE_API_URL: &str = "https://bigquerystorage.googleapis.com";
+/// Domain name for BigQuery Storage API TLS configuration.
+const BIGQUERY_STORAGE_API_DOMAIN: &str = "bigquerystorage.googleapis.com";
+/// Maximum message size for Storage Write gRPC requests and responses.
+const STORAGE_WRITE_MAX_MESSAGE_SIZE_BYTES: usize = 20 * 1024 * 1024;
+/// HTTP/2 keepalive interval for committed-stream Storage Write connections.
+const STORAGE_WRITE_HTTP2_KEEPALIVE_INTERVAL_SECS: u64 = 30;
+/// HTTP/2 keepalive timeout for committed-stream Storage Write connections.
+const STORAGE_WRITE_HTTP2_KEEPALIVE_TIMEOUT_SECS: u64 = 10;
+/// Retry policy for committed-stream append RPC failures.
+const COMMITTED_STREAM_RETRY_POLICY: RetryPolicy = RetryPolicy {
+    max_retries: 8,
+    initial_delay: Duration::from_secs(1),
+    max_delay: Duration::from_secs(30),
+};
 /// BigQuery project identifier.
 pub type BigQueryProjectId = String;
 /// BigQuery dataset identifier.
 pub type BigQueryDatasetId = String;
 /// BigQuery table identifier.
 pub type BigQueryTableId = String;
+
+/// Local authenticator used for low-level Storage Write RPCs not exposed by
+/// the high-level client wrapper.
+#[derive(Clone)]
+struct BigQueryAuthenticator {
+    auth: DefaultAuthenticator,
+    scopes: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct CredentialType {
+    #[serde(rename = "type")]
+    cred_type: String,
+}
+
+fn default_adc_path() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var("APPDATA").ok().map(|appdata| {
+            PathBuf::from(appdata).join("gcloud/application_default_credentials.json")
+        })
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::env::var("HOME").ok().map(|home| {
+            PathBuf::from(home).join(".config/gcloud/application_default_credentials.json")
+        })
+    }
+}
+
+fn adc_credential_path() -> Option<PathBuf> {
+    std::env::var("GOOGLE_APPLICATION_CREDENTIALS")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(default_adc_path)
+}
+
+impl BigQueryAuthenticator {
+    async fn from_service_account_key(
+        service_account_key: ServiceAccountKey,
+        scopes: &[&str],
+    ) -> Result<Arc<dyn Authenticator>, BQError> {
+        let auth = gcp_bigquery_client::yup_oauth2::ServiceAccountAuthenticator::builder(
+            service_account_key,
+        )
+        .build()
+        .await
+        .map_err(BQError::InvalidServiceAccountAuthenticator)?;
+
+        Ok(Arc::new(Self { auth, scopes: scopes.iter().map(|scope| scope.to_string()).collect() }))
+    }
+
+    async fn from_application_default_credentials(
+        scopes: &[&str],
+    ) -> Result<Arc<dyn Authenticator>, BQError> {
+        if let Some(auth) =
+            Self::try_authorized_user_application_default_credentials(scopes).await?
+        {
+            return Ok(auth);
+        }
+
+        let opts = ApplicationDefaultCredentialsFlowOpts::default();
+        let auth = match YupApplicationDefaultCredentialsAuthenticator::builder(opts).await {
+            ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth.build().await,
+            ApplicationDefaultCredentialsTypes::ServiceAccount(auth) => auth.build().await,
+        }
+        .map_err(BQError::InvalidApplicationDefaultCredentialsAuthenticator)?;
+
+        Ok(Arc::new(Self { auth, scopes: scopes.iter().map(|scope| scope.to_string()).collect() }))
+    }
+
+    async fn try_authorized_user_application_default_credentials(
+        scopes: &[&str],
+    ) -> Result<Option<Arc<dyn Authenticator>>, BQError> {
+        let Some(credential_path) = adc_credential_path() else {
+            return Ok(None);
+        };
+        let Ok(contents) = tokio::fs::read_to_string(&credential_path).await else {
+            return Ok(None);
+        };
+        let Ok(credential_type) = serde_json::from_str::<CredentialType>(&contents) else {
+            return Ok(None);
+        };
+        if credential_type.cred_type != "authorized_user" {
+            return Ok(None);
+        }
+
+        let secret: AuthorizedUserSecret = serde_json::from_str(&contents)?;
+        let auth = YupAuthorizedUserAuthenticator::builder(secret)
+            .build()
+            .await
+            .map_err(BQError::InvalidAuthorizedUserAuthenticator)?;
+
+        Ok(Some(Arc::new(Self {
+            auth,
+            scopes: scopes.iter().map(|scope| scope.to_string()).collect(),
+        })))
+    }
+
+    async fn from_installed_flow<S: AsRef<[u8]>, P: Into<PathBuf>>(
+        secret: S,
+        scopes: &[&str],
+        persistent_file_path: P,
+    ) -> Result<Arc<dyn Authenticator>, BQError> {
+        let app_secret: ApplicationSecret = parse_application_secret(secret)?;
+        let auth = YupInstalledFlowAuthenticator::builder(
+            app_secret,
+            InstalledFlowReturnMethod::HTTPRedirect,
+        )
+        .persist_tokens_to_disk(persistent_file_path)
+        .build()
+        .await
+        .map_err(BQError::InvalidInstalledFlowAuthenticator)?;
+
+        auth.token(scopes).await.map_err(BQError::YupAuthError)?;
+
+        Ok(Arc::new(Self { auth, scopes: scopes.iter().map(|scope| scope.to_string()).collect() }))
+    }
+}
+
+#[async_trait]
+impl Authenticator for BigQueryAuthenticator {
+    async fn access_token(&self) -> Result<String, BQError> {
+        Ok(self
+            .auth
+            .clone()
+            .token(self.scopes.as_ref())
+            .await?
+            .token()
+            .ok_or(BQError::NoToken)?
+            .to_string())
+    }
+}
 
 /// Change Data Capture operation types for BigQuery streaming.
 #[derive(Debug)]
@@ -188,8 +359,97 @@ fn format_retryable_storage_write_requests(requests: &[RetryableAppendRequest]) 
 }
 
 /// Creates a per-batch BigQuery trace identifier for Storage Write requests.
-fn create_append_trace_id(pipeline_id: PipelineId, table_id: &str, batch_index: usize) -> String {
+pub(super) fn create_append_trace_id(
+    pipeline_id: PipelineId,
+    table_id: &str,
+    batch_index: usize,
+) -> String {
     format!("supabase_etl_{pipeline_id}_{table_id}_{batch_index}_{}", random::<u32>())
+}
+
+/// Creates an authenticated gRPC request with Bearer token authorization.
+async fn new_authorized_storage_request<T>(
+    auth: Arc<dyn Authenticator>,
+    message: T,
+) -> Result<Request<T>, BQError> {
+    let bearer_token = format!("Bearer {}", auth.access_token().await?);
+    let bearer_value = bearer_token.as_str().try_into()?;
+
+    let mut request = Request::new(message);
+    request.metadata_mut().insert("authorization", bearer_value);
+
+    Ok(request)
+}
+
+/// Creates a configured gRPC client for BigQuery Storage Write API.
+async fn create_storage_grpc_client() -> Result<BigQueryWriteClient<Channel>, BQError> {
+    let tls_config =
+        ClientTlsConfig::new().domain_name(BIGQUERY_STORAGE_API_DOMAIN).with_enabled_roots();
+
+    let channel = Channel::from_static(BIG_QUERY_STORAGE_API_URL)
+        .tls_config(tls_config)?
+        .http2_keep_alive_interval(Duration::from_secs(STORAGE_WRITE_HTTP2_KEEPALIVE_INTERVAL_SECS))
+        .keep_alive_timeout(Duration::from_secs(STORAGE_WRITE_HTTP2_KEEPALIVE_TIMEOUT_SECS))
+        .keep_alive_while_idle(true)
+        .connect()
+        .await?;
+
+    Ok(BigQueryWriteClient::new(channel)
+        .max_encoding_message_size(STORAGE_WRITE_MAX_MESSAGE_SIZE_BYTES)
+        .max_decoding_message_size(STORAGE_WRITE_MAX_MESSAGE_SIZE_BYTES)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip))
+}
+
+/// Returns true when a committed-stream append status can be retried locally.
+fn is_retryable_committed_stream_status(status: &Status) -> bool {
+    matches!(
+        status.code(),
+        Code::Aborted | Code::Internal | Code::ResourceExhausted | Code::Unavailable
+    )
+}
+
+/// Returns true when a committed-stream response error can be retried locally.
+fn is_retryable_committed_stream_response_status(status: &GoogleRpcStatus) -> bool {
+    matches!(
+        Code::from_i32(status.code),
+        Code::Aborted | Code::Internal | Code::ResourceExhausted | Code::Unavailable
+    )
+}
+
+/// Returns true when BigQuery has already accepted the rows at this offset.
+fn is_committed_stream_already_exists(status: &GoogleRpcStatus) -> bool {
+    Code::from_i32(status.code) == Code::AlreadyExists
+}
+
+/// Converts a committed-stream append response error into an ETL error.
+fn committed_stream_response_error_to_etl_error(status: &GoogleRpcStatus) -> EtlError {
+    etl_error!(
+        ErrorKind::DestinationError,
+        "BigQuery committed stream append failed",
+        format!(
+            "BigQuery returned gRPC code {} while appending with an explicit offset",
+            status.code
+        )
+    )
+}
+
+/// Converts a committed-stream transport status into an ETL error.
+fn committed_stream_status_to_etl_error(status: Status) -> EtlError {
+    let kind = if is_retryable_committed_stream_status(&status) {
+        ErrorKind::DestinationAtomicBatchRetryable
+    } else {
+        ErrorKind::DestinationError
+    };
+
+    etl_error!(
+        kind,
+        "BigQuery committed stream append failed",
+        format!(
+            "BigQuery Storage Write API returned {} while appending with an explicit offset",
+            status.code()
+        )
+    )
 }
 
 /// Computes the maximum number of inflight requests for the BigQuery Storage
@@ -384,13 +644,11 @@ fn bq_error_to_etl_error(err: BQError) -> EtlError {
             (ErrorKind::DestinationAuthenticationError, "BigQuery authentication token missing")
         }
 
-        // Network and transport errors
         BQError::RequestError(_) => (ErrorKind::DestinationIoError, "BigQuery request failed"),
         BQError::TonicTransportError(_) => {
             (ErrorKind::DestinationIoError, "BigQuery transport error")
         }
 
-        // Query and data errors
         BQError::ResponseError { .. } => {
             (ErrorKind::DestinationQueryFailed, "BigQuery response error")
         }
@@ -407,103 +665,41 @@ fn bq_error_to_etl_error(err: BQError) -> EtlError {
             (ErrorKind::ConversionError, "BigQuery column type mismatch")
         }
 
-        // Serialization errors
         BQError::SerializationError(_) => {
             (ErrorKind::SerializationError, "BigQuery JSON serialization error")
         }
 
-        // gRPC errors
         BQError::TonicInvalidMetadataValueError(_) => {
             (ErrorKind::InvalidData, "BigQuery invalid metadata value")
         }
         BQError::TonicStatusError(status) => match status.code() {
-            // Code::Unavailable (14) - Canonical "service unavailable" code.
-            // Indicates transient conditions like network issues, server overload, or intentional
-            // throttling. BigQuery returns this with messages like "Task is overloaded".
-            // Retriable per Google's Storage Write API guidance.
             Code::Unavailable => (ErrorKind::DestinationError, "BigQuery unavailable"),
-
-            // Code::Internal (13) - Internal server errors.
-            // In BigQuery context, often manifests as transient backend issues, GOAWAY frames,
-            // or temporary processing failures. Retriable per BigQuery backend team guidance.
             Code::Internal => (ErrorKind::DestinationError, "BigQuery internal error"),
-
-            // Code::Aborted (10) - Concurrency conflicts or server-initiated aborts.
-            // For Storage Write API, includes sequencer failures and stream aborts due to
-            // transient conditions. Retriable per BigQuery backend team guidance.
             Code::Aborted => (ErrorKind::DestinationError, "BigQuery operation aborted"),
-
-            // Code::Cancelled (1) - Server-cancelled operations.
-            // In streaming context, server may cancel in-flight appends due to internal
-            // reshuffling. Retriable per BigQuery backend team guidance.
             Code::Cancelled => (ErrorKind::DestinationError, "BigQuery operation cancelled"),
-
-            // Code::DeadlineExceeded (4) - Operation timeout.
-            // Request may or may not have completed server-side. Safe to retry with offset-based
-            // deduplication in Storage Write API. Retriable per Google's guidance.
             Code::DeadlineExceeded => (ErrorKind::DestinationError, "BigQuery deadline exceeded"),
-
-            // Code::ResourceExhausted (8) - Quota or rate limit exhaustion.
-            // Requires exponential backoff to allow server capacity recovery. Retriable per
-            // Google's Storage Write API guidance, though may need longer backoff periods.
             Code::ResourceExhausted => (ErrorKind::DestinationError, "BigQuery resource exhausted"),
-
-            // Code::FailedPrecondition (9) - Precondition failures.
-            // Indicates issues like STREAM_FINALIZED, INVALID_STREAM_STATE, or SCHEMA_MISMATCH.
-            // Requires fixing the underlying issue before retrying. Never retry automatically.
             Code::FailedPrecondition => {
                 (ErrorKind::DestinationError, "BigQuery precondition failed")
             }
-
-            // Code::Unknown (2) - Transport-level errors.
-            // When message contains "transport" or "connection", indicates errors that never
-            // reached the server (TCP resets, HTTP/2 GOAWAY). Retriable as per transport error
-            // guidance.
             Code::Unknown => (ErrorKind::DestinationError, "BigQuery unknown error"),
-
-            // Code::PermissionDenied (7) - Authorization failure.
-            // Requires IAM permission changes. Never retry.
             Code::PermissionDenied => (ErrorKind::DestinationError, "BigQuery permission denied"),
-
-            // Code::Unauthenticated (16) - Authentication failure.
-            // Requires credential refresh or configuration fix. Never retry.
             Code::Unauthenticated => {
                 (ErrorKind::DestinationError, "BigQuery authentication failed")
             }
-
-            // Code::InvalidArgument (3) - Malformed request or invalid data.
-            // Client bug that requires code changes. Never retry.
             Code::InvalidArgument => (ErrorKind::DestinationError, "BigQuery invalid argument"),
-
-            // Code::NotFound (5) - Resource doesn't exist.
-            // Requires creating the resource (table, dataset, stream) first. Never retry.
             Code::NotFound => (ErrorKind::DestinationTableMissing, "BigQuery entity not found"),
-
-            // Code::AlreadyExists (6) - Entity conflict during creation.
-            // For streaming with offsets, may indicate row was already written. Never retry.
             Code::AlreadyExists => {
                 (ErrorKind::DestinationTableAlreadyExists, "BigQuery entity already exists")
             }
-
-            // Code::OutOfRange (11) - Invalid offset for streaming.
-            // Offset beyond current stream end. Requires application-level recovery. Never retry.
             Code::OutOfRange => (ErrorKind::DestinationError, "BigQuery offset out of range"),
-
-            // Code::Unimplemented (12) - Operation not available.
-            // Feature not supported by BigQuery. Never retry.
             Code::Unimplemented => {
                 (ErrorKind::DestinationError, "BigQuery operation not supported")
             }
-
-            // Code::DataLoss (15) - Unrecoverable data corruption.
-            // Severe error requiring manual intervention. Never retry.
             Code::DataLoss => (ErrorKind::DestinationError, "BigQuery data loss"),
-
-            // Code::Ok (0) - Should never be an error
             Code::Ok => (ErrorKind::DestinationError, "BigQuery unexpected ok status"),
         },
 
-        // Concurrency and task errors
         BQError::SemaphorePermitError(_) => {
             (ErrorKind::DestinationError, "BigQuery semaphore permit error")
         }
@@ -648,6 +844,8 @@ async fn retryable_storage_write_error_detail(
 pub struct BigQueryClient {
     project_id: BigQueryProjectId,
     client: Client,
+    auth: Arc<dyn Authenticator>,
+    storage_write_client: BigQueryWriteClient<Channel>,
 }
 
 impl BigQueryClient {
@@ -663,14 +861,25 @@ impl BigQueryClient {
     ) -> EtlResult<BigQueryClient> {
         let max_inflight_requests = compute_max_inflight_requests(connection_pool_size);
         let storage_config = StorageApiConfig { connection_pool_size, max_inflight_requests };
-
-        let client = ClientBuilder::new()
-            .with_storage_config(storage_config)
-            .build_from_service_account_key_file(sa_key_file)
+        let scopes = [BIG_QUERY_AUTH_URL];
+        let service_account_key =
+            gcp_bigquery_client::yup_oauth2::read_service_account_key(sa_key_file)
+                .await
+                .map_err(BQError::from)
+                .map_err(bq_error_to_etl_error)?;
+        let auth = BigQueryAuthenticator::from_service_account_key(service_account_key, &scopes)
             .await
             .map_err(bq_error_to_etl_error)?;
 
-        Ok(BigQueryClient { project_id, client })
+        let client = ClientBuilder::new()
+            .with_storage_config(storage_config)
+            .build_from_authenticator(auth.clone())
+            .await
+            .map_err(bq_error_to_etl_error)?;
+        let storage_write_client =
+            create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
+
+        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
     }
 
     /// Creates a new [`BigQueryClient`] from a service account key JSON string.
@@ -684,17 +893,23 @@ impl BigQueryClient {
     ) -> EtlResult<BigQueryClient> {
         let max_inflight_requests = compute_max_inflight_requests(connection_pool_size);
         let storage_config = StorageApiConfig { connection_pool_size, max_inflight_requests };
+        let scopes = [BIG_QUERY_AUTH_URL];
 
         let sa_key = parse_service_account_key(sa_key)
             .map_err(BQError::from)
             .map_err(bq_error_to_etl_error)?;
-        let client = ClientBuilder::new()
-            .with_storage_config(storage_config)
-            .build_from_service_account_key(sa_key, false)
+        let auth = BigQueryAuthenticator::from_service_account_key(sa_key, &scopes)
             .await
             .map_err(bq_error_to_etl_error)?;
+        let client = ClientBuilder::new()
+            .with_storage_config(storage_config)
+            .build_from_authenticator(auth.clone())
+            .await
+            .map_err(bq_error_to_etl_error)?;
+        let storage_write_client =
+            create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
 
-        Ok(BigQueryClient { project_id, client })
+        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
     }
 
     /// Creates a new [`BigQueryClient`] using Application Default Credentials.
@@ -708,14 +923,20 @@ impl BigQueryClient {
     ) -> EtlResult<BigQueryClient> {
         let max_inflight_requests = compute_max_inflight_requests(connection_pool_size);
         let storage_config = StorageApiConfig { connection_pool_size, max_inflight_requests };
-
-        let client = ClientBuilder::new()
-            .with_storage_config(storage_config)
-            .build_from_application_default_credentials()
+        let scopes = [BIG_QUERY_AUTH_URL];
+        let auth = BigQueryAuthenticator::from_application_default_credentials(&scopes)
             .await
             .map_err(bq_error_to_etl_error)?;
 
-        Ok(BigQueryClient { project_id, client })
+        let client = ClientBuilder::new()
+            .with_storage_config(storage_config)
+            .build_from_authenticator(auth.clone())
+            .await
+            .map_err(bq_error_to_etl_error)?;
+        let storage_write_client =
+            create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
+
+        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
     }
 
     /// Creates a new [`BigQueryClient`] using OAuth2 installed flow
@@ -731,14 +952,21 @@ impl BigQueryClient {
     ) -> EtlResult<BigQueryClient> {
         let max_inflight_requests = compute_max_inflight_requests(connection_pool_size);
         let storage_config = StorageApiConfig { connection_pool_size, max_inflight_requests };
+        let scopes = [BIG_QUERY_AUTH_URL];
+        let auth =
+            BigQueryAuthenticator::from_installed_flow(secret, &scopes, persistent_file_path)
+                .await
+                .map_err(bq_error_to_etl_error)?;
 
         let client = ClientBuilder::new()
             .with_storage_config(storage_config)
-            .build_from_installed_flow_authenticator(secret, persistent_file_path)
+            .build_from_authenticator(auth.clone())
             .await
             .map_err(bq_error_to_etl_error)?;
+        let storage_write_client =
+            create_storage_grpc_client().await.map_err(bq_error_to_etl_error)?;
 
-        Ok(BigQueryClient { project_id, client })
+        Ok(BigQueryClient { project_id, client, auth, storage_write_client })
     }
 
     /// Returns the fully qualified BigQuery table name.
@@ -816,6 +1044,22 @@ impl BigQueryClient {
         Ok(true)
     }
 
+    /// Creates an append-only history table if it doesn't exist.
+    pub async fn create_append_only_table_if_missing(
+        &self,
+        dataset_id: &BigQueryDatasetId,
+        table_id: &BigQueryTableId,
+        replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<bool> {
+        if self.table_exists(dataset_id, table_id).await? {
+            return Ok(false);
+        }
+
+        self.create_append_only_table(dataset_id, table_id, replicated_table_schema).await?;
+
+        Ok(true)
+    }
+
     /// Creates a new table in the BigQuery dataset.
     ///
     /// Builds and executes a CREATE TABLE statement with the provided column
@@ -839,6 +1083,25 @@ impl BigQueryClient {
         info!(%full_table_name, "creating table in bigquery");
 
         let query = format!("create table {full_table_name} {columns_spec} {max_staleness_option}");
+
+        let _ = self.query(QueryRequest::new(query)).await?;
+
+        Ok(())
+    }
+
+    /// Creates an append-only history table in BigQuery.
+    pub async fn create_append_only_table(
+        &self,
+        dataset_id: &BigQueryDatasetId,
+        table_id: &BigQueryTableId,
+        replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()> {
+        let full_table_name = self.full_table_name(dataset_id, table_id)?;
+        let columns_spec = create_append_only_columns_spec(replicated_table_schema)?;
+
+        info!(%full_table_name, "creating append-only table in bigquery");
+
+        let query = format!("create table {full_table_name} {columns_spec}");
 
         let _ = self.query(QueryRequest::new(query)).await?;
 
@@ -1131,6 +1394,208 @@ impl BigQueryClient {
         }
     }
 
+    /// Creates an explicitly-created committed Storage Write stream.
+    pub(super) async fn create_committed_write_stream(
+        &self,
+        dataset_id: &BigQueryDatasetId,
+        table_id: &BigQueryTableId,
+    ) -> EtlResult<String> {
+        let parent =
+            format!("projects/{}/datasets/{dataset_id}/tables/{table_id}", self.project_id);
+        let request = CreateWriteStreamRequest {
+            parent: parent.clone(),
+            write_stream: Some(WriteStream {
+                name: String::new(),
+                r#type: write_stream::Type::Committed as i32,
+                create_time: None,
+                commit_time: None,
+                table_schema: None,
+                write_mode: write_stream::WriteMode::Insert as i32,
+                location: String::new(),
+            }),
+        };
+
+        let request = new_authorized_storage_request(self.auth.clone(), request)
+            .await
+            .map_err(bq_error_to_etl_error)?;
+        let mut grpc_client = self.storage_write_client.clone();
+        let write_stream = grpc_client
+            .create_write_stream(request)
+            .await
+            .map_err(|status| committed_stream_status_to_etl_error(status))?
+            .into_inner();
+
+        Ok(write_stream.name)
+    }
+
+    /// Appends rows to a committed stream using explicit offsets.
+    pub(super) async fn append_committed_stream_rows(
+        &self,
+        stream_name: &str,
+        table_descriptor: TableDescriptor,
+        rows: &[BigQueryTableRow],
+        start_offset: i64,
+        trace_id: String,
+    ) -> EtlResult<(usize, usize)> {
+        if rows.is_empty() {
+            return Ok((0, 0));
+        }
+
+        let mut current_index = 0;
+        let mut current_offset = start_offset;
+        let mut total_bytes_sent = 0;
+        let mut total_bytes_received = 0;
+
+        while current_index < rows.len() {
+            let (encoded_rows, processed_count) = StorageApi::create_rows(
+                &table_descriptor,
+                &rows[current_index..],
+                MAX_BATCH_SIZE_BYTES,
+            );
+            if processed_count == 0 {
+                return Err(etl_error!(
+                    ErrorKind::DestinationError,
+                    "BigQuery committed stream row is too large",
+                    "A single encoded row exceeded the Storage Write API request size limit"
+                ));
+            }
+
+            let request = AppendRowsRequest {
+                write_stream: stream_name.to_owned(),
+                offset: Some(current_offset),
+                trace_id: trace_id.clone(),
+                missing_value_interpretations: HashMap::new(),
+                default_missing_value_interpretation:
+                    append_rows_request::MissingValueInterpretation::Unspecified as i32,
+                rows: Some(encoded_rows),
+            };
+            let request_bytes = request.encoded_len();
+
+            let response_bytes = retry_with_backoff(
+                COMMITTED_STREAM_RETRY_POLICY,
+                |err: &EtlError| {
+                    if err.kind() == ErrorKind::DestinationAtomicBatchRetryable {
+                        RetryDecision::Retry
+                    } else {
+                        RetryDecision::Stop
+                    }
+                },
+                storage_write_retry_delay_with_jitter,
+                |attempt| {
+                    warn!(
+                        retry_index = attempt.retry_index,
+                        max_retries = attempt.max_retries,
+                        sleep_ms = attempt.sleep_delay.as_millis(),
+                        error = %attempt.error,
+                        "retrying retryable bigquery committed stream append error"
+                    );
+                },
+                || {
+                    let request = request.clone();
+                    async move {
+                        self.append_committed_stream_request(stream_name, request, current_offset)
+                            .await
+                    }
+                },
+            )
+            .await
+            .map_err(|failure| failure.last_error)?;
+
+            total_bytes_sent += request_bytes;
+            total_bytes_received += response_bytes;
+            current_index += processed_count;
+            current_offset += processed_count as i64;
+        }
+
+        Ok((total_bytes_sent, total_bytes_received))
+    }
+
+    async fn append_committed_stream_request(
+        &self,
+        stream_name: &str,
+        request: AppendRowsRequest,
+        expected_offset: i64,
+    ) -> EtlResult<usize> {
+        let request =
+            new_authorized_storage_request(self.auth.clone(), tokio_stream::iter(vec![request]))
+                .await
+                .map_err(bq_error_to_etl_error)?;
+        let mut grpc_client = self.storage_write_client.clone();
+        let mut responses = grpc_client
+            .append_rows(request)
+            .await
+            .map_err(committed_stream_status_to_etl_error)?
+            .into_inner();
+
+        let response = responses
+            .message()
+            .await
+            .map_err(committed_stream_status_to_etl_error)?
+            .ok_or_else(|| {
+                etl_error!(
+                    ErrorKind::DestinationAtomicBatchRetryable,
+                    "BigQuery committed stream append returned no response",
+                    "Storage Write API closed the append stream before acknowledging the request"
+                )
+            })?;
+        let response_bytes = response.encoded_len();
+
+        if !response.row_errors.is_empty() {
+            return Err(row_error_to_etl_error(response.row_errors[0].clone()));
+        }
+
+        match response.response {
+            Some(append_rows_response::Response::AppendResult(result)) => {
+                if let Some(offset) = result.offset
+                    && offset != expected_offset
+                {
+                    return Err(etl_error!(
+                        ErrorKind::DestinationError,
+                        "BigQuery committed stream append returned an unexpected offset",
+                        format!(
+                            "Expected offset {expected_offset} for stream {stream_name}, got {offset}"
+                        )
+                    ));
+                }
+
+                Ok(response_bytes)
+            }
+            Some(append_rows_response::Response::Error(status))
+                if is_committed_stream_already_exists(&status) =>
+            {
+                Err(etl_error!(
+                    ErrorKind::DestinationError,
+                    "BigQuery committed stream append overlapped an existing offset",
+                    format!(
+                        "BigQuery reported ALREADY_EXISTS for stream {stream_name} at offset \
+                         {expected_offset}; refusing to treat the request as successful because \
+                         replay batch boundaries may not match the original append"
+                    )
+                ))
+            }
+            Some(append_rows_response::Response::Error(status))
+                if is_retryable_committed_stream_response_status(&status) =>
+            {
+                Err(etl_error!(
+                    ErrorKind::DestinationAtomicBatchRetryable,
+                    "BigQuery committed stream append returned a retryable error",
+                    format!(
+                        "BigQuery returned gRPC code {} for stream {stream_name} at offset {expected_offset}",
+                        status.code
+                    )
+                ))
+            }
+            Some(append_rows_response::Response::Error(status)) => {
+                Err(committed_stream_response_error_to_etl_error(&status))
+            }
+            None => Err(etl_error!(
+                ErrorKind::DestinationAtomicBatchRetryable,
+                "BigQuery committed stream append returned an empty response",
+                "Storage Write API did not include an append result or error"
+            )),
+        }
+    }
+
     /// Appends table batches to BigQuery using the concurrent Storage Write
     /// API.
     ///
@@ -1367,8 +1832,8 @@ impl BigQueryClient {
 
     /// Creates a batch append request for a specific table with validated rows.
     ///
-    /// Converts TableRow instances to BigQueryTableRow and creates a properly
-    /// configured [`BigQueryAppendRequest`] for efficient append retries.
+    /// Creates a properly configured [`BigQueryAppendRequest`] for efficient
+    /// append retries.
     pub(super) fn create_batch_append_request(
         &self,
         pipeline_id: PipelineId,

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -432,6 +432,10 @@ fn is_committed_stream_already_exists(status: &GoogleRpcStatus) -> bool {
     Code::from_i32(status.code) == Code::AlreadyExists
 }
 
+fn committed_stream_already_exists_is_success(attempt_count: u32) -> bool {
+    attempt_count > 1
+}
+
 /// Converts a committed-stream append response error into an ETL error.
 fn committed_stream_response_error_to_etl_error(status: &GoogleRpcStatus) -> EtlError {
     etl_error!(
@@ -1536,10 +1540,22 @@ impl BigQueryClient {
                     "retrying retryable bigquery committed stream append error"
                 );
             },
-            || {
-                let request = request.clone();
-                async move {
-                    self.append_committed_stream_request(stream_name, request, start_offset).await
+            {
+                let mut attempt_count = 0_u32;
+                move || {
+                    attempt_count = attempt_count.saturating_add(1);
+                    let already_exists_is_success =
+                        committed_stream_already_exists_is_success(attempt_count);
+                    let request = request.clone();
+                    async move {
+                        self.append_committed_stream_request(
+                            stream_name,
+                            request,
+                            start_offset,
+                            already_exists_is_success,
+                        )
+                        .await
+                    }
                 }
             },
         )
@@ -1554,6 +1570,7 @@ impl BigQueryClient {
         stream_name: &str,
         request: AppendRowsRequest,
         expected_offset: i64,
+        already_exists_is_success: bool,
     ) -> EtlResult<usize> {
         let _permit = self
             .committed_stream_append_permits
@@ -1614,6 +1631,15 @@ impl BigQueryClient {
             Some(append_rows_response::Response::Error(status))
                 if is_committed_stream_already_exists(&status) =>
             {
+                if already_exists_is_success {
+                    warn!(
+                        stream_name,
+                        expected_offset,
+                        "treating BigQuery committed stream ALREADY_EXISTS as success for retried append request"
+                    );
+                    return Ok(response_bytes);
+                }
+
                 Err(etl_error!(
                     ErrorKind::DestinationError,
                     "BigQuery committed stream append overlapped an existing offset",
@@ -1963,6 +1989,13 @@ mod tests {
     fn committed_stream_max_inflight_uses_connection_pool_size_as_proactive_limit() {
         assert_eq!(compute_committed_stream_max_inflight_requests(0), 1);
         assert_eq!(compute_committed_stream_max_inflight_requests(3), 3);
+    }
+
+    #[test]
+    fn committed_stream_already_exists_only_succeeds_on_retry_attempts() {
+        assert!(!committed_stream_already_exists_is_success(0));
+        assert!(!committed_stream_already_exists_is_success(1));
+        assert!(committed_stream_already_exists_is_success(2));
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -415,7 +415,14 @@ async fn create_storage_grpc_client() -> Result<BigQueryWriteClient<Channel>, BQ
 fn is_retryable_committed_stream_status(status: &Status) -> bool {
     matches!(
         status.code(),
-        Code::Aborted | Code::Internal | Code::ResourceExhausted | Code::Unavailable
+        // BigQuery can briefly return INVALID_ARGUMENT for explicit committed
+        // stream appends created immediately after a table schema change while
+        // the Storage Write schema metadata catches up with the DDL.
+        Code::Aborted
+            | Code::Internal
+            | Code::InvalidArgument
+            | Code::ResourceExhausted
+            | Code::Unavailable
     )
 }
 
@@ -423,7 +430,13 @@ fn is_retryable_committed_stream_status(status: &Status) -> bool {
 fn is_retryable_committed_stream_response_status(status: &GoogleRpcStatus) -> bool {
     matches!(
         Code::from_i32(status.code),
-        Code::Aborted | Code::Internal | Code::ResourceExhausted | Code::Unavailable
+        // See `is_retryable_committed_stream_status` for why INVALID_ARGUMENT
+        // is retried on committed stream append responses.
+        Code::Aborted
+            | Code::Internal
+            | Code::InvalidArgument
+            | Code::ResourceExhausted
+            | Code::Unavailable
     )
 }
 
@@ -1996,6 +2009,18 @@ mod tests {
         assert!(!committed_stream_already_exists_is_success(0));
         assert!(!committed_stream_already_exists_is_success(1));
         assert!(committed_stream_already_exists_is_success(2));
+    }
+
+    #[test]
+    fn committed_stream_invalid_argument_is_retryable() {
+        assert!(is_retryable_committed_stream_status(&Status::invalid_argument(
+            "schema metadata is not ready"
+        )));
+        assert!(is_retryable_committed_stream_response_status(&GoogleRpcStatus {
+            code: Code::InvalidArgument as i32,
+            message: "schema metadata is not ready".to_owned(),
+            details: Vec::new(),
+        }));
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fmt, path::PathBuf, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    path::PathBuf,
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use etl::{
@@ -66,7 +71,10 @@ use crate::{
             create_append_only_columns_spec, create_columns_spec, default_expression_sql,
             postgres_to_bigquery_type,
         },
-        sql::{quote_identifier, quote_information_schema_tables_path, quote_table_path},
+        sql::{
+            quote_identifier, quote_information_schema_columns_path,
+            quote_information_schema_tables_path, quote_table_path,
+        },
     },
     retry::{RetryDecision, RetryPolicy, retry_with_backoff},
 };
@@ -1309,6 +1317,47 @@ impl BigQueryClient {
         }
 
         Ok(table_ids)
+    }
+
+    /// Lists column names for a physical BigQuery table.
+    pub async fn list_table_column_names(
+        &self,
+        dataset_id: &BigQueryDatasetId,
+        table_id: &BigQueryTableId,
+    ) -> EtlResult<HashSet<String>> {
+        info!(%dataset_id, %table_id, "listing table columns from bigquery");
+
+        let information_schema_columns =
+            quote_information_schema_columns_path(&self.project_id, dataset_id)?;
+        let query = format!(
+            "select column_name from {information_schema_columns} where table_name = @table_name"
+        );
+        let mut request = QueryRequest::new(query);
+        request.parameter_mode = Some("NAMED".to_owned());
+        request.query_parameters = Some(vec![QueryParameter {
+            name: Some("table_name".to_owned()),
+            parameter_type: Some(QueryParameterType {
+                r#type: "STRING".to_owned(),
+                ..Default::default()
+            }),
+            parameter_value: Some(QueryParameterValue {
+                value: Some(table_id.clone()),
+                ..Default::default()
+            }),
+        }]);
+
+        let mut result_set = self.query(request).await?;
+        let mut column_names = HashSet::new();
+
+        while result_set.next_row() {
+            if let Some(column_name) =
+                result_set.get_string_by_name("column_name").map_err(bq_error_to_etl_error)?
+            {
+                column_names.insert(column_name);
+            }
+        }
+
+        Ok(column_names)
     }
 
     /// Adds a column to an existing BigQuery table.

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -34,9 +34,9 @@ use crate::{
     bigquery::{
         BigQueryDatasetId, BigQueryTableId,
         append_only::{
-            AppendOnlyChangeType, append_only_backfill_timestamp, append_only_copy_metadata,
-            append_only_delete_old_row, append_only_event_metadata, append_only_row,
-            append_only_schema_columns_to_add, append_only_update_rows,
+            AppendOnlyChangeType, AppendOnlyTableRow, append_only_backfill_timestamp,
+            append_only_copy_metadata, append_only_delete_old_row, append_only_event_metadata,
+            append_only_schema_columns_to_add, append_only_tracked_row, append_only_update_rows,
         },
         client::{BigQueryClient, BigQueryOperationType, create_append_trace_id},
         encoding::BigQueryTableRow,
@@ -817,7 +817,7 @@ where
                     source_timestamp,
                     copy_ordinal,
                 );
-                append_only_row(
+                append_only_tracked_row(
                     replicated_table_schema,
                     table_row,
                     AppendOnlyChangeType::Insert,
@@ -1460,8 +1460,10 @@ where
 
     /// Writes CDC events as append-only history rows.
     async fn write_append_only_events(&self, events: Vec<Event>) -> EtlResult<()> {
-        let mut table_id_to_data: HashMap<TableId, (ReplicatedTableSchema, Vec<BigQueryTableRow>)> =
-            HashMap::new();
+        let mut table_id_to_data: HashMap<
+            TableId,
+            (ReplicatedTableSchema, Vec<AppendOnlyTableRow>),
+        > = HashMap::new();
         let mut current_source_timestamp = self
             .inner
             .lock()
@@ -1486,7 +1488,7 @@ where
                         BIGQUERY_SEQUENCE_ORDINAL_FIRST,
                         current_source_timestamp,
                     );
-                    let row = append_only_row(
+                    let row = append_only_tracked_row(
                         &insert.replicated_table_schema,
                         insert.table_row,
                         AppendOnlyChangeType::Insert,
@@ -1522,7 +1524,7 @@ where
                         &delete.replicated_table_schema,
                         delete.old_table_row,
                     )?;
-                    let row = append_only_row(
+                    let row = append_only_tracked_row(
                         &delete.replicated_table_schema,
                         old_table_row,
                         AppendOnlyChangeType::Delete,
@@ -1556,7 +1558,7 @@ where
     /// Flushes accumulated append-only rows.
     async fn flush_append_only_rows(
         &self,
-        table_id_to_data: &mut HashMap<TableId, (ReplicatedTableSchema, Vec<BigQueryTableRow>)>,
+        table_id_to_data: &mut HashMap<TableId, (ReplicatedTableSchema, Vec<AppendOnlyTableRow>)>,
     ) -> EtlResult<()> {
         for (_, (replicated_table_schema, rows)) in std::mem::take(table_id_to_data) {
             let sequenced_bigquery_table_id =
@@ -1577,7 +1579,7 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         sequenced_bigquery_table_id: &SequencedBigQueryTableId,
-        rows: Vec<BigQueryTableRow>,
+        rows: Vec<AppendOnlyTableRow>,
     ) -> EtlResult<()> {
         if rows.is_empty() {
             return Ok(());
@@ -1640,12 +1642,18 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         sequenced_bigquery_table_id: &SequencedBigQueryTableId,
-        rows: Vec<BigQueryTableRow>,
+        rows: Vec<AppendOnlyTableRow>,
         stream_state: DestinationWriteStreamState,
     ) -> EtlResult<()> {
         let table_descriptor = append_only_table_descriptor(replicated_table_schema);
-        let target_batches = calculate_target_batches_for_table_copy(&rows)?;
-        let row_batches = split_table_rows(rows, target_batches);
+        let rows =
+            append_only_rows_after_sequence(rows, stream_state.last_sequence_number.as_deref());
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let target_batches = calculate_target_batches_for_append_only(&rows)?;
+        let row_batches = split_append_only_rows(rows, target_batches);
         let sequenced_bigquery_table_id_string = sequenced_bigquery_table_id.to_string();
         let mut next_offset = stream_state.next_offset;
         let stream_name = stream_state.stream_name.clone();
@@ -1661,30 +1669,35 @@ where
                 &sequenced_bigquery_table_id_string,
                 batch_index,
             );
-            let _ = self
-                .client
-                .append_committed_stream_rows(
-                    &stream_name,
-                    table_descriptor.clone(),
-                    &rows,
-                    next_offset,
-                    trace_id,
-                )
-                .await?;
+            let (table_rows, sequence_numbers): (Vec<_>, Vec<_>) =
+                rows.into_iter().map(AppendOnlyTableRow::into_parts).unzip();
+            let mut current_index = 0;
+            while current_index < table_rows.len() {
+                let append_result = self
+                    .client
+                    .append_committed_stream_rows(
+                        &stream_name,
+                        table_descriptor.clone(),
+                        &table_rows[current_index..],
+                        next_offset,
+                        trace_id.clone(),
+                    )
+                    .await?;
+                let _ = (append_result.bytes_sent, append_result.bytes_received);
+                let appended_row_count = append_result.row_count;
+                let last_sequence_number =
+                    sequence_numbers[current_index + appended_row_count - 1].clone();
 
-            next_offset += rows.len() as i64;
+                next_offset += appended_row_count as i64;
+                self.state_store
+                    .store_destination_write_stream_state(
+                        replicated_table_schema.id(),
+                        stream_state.advanced_to(next_offset, last_sequence_number),
+                    )
+                    .await?;
+                current_index += appended_row_count;
+            }
         }
-
-        self.state_store
-            .store_destination_write_stream_state(
-                replicated_table_schema.id(),
-                DestinationWriteStreamState::new(
-                    sequenced_bigquery_table_id_string,
-                    stream_name,
-                    next_offset,
-                ),
-            )
-            .await?;
 
         Ok(())
     }
@@ -2366,6 +2379,26 @@ fn calculate_target_batches_for_table_copy(table_rows: &[BigQueryTableRow]) -> E
     Ok(target_batches)
 }
 
+fn calculate_target_batches_for_append_only(table_rows: &[AppendOnlyTableRow]) -> EtlResult<usize> {
+    let Some(encoded_row) = table_rows.first() else {
+        return Ok(0);
+    };
+    let total_rows = table_rows.len();
+    let estimated_row_size = encoded_row.row().encoded_len();
+    let rows_per_batch = MAX_BATCH_SIZE_BYTES.checked_div(estimated_row_size).unwrap_or(total_rows);
+    let target_batches = if rows_per_batch > 0 { total_rows.div_ceil(rows_per_batch) } else { 1 };
+
+    debug!(
+        total_rows,
+        estimated_row_size,
+        rows_per_batch,
+        target_batches,
+        "calculated target batches for append-only writes"
+    );
+
+    Ok(target_batches)
+}
+
 /// Splits table rows into optimal sub-batches for parallel execution.
 ///
 /// Calculates the optimal distribution of rows across batches to produce the
@@ -2409,6 +2442,53 @@ fn split_table_rows(
     batches
 }
 
+fn split_append_only_rows(
+    table_rows: Vec<AppendOnlyTableRow>,
+    target_batches: usize,
+) -> Vec<Vec<AppendOnlyTableRow>> {
+    let total_rows = table_rows.len();
+
+    if total_rows == 0 {
+        return vec![];
+    }
+
+    if total_rows <= 1 || target_batches == 1 || total_rows <= target_batches {
+        return vec![table_rows];
+    }
+
+    let optimal_rows_per_batch = total_rows.div_ceil(target_batches);
+
+    if optimal_rows_per_batch == 0 {
+        return vec![table_rows];
+    }
+
+    let num_sub_batches = total_rows.div_ceil(optimal_rows_per_batch);
+    let rows_per_sub_batch = total_rows / num_sub_batches;
+    let extra_rows = total_rows % num_sub_batches;
+
+    let mut batches = Vec::with_capacity(num_sub_batches);
+    let mut remaining = table_rows;
+    for i in 0..num_sub_batches {
+        let batch_size = rows_per_sub_batch + if i < extra_rows { 1 } else { 0 };
+        let rest = remaining.split_off(batch_size);
+        batches.push(remaining);
+        remaining = rest;
+    }
+
+    batches
+}
+
+fn append_only_rows_after_sequence(
+    rows: Vec<AppendOnlyTableRow>,
+    last_sequence_number: Option<&str>,
+) -> Vec<AppendOnlyTableRow> {
+    let Some(last_sequence_number) = last_sequence_number else {
+        return rows;
+    };
+
+    rows.into_iter().filter(|row| row.sequence_number() > last_sequence_number).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -2421,7 +2501,7 @@ mod tests {
     };
     use prost::Message;
 
-    use super::super::append_only::append_only_sequence_number;
+    use super::super::append_only::{append_only_row, append_only_sequence_number};
     use super::*;
 
     fn replicated_schema(identity_type: IdentityType) -> ReplicatedTableSchema {
@@ -3052,6 +3132,47 @@ mod tests {
     }
 
     #[test]
+    fn append_only_rows_after_sequence_skips_already_durable_rows() {
+        let rows = vec![
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+            ),
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000001/0000000000000000/0000000000000001".to_owned(),
+            ),
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000002/0000000000000000/0000000000000000".to_owned(),
+            ),
+        ];
+
+        let result = append_only_rows_after_sequence(
+            rows,
+            Some("0000000000000001/0000000000000000/0000000000000001"),
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].sequence_number(),
+            "0000000000000002/0000000000000000/0000000000000000"
+        );
+    }
+
+    #[test]
+    fn append_only_rows_after_sequence_keeps_all_rows_without_watermark() {
+        let rows = vec![AppendOnlyTableRow::new(
+            BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+            "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+        )];
+
+        let result = append_only_rows_after_sequence(rows, None);
+
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
     fn calculate_target_batches_empty_rows() {
         let rows: Vec<BigQueryTableRow> = vec![];
         let result = calculate_target_batches_for_table_copy(&rows).unwrap();
@@ -3260,7 +3381,7 @@ mod tests {
 
         assert_eq!(rows.len(), 2);
         assert_eq!(
-            rows[0].debug_cells(),
+            rows[0].row().debug_cells(),
             vec![
                 (1, CellNonOptional::I32(1)),
                 (2, CellNonOptional::String("before".to_owned())),
@@ -3289,7 +3410,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            rows[1].debug_cells(),
+            rows[1].row().debug_cells(),
             vec![
                 (1, CellNonOptional::I32(2)),
                 (2, CellNonOptional::String("after".to_owned())),
@@ -3339,7 +3460,7 @@ mod tests {
 
         assert_eq!(rows.len(), 2);
         assert_eq!(
-            rows[0].debug_cells(),
+            rows[0].row().debug_cells(),
             vec![
                 (1, CellNonOptional::I32(1)),
                 (2, CellNonOptional::Null),
@@ -3368,7 +3489,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            rows[1].debug_cells(),
+            rows[1].row().debug_cells(),
             vec![
                 (1, CellNonOptional::I32(2)),
                 (2, CellNonOptional::String("after".to_owned())),

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -18,7 +18,8 @@ use etl::{
     event::{Event, EventSequenceKey},
     pipeline::PipelineId,
     schema::{
-        ColumnModification, IdentityType, ReplicatedTableSchema, SchemaDiff, TableId, TableName,
+        ColumnModification, ColumnSchema, IdentityType, ReplicatedTableSchema, SchemaDiff, TableId,
+        TableName,
     },
     store::DestinationStore,
 };
@@ -42,8 +43,10 @@ use crate::{
         encoding::BigQueryTableRow,
         metrics::{ETL_BQ_APPEND_BATCHES_BATCH_SIZE, register_metrics},
         schema::{
-            append_only_table_descriptor, column_schemas_to_table_descriptor,
-            supports_column_default,
+            APPEND_ONLY_CHANGE_SEQUENCE_NUMBER_COLUMN, APPEND_ONLY_CHANGE_TYPE_COLUMN,
+            APPEND_ONLY_SORT_KEYS_COLUMN, APPEND_ONLY_SOURCE_TIMESTAMP_COLUMN,
+            APPEND_ONLY_UUID_COLUMN, append_only_table_descriptor,
+            column_schemas_to_table_descriptor, supports_column_default,
         },
     },
     table_name::try_stringify_table_name,
@@ -484,10 +487,21 @@ where
         // created, the inserts will fail because the table will be missing and
         // won't be created.
         if !inner.created_tables.contains(&sequenced_bigquery_table_id) {
+            let destination_table_id = sequenced_bigquery_table_id.to_string();
+            let table_exists =
+                self.client.table_exists(&self.dataset_id, &destination_table_id).await?;
+            if table_exists {
+                self.validate_existing_table_write_mode(
+                    &sequenced_bigquery_table_id,
+                    BigQueryWriteMode::CurrentState,
+                )
+                .await?;
+            }
+
             // Create metadata with applying status. For new tables, this is the initial
             // insert. For existing tables, this updates the status.
             let metadata = DestinationTableMetadata::new_applying(
-                sequenced_bigquery_table_id.to_string(),
+                destination_table_id.clone(),
                 snapshot_id,
                 replication_mask.clone(),
             );
@@ -495,14 +509,22 @@ where
             // Store or update metadata before creating the table.
             self.state_store.store_destination_table_metadata(table_id, metadata.clone()).await?;
 
-            self.client
+            let table_was_created = self
+                .client
                 .create_table_if_missing(
                     &self.dataset_id,
-                    &sequenced_bigquery_table_id.to_string(),
+                    &destination_table_id,
                     replicated_table_schema,
                     self.max_staleness_mins,
                 )
                 .await?;
+            if !table_was_created && !table_exists {
+                self.validate_existing_table_write_mode(
+                    &sequenced_bigquery_table_id,
+                    BigQueryWriteMode::CurrentState,
+                )
+                .await?;
+            }
 
             // Mark as applied after successful table creation.
             self.state_store
@@ -561,20 +583,39 @@ where
         };
 
         if !inner.created_tables.contains(&sequenced_bigquery_table_id) {
+            let destination_table_id = sequenced_bigquery_table_id.to_string();
+            let table_exists =
+                self.client.table_exists(&self.dataset_id, &destination_table_id).await?;
+            if table_exists {
+                self.validate_existing_table_write_mode(
+                    &sequenced_bigquery_table_id,
+                    BigQueryWriteMode::AppendOnly,
+                )
+                .await?;
+            }
+
             let metadata = DestinationTableMetadata::new_applying(
-                sequenced_bigquery_table_id.to_string(),
+                destination_table_id.clone(),
                 snapshot_id,
                 replication_mask,
             );
             self.state_store.store_destination_table_metadata(table_id, metadata.clone()).await?;
 
-            self.client
+            let table_was_created = self
+                .client
                 .create_append_only_table_if_missing(
                     &self.dataset_id,
-                    &sequenced_bigquery_table_id.to_string(),
+                    &destination_table_id,
                     replicated_table_schema,
                 )
                 .await?;
+            if !table_was_created && !table_exists {
+                self.validate_existing_table_write_mode(
+                    &sequenced_bigquery_table_id,
+                    BigQueryWriteMode::AppendOnly,
+                )
+                .await?;
+            }
 
             self.state_store
                 .store_destination_table_metadata(table_id, metadata.to_applied())
@@ -590,6 +631,18 @@ where
         .await?;
 
         Ok(sequenced_bigquery_table_id)
+    }
+
+    async fn validate_existing_table_write_mode(
+        &self,
+        sequenced_bigquery_table_id: &SequencedBigQueryTableId,
+        expected_write_mode: BigQueryWriteMode,
+    ) -> EtlResult<()> {
+        let destination_table_id = sequenced_bigquery_table_id.to_string();
+        let column_names =
+            self.client.list_table_column_names(&self.dataset_id, &destination_table_id).await?;
+
+        ensure_existing_table_write_mode(&destination_table_id, &column_names, expected_write_mode)
     }
 
     /// Adds a table to the creation cache to avoid redundant existence checks.
@@ -1261,7 +1314,14 @@ where
             return Ok(());
         }
 
-        for column in append_only_schema_columns_to_add(diff) {
+        let existing_column_names = self
+            .client
+            .list_table_column_names(&self.dataset_id, &sequenced_bigquery_table_id.to_string())
+            .await?;
+
+        for column in
+            append_only_schema_columns_to_add_for_existing_columns(diff, &existing_column_names)
+        {
             self.client
                 .add_column(&self.dataset_id, &sequenced_bigquery_table_id.to_string(), column)
                 .await?;
@@ -1965,6 +2025,59 @@ fn validate_bigquery_table_shape(replicated_table_schema: &ReplicatedTableSchema
     }
 
     Ok(())
+}
+
+fn append_only_metadata_column_names() -> [&'static str; 5] {
+    [
+        APPEND_ONLY_UUID_COLUMN,
+        APPEND_ONLY_SOURCE_TIMESTAMP_COLUMN,
+        APPEND_ONLY_CHANGE_SEQUENCE_NUMBER_COLUMN,
+        APPEND_ONLY_CHANGE_TYPE_COLUMN,
+        APPEND_ONLY_SORT_KEYS_COLUMN,
+    ]
+}
+
+fn table_has_append_only_metadata_columns(column_names: &HashSet<String>) -> bool {
+    append_only_metadata_column_names()
+        .into_iter()
+        .all(|column_name| column_names.contains(column_name))
+}
+
+fn ensure_existing_table_write_mode(
+    destination_table_id: &str,
+    column_names: &HashSet<String>,
+    expected_write_mode: BigQueryWriteMode,
+) -> EtlResult<()> {
+    let existing_write_mode = if table_has_append_only_metadata_columns(column_names) {
+        BigQueryWriteMode::AppendOnly
+    } else {
+        BigQueryWriteMode::CurrentState
+    };
+
+    if existing_write_mode != expected_write_mode {
+        bail!(
+            ErrorKind::InvalidState,
+            "BigQuery write mode changed for existing destination table",
+            format!(
+                "Table '{destination_table_id}' was created for {:?} writes but the destination \
+                 is configured for {:?} writes. Recreate or reset the destination table before \
+                 changing BigQuery write mode.",
+                existing_write_mode, expected_write_mode
+            )
+        );
+    }
+
+    Ok(())
+}
+
+fn append_only_schema_columns_to_add_for_existing_columns<'a>(
+    diff: &'a SchemaDiff,
+    existing_column_names: &HashSet<String>,
+) -> Vec<&'a ColumnSchema> {
+    append_only_schema_columns_to_add(diff)
+        .into_iter()
+        .filter(|column| !existing_column_names.contains(&column.name))
+        .collect()
 }
 
 impl<S> Destination for BigQueryDestination<S>
@@ -2965,6 +3078,72 @@ mod tests {
     }
 
     #[test]
+    fn append_only_schema_columns_to_add_for_existing_columns_skips_preserved_column_names() {
+        let added_column = ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true);
+        let new_name_column = ColumnSchema::new("display_name".to_owned(), Type::TEXT, -1, 3, true);
+        let diff = SchemaDiff {
+            columns_to_add: vec![added_column],
+            columns_to_remove: vec![],
+            columns_to_change: vec![etl::schema::ColumnChange {
+                ordinal_position: 3,
+                old_column: ColumnSchema::new(
+                    "old_display_name".to_owned(),
+                    Type::TEXT,
+                    -1,
+                    3,
+                    true,
+                ),
+                new_column: new_name_column,
+                modifications: vec![ColumnModification::Rename {
+                    old_name: "old_display_name".to_owned(),
+                    new_name: "display_name".to_owned(),
+                }],
+            }],
+        };
+        let existing_columns = std::collections::HashSet::from(["name".to_owned()]);
+
+        let columns =
+            append_only_schema_columns_to_add_for_existing_columns(&diff, &existing_columns)
+                .into_iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>();
+
+        assert_eq!(columns, vec!["display_name"]);
+    }
+
+    #[test]
+    fn ensure_existing_table_write_mode_rejects_current_state_config_for_append_only_table() {
+        let column_names = std::collections::HashSet::from(
+            append_only_metadata_column_names().map(std::string::ToString::to_string),
+        );
+
+        let error = ensure_existing_table_write_mode(
+            "public_users_0",
+            &column_names,
+            BigQueryWriteMode::CurrentState,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidState);
+        assert!(error.to_string().contains("BigQuery write mode changed"));
+    }
+
+    #[test]
+    fn ensure_existing_table_write_mode_rejects_append_only_config_for_current_state_table() {
+        let column_names = std::collections::HashSet::from(["id".to_owned(), "name".to_owned()]);
+
+        let error = ensure_existing_table_write_mode(
+            "public_users_0",
+            &column_names,
+            BigQueryWriteMode::AppendOnly,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidState);
+        assert!(error.to_string().contains("BigQuery write mode changed"));
+    }
+
+    #[test]
     fn validate_bigquery_table_shape_accepts_alternative_identity() {
         let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
 
@@ -3703,6 +3882,19 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn append_only_delete_key_row_uses_replica_identity_columns() {
+        let replicated_table_schema = replicated_schema(IdentityType::AlternativeKey);
+
+        let old_table_row = append_only_delete_old_row(
+            &replicated_table_schema,
+            Some(OldTableRow::Key(TableRow::new(vec![Cell::String("alice".to_owned())]))),
+        )
+        .unwrap();
+
+        assert_eq!(old_table_row.values(), &[Cell::Null, Cell::String("alice".to_owned())]);
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -2576,6 +2576,19 @@ mod tests {
         ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask)
     }
 
+    fn replicated_schema_without_primary_key() -> ReplicatedTableSchema {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_owned(), "users".to_owned()),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false),
+                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+            ],
+        ));
+
+        ReplicatedTableSchema::all(table_schema)
+    }
+
     #[test]
     fn table_name_to_bigquery_table_id_no_underscores() {
         let table_name = TableName::new("schema".to_owned(), "table".to_owned());
@@ -2845,15 +2858,39 @@ mod tests {
         assert_eq!(metadata.uuid, changed_non_key_metadata.uuid);
         assert_eq!(metadata.change_sequence_number, same_metadata.change_sequence_number);
         assert_ne!(metadata.uuid, different_metadata.uuid);
-        assert_ne!(metadata.uuid, same_row_different_copy_ordinal.uuid);
+        assert_eq!(metadata.uuid, same_row_different_copy_ordinal.uuid);
         assert_eq!(metadata.source_timestamp, source_timestamp);
+        assert!(metadata.change_sequence_number.starts_with("0000000000000000/0000000000000000/"));
         assert_eq!(
             metadata.sort_keys,
             vec![
                 "0000000000000000".to_owned(),
-                "0000000000000000/0000000000000000/0000000000000000".to_owned(),
+                metadata.change_sequence_number.clone(),
                 metadata.uuid.clone(),
             ]
+        );
+    }
+
+    #[test]
+    fn append_only_copy_metadata_preserves_duplicate_rows_without_primary_key() {
+        let replicated_table_schema = replicated_schema_without_primary_key();
+        let source_timestamp = 42;
+        let table_row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+        let same_table_row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+
+        let metadata =
+            append_only_copy_metadata(&replicated_table_schema, &table_row, source_timestamp, 0);
+        let same_row_different_copy_ordinal = append_only_copy_metadata(
+            &replicated_table_schema,
+            &same_table_row,
+            source_timestamp,
+            1,
+        );
+
+        assert_ne!(metadata.uuid, same_row_different_copy_ordinal.uuid);
+        assert_ne!(
+            metadata.change_sequence_number,
+            same_row_different_copy_ordinal.change_sequence_number
         );
     }
 

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -857,6 +857,13 @@ where
         self.write_table_rows(replicated_table_schema, table_rows).await
     }
 
+    /// Writes streaming replication events through the destination write path in
+    /// tests.
+    #[cfg(feature = "test-utils")]
+    pub async fn write_events_for_tests(&self, events: Vec<Event>) -> EtlResult<()> {
+        self.write_events(events).await
+    }
+
     /// Handles a schema change event (Relation) by computing the diff and
     /// applying changes.
     ///
@@ -2521,7 +2528,23 @@ fn append_only_rows_after_sequence(
         return rows;
     };
 
+    if is_append_only_copy_sequence_number(last_sequence_number) {
+        if let Some(last_sequence_index) =
+            rows.iter().position(|row| row.sequence_number() == last_sequence_number)
+        {
+            return rows.into_iter().skip(last_sequence_index + 1).collect();
+        }
+
+        if rows.iter().all(|row| is_append_only_copy_sequence_number(row.sequence_number())) {
+            return rows;
+        }
+    }
+
     rows.into_iter().filter(|row| row.sequence_number() > last_sequence_number).collect()
+}
+
+fn is_append_only_copy_sequence_number(sequence_number: &str) -> bool {
+    sequence_number.starts_with("0000000000000000/0000000000000000/")
 }
 
 #[cfg(test)]
@@ -3229,6 +3252,56 @@ mod tests {
         assert_eq!(
             result[0].sequence_number(),
             "0000000000000002/0000000000000000/0000000000000000"
+        );
+    }
+
+    #[test]
+    fn append_only_copy_rows_after_sequence_keeps_new_copy_chunk() {
+        let rows = vec![
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000000/0000000000000000/0000000000000001".to_owned(),
+            ),
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000000/0000000000000000/1111111111111111".to_owned(),
+            ),
+        ];
+
+        let result = append_only_rows_after_sequence(
+            rows,
+            Some("0000000000000000/0000000000000000/ffffffffffffffff"),
+        );
+
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn append_only_copy_rows_after_sequence_skips_replayed_copy_prefix() {
+        let rows = vec![
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000000/0000000000000000/aaaaaaaaaaaaaaaa".to_owned(),
+            ),
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000000/0000000000000000/ffffffffffffffff".to_owned(),
+            ),
+            AppendOnlyTableRow::new(
+                BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+                "0000000000000000/0000000000000000/0000000000000001".to_owned(),
+            ),
+        ];
+
+        let result = append_only_rows_after_sequence(
+            rows,
+            Some("0000000000000000/0000000000000000/ffffffffffffffff"),
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].sequence_number(),
+            "0000000000000000/0000000000000000/0000000000000001"
         );
     }
 

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1048,6 +1048,10 @@ where
             current_replication_mask.clone(),
         );
         let sequenced_bigquery_table_id = metadata.destination_table_id.parse()?;
+        let previous_stream_state = self
+            .state_store
+            .get_destination_write_stream_state(table_id, metadata.destination_table_id.clone())
+            .await?;
         let table_lock = self.append_only_table_lock(&sequenced_bigquery_table_id).await;
         let _guard = table_lock.lock().await;
 
@@ -1079,9 +1083,12 @@ where
 
         let bigquery_table_id = sequenced_bigquery_table_id.to_bigquery_table_id();
         self.recreate_view_for_table(&bigquery_table_id, &sequenced_bigquery_table_id).await?;
-        self.state_store
-            .delete_destination_write_stream_state(table_id, metadata.destination_table_id.clone())
-            .await?;
+        self.rotate_append_only_write_stream_state(
+            table_id,
+            &sequenced_bigquery_table_id,
+            previous_stream_state,
+        )
+        .await?;
         self.state_store
             .store_destination_table_metadata(table_id, updated_metadata.to_applied())
             .await?;
@@ -1636,6 +1643,34 @@ where
         self.state_store.store_destination_write_stream_state(table_id, state.clone()).await?;
 
         Ok(state)
+    }
+
+    async fn rotate_append_only_write_stream_state(
+        &self,
+        table_id: TableId,
+        sequenced_bigquery_table_id: &SequencedBigQueryTableId,
+        previous_state: Option<DestinationWriteStreamState>,
+    ) -> EtlResult<()> {
+        let destination_table_id = sequenced_bigquery_table_id.to_string();
+        let stream_name = self
+            .client
+            .create_committed_write_stream(&self.dataset_id, &destination_table_id)
+            .await?;
+        let next_state = DestinationWriteStreamState::new(destination_table_id, stream_name, 0);
+
+        if let Some(previous_state) = previous_state {
+            let next_state =
+                next_state.with_last_sequence_number(previous_state.last_sequence_number.clone());
+            self.state_store
+                .replace_destination_write_stream_state(
+                    table_id,
+                    previous_state.stream_name,
+                    next_state,
+                )
+                .await
+        } else {
+            self.state_store.store_destination_write_stream_state(table_id, next_state).await
+        }
     }
 
     async fn append_append_only_rows_with_state(

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -10,7 +10,8 @@ use etl::{
     data::{Cell, OldTableRow, TableRow, UpdatedTableRow},
     destination::{
         Destination, DestinationTableMetadata, DestinationTableSchemaStatus,
-        DropTableForCopyResult, TaskSet, WriteEventsResult, WriteTableRowsResult,
+        DestinationWriteStreamState, DropTableForCopyResult, TaskSet, WriteEventsResult,
+        WriteTableRowsResult,
     },
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
@@ -32,10 +33,18 @@ use crate::egress::{PROCESSING_TYPE_STREAMING, PROCESSING_TYPE_TABLE_COPY, log_p
 use crate::{
     bigquery::{
         BigQueryDatasetId, BigQueryTableId,
-        client::{BigQueryClient, BigQueryOperationType},
+        append_only::{
+            AppendOnlyChangeType, append_only_backfill_timestamp, append_only_copy_metadata,
+            append_only_delete_old_row, append_only_event_metadata, append_only_row,
+            append_only_schema_columns_to_add, append_only_update_rows,
+        },
+        client::{BigQueryClient, BigQueryOperationType, create_append_trace_id},
         encoding::BigQueryTableRow,
         metrics::{ETL_BQ_APPEND_BATCHES_BATCH_SIZE, register_metrics},
-        schema::{column_schemas_to_table_descriptor, supports_column_default},
+        schema::{
+            append_only_table_descriptor, column_schemas_to_table_descriptor,
+            supports_column_default,
+        },
     },
     table_name::try_stringify_table_name,
 };
@@ -44,6 +53,19 @@ use crate::{
 const BIGQUERY_SEQUENCE_ORDINAL_FIRST: u64 = 0;
 /// Internal CDC sequence ordinal for generated upserts after generated deletes.
 const BIGQUERY_SEQUENCE_ORDINAL_SECOND: u64 = 1;
+/// Fallback source timestamp used by tests and paths that do not carry a source
+/// timestamp.
+const APPEND_ONLY_UNKNOWN_SOURCE_TIMESTAMP: i64 = 0;
+
+/// BigQuery destination write mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BigQueryWriteMode {
+    /// Maintain a current-state table with BigQuery CDC.
+    #[default]
+    CurrentState,
+    /// Preserve source changes as append-only history rows.
+    AppendOnly,
+}
 
 /// Returns the [`BigQueryTableId`] for a supplied [`TableName`].
 ///
@@ -195,16 +217,30 @@ struct Inner {
     /// # Example
     /// `{ users_table: users_table_10, orders_table: orders_table_3 }`
     created_views: HashMap<BigQueryTableId, SequencedBigQueryTableId>,
+    /// Source timestamp for the currently open append-only transaction.
+    ///
+    /// Huge transactions may be flushed to the destination before the commit
+    /// event arrives, so this cannot be kept only in `write_append_only_events`
+    /// local state.
+    current_append_only_source_timestamp: Option<i64>,
+    /// Per physical append-only table locks used to serialize explicit stream
+    /// offsets without blocking unrelated tables.
+    append_only_table_locks: HashMap<String, Arc<Mutex<()>>>,
 }
 
 impl Inner {
     /// Creates empty synchronized destination state.
     fn new() -> Self {
-        Self { created_tables: HashSet::new(), created_views: HashMap::new() }
+        Self {
+            created_tables: HashSet::new(),
+            created_views: HashMap::new(),
+            current_append_only_source_timestamp: None,
+            append_only_table_locks: HashMap::new(),
+        }
     }
 
     /// Clears cached state for a destination table.
-    fn clear_table_cache(&mut self, base_table_id: &BigQueryTableId) {
+    fn clear_table_cache(&mut self, _table_id: TableId, base_table_id: &BigQueryTableId) {
         self.created_views.remove(base_table_id);
         self.created_tables.retain(|table_id| !table_id.belongs_to_base(base_table_id));
     }
@@ -224,6 +260,7 @@ pub struct BigQueryDestination<S> {
     client: BigQueryClient,
     dataset_id: BigQueryDatasetId,
     max_staleness_mins: Option<u16>,
+    write_mode: BigQueryWriteMode,
     pipeline_id: PipelineId,
     state_store: S,
     inner: Arc<Mutex<Inner>>,
@@ -253,6 +290,7 @@ where
             client,
             dataset_id,
             max_staleness_mins,
+            write_mode: BigQueryWriteMode::CurrentState,
             pipeline_id,
             state_store,
             inner: Arc::new(Mutex::new(Inner::new())),
@@ -285,6 +323,7 @@ where
             client,
             dataset_id,
             max_staleness_mins,
+            write_mode: BigQueryWriteMode::CurrentState,
             pipeline_id,
             state_store,
             inner: Arc::new(Mutex::new(Inner::new())),
@@ -316,6 +355,7 @@ where
             client,
             dataset_id,
             max_staleness_mins,
+            write_mode: BigQueryWriteMode::CurrentState,
             pipeline_id,
             state_store,
             inner: Arc::new(Mutex::new(Inner::new())),
@@ -345,6 +385,7 @@ where
             client,
             dataset_id,
             max_staleness_mins,
+            write_mode: BigQueryWriteMode::CurrentState,
             pipeline_id,
             state_store,
             inner: Arc::new(Mutex::new(Inner::new())),
@@ -388,11 +429,18 @@ where
             client,
             dataset_id,
             max_staleness_mins,
+            write_mode: BigQueryWriteMode::CurrentState,
             pipeline_id,
             state_store: store,
             inner: Arc::new(Mutex::new(Inner::new())),
             tasks: TaskSet::new(),
         })
+    }
+
+    /// Returns a copy of this destination with a different write mode.
+    pub fn with_write_mode(mut self, write_mode: BigQueryWriteMode) -> Self {
+        self.write_mode = write_mode;
+        self
     }
 
     /// Prepares a table for BigQuery writes with schema-aware table creation.
@@ -491,6 +539,57 @@ where
             column_schemas_to_table_descriptor(replicated_table_schema, use_cdc_sequence_column);
 
         Ok((sequenced_bigquery_table_id, table_descriptor))
+    }
+
+    /// Prepares a table for append-only history writes.
+    async fn prepare_table_for_append_only(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<SequencedBigQueryTableId> {
+        let mut inner = self.inner.lock().await;
+
+        let table_id = replicated_table_schema.id();
+        let bigquery_table_id = table_name_to_bigquery_table_id(replicated_table_schema.name())?;
+        let snapshot_id = replicated_table_schema.inner().snapshot_id;
+        let replication_mask = replicated_table_schema.replication_mask().clone();
+
+        let existing_metadata =
+            self.state_store.get_applied_destination_table_metadata(table_id).await?;
+        let sequenced_bigquery_table_id = match &existing_metadata {
+            Some(metadata) => metadata.destination_table_id.parse()?,
+            None => SequencedBigQueryTableId::new(bigquery_table_id.clone()),
+        };
+
+        if !inner.created_tables.contains(&sequenced_bigquery_table_id) {
+            let metadata = DestinationTableMetadata::new_applying(
+                sequenced_bigquery_table_id.to_string(),
+                snapshot_id,
+                replication_mask,
+            );
+            self.state_store.store_destination_table_metadata(table_id, metadata.clone()).await?;
+
+            self.client
+                .create_append_only_table_if_missing(
+                    &self.dataset_id,
+                    &sequenced_bigquery_table_id.to_string(),
+                    replicated_table_schema,
+                )
+                .await?;
+
+            self.state_store
+                .store_destination_table_metadata(table_id, metadata.to_applied())
+                .await?;
+            Self::add_to_created_tables_cache(&mut inner, &sequenced_bigquery_table_id);
+        }
+
+        self.ensure_view_points_to_table(
+            &mut inner,
+            &bigquery_table_id,
+            &sequenced_bigquery_table_id,
+        )
+        .await?;
+
+        Ok(sequenced_bigquery_table_id)
     }
 
     /// Adds a table to the creation cache to avoid redundant existence checks.
@@ -602,6 +701,16 @@ where
         replicated_table_schema: &ReplicatedTableSchema,
         mut table_rows: Vec<TableRow>,
     ) -> EtlResult<()> {
+        if self.write_mode == BigQueryWriteMode::AppendOnly {
+            return self
+                .write_append_only_table_rows(
+                    replicated_table_schema,
+                    table_rows,
+                    append_only_backfill_timestamp()?,
+                )
+                .await;
+        }
+
         // Prepare table for streaming.
         let (sequenced_bigquery_table_id, table_descriptor) =
             self.prepare_table_for_streaming(replicated_table_schema, false).await?;
@@ -657,6 +766,85 @@ where
         }
 
         Ok(())
+    }
+
+    /// Writes table-copy rows as append-only inserts.
+    async fn write_append_only_table_rows(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+        table_rows: Vec<TableRow>,
+        source_timestamp: i64,
+    ) -> EtlResult<()> {
+        let sequenced_bigquery_table_id =
+            self.prepare_table_for_append_only(replicated_table_schema).await?;
+        if table_rows.is_empty() {
+            return Ok(());
+        }
+
+        let table_lock = self.append_only_table_lock(&sequenced_bigquery_table_id).await;
+        let _guard = table_lock.lock().await;
+        let stream_state = self
+            .ensure_append_only_write_stream_state(
+                replicated_table_schema.id(),
+                &sequenced_bigquery_table_id,
+            )
+            .await?;
+        let copy_base_offset = u64::try_from(stream_state.next_offset).map_err(|_| {
+            etl_error!(
+                ErrorKind::InvalidState,
+                "Append-only write stream state has a negative offset",
+                format!(
+                    "Destination table '{}' has invalid next_offset {}",
+                    stream_state.destination_table_id, stream_state.next_offset
+                )
+            )
+        })?;
+        let rows = table_rows
+            .into_iter()
+            .enumerate()
+            .map(|(row_index, table_row)| {
+                let copy_ordinal =
+                    copy_base_offset.checked_add(row_index as u64).ok_or_else(|| {
+                        etl_error!(
+                            ErrorKind::InvalidState,
+                            "Append-only copy ordinal exceeded supported range",
+                            "Initial-copy row offset overflowed"
+                        )
+                    })?;
+                let metadata = append_only_copy_metadata(
+                    replicated_table_schema,
+                    &table_row,
+                    source_timestamp,
+                    copy_ordinal,
+                );
+                append_only_row(
+                    replicated_table_schema,
+                    table_row,
+                    AppendOnlyChangeType::Insert,
+                    metadata,
+                )
+            })
+            .collect::<EtlResult<Vec<_>>>()?;
+
+        self.append_append_only_rows_with_state(
+            replicated_table_schema,
+            &sequenced_bigquery_table_id,
+            rows,
+            stream_state,
+        )
+        .await
+    }
+
+    async fn append_only_table_lock(
+        &self,
+        sequenced_bigquery_table_id: &SequencedBigQueryTableId,
+    ) -> Arc<Mutex<()>> {
+        let mut inner = self.inner.lock().await;
+        inner
+            .append_only_table_locks
+            .entry(sequenced_bigquery_table_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
     }
 
     /// Writes table-copy rows through the destination write path in tests.
@@ -812,6 +1000,95 @@ where
         Ok(())
     }
 
+    /// Handles a schema change event for append-only history tables.
+    async fn handle_append_only_relation_event(
+        &self,
+        new_replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()> {
+        let table_id = new_replicated_table_schema.id();
+        let new_snapshot_id = new_replicated_table_schema.inner().snapshot_id;
+
+        let Some(metadata) =
+            self.state_store.get_applied_destination_table_metadata(table_id).await?
+        else {
+            self.prepare_table_for_append_only(new_replicated_table_schema).await?;
+            return Ok(());
+        };
+
+        let current_snapshot_id = metadata.snapshot_id;
+        let current_replication_mask = metadata.replication_mask.clone();
+        let new_replication_mask = new_replicated_table_schema.replication_mask().clone();
+        if current_snapshot_id == new_snapshot_id
+            && current_replication_mask == new_replication_mask
+        {
+            info!(
+                "append-only schema for table {} unchanged (snapshot_id: {}, replication_mask: {})",
+                table_id, new_snapshot_id, new_replication_mask
+            );
+
+            return Ok(());
+        }
+
+        let current_table_schema =
+            self.state_store.get_table_schema(&table_id, current_snapshot_id).await?.ok_or_else(
+                || {
+                    etl_error!(
+                        ErrorKind::InvalidState,
+                        "Stored schema snapshot missing for BigQuery append-only schema change",
+                        format!(
+                            "Table {} needs stored schema snapshot {} to compare with incoming \
+                             snapshot {}, but it was not found.",
+                            table_id, current_snapshot_id, new_snapshot_id
+                        )
+                    )
+                },
+            )?;
+        let current_schema = ReplicatedTableSchema::from_mask(
+            current_table_schema,
+            current_replication_mask.clone(),
+        );
+        let sequenced_bigquery_table_id = metadata.destination_table_id.parse()?;
+        let table_lock = self.append_only_table_lock(&sequenced_bigquery_table_id).await;
+        let _guard = table_lock.lock().await;
+
+        let updated_metadata = DestinationTableMetadata::new_applied(
+            metadata.destination_table_id.clone(),
+            current_snapshot_id,
+            current_replication_mask.clone(),
+        )
+        .with_schema_change(
+            new_snapshot_id,
+            new_replication_mask.clone(),
+            DestinationTableSchemaStatus::Applying,
+        );
+        self.state_store
+            .store_destination_table_metadata(table_id, updated_metadata.clone())
+            .await?;
+
+        let diff = current_schema.diff(new_replicated_table_schema);
+        if let Err(err) =
+            self.apply_append_only_schema_diff(&table_id, &sequenced_bigquery_table_id, &diff).await
+        {
+            warn!(
+                "append-only schema change failed for table {}: {}. Manual intervention may be \
+                 required.",
+                table_id, err
+            );
+            return Err(err);
+        }
+
+        let bigquery_table_id = sequenced_bigquery_table_id.to_bigquery_table_id();
+        self.recreate_view_for_table(&bigquery_table_id, &sequenced_bigquery_table_id).await?;
+        self.state_store
+            .delete_destination_write_stream_state(table_id, metadata.destination_table_id.clone())
+            .await?;
+        self.state_store
+            .store_destination_table_metadata(table_id, updated_metadata.to_applied())
+            .await?;
+
+        Ok(())
+    }
+
     /// Applies a schema diff to the BigQuery table.
     ///
     /// Executes the necessary DDL operations (ADD COLUMN, DROP COLUMN, RENAME
@@ -958,6 +1235,58 @@ where
         Ok(())
     }
 
+    /// Applies a schema diff to an append-only BigQuery history table.
+    async fn apply_append_only_schema_diff(
+        &self,
+        table_id: &TableId,
+        sequenced_bigquery_table_id: &SequencedBigQueryTableId,
+        diff: &SchemaDiff,
+    ) -> EtlResult<()> {
+        if diff.is_empty() {
+            debug!(%table_id, "no append-only schema changes to apply for table");
+            return Ok(());
+        }
+
+        for column in append_only_schema_columns_to_add(diff) {
+            self.client
+                .add_column(&self.dataset_id, &sequenced_bigquery_table_id.to_string(), column)
+                .await?;
+        }
+
+        for change in &diff.columns_to_change {
+            for modification in &change.modifications {
+                match modification {
+                    ColumnModification::Rename { old_name, new_name } => {
+                        debug!(
+                            table_id = %table_id,
+                            old_column_name = %old_name,
+                            new_column_name = %new_name,
+                            "preserving renamed append-only source column and writing future rows \
+                             to the added column"
+                        );
+                    }
+                    ColumnModification::Default { .. } | ColumnModification::Nullability { .. } => {
+                        debug!(
+                            table_id = %table_id,
+                            column_name = %change.new_column.name,
+                            "skipping source column constraint change for append-only BigQuery table"
+                        );
+                    }
+                }
+            }
+        }
+
+        for column in &diff.columns_to_remove {
+            debug!(
+                table_id = %table_id,
+                column_name = %column.name,
+                "preserving removed source column in append-only BigQuery history table"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Processes CDC events in batches with proper ordering and truncate
     /// handling.
     ///
@@ -966,6 +1295,10 @@ where
     /// creating new versioned tables. Uses the schema from the first event
     /// of each table for table creation and descriptor building.
     async fn write_events(&self, events: Vec<Event>) -> EtlResult<()> {
+        if self.write_mode == BigQueryWriteMode::AppendOnly {
+            return self.write_append_only_events(events).await;
+        }
+
         let mut events_iter = events.into_iter().peekable();
 
         while events_iter.peek().is_some() {
@@ -1121,6 +1454,237 @@ where
                 self.process_truncate_for_schemas(truncate_schemas.into_values()).await?;
             }
         }
+
+        Ok(())
+    }
+
+    /// Writes CDC events as append-only history rows.
+    async fn write_append_only_events(&self, events: Vec<Event>) -> EtlResult<()> {
+        let mut table_id_to_data: HashMap<TableId, (ReplicatedTableSchema, Vec<BigQueryTableRow>)> =
+            HashMap::new();
+        let mut current_source_timestamp = self
+            .inner
+            .lock()
+            .await
+            .current_append_only_source_timestamp
+            .unwrap_or(APPEND_ONLY_UNKNOWN_SOURCE_TIMESTAMP);
+
+        for event in events {
+            match event {
+                Event::Begin(begin) => {
+                    current_source_timestamp = begin.timestamp;
+                    self.inner.lock().await.current_append_only_source_timestamp =
+                        Some(begin.timestamp);
+                }
+                Event::Commit(_) => {
+                    current_source_timestamp = APPEND_ONLY_UNKNOWN_SOURCE_TIMESTAMP;
+                    self.inner.lock().await.current_append_only_source_timestamp = None;
+                }
+                Event::Insert(insert) => {
+                    let metadata = append_only_event_metadata(
+                        insert.event_sequence_key(),
+                        BIGQUERY_SEQUENCE_ORDINAL_FIRST,
+                        current_source_timestamp,
+                    );
+                    let row = append_only_row(
+                        &insert.replicated_table_schema,
+                        insert.table_row,
+                        AppendOnlyChangeType::Insert,
+                        metadata,
+                    )?;
+                    let table_id = insert.replicated_table_schema.id();
+                    let entry = table_id_to_data
+                        .entry(table_id)
+                        .or_insert_with(|| (insert.replicated_table_schema.clone(), Vec::new()));
+                    entry.1.push(row);
+                }
+                Event::Update(update) => {
+                    let sequence_key = update.event_sequence_key();
+                    let table_id = update.replicated_table_schema.id();
+                    let entry = table_id_to_data
+                        .entry(table_id)
+                        .or_insert_with(|| (update.replicated_table_schema.clone(), Vec::new()));
+                    entry.1.extend(append_only_update_rows(
+                        &update.replicated_table_schema,
+                        update.old_table_row,
+                        update.updated_table_row,
+                        sequence_key,
+                        current_source_timestamp,
+                    )?);
+                }
+                Event::Delete(delete) => {
+                    let metadata = append_only_event_metadata(
+                        delete.event_sequence_key(),
+                        BIGQUERY_SEQUENCE_ORDINAL_FIRST,
+                        current_source_timestamp,
+                    );
+                    let old_table_row = append_only_delete_old_row(
+                        &delete.replicated_table_schema,
+                        delete.old_table_row,
+                    )?;
+                    let row = append_only_row(
+                        &delete.replicated_table_schema,
+                        old_table_row,
+                        AppendOnlyChangeType::Delete,
+                        metadata,
+                    )?;
+                    let table_id = delete.replicated_table_schema.id();
+                    let entry = table_id_to_data
+                        .entry(table_id)
+                        .or_insert_with(|| (delete.replicated_table_schema.clone(), Vec::new()));
+                    entry.1.push(row);
+                }
+                Event::Relation(relation) => {
+                    self.flush_append_only_rows(&mut table_id_to_data).await?;
+                    self.handle_append_only_relation_event(&relation.replicated_table_schema)
+                        .await?;
+                }
+                Event::Truncate(_) => {
+                    self.flush_append_only_rows(&mut table_id_to_data).await?;
+                }
+                event => {
+                    debug!(event_type = %event.event_type(), "skipping unsupported event type");
+                }
+            }
+        }
+
+        self.flush_append_only_rows(&mut table_id_to_data).await?;
+
+        Ok(())
+    }
+
+    /// Flushes accumulated append-only rows.
+    async fn flush_append_only_rows(
+        &self,
+        table_id_to_data: &mut HashMap<TableId, (ReplicatedTableSchema, Vec<BigQueryTableRow>)>,
+    ) -> EtlResult<()> {
+        for (_, (replicated_table_schema, rows)) in std::mem::take(table_id_to_data) {
+            let sequenced_bigquery_table_id =
+                self.prepare_table_for_append_only(&replicated_table_schema).await?;
+            self.append_append_only_rows(
+                &replicated_table_schema,
+                &sequenced_bigquery_table_id,
+                rows,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Appends append-only history rows through the BigQuery Storage Write API.
+    async fn append_append_only_rows(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+        sequenced_bigquery_table_id: &SequencedBigQueryTableId,
+        rows: Vec<BigQueryTableRow>,
+    ) -> EtlResult<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let table_lock = self.append_only_table_lock(sequenced_bigquery_table_id).await;
+        let _guard = table_lock.lock().await;
+        let stream_state = self
+            .ensure_append_only_write_stream_state(
+                replicated_table_schema.id(),
+                sequenced_bigquery_table_id,
+            )
+            .await?;
+
+        self.append_append_only_rows_with_state(
+            replicated_table_schema,
+            sequenced_bigquery_table_id,
+            rows,
+            stream_state,
+        )
+        .await
+    }
+
+    async fn ensure_append_only_write_stream_state(
+        &self,
+        table_id: TableId,
+        sequenced_bigquery_table_id: &SequencedBigQueryTableId,
+    ) -> EtlResult<DestinationWriteStreamState> {
+        let destination_table_id = sequenced_bigquery_table_id.to_string();
+        if let Some(state) = self
+            .state_store
+            .get_destination_write_stream_state(table_id, destination_table_id.clone())
+            .await?
+        {
+            if state.next_offset < 0 {
+                return Err(etl_error!(
+                    ErrorKind::InvalidState,
+                    "Append-only write stream state has a negative offset",
+                    format!(
+                        "Destination table '{}' has invalid next_offset {}",
+                        state.destination_table_id, state.next_offset
+                    )
+                ));
+            }
+
+            return Ok(state);
+        }
+
+        let stream_name = self
+            .client
+            .create_committed_write_stream(&self.dataset_id, &destination_table_id)
+            .await?;
+        let state = DestinationWriteStreamState::new(destination_table_id, stream_name, 0);
+        self.state_store.store_destination_write_stream_state(table_id, state.clone()).await?;
+
+        Ok(state)
+    }
+
+    async fn append_append_only_rows_with_state(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+        sequenced_bigquery_table_id: &SequencedBigQueryTableId,
+        rows: Vec<BigQueryTableRow>,
+        stream_state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let table_descriptor = append_only_table_descriptor(replicated_table_schema);
+        let target_batches = calculate_target_batches_for_table_copy(&rows)?;
+        let row_batches = split_table_rows(rows, target_batches);
+        let sequenced_bigquery_table_id_string = sequenced_bigquery_table_id.to_string();
+        let mut next_offset = stream_state.next_offset;
+        let stream_name = stream_state.stream_name.clone();
+
+        for (batch_index, rows) in row_batches.into_iter().enumerate() {
+            if rows.is_empty() {
+                continue;
+            }
+
+            histogram!(ETL_BQ_APPEND_BATCHES_BATCH_SIZE).record(rows.len() as f64);
+            let trace_id = create_append_trace_id(
+                self.pipeline_id,
+                &sequenced_bigquery_table_id_string,
+                batch_index,
+            );
+            let _ = self
+                .client
+                .append_committed_stream_rows(
+                    &stream_name,
+                    table_descriptor.clone(),
+                    &rows,
+                    next_offset,
+                    trace_id,
+                )
+                .await?;
+
+            next_offset += rows.len() as i64;
+        }
+
+        self.state_store
+            .store_destination_write_stream_state(
+                replicated_table_schema.id(),
+                DestinationWriteStreamState::new(
+                    sequenced_bigquery_table_id_string,
+                    stream_name,
+                    next_offset,
+                ),
+            )
+            .await?;
 
         Ok(())
     }
@@ -1294,7 +1858,7 @@ where
 
         // Once destination cleanup is done, remove any stale local cache entries.
         let mut inner = self.inner.lock().await;
-        inner.clear_table_cache(&base_bigquery_table_id);
+        inner.clear_table_cache(table_id, &base_bigquery_table_id);
 
         info!(table_id = table_id.0, "dropped bigquery table before copy");
 
@@ -1494,7 +2058,7 @@ fn bigquery_update_rows(
 }
 
 /// Returns the full new row required for a BigQuery update upsert.
-fn bigquery_update_new_row(
+pub(super) fn bigquery_update_new_row(
     replicated_table_schema: &ReplicatedTableSchema,
     updated_table_row: UpdatedTableRow,
 ) -> EtlResult<TableRow> {
@@ -1513,7 +2077,7 @@ fn bigquery_update_new_row(
 }
 
 /// Returns the old row image required for a BigQuery delete.
-fn bigquery_delete_old_row(
+pub(super) fn bigquery_delete_old_row(
     replicated_table_schema: &ReplicatedTableSchema,
     old_table_row: Option<OldTableRow>,
 ) -> EtlResult<OldTableRow> {
@@ -1553,7 +2117,7 @@ fn ensure_bigquery_update_without_old_row_can_skip_delete(
 }
 
 /// Verifies that a key-only row image carries source primary-key values.
-fn ensure_bigquery_key_image_matches_primary_key(
+pub(super) fn ensure_bigquery_key_image_matches_primary_key(
     replicated_table_schema: &ReplicatedTableSchema,
 ) -> EtlResult<()> {
     if matches!(replicated_table_schema.identity_type(), IdentityType::PrimaryKey) {
@@ -1850,11 +2414,14 @@ mod tests {
     use std::sync::Arc;
 
     use etl::{
-        data::CellNonOptional,
-        schema::{ColumnSchema, IdentityMask, PgLsn, TableId, TableSchema, Type},
+        data::{ArrayCellNonOptional, CellNonOptional},
+        schema::{
+            ColumnModification, ColumnSchema, IdentityMask, PgLsn, TableId, TableSchema, Type,
+        },
     };
     use prost::Message;
 
+    use super::super::append_only::append_only_sequence_number;
     use super::*;
 
     fn replicated_schema(identity_type: IdentityType) -> ReplicatedTableSchema {
@@ -2093,7 +2660,7 @@ mod tests {
             SequencedBigQueryTableId("orders_table".to_owned(), 0),
         );
 
-        inner.clear_table_cache(&base_table_id);
+        inner.clear_table_cache(TableId::new(1), &base_table_id);
 
         assert_eq!(
             inner.created_tables,
@@ -2106,6 +2673,120 @@ mod tests {
                 SequencedBigQueryTableId("orders_table".to_owned(), 0),
             )])
         );
+    }
+
+    #[test]
+    fn append_only_copy_sort_key_sorts_before_cdc_even_when_copy_timestamp_is_newer() {
+        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+        let table_row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+        let copy_metadata =
+            append_only_copy_metadata(&replicated_table_schema, &table_row, 1000, 0);
+        let cdc_metadata =
+            append_only_event_metadata(EventSequenceKey::new(PgLsn::from(1), 0), 0, 900);
+
+        assert!(copy_metadata.sort_keys < cdc_metadata.sort_keys);
+        assert!(copy_metadata.change_sequence_number < cdc_metadata.change_sequence_number);
+    }
+
+    #[test]
+    fn append_only_copy_metadata_uses_stable_row_identity() {
+        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+        let source_timestamp = 42;
+        let table_row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+        let same_table_row = TableRow::new(vec![Cell::I32(1), Cell::String("alice".to_owned())]);
+        let changed_non_key_table_row =
+            TableRow::new(vec![Cell::I32(1), Cell::String("updated".to_owned())]);
+        let different_table_row =
+            TableRow::new(vec![Cell::I32(2), Cell::String("alice".to_owned())]);
+
+        let metadata =
+            append_only_copy_metadata(&replicated_table_schema, &table_row, source_timestamp, 0);
+        let same_metadata = append_only_copy_metadata(
+            &replicated_table_schema,
+            &same_table_row,
+            source_timestamp,
+            0,
+        );
+        let changed_non_key_metadata = append_only_copy_metadata(
+            &replicated_table_schema,
+            &changed_non_key_table_row,
+            source_timestamp,
+            0,
+        );
+        let different_metadata = append_only_copy_metadata(
+            &replicated_table_schema,
+            &different_table_row,
+            source_timestamp,
+            0,
+        );
+        let same_row_different_copy_ordinal = append_only_copy_metadata(
+            &replicated_table_schema,
+            &same_table_row,
+            source_timestamp,
+            1,
+        );
+
+        assert_eq!(metadata.uuid, same_metadata.uuid);
+        assert_eq!(metadata.uuid, changed_non_key_metadata.uuid);
+        assert_eq!(metadata.change_sequence_number, same_metadata.change_sequence_number);
+        assert_ne!(metadata.uuid, different_metadata.uuid);
+        assert_ne!(metadata.uuid, same_row_different_copy_ordinal.uuid);
+        assert_eq!(metadata.source_timestamp, source_timestamp);
+        assert_eq!(
+            metadata.sort_keys,
+            vec![
+                "0000000000000000".to_owned(),
+                "0000000000000000/0000000000000000/0000000000000000".to_owned(),
+                metadata.uuid.clone(),
+            ]
+        );
+    }
+
+    #[test]
+    fn append_only_event_metadata_preserves_source_timestamp_and_sort_keys() {
+        let sequence_key = EventSequenceKey::new(PgLsn::from(1), 2);
+        let metadata = append_only_event_metadata(sequence_key, 3, 42);
+
+        assert_eq!(metadata.uuid, "0000000000000001/0000000000000002/0000000000000003");
+        assert_eq!(metadata.source_timestamp, 42);
+        assert_eq!(metadata.change_sequence_number, metadata.uuid);
+        assert_eq!(
+            metadata.sort_keys,
+            vec![
+                "800000000000002a".to_owned(),
+                "0000000000000001/0000000000000002".to_owned(),
+                "0000000000000003".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn append_only_schema_columns_to_add_preserves_renamed_and_removed_history_columns() {
+        let id_column = ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false);
+        let old_name_column = ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true);
+        let new_name_column = ColumnSchema::new("display_name".to_owned(), Type::TEXT, -1, 2, true);
+        let added_column = ColumnSchema::new("email".to_owned(), Type::TEXT, -1, 3, true);
+
+        let diff = SchemaDiff {
+            columns_to_add: vec![added_column.clone()],
+            columns_to_remove: vec![id_column],
+            columns_to_change: vec![etl::schema::ColumnChange {
+                ordinal_position: 2,
+                old_column: old_name_column,
+                new_column: new_name_column.clone(),
+                modifications: vec![ColumnModification::Rename {
+                    old_name: "name".to_owned(),
+                    new_name: "display_name".to_owned(),
+                }],
+            }],
+        };
+
+        let columns = append_only_schema_columns_to_add(&diff)
+            .into_iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(columns, vec!["email", "display_name"]);
     }
 
     #[test]
@@ -2551,6 +3232,208 @@ mod tests {
                     CellNonOptional::String(
                         "0000000000000001/0000000000000000/0000000000000001".to_owned(),
                     ),
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn append_only_update_rows_emits_before_and_after_images_for_full_identity() {
+        let replicated_table_schema = replicated_schema(IdentityType::Full);
+        let sequence_key = EventSequenceKey::new(PgLsn::from(1), 0);
+        let source_timestamp = 42;
+
+        let rows = append_only_update_rows(
+            &replicated_table_schema,
+            Some(OldTableRow::Full(TableRow::new(vec![
+                Cell::I32(1),
+                Cell::String("before".to_owned()),
+            ]))),
+            UpdatedTableRow::Full(TableRow::new(vec![
+                Cell::I32(2),
+                Cell::String("after".to_owned()),
+            ])),
+            sequence_key,
+            source_timestamp,
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(1)),
+                (2, CellNonOptional::String("before".to_owned())),
+                (
+                    3,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+                    ),
+                ),
+                (4, CellNonOptional::I64(source_timestamp)),
+                (
+                    5,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+                    ),
+                ),
+                (6, CellNonOptional::String("UPDATE-DELETE".to_owned())),
+                (
+                    7,
+                    CellNonOptional::Array(ArrayCellNonOptional::String(vec![
+                        "800000000000002a".to_owned(),
+                        "0000000000000001/0000000000000000".to_owned(),
+                        "0000000000000000".to_owned(),
+                    ])),
+                ),
+            ]
+        );
+        assert_eq!(
+            rows[1].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(2)),
+                (2, CellNonOptional::String("after".to_owned())),
+                (
+                    3,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000001".to_owned(),
+                    ),
+                ),
+                (4, CellNonOptional::I64(source_timestamp)),
+                (
+                    5,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000001".to_owned(),
+                    ),
+                ),
+                (6, CellNonOptional::String("UPDATE-INSERT".to_owned())),
+                (
+                    7,
+                    CellNonOptional::Array(ArrayCellNonOptional::String(vec![
+                        "800000000000002a".to_owned(),
+                        "0000000000000001/0000000000000000".to_owned(),
+                        "0000000000000001".to_owned(),
+                    ])),
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn append_only_update_rows_expands_key_old_image_to_before_image() {
+        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+        let sequence_key = EventSequenceKey::new(PgLsn::from(1), 0);
+        let source_timestamp = 42;
+
+        let rows = append_only_update_rows(
+            &replicated_table_schema,
+            Some(OldTableRow::Key(TableRow::new(vec![Cell::I32(1)]))),
+            UpdatedTableRow::Full(TableRow::new(vec![
+                Cell::I32(2),
+                Cell::String("after".to_owned()),
+            ])),
+            sequence_key,
+            source_timestamp,
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(1)),
+                (2, CellNonOptional::Null),
+                (
+                    3,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+                    ),
+                ),
+                (4, CellNonOptional::I64(source_timestamp)),
+                (
+                    5,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+                    ),
+                ),
+                (6, CellNonOptional::String("UPDATE-DELETE".to_owned())),
+                (
+                    7,
+                    CellNonOptional::Array(ArrayCellNonOptional::String(vec![
+                        "800000000000002a".to_owned(),
+                        "0000000000000001/0000000000000000".to_owned(),
+                        "0000000000000000".to_owned(),
+                    ])),
+                ),
+            ]
+        );
+        assert_eq!(
+            rows[1].debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(2)),
+                (2, CellNonOptional::String("after".to_owned())),
+                (
+                    3,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000001".to_owned(),
+                    ),
+                ),
+                (4, CellNonOptional::I64(source_timestamp)),
+                (
+                    5,
+                    CellNonOptional::String(
+                        "0000000000000001/0000000000000000/0000000000000001".to_owned(),
+                    ),
+                ),
+                (6, CellNonOptional::String("UPDATE-INSERT".to_owned())),
+                (
+                    7,
+                    CellNonOptional::Array(ArrayCellNonOptional::String(vec![
+                        "800000000000002a".to_owned(),
+                        "0000000000000001/0000000000000000".to_owned(),
+                        "0000000000000001".to_owned(),
+                    ])),
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn append_only_delete_key_row_expands_to_sparse_storage_write_row() {
+        let replicated_table_schema = replicated_schema(IdentityType::PrimaryKey);
+        let sequence_key = EventSequenceKey::new(PgLsn::from(1), 0);
+        let source_timestamp = 42;
+        let sequence_number = append_only_sequence_number(sequence_key, 0);
+
+        let old_table_row = append_only_delete_old_row(
+            &replicated_table_schema,
+            Some(OldTableRow::Key(TableRow::new(vec![Cell::I32(42)]))),
+        )
+        .unwrap();
+        let row = append_only_row(
+            &replicated_table_schema,
+            old_table_row,
+            AppendOnlyChangeType::Delete,
+            append_only_event_metadata(sequence_key, 0, source_timestamp),
+        )
+        .unwrap();
+
+        assert_eq!(
+            row.debug_cells(),
+            vec![
+                (1, CellNonOptional::I32(42)),
+                (2, CellNonOptional::Null),
+                (3, CellNonOptional::String(sequence_number.clone())),
+                (4, CellNonOptional::I64(source_timestamp)),
+                (5, CellNonOptional::String(sequence_number.clone())),
+                (6, CellNonOptional::String("DELETE".to_owned())),
+                (
+                    7,
+                    CellNonOptional::Array(ArrayCellNonOptional::String(vec![
+                        "800000000000002a".to_owned(),
+                        "0000000000000001/0000000000000000".to_owned(),
+                        "0000000000000000".to_owned(),
+                    ])),
                 ),
             ]
         );

--- a/crates/etl-destinations/src/bigquery/mod.rs
+++ b/crates/etl-destinations/src/bigquery/mod.rs
@@ -1,3 +1,4 @@
+mod append_only;
 mod client;
 mod core;
 mod encoding;
@@ -8,8 +9,8 @@ mod sql;
 pub mod test_utils;
 mod validation;
 
-pub use core::BigQueryDestination;
 #[cfg(feature = "test-utils")]
 pub use core::table_name_to_bigquery_table_id;
+pub use core::{BigQueryDestination, BigQueryWriteMode};
 
 pub use client::{BigQueryClient, BigQueryDatasetId, BigQueryProjectId, BigQueryTableId};

--- a/crates/etl-destinations/src/bigquery/schema.rs
+++ b/crates/etl-destinations/src/bigquery/schema.rs
@@ -218,7 +218,7 @@ fn append_only_metadata_column_specs() -> Vec<String> {
         format!("`{APPEND_ONLY_SOURCE_TIMESTAMP_COLUMN}` int64 not null"),
         format!("`{APPEND_ONLY_CHANGE_SEQUENCE_NUMBER_COLUMN}` string not null"),
         format!("`{APPEND_ONLY_CHANGE_TYPE_COLUMN}` string not null"),
-        format!("`{APPEND_ONLY_SORT_KEYS_COLUMN}` array<string> not null"),
+        format!("`{APPEND_ONLY_SORT_KEYS_COLUMN}` array<string>"),
     ]
 }
 
@@ -760,7 +760,7 @@ mod tests {
             spec,
             "(`id` int64,`name` string,`_etl_uuid` string not null,`_etl_source_timestamp` int64 \
              not null,`_etl_change_sequence_number` string not null,`_etl_change_type` string not \
-             null,`_etl_sort_keys` array<string> not null)"
+             null,`_etl_sort_keys` array<string>)"
         );
         assert!(!spec.contains("primary key"));
     }

--- a/crates/etl-destinations/src/bigquery/schema.rs
+++ b/crates/etl-destinations/src/bigquery/schema.rs
@@ -16,6 +16,13 @@ const BIGQUERY_CDC_SPECIAL_COLUMN: &str = "_CHANGE_TYPE";
 /// Special column name for Change Data Capture sequence ordering in BigQuery.
 const BIGQUERY_CDC_SEQUENCE_COLUMN: &str = "_CHANGE_SEQUENCE_NUMBER";
 
+/// Append-only metadata column names.
+pub(super) const APPEND_ONLY_UUID_COLUMN: &str = "_etl_uuid";
+pub(super) const APPEND_ONLY_SOURCE_TIMESTAMP_COLUMN: &str = "_etl_source_timestamp";
+pub(super) const APPEND_ONLY_CHANGE_SEQUENCE_NUMBER_COLUMN: &str = "_etl_change_sequence_number";
+pub(super) const APPEND_ONLY_CHANGE_TYPE_COLUMN: &str = "_etl_change_type";
+pub(super) const APPEND_ONLY_SORT_KEYS_COLUMN: &str = "_etl_sort_keys";
+
 /// Generates SQL column specification for CREATE TABLE statements.
 pub(super) fn column_spec(column_schema: &ColumnSchema) -> EtlResult<String> {
     let column_name = quote_identifier(&column_schema.name, "BigQuery column name")?;
@@ -192,6 +199,35 @@ pub(super) fn create_columns_spec(
     Ok(format!("({column_spec})"))
 }
 
+/// Builds column specifications for append-only history tables.
+pub(super) fn create_append_only_columns_spec(
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> EtlResult<String> {
+    let mut column_specs = replicated_table_schema
+        .column_schemas()
+        .map(append_only_column_spec)
+        .collect::<EtlResult<Vec<_>>>()?;
+    column_specs.extend(append_only_metadata_column_specs());
+
+    Ok(format!("({})", column_specs.join(",")))
+}
+
+fn append_only_metadata_column_specs() -> Vec<String> {
+    vec![
+        format!("`{APPEND_ONLY_UUID_COLUMN}` string not null"),
+        format!("`{APPEND_ONLY_SOURCE_TIMESTAMP_COLUMN}` int64 not null"),
+        format!("`{APPEND_ONLY_CHANGE_SEQUENCE_NUMBER_COLUMN}` string not null"),
+        format!("`{APPEND_ONLY_CHANGE_TYPE_COLUMN}` string not null"),
+        format!("`{APPEND_ONLY_SORT_KEYS_COLUMN}` array<string> not null"),
+    ]
+}
+
+/// Generates nullable SQL column specification for append-only history tables.
+fn append_only_column_spec(column_schema: &ColumnSchema) -> EtlResult<String> {
+    let column_name = quote_identifier(&column_schema.name, "BigQuery column name")?;
+    Ok(format!("{} {}", column_name, postgres_to_bigquery_type(&column_schema.typ)))
+}
+
 /// Converts Postgres data types to BigQuery equivalent types.
 pub(super) fn postgres_to_bigquery_type(typ: &Type) -> String {
     if is_array_type(typ) {
@@ -304,6 +340,85 @@ pub(crate) fn column_schemas_to_table_descriptor(
     }
 
     TableDescriptor { field_descriptors }
+}
+
+/// Converts append-only table schemas to a BigQuery [`TableDescriptor`].
+///
+/// Source columns are nullable because delete rows contain sparse source
+/// images. Metadata columns are appended as flat fields so the
+/// existing Storage Write protobuf encoder can write append-only rows without
+/// nested message support.
+pub(crate) fn append_only_table_descriptor(
+    replicated_table_schema: &ReplicatedTableSchema,
+) -> TableDescriptor {
+    let mut field_descriptors = vec![];
+    let mut number = 1;
+
+    for column_schema in replicated_table_schema.column_schemas() {
+        field_descriptors.push(FieldDescriptor {
+            number,
+            name: column_schema.name.clone(),
+            typ: column_schema_to_storage_type(&column_schema.typ),
+            mode: if is_array_type(&column_schema.typ) {
+                ColumnMode::Repeated
+            } else {
+                ColumnMode::Nullable
+            },
+        });
+        number += 1;
+    }
+
+    field_descriptors.extend([
+        FieldDescriptor {
+            number,
+            name: APPEND_ONLY_UUID_COLUMN.to_owned(),
+            typ: ColumnType::String,
+            mode: ColumnMode::Required,
+        },
+        FieldDescriptor {
+            number: number + 1,
+            name: APPEND_ONLY_SOURCE_TIMESTAMP_COLUMN.to_owned(),
+            typ: ColumnType::Int64,
+            mode: ColumnMode::Required,
+        },
+        FieldDescriptor {
+            number: number + 2,
+            name: APPEND_ONLY_CHANGE_SEQUENCE_NUMBER_COLUMN.to_owned(),
+            typ: ColumnType::String,
+            mode: ColumnMode::Required,
+        },
+        FieldDescriptor {
+            number: number + 3,
+            name: APPEND_ONLY_CHANGE_TYPE_COLUMN.to_owned(),
+            typ: ColumnType::String,
+            mode: ColumnMode::Required,
+        },
+        FieldDescriptor {
+            number: number + 4,
+            name: APPEND_ONLY_SORT_KEYS_COLUMN.to_owned(),
+            typ: ColumnType::String,
+            mode: ColumnMode::Repeated,
+        },
+    ]);
+
+    TableDescriptor { field_descriptors }
+}
+
+/// Maps a Postgres source type to the scalar protobuf type used by the Storage
+/// Write row descriptor.
+fn column_schema_to_storage_type(typ: &Type) -> ColumnType {
+    match typ {
+        &Type::BOOL | &Type::BOOL_ARRAY => ColumnType::Bool,
+        &Type::INT2 | &Type::INT4 | &Type::INT2_ARRAY | &Type::INT4_ARRAY => ColumnType::Int32,
+        &Type::INT8 | &Type::TIMESTAMPTZ | &Type::INT8_ARRAY | &Type::TIMESTAMPTZ_ARRAY => {
+            ColumnType::Int64
+        }
+        &Type::FLOAT4 | &Type::FLOAT4_ARRAY => ColumnType::Float,
+        &Type::FLOAT8 | &Type::FLOAT8_ARRAY => ColumnType::Double,
+        &Type::OID | &Type::OID_ARRAY => ColumnType::Int32,
+        &Type::BYTEA | &Type::BYTEA_ARRAY => ColumnType::Bytes,
+        _ => ColumnType::String,
+    }
 }
 
 #[cfg(test)]
@@ -629,5 +744,63 @@ mod tests {
         assert!(matches!(descriptor.field_descriptors[8].mode, ColumnMode::Repeated));
         assert!(matches!(descriptor.field_descriptors[9].typ, ColumnType::Int64));
         assert!(matches!(descriptor.field_descriptors[9].mode, ColumnMode::Repeated));
+    }
+
+    #[test]
+    fn create_append_only_columns_spec_appends_flat_metadata_without_pk() {
+        let columns = vec![
+            test_column("id", Type::INT4, 1, false, Some(1)),
+            test_column("name", Type::TEXT, 2, true, None),
+        ];
+        let schema = test_replicated_schema(columns);
+
+        let spec = create_append_only_columns_spec(&schema).unwrap();
+
+        assert_eq!(
+            spec,
+            "(`id` int64,`name` string,`_etl_uuid` string not null,`_etl_source_timestamp` int64 \
+             not null,`_etl_change_sequence_number` string not null,`_etl_change_type` string not \
+             null,`_etl_sort_keys` array<string> not null)"
+        );
+        assert!(!spec.contains("primary key"));
+    }
+
+    #[test]
+    fn append_only_table_descriptor_appends_flat_metadata_fields() {
+        let columns = vec![
+            test_column("id", Type::INT4, 1, false, Some(1)),
+            test_column("payload", Type::JSONB, 2, true, None),
+        ];
+        let schema = test_replicated_schema(columns);
+
+        let descriptor = append_only_table_descriptor(&schema);
+
+        assert_eq!(descriptor.field_descriptors.len(), 7);
+        assert_eq!(descriptor.field_descriptors[0].name, "id");
+        assert!(matches!(descriptor.field_descriptors[0].mode, ColumnMode::Nullable));
+        assert_eq!(descriptor.field_descriptors[1].name, "payload");
+        assert!(matches!(descriptor.field_descriptors[1].typ, ColumnType::String));
+        assert!(matches!(descriptor.field_descriptors[1].mode, ColumnMode::Nullable));
+
+        let metadata = &descriptor.field_descriptors[2..];
+        assert_eq!(metadata[0].name, APPEND_ONLY_UUID_COLUMN);
+        assert!(matches!(metadata[0].typ, ColumnType::String));
+        assert!(matches!(metadata[0].mode, ColumnMode::Required));
+        assert_eq!(metadata[1].name, APPEND_ONLY_SOURCE_TIMESTAMP_COLUMN);
+        assert!(matches!(metadata[1].typ, ColumnType::Int64));
+        assert!(matches!(metadata[1].mode, ColumnMode::Required));
+        assert_eq!(metadata[2].name, APPEND_ONLY_CHANGE_SEQUENCE_NUMBER_COLUMN);
+        assert!(matches!(metadata[2].typ, ColumnType::String));
+        assert!(matches!(metadata[2].mode, ColumnMode::Required));
+        assert_eq!(metadata[3].name, APPEND_ONLY_CHANGE_TYPE_COLUMN);
+        assert!(matches!(metadata[3].typ, ColumnType::String));
+        assert!(matches!(metadata[3].mode, ColumnMode::Required));
+        assert_eq!(metadata[4].name, APPEND_ONLY_SORT_KEYS_COLUMN);
+        assert!(matches!(metadata[4].typ, ColumnType::String));
+        assert!(matches!(metadata[4].mode, ColumnMode::Repeated));
+
+        let field_numbers: Vec<u32> =
+            descriptor.field_descriptors.iter().map(|field| field.number).collect();
+        assert_eq!(field_numbers, vec![1, 2, 3, 4, 5, 6, 7]);
     }
 }

--- a/crates/etl-destinations/src/bigquery/sql.rs
+++ b/crates/etl-destinations/src/bigquery/sql.rs
@@ -79,6 +79,20 @@ pub(super) fn quote_information_schema_tables_path(
     Ok(format!("`{project_id}.{dataset_id}.INFORMATION_SCHEMA.TABLES`"))
 }
 
+/// Quotes the BigQuery `INFORMATION_SCHEMA.COLUMNS` path for a dataset.
+///
+/// The fixed `INFORMATION_SCHEMA.COLUMNS` suffix is intentionally not escaped
+/// as user input.
+pub(super) fn quote_information_schema_columns_path(
+    project_id: &BigQueryProjectId,
+    dataset_id: &BigQueryDatasetId,
+) -> EtlResult<String> {
+    let project_id = escape_identifier(project_id, "BigQuery project id")?;
+    let dataset_id = escape_identifier(dataset_id, "BigQuery dataset id")?;
+
+    Ok(format!("`{project_id}.{dataset_id}.INFORMATION_SCHEMA.COLUMNS`"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/etl-postgres/src/store/destination_write_stream.rs
+++ b/crates/etl-postgres/src/store/destination_write_stream.rs
@@ -72,14 +72,11 @@ pub async fn store_destination_write_stream(
             next_offset = excluded.next_offset,
             last_sequence_number = excluded.last_sequence_number,
             updated_at = now()
-        where etl.destination_write_streams.next_offset < excluded.next_offset
-            or (
-                etl.destination_write_streams.next_offset = excluded.next_offset
-                and etl.destination_write_streams.stream_name = excluded.stream_name
-                and (
-                    etl.destination_write_streams.last_sequence_number is null
-                    or excluded.last_sequence_number >= etl.destination_write_streams.last_sequence_number
-                )
+        where etl.destination_write_streams.stream_name = excluded.stream_name
+            and etl.destination_write_streams.next_offset <= excluded.next_offset
+            and (
+                etl.destination_write_streams.last_sequence_number is null
+                or excluded.last_sequence_number >= etl.destination_write_streams.last_sequence_number
             )
         "#,
     )
@@ -93,6 +90,48 @@ pub async fn store_destination_write_stream(
     .await?;
 
     Ok(())
+}
+
+/// Replaces write stream state when a destination rotates streams.
+pub async fn replace_destination_write_stream(
+    pool: &PgPool,
+    pipeline_id: i64,
+    table_id: TableId,
+    destination_table_id: &str,
+    expected_stream_name: &str,
+    stream_name: &str,
+    next_offset: i64,
+    last_sequence_number: Option<&str>,
+) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        r#"
+        insert into etl.destination_write_streams
+            (pipeline_id, table_id, destination_table_id, stream_name, next_offset, last_sequence_number)
+        values ($1, $2, $3, $5, $6, $7)
+        on conflict (pipeline_id, table_id, destination_table_id)
+        do update set
+            stream_name = excluded.stream_name,
+            next_offset = excluded.next_offset,
+            last_sequence_number = excluded.last_sequence_number,
+            updated_at = now()
+        where etl.destination_write_streams.stream_name = $4
+            and (
+                etl.destination_write_streams.last_sequence_number is null
+                or excluded.last_sequence_number >= etl.destination_write_streams.last_sequence_number
+            )
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(destination_table_id)
+    .bind(expected_stream_name)
+    .bind(stream_name)
+    .bind(next_offset)
+    .bind(last_sequence_number)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
 }
 
 /// Deletes write stream state for a single source table.

--- a/crates/etl-postgres/src/store/destination_write_stream.rs
+++ b/crates/etl-postgres/src/store/destination_write_stream.rs
@@ -15,6 +15,8 @@ pub struct StoredDestinationWriteStreamRow {
     pub stream_name: String,
     /// Next contiguous row offset to append.
     pub next_offset: i64,
+    /// Last append-only sequence number durably appended to this stream.
+    pub last_sequence_number: Option<String>,
 }
 
 /// Gets write stream state for a physical destination table.
@@ -26,7 +28,7 @@ pub async fn get_destination_write_stream(
 ) -> Result<Option<StoredDestinationWriteStreamRow>, sqlx::Error> {
     let row = sqlx::query(
         r#"
-        select table_id, destination_table_id, stream_name, next_offset
+        select table_id, destination_table_id, stream_name, next_offset, last_sequence_number
         from etl.destination_write_streams
         where pipeline_id = $1 and table_id = $2 and destination_table_id = $3
         "#,
@@ -44,6 +46,7 @@ pub async fn get_destination_write_stream(
             destination_table_id: row.get("destination_table_id"),
             stream_name: row.get("stream_name"),
             next_offset: row.get("next_offset"),
+            last_sequence_number: row.get("last_sequence_number"),
         }
     }))
 }
@@ -56,21 +59,27 @@ pub async fn store_destination_write_stream(
     destination_table_id: &str,
     stream_name: &str,
     next_offset: i64,
+    last_sequence_number: Option<&str>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
         insert into etl.destination_write_streams
-            (pipeline_id, table_id, destination_table_id, stream_name, next_offset)
-        values ($1, $2, $3, $4, $5)
+            (pipeline_id, table_id, destination_table_id, stream_name, next_offset, last_sequence_number)
+        values ($1, $2, $3, $4, $5, $6)
         on conflict (pipeline_id, table_id, destination_table_id)
         do update set
             stream_name = excluded.stream_name,
             next_offset = excluded.next_offset,
+            last_sequence_number = excluded.last_sequence_number,
             updated_at = now()
         where etl.destination_write_streams.next_offset < excluded.next_offset
             or (
                 etl.destination_write_streams.next_offset = excluded.next_offset
                 and etl.destination_write_streams.stream_name = excluded.stream_name
+                and (
+                    etl.destination_write_streams.last_sequence_number is null
+                    or excluded.last_sequence_number >= etl.destination_write_streams.last_sequence_number
+                )
             )
         "#,
     )
@@ -79,6 +88,7 @@ pub async fn store_destination_write_stream(
     .bind(destination_table_id)
     .bind(stream_name)
     .bind(next_offset)
+    .bind(last_sequence_number)
     .execute(pool)
     .await?;
 

--- a/crates/etl-postgres/src/store/destination_write_stream.rs
+++ b/crates/etl-postgres/src/store/destination_write_stream.rs
@@ -1,0 +1,157 @@
+//! SQL accessors for durable destination write stream state.
+
+use sqlx::{PgExecutor, PgPool, Row, postgres::types::Oid as SqlxTableId};
+
+use crate::schema::TableId;
+
+/// Database row representation of destination write stream state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredDestinationWriteStreamRow {
+    /// Source table identifier.
+    pub table_id: TableId,
+    /// Destination-specific physical table identifier.
+    pub destination_table_id: String,
+    /// Fully-qualified BigQuery Storage Write API stream name.
+    pub stream_name: String,
+    /// Next contiguous row offset to append.
+    pub next_offset: i64,
+}
+
+/// Gets write stream state for a physical destination table.
+pub async fn get_destination_write_stream(
+    pool: &PgPool,
+    pipeline_id: i64,
+    table_id: TableId,
+    destination_table_id: &str,
+) -> Result<Option<StoredDestinationWriteStreamRow>, sqlx::Error> {
+    let row = sqlx::query(
+        r#"
+        select table_id, destination_table_id, stream_name, next_offset
+        from etl.destination_write_streams
+        where pipeline_id = $1 and table_id = $2 and destination_table_id = $3
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(destination_table_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|row| {
+        let table_id: SqlxTableId = row.get("table_id");
+        StoredDestinationWriteStreamRow {
+            table_id: TableId::new(table_id.0),
+            destination_table_id: row.get("destination_table_id"),
+            stream_name: row.get("stream_name"),
+            next_offset: row.get("next_offset"),
+        }
+    }))
+}
+
+/// Stores write stream state for a physical destination table.
+pub async fn store_destination_write_stream(
+    pool: &PgPool,
+    pipeline_id: i64,
+    table_id: TableId,
+    destination_table_id: &str,
+    stream_name: &str,
+    next_offset: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        insert into etl.destination_write_streams
+            (pipeline_id, table_id, destination_table_id, stream_name, next_offset)
+        values ($1, $2, $3, $4, $5)
+        on conflict (pipeline_id, table_id, destination_table_id)
+        do update set
+            stream_name = excluded.stream_name,
+            next_offset = excluded.next_offset,
+            updated_at = now()
+        where etl.destination_write_streams.next_offset < excluded.next_offset
+            or (
+                etl.destination_write_streams.next_offset = excluded.next_offset
+                and etl.destination_write_streams.stream_name = excluded.stream_name
+            )
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(destination_table_id)
+    .bind(stream_name)
+    .bind(next_offset)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Deletes write stream state for a single source table.
+pub async fn delete_destination_write_streams_for_table<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+    table_id: TableId,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    let result = sqlx::query(
+        r#"
+        delete from etl.destination_write_streams
+        where pipeline_id = $1 and table_id = $2
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+/// Deletes write stream state for one physical destination table.
+pub async fn delete_destination_write_stream<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+    table_id: TableId,
+    destination_table_id: &str,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    let result = sqlx::query(
+        r#"
+        delete from etl.destination_write_streams
+        where pipeline_id = $1
+          and table_id = $2
+          and destination_table_id = $3
+        "#,
+    )
+    .bind(pipeline_id)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .bind(destination_table_id)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+/// Deletes all write stream state for a pipeline.
+pub async fn delete_destination_write_streams_for_all_tables<'c, E>(
+    executor: E,
+    pipeline_id: i64,
+) -> Result<u64, sqlx::Error>
+where
+    E: PgExecutor<'c>,
+{
+    let result = sqlx::query(
+        r#"
+        delete from etl.destination_write_streams
+        where pipeline_id = $1
+        "#,
+    )
+    .bind(pipeline_id)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
+}

--- a/crates/etl-postgres/src/store/destination_write_stream.rs
+++ b/crates/etl-postgres/src/store/destination_write_stream.rs
@@ -73,10 +73,15 @@ pub async fn store_destination_write_stream(
             last_sequence_number = excluded.last_sequence_number,
             updated_at = now()
         where etl.destination_write_streams.stream_name = excluded.stream_name
-            and etl.destination_write_streams.next_offset <= excluded.next_offset
             and (
-                etl.destination_write_streams.last_sequence_number is null
-                or excluded.last_sequence_number >= etl.destination_write_streams.last_sequence_number
+                etl.destination_write_streams.next_offset < excluded.next_offset
+                or (
+                    etl.destination_write_streams.next_offset = excluded.next_offset
+                    and (
+                        etl.destination_write_streams.last_sequence_number is null
+                        or excluded.last_sequence_number >= etl.destination_write_streams.last_sequence_number
+                    )
+                )
             )
         "#,
     )

--- a/crates/etl-postgres/src/store/mod.rs
+++ b/crates/etl-postgres/src/store/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod catalog;
 pub mod destination_table_metadata;
+pub mod destination_write_stream;
 pub mod health;
 pub mod progress;
 pub mod schema;

--- a/crates/etl-replicator/src/core/destinations.rs
+++ b/crates/etl-replicator/src/core/destinations.rs
@@ -90,8 +90,12 @@ fn disabled_destination_error(kind: DestinationKind) -> crate::error::Replicator
 #[cfg(feature = "bigquery")]
 mod bigquery {
     use etl::pipeline::Pipeline;
-    use etl_config::shared::{DestinationConfig, ReplicatorConfig};
-    use etl_destinations::bigquery::BigQueryDestination;
+    use etl_config::shared::{
+        BigQueryWriteMode as ConfigBigQueryWriteMode, DestinationConfig, ReplicatorConfig,
+    };
+    use etl_destinations::bigquery::{
+        BigQueryDestination, BigQueryWriteMode as DestinationBigQueryWriteMode,
+    };
     use secrecy::ExposeSecret;
 
     use super::super::{ReplicatorStore, pipeline};
@@ -110,9 +114,14 @@ mod bigquery {
             service_account_key,
             max_staleness_mins,
             connection_pool_size,
+            write_mode,
         } = &replicator_config.destination
         else {
             unreachable!("Destination kind should match BigQuery config");
+        };
+        let write_mode = match write_mode {
+            ConfigBigQueryWriteMode::CurrentState => DestinationBigQueryWriteMode::CurrentState,
+            ConfigBigQueryWriteMode::AppendOnly => DestinationBigQueryWriteMode::AppendOnly,
         };
 
         let destination = BigQueryDestination::new_with_key(
@@ -124,7 +133,8 @@ mod bigquery {
             pipeline_id,
             store.clone(),
         )
-        .await?;
+        .await?
+        .with_write_mode(write_mode);
 
         let pipeline = Pipeline::new(replicator_config.pipeline, store, destination);
         pipeline::start(pipeline).await

--- a/crates/etl-replicator/src/error_reporting.rs
+++ b/crates/etl-replicator/src/error_reporting.rs
@@ -166,6 +166,17 @@ where
         self.inner.store_destination_write_stream_state(table_id, state).await
     }
 
+    async fn replace_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        expected_stream_name: String,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        self.inner
+            .replace_destination_write_stream_state(table_id, expected_stream_name, state)
+            .await
+    }
+
     async fn delete_destination_write_stream_state(
         &self,
         table_id: TableId,

--- a/crates/etl-replicator/src/error_reporting.rs
+++ b/crates/etl-replicator/src/error_reporting.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, sync::Arc};
 
 use etl::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::{EtlError, EtlResult},
     schema::{PgLsn, SnapshotId, TableId, TableSchema},
     store::{
@@ -146,6 +148,30 @@ where
         metadata: DestinationTableMetadata,
     ) -> EtlResult<()> {
         self.inner.store_destination_table_metadata(table_id, metadata).await
+    }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        self.inner.get_destination_write_stream_state(table_id, destination_table_id).await
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        self.inner.store_destination_write_stream_state(table_id, state).await
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        self.inner.delete_destination_write_stream_state(table_id, destination_table_id).await
     }
 }
 

--- a/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.down.sql
+++ b/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.down.sql
@@ -1,0 +1,1 @@
+drop table if exists etl.destination_write_streams;

--- a/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.up.sql
+++ b/crates/etl/migrations/postgres_store/20260703000000_destination_write_streams.up.sql
@@ -1,0 +1,21 @@
+-- Durable destination write stream state.
+--
+-- Append-only BigQuery writes use explicitly-created committed streams and
+-- offsets. Persisting the stream name and next offset lets retries reuse the
+-- same stream position after an unknown append result.
+
+create table etl.destination_write_streams (
+    id bigint generated always as identity primary key,
+    pipeline_id bigint not null,
+    table_id oid not null,
+    destination_table_id text not null,
+    stream_name text not null,
+    next_offset bigint not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint destination_write_streams_next_offset_check check (next_offset >= 0),
+    unique (pipeline_id, table_id, destination_table_id)
+);
+
+create index idx_destination_write_streams_pipeline_table
+    on etl.destination_write_streams (pipeline_id, table_id);

--- a/crates/etl/migrations/postgres_store/20260704000000_destination_write_stream_sequence.down.sql
+++ b/crates/etl/migrations/postgres_store/20260704000000_destination_write_stream_sequence.down.sql
@@ -1,0 +1,2 @@
+alter table etl.destination_write_streams
+    drop column last_sequence_number;

--- a/crates/etl/migrations/postgres_store/20260704000000_destination_write_stream_sequence.up.sql
+++ b/crates/etl/migrations/postgres_store/20260704000000_destination_write_stream_sequence.up.sql
@@ -1,0 +1,2 @@
+alter table etl.destination_write_streams
+    add column last_sequence_number text;

--- a/crates/etl/src/destination/metadata.rs
+++ b/crates/etl/src/destination/metadata.rs
@@ -163,3 +163,35 @@ pub struct AppliedDestinationTableMetadata {
     /// The replication mask indicating which columns are replicated.
     pub replication_mask: ReplicationMask,
 }
+
+/// Durable Storage Write API stream position for an append-only destination
+/// table.
+///
+/// Destinations that use explicitly-created write streams need both the stream
+/// name and the next contiguous offset to retry appends without duplicating
+/// rows after an unknown write outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DestinationWriteStreamState {
+    /// Destination-specific physical table identifier.
+    pub destination_table_id: String,
+    /// Fully-qualified Storage Write API stream name.
+    pub stream_name: String,
+    /// Next contiguous row offset to append.
+    pub next_offset: i64,
+}
+
+impl DestinationWriteStreamState {
+    /// Creates durable stream state for a destination table.
+    pub fn new(destination_table_id: String, stream_name: String, next_offset: i64) -> Self {
+        Self { destination_table_id, stream_name, next_offset }
+    }
+
+    /// Returns this stream state advanced by `row_count` rows.
+    pub fn advanced_by(&self, row_count: usize) -> Self {
+        Self {
+            destination_table_id: self.destination_table_id.clone(),
+            stream_name: self.stream_name.clone(),
+            next_offset: self.next_offset + row_count as i64,
+        }
+    }
+}

--- a/crates/etl/src/destination/metadata.rs
+++ b/crates/etl/src/destination/metadata.rs
@@ -178,12 +178,30 @@ pub struct DestinationWriteStreamState {
     pub stream_name: String,
     /// Next contiguous row offset to append.
     pub next_offset: i64,
+    /// Last append-only sequence number durably appended to this stream.
+    pub last_sequence_number: Option<String>,
 }
 
 impl DestinationWriteStreamState {
     /// Creates durable stream state for a destination table.
     pub fn new(destination_table_id: String, stream_name: String, next_offset: i64) -> Self {
-        Self { destination_table_id, stream_name, next_offset }
+        Self { destination_table_id, stream_name, next_offset, last_sequence_number: None }
+    }
+
+    /// Creates durable stream state including the last appended sequence number.
+    pub fn new_with_last_sequence_number(
+        destination_table_id: String,
+        stream_name: String,
+        next_offset: i64,
+        last_sequence_number: Option<String>,
+    ) -> Self {
+        Self { destination_table_id, stream_name, next_offset, last_sequence_number }
+    }
+
+    /// Sets the last appended sequence number on this stream state.
+    pub fn with_last_sequence_number(mut self, last_sequence_number: Option<String>) -> Self {
+        self.last_sequence_number = last_sequence_number;
+        self
     }
 
     /// Returns this stream state advanced by `row_count` rows.
@@ -192,6 +210,17 @@ impl DestinationWriteStreamState {
             destination_table_id: self.destination_table_id.clone(),
             stream_name: self.stream_name.clone(),
             next_offset: self.next_offset + row_count as i64,
+            last_sequence_number: self.last_sequence_number.clone(),
+        }
+    }
+
+    /// Returns this stream state advanced to an explicit offset and sequence.
+    pub fn advanced_to(&self, next_offset: i64, last_sequence_number: String) -> Self {
+        Self {
+            destination_table_id: self.destination_table_id.clone(),
+            stream_name: self.stream_name.clone(),
+            next_offset,
+            last_sequence_number: Some(last_sequence_number),
         }
     }
 }

--- a/crates/etl/src/destination/mod.rs
+++ b/crates/etl/src/destination/mod.rs
@@ -22,6 +22,7 @@ pub use base::Destination;
 pub use capabilities::PipelineDestination;
 pub use metadata::{
     AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationTableSchemaStatus,
+    DestinationWriteStreamState,
 };
 
 pub use crate::runtime::concurrency::TaskSet;

--- a/crates/etl/src/store/both/memory.rs
+++ b/crates/etl/src/store/both/memory.rs
@@ -7,14 +7,17 @@ use tokio::sync::Mutex;
 use tokio_postgres::types::PgLsn;
 
 use crate::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::{ErrorKind, EtlResult},
     etl_error,
     replication::{WorkerType, state::TableState},
     schema::{SnapshotId, TableId, TableSchema},
     store::{
-        DestinationTablesMetadata, SchemaStore, StateStore, TableSchemaRetention,
-        TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation, TableStates,
+        DestinationTablesMetadata, DestinationWriteStreamStates, SchemaStore, StateStore,
+        TableSchemaRetention, TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation,
+        TableStates,
     },
 };
 
@@ -34,6 +37,8 @@ struct Inner {
     table_schemas: Arc<TableSchemaSnapshots>,
     /// Cached destination table metadata indexed by table ID.
     destination_tables_metadata: DestinationTablesMetadata,
+    /// Durable write stream state indexed by source table and destination table.
+    destination_write_stream_states: DestinationWriteStreamStates,
     /// Durable replication progress indexed by worker type and optional table.
     replication_progress: HashMap<WorkerType, PgLsn>,
 }
@@ -65,6 +70,7 @@ impl MemoryStore {
             table_state_history: HashMap::new(),
             table_schemas: Arc::new(TableSchemaSnapshots::default()),
             destination_tables_metadata: Arc::new(BTreeMap::new()),
+            destination_write_stream_states: Arc::new(BTreeMap::new()),
             replication_progress: HashMap::new(),
         };
 
@@ -209,6 +215,59 @@ impl StateStore for MemoryStore {
 
         Ok(())
     }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        let inner = self.inner.lock().await;
+
+        Ok(inner.destination_write_stream_states.get(&(table_id, destination_table_id)).cloned())
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
+        let key = (table_id, state.destination_table_id.clone());
+        if should_store_destination_write_stream_state(
+            inner.destination_write_stream_states.get(&key),
+            &state,
+        ) {
+            Arc::make_mut(&mut inner.destination_write_stream_states).insert(key, state);
+        }
+
+        Ok(())
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
+        Arc::make_mut(&mut inner.destination_write_stream_states)
+            .remove(&(table_id, destination_table_id));
+
+        Ok(())
+    }
+}
+
+fn should_store_destination_write_stream_state(
+    current: Option<&DestinationWriteStreamState>,
+    next: &DestinationWriteStreamState,
+) -> bool {
+    match current {
+        None => true,
+        Some(current) => {
+            current.next_offset < next.next_offset
+                || (current.next_offset == next.next_offset
+                    && current.stream_name == next.stream_name)
+        }
+    }
 }
 
 impl SchemaStore for MemoryStore {
@@ -266,6 +325,8 @@ impl TableStateLifecycleStore for MemoryStore {
                 let mut inner = self.inner.lock().await;
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
 
                 Ok(0)
@@ -291,6 +352,7 @@ impl TableStateLifecycleStore for MemoryStore {
                 }
 
                 inner.replication_progress.remove(&WorkerType::Apply);
+                Arc::make_mut(&mut inner.destination_write_stream_states).clear();
 
                 Ok(reset_count)
             }
@@ -302,6 +364,8 @@ impl TableStateLifecycleStore for MemoryStore {
                 inner.table_state_history.remove(&table_id);
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
 
                 Ok(affected_table_count)

--- a/crates/etl/src/store/both/memory.rs
+++ b/crates/etl/src/store/both/memory.rs
@@ -243,6 +243,24 @@ impl StateStore for MemoryStore {
         Ok(())
     }
 
+    async fn replace_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        expected_stream_name: String,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.lock().await;
+        let key = (table_id, state.destination_table_id.clone());
+        ensure_destination_write_stream_state_can_be_replaced(
+            inner.destination_write_stream_states.get(&key),
+            &expected_stream_name,
+            &state,
+        )?;
+        Arc::make_mut(&mut inner.destination_write_stream_states).insert(key, state);
+
+        Ok(())
+    }
+
     async fn delete_destination_write_stream_state(
         &self,
         table_id: TableId,
@@ -263,12 +281,39 @@ fn should_store_destination_write_stream_state(
     match current {
         None => true,
         Some(current) => {
-            current.next_offset < next.next_offset
-                || (current.next_offset == next.next_offset
-                    && current.stream_name == next.stream_name
-                    && current.last_sequence_number <= next.last_sequence_number)
+            current.stream_name == next.stream_name
+                && current.next_offset <= next.next_offset
+                && current.last_sequence_number <= next.last_sequence_number
         }
     }
+}
+
+fn ensure_destination_write_stream_state_can_be_replaced(
+    current: Option<&DestinationWriteStreamState>,
+    expected_stream_name: &str,
+    next: &DestinationWriteStreamState,
+) -> EtlResult<()> {
+    let Some(current) = current else {
+        return Ok(());
+    };
+
+    if current.stream_name != expected_stream_name {
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            "Destination write stream state changed before replacement",
+            format!("Expected stream '{}', found '{}'", expected_stream_name, current.stream_name)
+        ));
+    }
+
+    if current.last_sequence_number > next.last_sequence_number {
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            "Destination write stream sequence would move backwards",
+            "The replacement state has an older append-only sequence watermark"
+        ));
+    }
+
+    Ok(())
 }
 
 impl SchemaStore for MemoryStore {

--- a/crates/etl/src/store/both/memory.rs
+++ b/crates/etl/src/store/both/memory.rs
@@ -282,8 +282,9 @@ fn should_store_destination_write_stream_state(
         None => true,
         Some(current) => {
             current.stream_name == next.stream_name
-                && current.next_offset <= next.next_offset
-                && current.last_sequence_number <= next.last_sequence_number
+                && (current.next_offset < next.next_offset
+                    || (current.next_offset == next.next_offset
+                        && current.last_sequence_number <= next.last_sequence_number))
         }
     }
 }
@@ -417,5 +418,35 @@ impl TableStateLifecycleStore for MemoryStore {
                 Ok(affected_table_count)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream_state(next_offset: i64, last_sequence_number: &str) -> DestinationWriteStreamState {
+        DestinationWriteStreamState::new_with_last_sequence_number(
+            "destination_table".to_owned(),
+            "stream".to_owned(),
+            next_offset,
+            Some(last_sequence_number.to_owned()),
+        )
+    }
+
+    #[test]
+    fn write_stream_state_advances_when_offset_increases_even_if_sequence_sorts_lower() {
+        let current = stream_state(10, "ffffffff");
+        let next = stream_state(20, "00000000");
+
+        assert!(should_store_destination_write_stream_state(Some(&current), &next));
+    }
+
+    #[test]
+    fn write_stream_state_rejects_same_offset_when_sequence_sorts_lower() {
+        let current = stream_state(10, "ffffffff");
+        let next = stream_state(10, "00000000");
+
+        assert!(!should_store_destination_write_stream_state(Some(&current), &next));
     }
 }

--- a/crates/etl/src/store/both/memory.rs
+++ b/crates/etl/src/store/both/memory.rs
@@ -265,7 +265,8 @@ fn should_store_destination_write_stream_state(
         Some(current) => {
             current.next_offset < next.next_offset
                 || (current.next_offset == next.next_offset
-                    && current.stream_name == next.stream_name)
+                    && current.stream_name == next.stream_name
+                    && current.last_sequence_number <= next.last_sequence_number)
         }
     }
 }

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -509,6 +509,7 @@ impl StateStore for PostgresStore {
                     row.stream_name,
                     row.next_offset,
                 )
+                .with_last_sequence_number(row.last_sequence_number)
             })
         })
         .map_err(|err| {
@@ -532,6 +533,7 @@ impl StateStore for PostgresStore {
             &state.destination_table_id,
             &state.stream_name,
             state.next_offset,
+            state.last_sequence_number.as_deref(),
         )
         .await
         .map_err(|err| {

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -545,6 +545,45 @@ impl StateStore for PostgresStore {
         })
     }
 
+    async fn replace_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        expected_stream_name: String,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let rows_affected = pg_destination_write_stream::replace_destination_write_stream(
+            &self.pool,
+            self.pipeline_id as i64,
+            table_id,
+            &state.destination_table_id,
+            &expected_stream_name,
+            &state.stream_name,
+            state.next_offset,
+            state.last_sequence_number.as_deref(),
+        )
+        .await
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination write stream state replacement failed",
+                source: err
+            )
+        })?;
+
+        if rows_affected == 0 {
+            return Err(etl_error!(
+                ErrorKind::InvalidState,
+                "Destination write stream state changed before replacement",
+                format!(
+                    "Expected stream '{}' for destination table '{}'",
+                    expected_stream_name, state.destination_table_id
+                )
+            ));
+        }
+
+        Ok(())
+    }
+
     async fn delete_destination_write_stream_state(
         &self,
         table_id: TableId,

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use etl_postgres::store::{
-    destination_table_metadata as pg_destination_table_metadata, progress, schema,
+    destination_table_metadata as pg_destination_table_metadata,
+    destination_write_stream as pg_destination_write_stream, progress, schema,
     table_state as pg_table_state,
 };
 use metrics::gauge;
@@ -19,6 +20,7 @@ use crate::{
     config::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions},
     destination::{
         AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationTableSchemaStatus,
+        DestinationWriteStreamState,
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -487,6 +489,81 @@ impl StateStore for PostgresStore {
 
         Ok(())
     }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        pg_destination_write_stream::get_destination_write_stream(
+            &self.pool,
+            self.pipeline_id as i64,
+            table_id,
+            &destination_table_id,
+        )
+        .await
+        .map(|row| {
+            row.map(|row| {
+                DestinationWriteStreamState::new(
+                    row.destination_table_id,
+                    row.stream_name,
+                    row.next_offset,
+                )
+            })
+        })
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination write stream state loading failed",
+                source: err
+            )
+        })
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        pg_destination_write_stream::store_destination_write_stream(
+            &self.pool,
+            self.pipeline_id as i64,
+            table_id,
+            &state.destination_table_id,
+            &state.stream_name,
+            state.next_offset,
+        )
+        .await
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination write stream state storage failed",
+                source: err
+            )
+        })
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        pg_destination_write_stream::delete_destination_write_stream(
+            &self.pool,
+            self.pipeline_id as i64,
+            table_id,
+            &destination_table_id,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|err| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Destination write stream state deletion failed",
+                source: err
+            )
+        })
+    }
 }
 
 impl SchemaStore for PostgresStore {
@@ -666,6 +743,20 @@ impl TableStateLifecycleStore for PostgresStore {
                     )
                 })?;
 
+                pg_destination_write_stream::delete_destination_write_streams_for_table(
+                    &mut *tx,
+                    self.pipeline_id as i64,
+                    table_id,
+                )
+                .await
+                .map_err(|err| {
+                    etl_error!(
+                        ErrorKind::SourceQueryFailed,
+                        "Destination write stream state deletion failed",
+                        source: err
+                    )
+                })?;
+
                 schema::delete_table_schema_for_table(&mut *tx, self.pipeline_id as i64, table_id)
                     .await
                     .map_err(|err| {
@@ -730,6 +821,19 @@ impl TableStateLifecycleStore for PostgresStore {
                     )
                 })?;
 
+                pg_destination_write_stream::delete_destination_write_streams_for_all_tables(
+                    &mut *tx,
+                    self.pipeline_id as i64,
+                )
+                .await
+                .map_err(|err| {
+                    etl_error!(
+                        ErrorKind::SourceQueryFailed,
+                        "Destination write stream state deletion failed",
+                        source: err
+                    )
+                })?;
+
                 tx.commit().await?;
 
                 for table_id in table_ids {
@@ -754,6 +858,20 @@ impl TableStateLifecycleStore for PostgresStore {
                     etl_error!(
                         ErrorKind::SourceQueryFailed,
                         "Destination table metadata deletion failed",
+                        source: err
+                    )
+                })?;
+
+                pg_destination_write_stream::delete_destination_write_streams_for_table(
+                    &mut *tx,
+                    self.pipeline_id as i64,
+                    table_id,
+                )
+                .await
+                .map_err(|err| {
+                    etl_error!(
+                        ErrorKind::SourceQueryFailed,
+                        "Destination write stream state deletion failed",
                         source: err
                     )
                 })?;

--- a/crates/etl/src/store/mod.rs
+++ b/crates/etl/src/store/mod.rs
@@ -28,7 +28,7 @@ pub use capabilities::{DestinationStore, PipelineStore, SharedStateStore};
 pub use lifecycle::{TableStateLifecycleStore, TableStateOperation};
 pub(crate) use schema::TableSchemaSnapshots;
 pub use schema::{SchemaStore, TableSchemaRetention};
-pub(crate) use state::DestinationTablesMetadata;
+pub(crate) use state::{DestinationTablesMetadata, DestinationWriteStreamStates};
 pub use state::{StateStore, TableStates};
 
 pub use crate::replication::{

--- a/crates/etl/src/store/state/base.rs
+++ b/crates/etl/src/store/state/base.rs
@@ -157,6 +157,15 @@ pub trait StateStore {
         state: DestinationWriteStreamState,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 
+    /// Replaces durable write stream state after a destination rotates to a new
+    /// stream for the same physical table.
+    fn replace_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        expected_stream_name: String,
+        state: DestinationWriteStreamState,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
+
     /// Deletes durable write stream state for a physical destination table.
     fn delete_destination_write_stream_state(
         &self,

--- a/crates/etl/src/store/state/base.rs
+++ b/crates/etl/src/store/state/base.rs
@@ -1,7 +1,9 @@
 use std::{collections::BTreeMap, future::Future, sync::Arc};
 
 use crate::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::EtlResult,
     schema::{PgLsn, TableId},
     store::{TableState, WorkerType},
@@ -12,6 +14,10 @@ pub type TableStates = Arc<BTreeMap<TableId, TableState>>;
 
 /// Arc-wrapped dictionary of destination table metadata.
 pub(crate) type DestinationTablesMetadata = Arc<BTreeMap<TableId, DestinationTableMetadata>>;
+
+/// Arc-wrapped dictionary of destination write stream states.
+pub(crate) type DestinationWriteStreamStates =
+    Arc<BTreeMap<(TableId, String), DestinationWriteStreamState>>;
 
 /// Trait for storing and retrieving table states, durable replication progress,
 /// and destination metadata.
@@ -135,5 +141,26 @@ pub trait StateStore {
         &self,
         table_id: TableId,
         metadata: DestinationTableMetadata,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
+
+    /// Returns durable write stream state for a physical destination table.
+    fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> impl Future<Output = EtlResult<Option<DestinationWriteStreamState>>> + Send;
+
+    /// Stores durable write stream state for a physical destination table.
+    fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> impl Future<Output = EtlResult<()>> + Send;
+
+    /// Deletes durable write stream state for a physical destination table.
+    fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 }

--- a/crates/etl/src/store/state/mod.rs
+++ b/crates/etl/src/store/state/mod.rs
@@ -1,4 +1,4 @@
 mod base;
 
-pub(crate) use base::DestinationTablesMetadata;
+pub(crate) use base::{DestinationTablesMetadata, DestinationWriteStreamStates};
 pub use base::{StateStore, TableStates};

--- a/crates/etl/src/test_utils/notifying_store.rs
+++ b/crates/etl/src/test_utils/notifying_store.rs
@@ -463,8 +463,9 @@ fn should_store_destination_write_stream_state(
         None => true,
         Some(current) => {
             current.stream_name == next.stream_name
-                && current.next_offset <= next.next_offset
-                && current.last_sequence_number <= next.last_sequence_number
+                && (current.next_offset < next.next_offset
+                    || (current.next_offset == next.next_offset
+                        && current.last_sequence_number <= next.last_sequence_number))
         }
     }
 }

--- a/crates/etl/src/test_utils/notifying_store.rs
+++ b/crates/etl/src/test_utils/notifying_store.rs
@@ -8,7 +8,9 @@ use tokio::sync::{Notify, RwLock};
 use tokio_postgres::types::PgLsn;
 
 use crate::{
-    destination::{AppliedDestinationTableMetadata, DestinationTableMetadata},
+    destination::{
+        AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationWriteStreamState,
+    },
     error::{ErrorKind, EtlResult},
     etl_error,
     replication::{
@@ -17,8 +19,9 @@ use crate::{
     },
     schema::{SnapshotId, TableId, TableSchema},
     store::{
-        DestinationTablesMetadata, SchemaStore, StateStore, TableSchemaRetention,
-        TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation, TableStates,
+        DestinationTablesMetadata, DestinationWriteStreamStates, SchemaStore, StateStore,
+        TableSchemaRetention, TableSchemaSnapshots, TableStateLifecycleStore, TableStateOperation,
+        TableStates,
     },
     test_utils::notify::TimedNotify,
 };
@@ -42,6 +45,7 @@ struct Inner {
     table_state_history: HashMap<TableId, Vec<TableState>>,
     table_schemas: Arc<TableSchemaSnapshots>,
     destination_tables_metadata: DestinationTablesMetadata,
+    destination_write_stream_states: DestinationWriteStreamStates,
     replication_progress: HashMap<WorkerType, PgLsn>,
     table_state_type_conditions: Vec<TableStateTypeCondition>,
     table_state_conditions: Vec<TableStateCondition>,
@@ -114,6 +118,7 @@ impl NotifyingStore {
             table_state_history: HashMap::new(),
             table_schemas: Arc::new(TableSchemaSnapshots::default()),
             destination_tables_metadata: Arc::new(BTreeMap::new()),
+            destination_write_stream_states: Arc::new(BTreeMap::new()),
             replication_progress: HashMap::new(),
             table_state_type_conditions: Vec::new(),
             table_state_conditions: Vec::new(),
@@ -388,6 +393,61 @@ impl StateStore for NotifyingStore {
         Arc::make_mut(&mut inner.destination_tables_metadata).insert(table_id, metadata);
         Ok(())
     }
+
+    async fn get_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<Option<DestinationWriteStreamState>> {
+        let inner = self.inner.read().await;
+
+        Ok(inner.destination_write_stream_states.get(&(table_id, destination_table_id)).cloned())
+    }
+
+    async fn store_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.write().await;
+        let key = (table_id, state.destination_table_id.clone());
+        if should_store_destination_write_stream_state(
+            inner.destination_write_stream_states.get(&key),
+            &state,
+        ) {
+            Arc::make_mut(&mut inner.destination_write_stream_states).insert(key, state);
+        }
+        inner.check_conditions();
+
+        Ok(())
+    }
+
+    async fn delete_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        destination_table_id: String,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.write().await;
+        Arc::make_mut(&mut inner.destination_write_stream_states)
+            .remove(&(table_id, destination_table_id));
+        inner.check_conditions();
+
+        Ok(())
+    }
+}
+
+fn should_store_destination_write_stream_state(
+    current: Option<&DestinationWriteStreamState>,
+    next: &DestinationWriteStreamState,
+) -> bool {
+    match current {
+        None => true,
+        Some(current) => {
+            current.next_offset < next.next_offset
+                || (current.next_offset == next.next_offset
+                    && current.stream_name == next.stream_name)
+        }
+    }
 }
 
 impl SchemaStore for NotifyingStore {
@@ -450,6 +510,8 @@ impl TableStateLifecycleStore for NotifyingStore {
                 let mut inner = self.inner.write().await;
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
                 inner.check_conditions();
 
@@ -476,6 +538,7 @@ impl TableStateLifecycleStore for NotifyingStore {
                 }
 
                 inner.replication_progress.remove(&WorkerType::Apply);
+                Arc::make_mut(&mut inner.destination_write_stream_states).clear();
                 inner.check_conditions();
 
                 Ok(reset_count)
@@ -488,6 +551,8 @@ impl TableStateLifecycleStore for NotifyingStore {
                 inner.table_state_history.remove(&table_id);
                 Arc::make_mut(&mut inner.table_schemas).remove_table(table_id);
                 Arc::make_mut(&mut inner.destination_tables_metadata).remove(&table_id);
+                Arc::make_mut(&mut inner.destination_write_stream_states)
+                    .retain(|(state_table_id, _), _| *state_table_id != table_id);
                 inner.replication_progress.remove(&WorkerType::TableSync { table_id });
                 inner.check_conditions();
 

--- a/crates/etl/src/test_utils/notifying_store.rs
+++ b/crates/etl/src/test_utils/notifying_store.rs
@@ -422,6 +422,25 @@ impl StateStore for NotifyingStore {
         Ok(())
     }
 
+    async fn replace_destination_write_stream_state(
+        &self,
+        table_id: TableId,
+        expected_stream_name: String,
+        state: DestinationWriteStreamState,
+    ) -> EtlResult<()> {
+        let mut inner = self.inner.write().await;
+        let key = (table_id, state.destination_table_id.clone());
+        ensure_destination_write_stream_state_can_be_replaced(
+            inner.destination_write_stream_states.get(&key),
+            &expected_stream_name,
+            &state,
+        )?;
+        Arc::make_mut(&mut inner.destination_write_stream_states).insert(key, state);
+        inner.check_conditions();
+
+        Ok(())
+    }
+
     async fn delete_destination_write_stream_state(
         &self,
         table_id: TableId,
@@ -443,12 +462,39 @@ fn should_store_destination_write_stream_state(
     match current {
         None => true,
         Some(current) => {
-            current.next_offset < next.next_offset
-                || (current.next_offset == next.next_offset
-                    && current.stream_name == next.stream_name
-                    && current.last_sequence_number <= next.last_sequence_number)
+            current.stream_name == next.stream_name
+                && current.next_offset <= next.next_offset
+                && current.last_sequence_number <= next.last_sequence_number
         }
     }
+}
+
+fn ensure_destination_write_stream_state_can_be_replaced(
+    current: Option<&DestinationWriteStreamState>,
+    expected_stream_name: &str,
+    next: &DestinationWriteStreamState,
+) -> EtlResult<()> {
+    let Some(current) = current else {
+        return Ok(());
+    };
+
+    if current.stream_name != expected_stream_name {
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            "Destination write stream state changed before replacement",
+            format!("Expected stream '{}', found '{}'", expected_stream_name, current.stream_name)
+        ));
+    }
+
+    if current.last_sequence_number > next.last_sequence_number {
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            "Destination write stream sequence would move backwards",
+            "The replacement state has an older append-only sequence watermark"
+        ));
+    }
+
+    Ok(())
 }
 
 impl SchemaStore for NotifyingStore {

--- a/crates/etl/src/test_utils/notifying_store.rs
+++ b/crates/etl/src/test_utils/notifying_store.rs
@@ -445,7 +445,8 @@ fn should_store_destination_write_stream_state(
         Some(current) => {
             current.next_offset < next.next_offset
                 || (current.next_offset == next.next_offset
-                    && current.stream_name == next.stream_name)
+                    && current.stream_name == next.stream_name
+                    && current.last_sequence_number <= next.last_sequence_number)
         }
     }
 }

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -323,6 +323,26 @@ async fn state_store_destination_write_stream_state_persists_and_clears() {
         Some(advanced.clone())
     );
 
+    let stale_higher_offset_lower_sequence = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        advanced.stream_name.clone(),
+        advanced.next_offset + 100,
+    )
+    .with_last_sequence_number(Some(
+        "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+    ));
+    store
+        .store_destination_write_stream_state(table_id, stale_higher_offset_lower_sequence)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
     let same_offset_different_stream = DestinationWriteStreamState::new(
         advanced.destination_table_id.clone(),
         "projects/p/datasets/d/tables/dest_table_0001/streams/same_offset_stale".to_owned(),
@@ -340,13 +360,45 @@ async fn state_store_destination_write_stream_state_persists_and_clears() {
         Some(advanced.clone())
     );
 
+    let rotated = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/rotated".to_owned(),
+        0,
+    )
+    .with_last_sequence_number(advanced.last_sequence_number.clone());
+    store
+        .replace_destination_write_stream_state(
+            table_id,
+            advanced.stream_name.clone(),
+            rotated.clone(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, rotated.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(rotated.clone())
+    );
+
+    let stale_old_stream = advanced.advanced_by(100);
+    store.store_destination_write_stream_state(table_id, stale_old_stream).await.unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, rotated.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(rotated.clone())
+    );
+
     let new_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
     assert_eq!(
         new_store
-            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .get_destination_write_stream_state(table_id, rotated.destination_table_id.clone())
             .await
             .unwrap(),
-        Some(advanced)
+        Some(rotated)
     );
 
     new_store.prepare_table_state_for_copy(table_id).await.unwrap();
@@ -402,10 +454,7 @@ where
     .with_last_sequence_number(Some(
         "0000000000000001/0000000000000000/0000000000000000".to_owned(),
     ));
-    store
-        .store_destination_write_stream_state(table_id, same_offset_lower_sequence)
-        .await
-        .unwrap();
+    store.store_destination_write_stream_state(table_id, same_offset_lower_sequence).await.unwrap();
     assert_eq!(
         store
             .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
@@ -448,7 +497,66 @@ where
             .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
             .await
             .unwrap(),
-        Some(same_offset_higher_sequence)
+        Some(same_offset_higher_sequence.clone())
+    );
+
+    let stale_higher_offset_lower_sequence = DestinationWriteStreamState::new(
+        same_offset_higher_sequence.destination_table_id.clone(),
+        same_offset_higher_sequence.stream_name.clone(),
+        same_offset_higher_sequence.next_offset + 100,
+    )
+    .with_last_sequence_number(Some(
+        "0000000000000002/0000000000000000/0000000000000000".to_owned(),
+    ));
+    store
+        .store_destination_write_stream_state(table_id, stale_higher_offset_lower_sequence)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(same_offset_higher_sequence.clone())
+    );
+
+    let stale_higher_offset_different_stream = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/higher_offset_stale".to_owned(),
+        advanced.next_offset + 100,
+    );
+    store
+        .store_destination_write_stream_state(table_id, stale_higher_offset_different_stream)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(same_offset_higher_sequence.clone())
+    );
+
+    let rotated = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/rotated".to_owned(),
+        0,
+    )
+    .with_last_sequence_number(same_offset_higher_sequence.last_sequence_number.clone());
+    store
+        .replace_destination_write_stream_state(
+            table_id,
+            same_offset_higher_sequence.stream_name,
+            rotated.clone(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(rotated)
     );
 }
 

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -296,7 +296,10 @@ async fn state_store_destination_write_stream_state_persists_and_clears() {
         .expect("stream state should be stored");
     assert_eq!(loaded, stream_state);
 
-    let advanced = stream_state.advanced_by(3);
+    let advanced = stream_state.advanced_to(
+        stream_state.next_offset + 3,
+        "0000000000000002/0000000000000000/0000000000000000".to_owned(),
+    );
     store.store_destination_write_stream_state(table_id, advanced.clone()).await.unwrap();
     assert_eq!(
         store
@@ -376,7 +379,10 @@ where
         "projects/p/datasets/d/tables/dest_table_0001/streams/s1".to_owned(),
         42,
     );
-    let advanced = stream_state.advanced_by(3);
+    let advanced = stream_state.advanced_to(
+        stream_state.next_offset + 3,
+        "0000000000000002/0000000000000000/0000000000000000".to_owned(),
+    );
 
     store.store_destination_write_stream_state(table_id, advanced.clone()).await.unwrap();
     store.store_destination_write_stream_state(table_id, stream_state).await.unwrap();
@@ -388,10 +394,50 @@ where
         Some(advanced.clone())
     );
 
-    let same_offset_different_stream = DestinationWriteStreamState::new(
+    let same_offset_lower_sequence = DestinationWriteStreamState::new(
         advanced.destination_table_id.clone(),
-        "projects/p/datasets/d/tables/dest_table_0001/streams/same_offset_stale".to_owned(),
+        advanced.stream_name.clone(),
         advanced.next_offset,
+    )
+    .with_last_sequence_number(Some(
+        "0000000000000001/0000000000000000/0000000000000000".to_owned(),
+    ));
+    store
+        .store_destination_write_stream_state(table_id, same_offset_lower_sequence)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let same_offset_higher_sequence = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        advanced.stream_name.clone(),
+        advanced.next_offset,
+    )
+    .with_last_sequence_number(Some(
+        "0000000000000003/0000000000000000/0000000000000000".to_owned(),
+    ));
+    store
+        .store_destination_write_stream_state(table_id, same_offset_higher_sequence.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(same_offset_higher_sequence.clone())
+    );
+
+    let same_offset_different_stream = DestinationWriteStreamState::new(
+        same_offset_higher_sequence.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/same_offset_stale".to_owned(),
+        same_offset_higher_sequence.next_offset,
     );
     store
         .store_destination_write_stream_state(table_id, same_offset_different_stream)
@@ -402,7 +448,7 @@ where
             .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
             .await
             .unwrap(),
-        Some(advanced)
+        Some(same_offset_higher_sequence)
     );
 }
 

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -3,15 +3,15 @@
 use std::collections::HashMap;
 
 use etl::{
-    destination::DestinationTableMetadata,
+    destination::{DestinationTableMetadata, DestinationWriteStreamState},
     error::ErrorKind,
     etl_error,
     schema::{ColumnSchema, ReplicationMask, SnapshotId, TableId, TableName, TableSchema},
     store::{
-        PostgresStore, SchemaStore, StateStore, TableRetryPolicy, TableSchemaRetention, TableState,
-        TableStateLifecycleStore, WorkerType,
+        MemoryStore, PostgresStore, SchemaStore, StateStore, TableRetryPolicy,
+        TableSchemaRetention, TableState, TableStateLifecycleStore, WorkerType,
     },
-    test_utils::database::spawn_source_database,
+    test_utils::{database::spawn_source_database, notifying_store::NotifyingStore},
 };
 use etl_postgres::source::connect_to_source_database;
 use etl_telemetry::tracing::init_test_tracing;
@@ -252,6 +252,208 @@ async fn state_store_replication_progress_is_monotonic() {
     store.delete_replication_progress(table_sync_worker).await.unwrap();
     assert_eq!(store.get_replication_progress(table_sync_worker).await.unwrap(), None);
     assert_eq!(store.get_replication_progress(apply_worker).await.unwrap(), Some(later_lsn));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn state_store_destination_write_stream_state_persists_and_clears() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let pipeline_id = 1;
+    let table_id = TableId::new(12345);
+    let other_table_id = TableId::new(67890);
+
+    let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    let stream_state = DestinationWriteStreamState::new(
+        "dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/s1".to_owned(),
+        42,
+    );
+    let other_stream_state = DestinationWriteStreamState::new(
+        "other_dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/other_dest_table_0001/streams/s2".to_owned(),
+        7,
+    );
+
+    assert!(
+        store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id.clone())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    store.store_destination_write_stream_state(table_id, stream_state.clone()).await.unwrap();
+    store
+        .store_destination_write_stream_state(other_table_id, other_stream_state.clone())
+        .await
+        .unwrap();
+
+    let loaded = store
+        .get_destination_write_stream_state(table_id, stream_state.destination_table_id.clone())
+        .await
+        .unwrap()
+        .expect("stream state should be stored");
+    assert_eq!(loaded, stream_state);
+
+    let advanced = stream_state.advanced_by(3);
+    store.store_destination_write_stream_state(table_id, advanced.clone()).await.unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let stale = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/stale".to_owned(),
+        advanced.next_offset - 1,
+    );
+    store.store_destination_write_stream_state(table_id, stale).await.unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let same_offset_different_stream = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/same_offset_stale".to_owned(),
+        advanced.next_offset,
+    );
+    store
+        .store_destination_write_stream_state(table_id, same_offset_different_stream)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let new_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    assert_eq!(
+        new_store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced)
+    );
+
+    new_store.prepare_table_state_for_copy(table_id).await.unwrap();
+    assert!(
+        new_store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        new_store
+            .get_destination_write_stream_state(
+                other_table_id,
+                other_stream_state.destination_table_id.clone()
+            )
+            .await
+            .unwrap(),
+        Some(other_stream_state)
+    );
+}
+
+async fn assert_destination_write_stream_state_is_monotonic<S>(store: S)
+where
+    S: StateStore,
+{
+    let table_id = TableId::new(12345);
+    let stream_state = DestinationWriteStreamState::new(
+        "dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/s1".to_owned(),
+        42,
+    );
+    let advanced = stream_state.advanced_by(3);
+
+    store.store_destination_write_stream_state(table_id, advanced.clone()).await.unwrap();
+    store.store_destination_write_stream_state(table_id, stream_state).await.unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced.clone())
+    );
+
+    let same_offset_different_stream = DestinationWriteStreamState::new(
+        advanced.destination_table_id.clone(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/same_offset_stale".to_owned(),
+        advanced.next_offset,
+    );
+    store
+        .store_destination_write_stream_state(table_id, same_offset_different_stream)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_destination_write_stream_state(table_id, advanced.destination_table_id.clone())
+            .await
+            .unwrap(),
+        Some(advanced)
+    );
+}
+
+#[tokio::test]
+async fn memory_store_destination_write_stream_state_is_monotonic() {
+    assert_destination_write_stream_state_is_monotonic(MemoryStore::new()).await;
+}
+
+#[tokio::test]
+async fn notifying_store_destination_write_stream_state_is_monotonic() {
+    assert_destination_write_stream_state_is_monotonic(NotifyingStore::new()).await;
+}
+
+async fn assert_reset_for_resync_clears_destination_write_stream_state<S>(store: S)
+where
+    S: StateStore + TableStateLifecycleStore,
+{
+    let table_id = TableId::new(12345);
+    let stream_state = DestinationWriteStreamState::new(
+        "dest_table_0001".to_owned(),
+        "projects/p/datasets/d/tables/dest_table_0001/streams/s1".to_owned(),
+        42,
+    );
+
+    store.store_destination_write_stream_state(table_id, stream_state.clone()).await.unwrap();
+    assert!(
+        store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id.clone())
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    store.reset_table_states_for_resync().await.unwrap();
+    assert!(
+        store
+            .get_destination_write_stream_state(table_id, stream_state.destination_table_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn memory_store_reset_for_resync_clears_destination_write_stream_state() {
+    assert_reset_for_resync_clears_destination_write_stream_state(MemoryStore::new()).await;
+}
+
+#[tokio::test]
+async fn notifying_store_reset_for_resync_clears_destination_write_stream_state() {
+    assert_reset_for_resync_clears_destination_write_stream_state(NotifyingStore::new()).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

Adds a BigQuery append-only history write mode for the BigQuery destination.

This PR depends on #874 for durable destination write stream state. It is currently a draft follow-up PR for #873.

## User-facing behavior

This adds a BigQuery write mode that preserves source changes as append-only history rows instead of maintaining only the latest row state.

- `current_state` remains the default BigQuery write mode.
- `append_only` creates append-only BigQuery tables.
- Initial copy rows are written as history rows.
- CDC insert/update/delete events are appended as new rows.
- Existing BigQuery current-state behavior is kept unchanged.
- Updating an existing destination from one `write_mode` to another is rejected, because the physical table schema and write behavior are different.

## BigQuery table shape

Append-only tables include the source columns plus flat Supabase ETL metadata columns:

- `_etl_uuid`
- `_etl_source_timestamp`
- `_etl_change_sequence_number`
- `_etl_change_type`
- `_etl_sort_keys`

The metadata is intentionally flat rather than a nested `datastream_metadata` struct so it can be written through the Storage Write API path used by this implementation.

## Change event mapping

The append-only mode maps source events to `_etl_change_type` values as follows:

| Source event | `_etl_change_type` |
|---|---|
| initial copy | `INSERT` |
| insert | `INSERT` |
| update old image | `UPDATE-DELETE` |
| update new image | `UPDATE-INSERT` |
| delete | `DELETE` |

For updates, the destination emits both before and after rows when the old image is available. Key-only old images are expanded into sparse before rows so primary-key changes can still be represented in history.

## Write path and retry behavior

Append-only writes use BigQuery Storage Write API committed streams.

The implementation uses the durable stream state added in #874 to remember:

- the BigQuery committed stream name
- the next append offset
- the associated destination table id
- the latest durable append-only sequence watermark

That lets retries and process restarts resume from the stored offset instead of generating a new stream position and duplicating rows.

The stored stream state is monotonic by committed-stream offset. Stale writers cannot move the offset backwards, and same-offset updates cannot move the sequence watermark backwards. Initial-copy sequence values are stable row identities rather than globally increasing CDC sequence values, so offset advancement is allowed even when the next copied row's sequence sorts lower than the previous copied row. Schema changes rotate to a fresh committed stream while preserving the sequence watermark. This keeps replay filtering intact if the process crashes around a schema change.

For BigQuery `ALREADY_EXISTS` responses, the committed stream path only treats the response as success for a retried append request. A first-attempt overlap is still returned as an error because batch boundaries may not match a previous append.

## Ordering and initial copy

Initial copy rows are emitted as `INSERT` rows.

For initial copy rows, the implementation builds a stable row identity from the source row and stores it in `_etl_uuid` / `_etl_change_sequence_number` using a reserved copy sequence prefix plus the row hash. This makes the metadata deterministic for the same copied row, which is important if the copy has to be retried.

Initial copy rows also get a dedicated low sort key prefix so they sort before CDC rows for the same source table, even when the initial copy timestamp is newer than an already captured CDC timestamp.

For example, a copied row and a later CDC row would sort like this:

| Row source | `_etl_change_type` | `_etl_change_sequence_number` example | `_etl_sort_keys` example |
|---|---|---|---|
| initial copy | `INSERT` | `0000000000000000/0000000000000000/<row-hash>` | `["0000000000000000", "0000000000000000/0000000000000000/<row-hash>", "copy/<sequence>/<row-hash>"]` |
| CDC insert/update/delete | `INSERT` / `UPDATE-*` / `DELETE` | `0000000000000001/0000000000000002/0000000000000003` | `["800000000000002a", "0000000000000001/0000000000000002", "0000000000000003"]` |

The CDC sequence number is derived from the event sequence key and an internal ordinal. That gives consumers a deterministic replay order: first sort by `_etl_sort_keys`, then interpret `_etl_change_type` to reconstruct history.

## Schema changes

Append-only tables can evolve with source schema changes.

- New source columns are added to the append-only table.
- Renamed / removed source columns are preserved as historical columns where needed.
- Append-only tables do not require a source primary key in the same way current-state tables do, because rows are appended rather than merged into a current-state table.

## PR split

This PR is split with pattern 1: bottom-up.

- #874: durable destination write stream state foundation
- #875: BigQuery append-only mode built on that foundation

Because this is a fork-to-upstream PR, GitHub cannot use the fork branch from #874 as the upstream base branch. Until #874 is merged, the normal GitHub diff for this PR still includes the #874 foundation commit.

For a focused review of only the append-only slice, use this compare view:

https://github.com/1neoneo3/etl/compare/feature/bigquery-append-only-history...feature/bigquery-write-stream-state

After #874 is merged, this PR can be rebased onto the updated `main`, and the normal GitHub diff will shrink to the append-only implementation only.

## Out of scope / follow-ups

- Per-table append-only selection is not implemented in this PR.
- Pattern-based table write mode selection is not implemented in this PR.
- Switching an existing BigQuery table in place from `current_state` to `append_only` is intentionally not supported.
- This PR does not try to exactly reproduce Datastream's nested metadata layout; it preserves the append-only semantics using Supabase ETL `_etl_*` metadata columns.

## Tests

- `cargo check -p etl --features test-utils`
- `cargo check -p etl-destinations --features test-utils,bigquery`
- `cargo check -p etl-replicator`
- `cargo test -p etl --features test-utils memory_store_destination_write_stream_state_is_monotonic --test main -- --nocapture`
- `cargo test -p etl --features test-utils notifying_store_destination_write_stream_state_is_monotonic --test main -- --nocapture`
- `cargo test -p etl --features test-utils state_store_destination_write_stream_state_persists_and_clears --test main -- --nocapture`
- `cargo test -p etl-destinations --features test-utils,bigquery append_only_rows_after_sequence -- --nocapture`
- `cargo test -p etl-destinations --features test-utils,bigquery committed_stream_already_exists_only_succeeds_on_retry_attempts -- --nocapture`
- `cargo test -p etl-destinations --features test-utils,bigquery committed_stream_max_inflight_uses_connection_pool_size_as_proactive_limit -- --nocapture`
- `cargo test -p etl-destinations --features bigquery,test-utils append_only -- --nocapture`
- `cargo test -p etl-destinations --features bigquery,test-utils committed_stream -- --nocapture`
- `cargo test -p etl-destinations --features bigquery committed_stream_ --lib`
- `cargo test -p etl write_stream_state_ --lib`
- `cargo test -p etl-destinations --features bigquery,test-utils append_only_copy_rows_after_sequence --lib`
- `git diff --no-ext-diff --check`

Local BigQuery smoke validation was also run without adding the smoke test source to this PR, to keep the review diff focused. This used a real BigQuery project and local test Postgres:

- `env TESTS_BIGQUERY_PROJECT_ID=oripaone TESTS_BIGQUERY_SA_KEY_PATH=/home/mk/.config/gcp/automation-bigquery.json REQUIRE_BIGQUERY_CREDENTIALS=true cargo test -p etl-destinations --features bigquery,test-utils local_append_only_smoke --test main -- --ignored --nocapture`

The latest local smoke run passed 11 ignored tests. Under those conditions, the following behavior has been verified:

- Initial copy rows are written as append-only `INSERT` rows.
- CDC insert/update/delete rows are written with deterministic append-only metadata.
- Replaying already durable initial-copy and CDC batches does not duplicate PK-table rows.
- A destination restart can resume from durable committed stream state and continue appending later CDC rows.
- A table added to an existing publication is initial-copied after pipeline restart, and later CDC rows for that table append successfully.
- A source schema `ADD COLUMN` can be followed by a committed stream append.
- A source schema `DROP COLUMN` preserves the historical BigQuery column and future appends still succeed.
- A source schema `RENAME COLUMN` preserves the old historical BigQuery column, adds the new column, and future appends still succeed.
- JSONB, timestamptz, numeric, arrays, and `NaN` float values append successfully through the append-only Storage Write path.
- Initial copy rows populate `_etl_source_timestamp`.
- No-primary-key duplicate initial-copy rows are preserved as distinct history rows.
- Multi-table append-only initial copy, CDC append, and replay deduplication work across separate tables.
- WAL retention smoke also passed outside the committed test source:
  - 1,000,000 initial-copy rows plus 100,000 CDC insert rows generated while table copy was running; BigQuery row count reached 1,100,000 in 176.53s, max observed retained WAL was 15,420,960 bytes, max observed unconfirmed WAL was 15,420,904 bytes, and no replication slot reached `lost` status.
  - 1,000,000 initial-copy rows plus 1,000,000 CDC insert rows generated while table copy was running; BigQuery row count reached 2,000,000 in 228.63s, max observed retained WAL was 150,197,736 bytes, max observed unconfirmed WAL was 150,197,680 bytes, and no replication slot reached `lost` status.
  - 100,000,000 initial-copy rows plus 1,000,000 CDC insert rows generated while table copy was running; the first large runs exposed missing committed-stream retry classification for `CANCELLED` and `UNKNOWN`, which this PR now treats as retryable transport uncertainty together with `DEADLINE_EXCEEDED`; after that fix, BigQuery row count reached 101,000,000 in 13,804.76s, max observed retained WAL was 6,508,233,144 bytes, max observed unconfirmed WAL was 6,508,233,088 bytes, and no replication slot reached `lost` status.
- Larger append-only table copies also passed outside the committed test source, using the same local smoke harness with row-count-only BigQuery verification:
  - 10,000 initial-copy rows + 1,000 CDC insert rows
  - 100,000 initial-copy rows + 1,000 CDC insert rows
  - 1,000,000 initial-copy rows + 1,000 CDC insert rows
  - 3,000,000 initial-copy rows + 1,000 CDC insert rows
  - 10,000,000 initial-copy rows + 1,000 CDC insert rows; initial copy count verified in 1411.83s and CDC count verified in 3.65s

The following existing BigQuery current-state regression tests were also run to check that this PR does not break the default mode:

- `env TESTS_BIGQUERY_PROJECT_ID=oripaone TESTS_BIGQUERY_SA_KEY_PATH=/home/mk/.config/gcp/automation-bigquery.json REQUIRE_BIGQUERY_CREDENTIALS=true cargo test -p etl-destinations --features bigquery,test-utils table_insert_update_delete --test main -- --nocapture`
- `env TESTS_BIGQUERY_PROJECT_ID=oripaone TESTS_BIGQUERY_SA_KEY_PATH=/home/mk/.config/gcp/automation-bigquery.json REQUIRE_BIGQUERY_CREDENTIALS=true cargo test -p etl-destinations --features bigquery,test-utils table_truncate_with_batching --test main -- --nocapture`
- `env TESTS_BIGQUERY_PROJECT_ID=oripaone TESTS_BIGQUERY_SA_KEY_PATH=/home/mk/.config/gcp/automation-bigquery.json REQUIRE_BIGQUERY_CREDENTIALS=true cargo test -p etl-destinations --features bigquery,test-utils schema_change_add_column_defaults --test main -- --nocapture`
- `env TESTS_BIGQUERY_PROJECT_ID=oripaone TESTS_BIGQUERY_SA_KEY_PATH=/home/mk/.config/gcp/automation-bigquery.json REQUIRE_BIGQUERY_CREDENTIALS=true cargo test -p etl-destinations --features bigquery,test-utils table_schema_change --test main -- --nocapture`

Refs #873