### PR TITLE
feat(api): Improve handling of replicators and restarts

### DIFF
--- a/crates/etl-api/.sqlx/query-cb5e029a3e12688bd813c036a7525294aa0d428054660cb1377940311608adc2.json
+++ b/crates/etl-api/.sqlx/query-cb5e029a3e12688bd813c036a7525294aa0d428054660cb1377940311608adc2.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        select id\n        from app.pipelines\n        where tenant_id = $1 and destination_id = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "app.pipelines",
+            "name": "id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "cb5e029a3e12688bd813c036a7525294aa0d428054660cb1377940311608adc2"
+}

--- a/crates/etl-api/.sqlx/query-e78f513310bed4041140dc3cf44eb7c0e0fda5f07e9bd9a7c3066ea3a55429ac.json
+++ b/crates/etl-api/.sqlx/query-e78f513310bed4041140dc3cf44eb7c0e0fda5f07e9bd9a7c3066ea3a55429ac.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        select id\n        from app.pipelines\n        where tenant_id = $1 and source_id = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "app.pipelines",
+            "name": "id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e78f513310bed4041140dc3cf44eb7c0e0fda5f07e9bd9a7c3066ea3a55429ac"
+}

--- a/crates/etl-api/README.md
+++ b/crates/etl-api/README.md
@@ -81,18 +81,22 @@ export APP_CONFIG_DIR=/etc/etl-api/config
 ### Replicator Resources
 
 The ETL API configuration must define the default Kubernetes requests for
-replicator containers:
+replicator and Vector containers:
 
 ```yaml
 k8s:
   replicator_resources:
-    replicator_cpu_request_millicores: 500
-    replicator_memory_request_mib: 2000
+    cpu_request_millicores: 500
+    memory_request_mib: 2000
+  vector_resources:
+    cpu_request_millicores: 75
+    memory_request_mib: 192
 ```
 
 These defaults are mandatory and request-only. The ETL API derives Kubernetes
 limits from the final request values with static multipliers in the Kubernetes
-materializer.
+materializer. Vector resources are configured only at the API level; pipeline
+configuration may override replicator resources only.
 
 Pipeline configuration may override any replicator resource field:
 

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -59,6 +59,8 @@ pub struct K8sConfig {
     /// replicator pod unless a pipeline-level override supplies one of those
     /// request values.
     pub replicator_resources: DefaultReplicatorResourcesConfig,
+    /// Default request sizing for the Vector sidecar.
+    pub vector_resources: DefaultVectorResourcesConfig,
 }
 
 /// Mandatory default request sizing for replicator workloads.
@@ -71,29 +73,50 @@ pub struct K8sConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct DefaultReplicatorResourcesConfig {
     /// Replicator memory request, in Mi.
-    pub replicator_memory_request_mib: i32,
+    pub memory_request_mib: i32,
     /// Replicator CPU request, in millicores.
-    pub replicator_cpu_request_millicores: i32,
+    pub cpu_request_millicores: i32,
+}
+
+/// Mandatory default request sizing for Vector sidecars.
+///
+/// These values are part of the ETL API service configuration and provide the
+/// baseline Kubernetes requests for Vector containers. Resource limits are
+/// derived from requests with the same static multipliers used for replicator
+/// containers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DefaultVectorResourcesConfig {
+    /// Vector memory request, in Mi.
+    pub memory_request_mib: i32,
+    /// Vector CPU request, in millicores.
+    pub cpu_request_millicores: i32,
 }
 
 impl ApiConfig {
     /// Validates API service configuration.
     pub fn validate(&self) -> Result<(), String> {
-        self.k8s.replicator_resources.validate()
+        self.k8s.replicator_resources.validate()?;
+        self.k8s.vector_resources.validate()?;
+
+        Ok(())
     }
 }
 
 impl DefaultReplicatorResourcesConfig {
     /// Validates that configured request values are positive.
     pub fn validate(&self) -> Result<(), String> {
-        validate_positive_request(
-            "K8s replicator memory request",
-            self.replicator_memory_request_mib,
-        )?;
-        validate_positive_request(
-            "K8s replicator cpu request",
-            self.replicator_cpu_request_millicores,
-        )?;
+        validate_positive_request("K8s replicator memory request", self.memory_request_mib)?;
+        validate_positive_request("K8s replicator cpu request", self.cpu_request_millicores)?;
+
+        Ok(())
+    }
+}
+
+impl DefaultVectorResourcesConfig {
+    /// Validates that configured request values are positive.
+    pub fn validate(&self) -> Result<(), String> {
+        validate_positive_request("K8s Vector memory request", self.memory_request_mib)?;
+        validate_positive_request("K8s Vector cpu request", self.cpu_request_millicores)?;
 
         Ok(())
     }

--- a/crates/etl-api/src/data/destinations_pipelines.rs
+++ b/crates/etl-api/src/data/destinations_pipelines.rs
@@ -69,7 +69,7 @@ pub async fn create_destination_and_pipeline(
 
 #[expect(clippy::too_many_arguments)]
 pub async fn update_destination_and_pipeline(
-    mut txn: PgTransaction<'_>,
+    txn: &mut PgTransaction<'_>,
     tenant_id: &str,
     destination_id: i64,
     pipeline_id: i64,
@@ -90,7 +90,6 @@ pub async fn update_destination_and_pipeline(
     .await?;
 
     if destination_id_res.is_none() {
-        txn.rollback().await?;
         return Err(DestinationPipelinesDbError::DestinationNotFound(destination_id));
     };
 
@@ -105,10 +104,8 @@ pub async fn update_destination_and_pipeline(
     .await?;
 
     if pipeline_id_res.is_none() {
-        txn.rollback().await?;
         return Err(DestinationPipelinesDbError::PipelineNotFound(pipeline_id));
     };
-    txn.commit().await?;
 
     Ok(())
 }

--- a/crates/etl-api/src/data/pipelines.rs
+++ b/crates/etl-api/src/data/pipelines.rs
@@ -383,6 +383,55 @@ where
     Ok(records)
 }
 
+/// Reads the ids of all pipelines that use `source_id` as their source.
+pub async fn read_pipeline_ids_for_source<'c, E>(
+    executor: E,
+    tenant_id: &str,
+    source_id: i64,
+) -> Result<Vec<i64>, PipelinesDbError>
+where
+    E: PgExecutor<'c>,
+{
+    let records = sqlx::query_scalar!(
+        r#"
+        select id
+        from app.pipelines
+        where tenant_id = $1 and source_id = $2
+        "#,
+        tenant_id,
+        source_id
+    )
+    .fetch_all(executor)
+    .await?;
+
+    Ok(records)
+}
+
+/// Reads the ids of all pipelines that use `destination_id` as their
+/// destination.
+pub async fn read_pipeline_ids_for_destination<'c, E>(
+    executor: E,
+    tenant_id: &str,
+    destination_id: i64,
+) -> Result<Vec<i64>, PipelinesDbError>
+where
+    E: PgExecutor<'c>,
+{
+    let records = sqlx::query_scalar!(
+        r#"
+        select id
+        from app.pipelines
+        where tenant_id = $1 and destination_id = $2
+        "#,
+        tenant_id,
+        destination_id
+    )
+    .fetch_all(executor)
+    .await?;
+
+    Ok(records)
+}
+
 pub async fn read_pipelines_for_source_for_deletion<'c, E>(
     executor: E,
     tenant_id: &str,

--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -291,8 +291,10 @@ pub trait K8sClient: Send + Sync {
     /// Creates or updates the replicator `StatefulSet`.
     ///
     /// The stateful set references secrets and config maps created by other
-    /// methods. Changing the configuration may trigger a rolling restart of
-    /// the pods.
+    /// methods. Applying this resource intentionally changes the pod template
+    /// restart annotation so the StatefulSet recreates its pods. This ensures
+    /// the replicator process observes newly materialized mounted config and
+    /// secret-backed environment values.
     async fn create_or_update_replicator_stateful_set(
         &self,
         config: ReplicatorStatefulSetConfig,

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -251,10 +251,14 @@ pub async fn should_reconcile_replicator_resources(
 
 /// Returns `true` when the replicator is active in Kubernetes.
 pub async fn is_replicator_active(
-    k8s_client: &dyn K8sClient,
+    k8s_client: Option<&dyn K8sClient>,
     tenant_id: &str,
     replicator_id: i64,
 ) -> Result<bool, K8sCoreError> {
+    let Some(k8s_client) = k8s_client else {
+        return Ok(false);
+    };
+
     let prefix = create_k8s_object_prefix(tenant_id, replicator_id);
     let pod_status = k8s_client.get_replicator_pod_status(&prefix).await?;
 
@@ -271,7 +275,7 @@ pub async fn is_replicator_active(
 /// Returns the first active pipeline id, if any pipeline is currently active in
 /// Kubernetes.
 pub async fn first_active_pipeline_id(
-    k8s_client: &dyn K8sClient,
+    k8s_client: Option<&dyn K8sClient>,
     tenant_id: &str,
     pipelines: &[PipelineDeletion],
 ) -> Result<Option<i64>, K8sCoreError> {
@@ -849,7 +853,7 @@ mod tests {
         let pipeline =
             PipelineDeletion { id: 1, source_id: 2, destination_id: 3, replicator_id: 4 };
 
-        let is_active = is_replicator_active(&client, "tenant-42", pipeline.replicator_id)
+        let is_active = is_replicator_active(Some(&client), "tenant-42", pipeline.replicator_id)
             .await
             .expect("failed to inspect pipeline status");
 

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -111,7 +111,9 @@ pub enum Secrets {
 /// This function orchestrates the creation or update of secrets, config maps,
 /// and stateful sets needed to run a pipeline in Kubernetes. It extracts
 /// credentials from the source and destination configurations, builds the
-/// replicator configuration, and applies all resources to the cluster.
+/// replicator configuration, and applies all resources to the cluster. Updating
+/// the StatefulSet intentionally forces pod recreation so the replicator
+/// process picks up the latest mounted config and secret-backed environment.
 #[allow(clippy::too_many_arguments)]
 pub async fn create_or_update_pipeline_resources_in_k8s(
     k8s_client: &dyn K8sClient,

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -34,6 +34,8 @@ use crate::{
     },
 };
 
+/// Server-side apply field manager for resources owned by the API service.
+const FIELD_MANAGER: &str = "etl-api";
 /// Secret name suffix for the BigQuery service account key.
 const BQ_SECRET_NAME_SUFFIX: &str = "bq-service-account-key";
 /// Secret name suffix for the ClickHouse password.
@@ -421,7 +423,7 @@ impl K8sClient for HttpK8sClient {
         // fields. If there is an override (likely during an incident or SREs
         // intervention), we want to override their changes. The API database is
         // the source of truth for credentials.
-        let pp = PatchParams::apply(&postgres_secret_name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.secrets_api.patch(&postgres_secret_name, &pp, &Patch::Apply(secret)).await?;
 
         Ok(())
@@ -448,7 +450,7 @@ impl K8sClient for HttpK8sClient {
         // fields. If there is an override (likely during an incident or SREs
         // intervention), we want to override their changes. The API database is
         // the source of truth for credentials.
-        let pp = PatchParams::apply(&bq_secret_name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.secrets_api.patch(&bq_secret_name, &pp, &Patch::Apply(secret)).await?;
 
         Ok(())
@@ -474,7 +476,7 @@ impl K8sClient for HttpK8sClient {
             // fields. If there is an override (likely during an incident or
             // SREs intervention), we want to override their changes. The API
             // database is the source of truth for credentials.
-            let pp = PatchParams::apply(&clickhouse_secret_name).force();
+            let pp = PatchParams::apply(FIELD_MANAGER).force();
             self.secrets_api.patch(&clickhouse_secret_name, &pp, &Patch::Apply(secret)).await?;
         }
 
@@ -509,7 +511,7 @@ impl K8sClient for HttpK8sClient {
         // fields. If there is an override (likely during an incident or SREs
         // intervention), we want to override their changes. The API database is
         // the source of truth for credentials.
-        let pp = PatchParams::apply(&iceberg_secret_name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.secrets_api.patch(&iceberg_secret_name, &pp, &Patch::Apply(secret)).await?;
 
         Ok(())
@@ -539,7 +541,7 @@ impl K8sClient for HttpK8sClient {
         );
         let secret: Secret = serde_json::from_value(ducklake_secret_json)?;
 
-        let pp = PatchParams::apply(&ducklake_secret_name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.secrets_api.patch(&ducklake_secret_name, &pp, &Patch::Apply(secret)).await?;
 
         Ok(())
@@ -624,7 +626,7 @@ impl K8sClient for HttpK8sClient {
         );
         let secret: Secret = serde_json::from_value(snowflake_secret_json)?;
 
-        let pp = PatchParams::apply(&snowflake_secret_name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.secrets_api.patch(&snowflake_secret_name, &pp, &Patch::Apply(secret)).await?;
 
         Ok(())
@@ -663,7 +665,7 @@ impl K8sClient for HttpK8sClient {
         // fields. If there is an override (likely during an incident or SREs
         // intervention), we want to override their changes. The API database is
         // the source of truth for configuration.
-        let pp = PatchParams::apply(&replicator_config_map_name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.config_maps_api
             .patch(&replicator_config_map_name, &pp, &Patch::Apply(config_map))
             .await?;
@@ -739,7 +741,7 @@ impl K8sClient for HttpK8sClient {
         // We are forcing the update since we are the field manager that should own the
         // fields. If there is an override (likely during an incident or SREs
         // intervention), we want to override their changes.
-        let pp = PatchParams::apply(&stateful_set_name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.stateful_sets_api.patch(&stateful_set_name, &pp, &Patch::Apply(stateful_set)).await?;
 
         Ok(())
@@ -781,7 +783,7 @@ impl K8sClient for HttpK8sClient {
 
         let name = create_ducklake_maintenance_name(prefix);
         let ducklake_maintenance_json = create_ducklake_maintenance_json(prefix, &name, config);
-        let pp = PatchParams::apply(&name).force();
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.ducklake_maintenance_api
             .patch(&name, &pp, &Patch::Apply(ducklake_maintenance_json))
             .await?;
@@ -1653,7 +1655,7 @@ fn create_replicator_stateful_set_json(
               "etl.supabase.com/app-type": REPLICATOR_APP_LABEL
             },
             "annotations": {
-              // Attach template annotations (e.g., restart checksum) to trigger a rolling restart
+              // Attach template annotations (e.g., restart checksum) to trigger a rolling restart.
               "etl.supabase.com/restarted-at": restarted_at_annotation,
             }
           },

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 use tracing::debug;
 
 use crate::{
-    config::{DefaultReplicatorResourcesConfig, K8sConfig},
+    config::{DefaultReplicatorResourcesConfig, DefaultVectorResourcesConfig, K8sConfig},
     configs::{
         log::LogLevel,
         pipeline::{DuckLakeMaintenanceConfig, ReplicatorResourcesConfig},
@@ -88,6 +88,10 @@ const DATA_PLANE_NAMESPACE: &str = "etl-data-plane";
 const LOGFLARE_SECRET_NAME: &str = "replicator-logflare-api-key";
 /// Docker image used for the Vector sidecar.
 const VECTOR_IMAGE_NAME: &str = "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc";
+/// Name of the replicator container port that serves Prometheus metrics.
+const REPLICATOR_METRICS_PORT_NAME: &str = "metrics";
+/// Port the replicator listens on for Prometheus metrics.
+const REPLICATOR_METRICS_PORT: i32 = 9000;
 /// ConfigMap name containing the Vector configuration.
 const VECTOR_CONFIG_MAP_NAME: &str = "replicator-vector-config";
 /// Volume name for the replicator config file.
@@ -115,10 +119,6 @@ const DUCKLAKE_MAINTENANCE_VERSION: &str = "v1alpha1";
 /// DuckLake maintenance CRD kind.
 const DUCKLAKE_MAINTENANCE_KIND: &str = "DuckLakeMaintenance";
 
-/// Vector memory request, in Mi.
-const VECTOR_MEMORY_REQUEST_MIB: i32 = 192;
-/// Vector CPU request, in millicores.
-const VECTOR_CPU_REQUEST_MILLICORES: i32 = 75;
 /// Minimum Kubernetes CPU quantity emitted by the API, in millicores.
 const MIN_K8S_CPU_MILLICORES: i32 = 1;
 /// Minimum Kubernetes memory quantity emitted by the API, in Mi.
@@ -150,7 +150,11 @@ impl ReplicatorStatefulSetResourcesConfig {
     #[cfg(test)]
     fn for_environment(environment: &Environment) -> Result<Self, K8sError> {
         let k8s_config = test_k8s_config(environment);
-        Self::from_default_replicator_resources(&k8s_config.replicator_resources, None)
+        Self::from_default_resources(
+            &k8s_config.replicator_resources,
+            &k8s_config.vector_resources,
+            None,
+        )
     }
 
     /// Builds StatefulSet resources from API defaults plus optional
@@ -159,28 +163,34 @@ impl ReplicatorStatefulSetResourcesConfig {
     /// Request precedence is pipeline override first, then the mandatory API
     /// default from `k8s.replicator_resources`. Limit precedence is explicit
     /// pipeline limit first, then the final request multiplied by the static
-    /// ETL API multiplier constants. Vector resources are always derived from
-    /// the static vector constants.
-    fn from_default_replicator_resources(
+    /// ETL API multiplier constants. Vector requests come from
+    /// `k8s.vector_resources`, and Vector limits are derived from those
+    /// requests with the same static multipliers.
+    fn from_default_resources(
         default_replicator_resources: &DefaultReplicatorResourcesConfig,
+        default_vector_resources: &DefaultVectorResourcesConfig,
         pipeline_replicator_resources: Option<&ReplicatorResourcesConfig>,
     ) -> Result<Self, K8sError> {
         let replicator_memory_request = clamp_k8s_resource_quantity(
             pipeline_replicator_resources
                 .and_then(|config| config.memory_request_mib)
-                .unwrap_or(default_replicator_resources.replicator_memory_request_mib),
+                .unwrap_or(default_replicator_resources.memory_request_mib),
             MIN_K8S_MEMORY_MIB,
         );
         let replicator_cpu_request = clamp_k8s_resource_quantity(
             pipeline_replicator_resources
                 .and_then(|config| config.cpu_request_millicores)
-                .unwrap_or(default_replicator_resources.replicator_cpu_request_millicores),
+                .unwrap_or(default_replicator_resources.cpu_request_millicores),
             MIN_K8S_CPU_MILLICORES,
         );
-        let vector_memory_request =
-            clamp_k8s_resource_quantity(VECTOR_MEMORY_REQUEST_MIB, MIN_K8S_MEMORY_MIB);
-        let vector_cpu_request =
-            clamp_k8s_resource_quantity(VECTOR_CPU_REQUEST_MILLICORES, MIN_K8S_CPU_MILLICORES);
+        let vector_memory_request = clamp_k8s_resource_quantity(
+            default_vector_resources.memory_request_mib,
+            MIN_K8S_MEMORY_MIB,
+        );
+        let vector_cpu_request = clamp_k8s_resource_quantity(
+            default_vector_resources.cpu_request_millicores,
+            MIN_K8S_CPU_MILLICORES,
+        );
 
         let replicator_memory_limit = pipeline_replicator_resources
             .and_then(|config| config.memory_limit_mib)
@@ -241,14 +251,18 @@ fn limit_from_request(request: i32, multiplier: f32) -> i32 {
 
 #[cfg(test)]
 fn test_k8s_config(environment: &Environment) -> K8sConfig {
-    let (replicator_memory_request_mib, replicator_cpu_request_millicores) = match environment {
+    let (memory_request_mib, cpu_request_millicores) = match environment {
         Environment::Prod => (500, 500),
         _ => (250, 125),
     };
     K8sConfig {
         replicator_resources: DefaultReplicatorResourcesConfig {
-            replicator_memory_request_mib,
-            replicator_cpu_request_millicores,
+            memory_request_mib,
+            cpu_request_millicores,
+        },
+        vector_resources: DefaultVectorResourcesConfig {
+            memory_request_mib: 192,
+            cpu_request_millicores: 75,
         },
     }
 }
@@ -724,11 +738,11 @@ impl K8sClient for HttpK8sClient {
 
         let prefix = request.prefix.as_str();
         let replicator_image = request.replicator_image.as_str();
-        let stateful_set_resources =
-            ReplicatorStatefulSetResourcesConfig::from_default_replicator_resources(
-                &self.k8s_config.replicator_resources,
-                request.replicator_resources.as_ref(),
-            )?;
+        let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &self.k8s_config.replicator_resources,
+            &self.k8s_config.vector_resources,
+            request.replicator_resources.as_ref(),
+        )?;
 
         let stateful_set_name = create_stateful_set_name(prefix);
         let legacy_stateful_set_name = create_legacy_stateful_set_name(prefix);
@@ -1412,7 +1426,16 @@ fn create_init_containers_json(
           {
             "name": vector_container_name,
             "image": VECTOR_IMAGE_NAME,
+            // The image tag is pinned to a specific Vector release, so the node-local
+            // cache is trustworthy and re-pulling on every restart is unnecessary.
+            "imagePullPolicy": "IfNotPresent",
             "restartPolicy": "Always",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": ["ALL"]
+              }
+            },
             "env": [
               {
                 "name": "LOGFLARE_API_KEY",
@@ -1694,6 +1717,16 @@ fn create_replicator_stateful_set_json(
           },
           "spec": {
             "serviceAccountName": REPLICATOR_SERVICE_ACCOUNT_NAME,
+            // `runAsNonRoot` is intentionally not set here: it would apply to every
+            // container in the pod, but the Vector init container's upstream image
+            // has no non-root user and would fail to start under that restriction.
+            // It is instead scoped to the replicator container below, whose own
+            // image already runs as a non-root user.
+            "securityContext": {
+              "seccompProfile": {
+                "type": "RuntimeDefault"
+              }
+            },
             "volumes": volumes,
             // Allow scheduling onto nodes tainted with the right node role.
             "tolerations": [
@@ -1713,10 +1746,25 @@ fn create_replicator_stateful_set_json(
               {
                 "name": replicator_container_name,
                 "image": replicator_image,
+                // Deliberately omitted: Kubernetes already defaults to `Always` for the
+                // mutable `:latest` tag used in dev, and `IfNotPresent` for the
+                // content-addressed, version-tagged images used in staging/prod. Pinning
+                // this to `Always` would force every replicator restart to round-trip to
+                // the registry even when the already-cached image is unchanged.
+                // The replicator image runs as a non-root user by default (see
+                // crates/etl-replicator/Dockerfile), so this is safe here even
+                // though it is not set at the pod level.
+                "securityContext": {
+                  "runAsNonRoot": true,
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": ["ALL"]
+                  }
+                },
                 "ports": [
                   {
-                    "name": "metrics",
-                    "containerPort": 9000,
+                    "name": REPLICATOR_METRICS_PORT_NAME,
+                    "containerPort": REPLICATOR_METRICS_PORT,
                     "protocol": "TCP"
                   }
                 ],
@@ -1895,6 +1943,10 @@ mod tests {
         assert_eq!(prod.replicator_memory_request, "500Mi");
         assert_eq!(staging.replicator_cpu_request, "125m");
         assert_eq!(staging.replicator_memory_request, "250Mi");
+        assert_eq!(prod.vector_cpu_request, "75m");
+        assert_eq!(prod.vector_memory_request, "192Mi");
+        assert_eq!(prod.vector_cpu_limit, "150m");
+        assert_eq!(prod.vector_memory_limit, "230Mi");
     }
 
     #[test]
@@ -1906,12 +1958,12 @@ mod tests {
         };
         let k8s_config = test_k8s_config(&Environment::Prod);
 
-        let stateful_set_resources =
-            ReplicatorStatefulSetResourcesConfig::from_default_replicator_resources(
-                &k8s_config.replicator_resources,
-                Some(&overrides),
-            )
-            .unwrap();
+        let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &k8s_config.replicator_resources,
+            &k8s_config.vector_resources,
+            Some(&overrides),
+        )
+        .unwrap();
 
         assert_eq!(stateful_set_resources.replicator_cpu_request, "750m");
         assert_eq!(stateful_set_resources.replicator_memory_request, "1536Mi");
@@ -1929,12 +1981,12 @@ mod tests {
         };
         let k8s_config = test_k8s_config(&Environment::Prod);
 
-        let stateful_set_resources =
-            ReplicatorStatefulSetResourcesConfig::from_default_replicator_resources(
-                &k8s_config.replicator_resources,
-                Some(&overrides),
-            )
-            .unwrap();
+        let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &k8s_config.replicator_resources,
+            &k8s_config.vector_resources,
+            Some(&overrides),
+        )
+        .unwrap();
 
         assert_eq!(stateful_set_resources.replicator_cpu_request, "750m");
         assert_eq!(stateful_set_resources.replicator_memory_request, "1536Mi");
@@ -1952,22 +2004,30 @@ mod tests {
         };
         let k8s_config = K8sConfig {
             replicator_resources: DefaultReplicatorResourcesConfig {
-                replicator_cpu_request_millicores: -10,
-                replicator_memory_request_mib: 0,
+                cpu_request_millicores: -10,
+                memory_request_mib: 0,
+            },
+            vector_resources: DefaultVectorResourcesConfig {
+                cpu_request_millicores: 0,
+                memory_request_mib: -20,
             },
         };
 
-        let stateful_set_resources =
-            ReplicatorStatefulSetResourcesConfig::from_default_replicator_resources(
-                &k8s_config.replicator_resources,
-                Some(&overrides),
-            )
-            .unwrap();
+        let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &k8s_config.replicator_resources,
+            &k8s_config.vector_resources,
+            Some(&overrides),
+        )
+        .unwrap();
 
         assert_eq!(stateful_set_resources.replicator_cpu_request, "1m");
         assert_eq!(stateful_set_resources.replicator_memory_request, "1Mi");
         assert_eq!(stateful_set_resources.replicator_cpu_limit, "1m");
         assert_eq!(stateful_set_resources.replicator_memory_limit, "1Mi");
+        assert_eq!(stateful_set_resources.vector_cpu_request, "1m");
+        assert_eq!(stateful_set_resources.vector_memory_request, "1Mi");
+        assert_eq!(stateful_set_resources.vector_cpu_limit, "2m");
+        assert_eq!(stateful_set_resources.vector_memory_limit, "1Mi");
     }
 
     #[test]
@@ -1980,17 +2040,43 @@ mod tests {
         };
         let k8s_config = test_k8s_config(&Environment::Prod);
 
-        let stateful_set_resources =
-            ReplicatorStatefulSetResourcesConfig::from_default_replicator_resources(
-                &k8s_config.replicator_resources,
-                Some(&overrides),
-            )
-            .unwrap();
+        let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &k8s_config.replicator_resources,
+            &k8s_config.vector_resources,
+            Some(&overrides),
+        )
+        .unwrap();
 
         assert_eq!(stateful_set_resources.replicator_cpu_request, "750m");
         assert_eq!(stateful_set_resources.replicator_memory_request, "1536Mi");
         assert_eq!(stateful_set_resources.replicator_cpu_limit, "750m");
         assert_eq!(stateful_set_resources.replicator_memory_limit, "1536Mi");
+    }
+
+    #[test]
+    fn test_replicator_resource_config_uses_api_vector_resources() {
+        let k8s_config = K8sConfig {
+            replicator_resources: DefaultReplicatorResourcesConfig {
+                cpu_request_millicores: 500,
+                memory_request_mib: 500,
+            },
+            vector_resources: DefaultVectorResourcesConfig {
+                cpu_request_millicores: 80,
+                memory_request_mib: 192,
+            },
+        };
+
+        let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &k8s_config.replicator_resources,
+            &k8s_config.vector_resources,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(stateful_set_resources.vector_cpu_request, "80m");
+        assert_eq!(stateful_set_resources.vector_memory_request, "192Mi");
+        assert_eq!(stateful_set_resources.vector_cpu_limit, "160m");
+        assert_eq!(stateful_set_resources.vector_memory_limit, "230Mi");
     }
 
     #[test]
@@ -2164,17 +2250,21 @@ mod tests {
         };
         let k8s_config = K8sConfig {
             replicator_resources: DefaultReplicatorResourcesConfig {
-                replicator_cpu_request_millicores: 300,
-                replicator_memory_request_mib: 400,
+                cpu_request_millicores: 300,
+                memory_request_mib: 400,
+            },
+            vector_resources: DefaultVectorResourcesConfig {
+                cpu_request_millicores: 80,
+                memory_request_mib: 192,
             },
         };
 
-        let stateful_set_resources =
-            ReplicatorStatefulSetResourcesConfig::from_default_replicator_resources(
-                &k8s_config.replicator_resources,
-                Some(&overrides),
-            )
-            .unwrap();
+        let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &k8s_config.replicator_resources,
+            &k8s_config.vector_resources,
+            Some(&overrides),
+        )
+        .unwrap();
 
         assert_eq!(stateful_set_resources.replicator_cpu_request, "900m");
         assert_eq!(stateful_set_resources.replicator_memory_request, "1800Mi");

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -1426,9 +1426,6 @@ fn create_init_containers_json(
           {
             "name": vector_container_name,
             "image": VECTOR_IMAGE_NAME,
-            // The image tag is pinned to a specific Vector release, so the node-local
-            // cache is trustworthy and re-pulling on every restart is unnecessary.
-            "imagePullPolicy": "IfNotPresent",
             "restartPolicy": "Always",
             "securityContext": {
               "allowPrivilegeEscalation": false,

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -1714,11 +1714,6 @@ fn create_replicator_stateful_set_json(
           },
           "spec": {
             "serviceAccountName": REPLICATOR_SERVICE_ACCOUNT_NAME,
-            // `runAsNonRoot` is intentionally not set here: it would apply to every
-            // container in the pod, but the Vector init container's upstream image
-            // has no non-root user and would fail to start under that restriction.
-            // It is instead scoped to the replicator container below, whose own
-            // image already runs as a non-root user.
             "securityContext": {
               "seccompProfile": {
                 "type": "RuntimeDefault"
@@ -1743,16 +1738,7 @@ fn create_replicator_stateful_set_json(
               {
                 "name": replicator_container_name,
                 "image": replicator_image,
-                // Deliberately omitted: Kubernetes already defaults to `Always` for the
-                // mutable `:latest` tag used in dev, and `IfNotPresent` for the
-                // content-addressed, version-tagged images used in staging/prod. Pinning
-                // this to `Always` would force every replicator restart to round-trip to
-                // the registry even when the already-cached image is unchanged.
-                // The replicator image runs as a non-root user by default (see
-                // crates/etl-replicator/Dockerfile), so this is safe here even
-                // though it is not set at the pod level.
                 "securityContext": {
-                  "runAsNonRoot": true,
                   "allowPrivilegeEscalation": false,
                   "capabilities": {
                     "drop": ["ALL"]

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -127,8 +127,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -156,7 +156,6 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -121,6 +121,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "250Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -147,6 +156,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {
@@ -159,6 +169,14 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             },
             "restartPolicy": "Always",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              }
+            },
             "volumeMounts": [
               {
                 "mountPath": "/etc/vector",
@@ -173,6 +191,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "nodeSelector": {
           "etl.supabase.com/node-role": "workloads"
+        },
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -152,7 +152,6 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -117,6 +117,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "500Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -143,6 +152,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {
@@ -155,6 +165,14 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             },
             "restartPolicy": "Always",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              }
+            },
             "volumeMounts": [
               {
                 "mountPath": "/etc/vector",
@@ -169,6 +187,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "nodeSelector": {
           "etl.supabase.com/node-role": "workloads"
+        },
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -123,8 +123,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
@@ -91,6 +91,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "250Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -101,6 +110,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "initContainers": [],
         "nodeSelector": {},
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
+        },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
         "tolerations": [

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
@@ -97,8 +97,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -145,8 +145,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -174,7 +174,6 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -139,6 +139,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "250Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -165,6 +174,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {
@@ -177,6 +187,14 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             },
             "restartPolicy": "Always",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              }
+            },
             "volumeMounts": [
               {
                 "mountPath": "/etc/vector",
@@ -191,6 +209,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "nodeSelector": {
           "etl.supabase.com/node-role": "workloads"
+        },
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -170,7 +170,6 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -141,8 +141,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -135,6 +135,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "500Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -161,6 +170,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {
@@ -173,6 +183,14 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             },
             "restartPolicy": "Always",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              }
+            },
             "volumeMounts": [
               {
                 "mountPath": "/etc/vector",
@@ -187,6 +205,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "nodeSelector": {
           "etl.supabase.com/node-role": "workloads"
+        },
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
@@ -115,8 +115,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
@@ -109,6 +109,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "250Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -119,6 +128,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "initContainers": [],
         "nodeSelector": {},
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
+        },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
         "tolerations": [

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -145,8 +145,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -174,7 +174,6 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -139,6 +139,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "250Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -165,6 +174,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {
@@ -177,6 +187,14 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             },
             "restartPolicy": "Always",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              }
+            },
             "volumeMounts": [
               {
                 "mountPath": "/etc/vector",
@@ -191,6 +209,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "nodeSelector": {
           "etl.supabase.com/node-role": "workloads"
+        },
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -170,7 +170,6 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -141,8 +141,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -135,6 +135,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "500Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -161,6 +170,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             ],
             "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "imagePullPolicy": "IfNotPresent",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {
@@ -173,6 +183,14 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
               }
             },
             "restartPolicy": "Always",
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              }
+            },
             "volumeMounts": [
               {
                 "mountPath": "/etc/vector",
@@ -187,6 +205,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "nodeSelector": {
           "etl.supabase.com/node-role": "workloads"
+        },
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
@@ -115,8 +115,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "drop": [
                   "ALL"
                 ]
-              },
-              "runAsNonRoot": true
+              }
             },
             "volumeMounts": [
               {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
@@ -109,6 +109,15 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "memory": "250Mi"
               }
             },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              },
+              "runAsNonRoot": true
+            },
             "volumeMounts": [
               {
                 "mountPath": "/app/configuration",
@@ -119,6 +128,11 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         ],
         "initContainers": [],
         "nodeSelector": {},
+        "securityContext": {
+          "seccompProfile": {
+            "type": "RuntimeDefault"
+          }
+        },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
         "tolerations": [

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-2.snap
@@ -16,7 +16,6 @@ expression: node_selector
       }
     ],
     "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-    "imagePullPolicy": "IfNotPresent",
     "name": "abcdefghijklmnopqrst-42-vector",
     "resources": {
       "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-2.snap
@@ -16,6 +16,7 @@ expression: node_selector
       }
     ],
     "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+    "imagePullPolicy": "IfNotPresent",
     "name": "abcdefghijklmnopqrst-42-vector",
     "resources": {
       "limits": {
@@ -28,6 +29,14 @@ expression: node_selector
       }
     },
     "restartPolicy": "Always",
+    "securityContext": {
+      "allowPrivilegeEscalation": false,
+      "capabilities": {
+        "drop": [
+          "ALL"
+        ]
+      }
+    },
     "volumeMounts": [
       {
         "mountPath": "/etc/vector",

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-3.snap
@@ -16,7 +16,6 @@ expression: node_selector
       }
     ],
     "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
-    "imagePullPolicy": "IfNotPresent",
     "name": "abcdefghijklmnopqrst-42-vector",
     "resources": {
       "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-3.snap
@@ -16,6 +16,7 @@ expression: node_selector
       }
     ],
     "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+    "imagePullPolicy": "IfNotPresent",
     "name": "abcdefghijklmnopqrst-42-vector",
     "resources": {
       "limits": {
@@ -28,6 +29,14 @@ expression: node_selector
       }
     },
     "restartPolicy": "Always",
+    "securityContext": {
+      "allowPrivilegeEscalation": false,
+      "capabilities": {
+        "drop": [
+          "ALL"
+        ]
+      }
+    },
     "volumeMounts": [
       {
         "mountPath": "/etc/vector",

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -1,9 +1,61 @@
 use crate::{
     config::ApiConfig,
-    configs::source::StoredSourceConfig,
-    k8s::SourceTlsConfig,
+    configs::{encryption::EncryptionKeyring, source::StoredSourceConfig},
+    data::pipelines::read_pipeline_components,
+    k8s::{
+        K8sClient, SourceTlsConfig,
+        core::{create_or_update_pipeline_resources_in_k8s, should_reconcile_replicator_resources},
+    },
+    routes::pipelines::PipelineError,
     validation::{self, ValidationContext, ValidationError, ValidationFailure},
 };
+
+/// Reconciles and restarts the running replicator for a pipeline.
+///
+/// Update endpoints that can change source, destination, pipeline, image, or
+/// runtime resource configuration should call this after persisting the new API
+/// state. The helper first materializes the latest Kubernetes Secrets,
+/// ConfigMap, maintenance resources, and StatefulSet from that state. It then
+/// relies on the StatefulSet materialization to change the pod template restart
+/// annotation, which intentionally kicks off pod recreation.
+///
+/// This forced recreation is part of the contract. The replicator loads its
+/// mounted config and secret-backed environment when the process starts, so a
+/// running pod must be restarted after config materialization in order to pick
+/// up those changes.
+///
+/// If the pipeline has no active Kubernetes resources, the call is a no-op.
+pub(crate) async fn restart_pipeline_replicator_if_running(
+    connection: &mut sqlx::PgConnection,
+    tenant_id: &str,
+    pipeline_id: i64,
+    encryption_key: &EncryptionKeyring,
+    k8s_client: &dyn K8sClient,
+    source_tls_config: &SourceTlsConfig,
+    api_config: &ApiConfig,
+) -> Result<(), PipelineError> {
+    let (pipeline, replicator, image, source, destination) =
+        read_pipeline_components(connection, tenant_id, pipeline_id, encryption_key).await?;
+
+    if !should_reconcile_replicator_resources(k8s_client, tenant_id, replicator.id).await? {
+        return Ok(());
+    }
+
+    create_or_update_pipeline_resources_in_k8s(
+        k8s_client,
+        tenant_id,
+        pipeline,
+        replicator,
+        image,
+        source,
+        destination,
+        api_config.supabase_api_url.as_deref(),
+        source_tls_config.get_tls_config(),
+    )
+    .await?;
+
+    Ok(())
+}
 
 /// Validates a source config against the trusted source profile, when enabled.
 pub async fn validate_source_config(

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -24,16 +24,21 @@ use crate::{
 /// running pod must be restarted after config materialization in order to pick
 /// up those changes.
 ///
-/// If the pipeline has no active Kubernetes resources, the call is a no-op.
+/// If Kubernetes support is unavailable, or the pipeline has no active
+/// Kubernetes resources, the call is a no-op.
 pub(crate) async fn restart_pipeline_replicator_if_running(
     connection: &mut sqlx::PgConnection,
     tenant_id: &str,
     pipeline_id: i64,
     encryption_key: &EncryptionKeyring,
-    k8s_client: &dyn K8sClient,
+    k8s_client: Option<&dyn K8sClient>,
     source_tls_config: &SourceTlsConfig,
     api_config: &ApiConfig,
 ) -> Result<(), PipelineError> {
+    let Some(k8s_client) = k8s_client else {
+        return Ok(());
+    };
+
     let (pipeline, replicator, image, source, destination) =
         read_pipeline_components(connection, tenant_id, pipeline_id, encryption_key).await?;
 

--- a/crates/etl-api/src/routes/destinations.rs
+++ b/crates/etl-api/src/routes/destinations.rs
@@ -309,7 +309,7 @@ pub(crate) async fn update_destination(
     Extension(pool): Extension<PgPool>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     destination_id: Path<i64>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     destination: Json<UpdateDestinationRequest>,
@@ -338,7 +338,7 @@ pub(crate) async fn update_destination(
             tenant_id,
             pipeline_id,
             &encryption_key,
-            k8s_client.as_ref(),
+            k8s_client.as_deref(),
             source_tls_config.as_ref(),
             api_config.as_ref(),
         )
@@ -372,7 +372,7 @@ pub(crate) async fn delete_destination(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     destination_id: Path<i64>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
 ) -> Result<impl IntoResponse, DestinationError> {
     let tenant_id = extract_tenant_id(&headers)?;
     let destination_id = destination_id.into_inner();
@@ -384,7 +384,7 @@ pub(crate) async fn delete_destination(
     let pipelines =
         read_pipelines_for_destination_for_deletion(&pool, tenant_id, destination_id).await?;
     if let Some(pipeline_id) =
-        first_active_pipeline_id(k8s_client.as_ref(), tenant_id, &pipelines).await?
+        first_active_pipeline_id(k8s_client.as_deref(), tenant_id, &pipelines).await?
     {
         return Err(DestinationError::ActivePipeline(pipeline_id));
     }

--- a/crates/etl-api/src/routes/destinations.rs
+++ b/crates/etl-api/src/routes/destinations.rs
@@ -22,7 +22,10 @@ use crate::{
     data,
     data::{
         destinations::{DestinationsDbError, destination_exists},
-        pipelines::{PipelinesDbError, read_pipelines_for_destination_for_deletion},
+        pipelines::{
+            PipelinesDbError, read_pipeline_ids_for_destination,
+            read_pipelines_for_destination_for_deletion,
+        },
         sources::SourcesDbError,
     },
     k8s::{
@@ -30,8 +33,8 @@ use crate::{
         core::{K8sCoreError, first_active_pipeline_id},
     },
     routes::{
-        ErrorMessage, IntoInner, TenantIdError, error_response_with_internal_error,
-        extract_tenant_id, utils,
+        ErrorMessage, IntoInner, TenantIdError, common::restart_pipeline_replicator_if_running,
+        error_response_with_internal_error, extract_tenant_id, pipelines::PipelineError, utils,
     },
     validation,
     validation::{FailureType, ValidationContext, ValidationError, ValidationFailure},
@@ -74,6 +77,9 @@ pub enum DestinationError {
 
     #[error("Invalid destination validation request: {0}")]
     InvalidValidationRequest(String),
+
+    #[error(transparent)]
+    Pipeline(#[from] PipelineError),
 }
 
 impl DestinationError {
@@ -84,7 +90,8 @@ impl DestinationError {
             | DestinationError::PipelinesDb(PipelinesDbError::Database(_))
             | DestinationError::SourcesDb(SourcesDbError::Database(_))
             | DestinationError::Environment(_)
-            | DestinationError::K8sCore(_) => "Internal server error".to_owned(),
+            | DestinationError::K8sCore(_)
+            | DestinationError::Pipeline(_) => "Internal server error".to_owned(),
             DestinationError::Validation(error) => {
                 utils::validation_error_message(error).to_owned()
             }
@@ -104,7 +111,8 @@ impl IntoResponse for DestinationError {
             | DestinationError::PipelinesDb(_)
             | DestinationError::SourcesDb(_)
             | DestinationError::Environment(_)
-            | DestinationError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            | DestinationError::K8sCore(_)
+            | DestinationError::Pipeline(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DestinationError::Validation(error) => utils::validation_error_status_code(error),
             DestinationError::DestinationNotFound(_) | DestinationError::SourceNotFound(_) => {
                 StatusCode::NOT_FOUND
@@ -293,9 +301,13 @@ pub(crate) async fn read_destination(
     ),
     tag = "Destinations"
 )]
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn update_destination(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
+    Extension(api_config): Extension<Arc<ApiConfig>>,
+    Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     destination_id: Path<i64>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     destination: Json<UpdateDestinationRequest>,
@@ -315,6 +327,22 @@ pub(crate) async fn update_destination(
     )
     .await?
     .ok_or(DestinationError::DestinationNotFound(destination_id))?;
+
+    let pipeline_ids =
+        read_pipeline_ids_for_destination(txn.deref_mut(), tenant_id, destination_id).await?;
+    for pipeline_id in pipeline_ids {
+        restart_pipeline_replicator_if_running(
+            txn.deref_mut(),
+            tenant_id,
+            pipeline_id,
+            &encryption_key,
+            k8s_client.as_ref(),
+            source_tls_config.as_ref(),
+            api_config.as_ref(),
+        )
+        .await?;
+    }
+
     txn.commit().await.map_err(DestinationsDbError::from)?;
 
     Ok(StatusCode::OK)

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -352,7 +352,7 @@ pub(crate) async fn update_destination_and_pipeline(
     Extension(pool): Extension<PgPool>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     destination_and_pipeline_ids: Path<(i64, i64)>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     destination_and_pipeline: Json<UpdateDestinationPipelineRequest>,
@@ -416,7 +416,7 @@ pub(crate) async fn update_destination_and_pipeline(
         tenant_id,
         pipeline_id,
         &encryption_key,
-        k8s_client.as_ref(),
+        k8s_client.as_deref(),
         source_tls_config.as_ref(),
         api_config.as_ref(),
     )
@@ -453,7 +453,7 @@ pub(crate) async fn delete_destination_and_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     destination_and_pipeline_ids: Path<(i64, i64)>,
 ) -> Result<impl IntoResponse, DestinationPipelineError> {
@@ -471,7 +471,7 @@ pub(crate) async fn delete_destination_and_pipeline(
         ));
     }
 
-    if is_replicator_active(k8s_client.as_ref(), tenant_id, pipeline.replicator_id).await? {
+    if is_replicator_active(k8s_client.as_deref(), tenant_id, pipeline.replicator_id).await? {
         return Err(DestinationPipelineError::ActivePipeline(pipeline.id));
     }
 

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -12,10 +12,11 @@ use thiserror::Error;
 use utoipa::ToSchema;
 
 use super::{
-    ErrorMessage, IntoInner, TenantIdError, error_response_with_internal_error, extract_tenant_id,
-    utils,
+    ErrorMessage, IntoInner, TenantIdError, common::restart_pipeline_replicator_if_running,
+    error_response_with_internal_error, extract_tenant_id, utils,
 };
 use crate::{
+    config::ApiConfig,
     configs::{
         destination::{FullApiDestinationConfig, UpdateApiDestinationConfig},
         encryption::EncryptionKeyring,
@@ -40,6 +41,7 @@ use crate::{
         K8sClient, SourceTlsConfig,
         core::{K8sCoreError, is_replicator_active},
     },
+    routes::pipelines::PipelineError,
     validation::ValidationError,
 };
 
@@ -104,6 +106,9 @@ pub(crate) enum DestinationPipelineError {
 
     #[error("Invalid pipeline request: {0}")]
     InvalidPipelineRequest(String),
+
+    #[error(transparent)]
+    Pipeline(#[from] PipelineError),
 }
 
 impl From<DestinationPipelinesDbError> for DestinationPipelineError {
@@ -133,7 +138,8 @@ impl DestinationPipelineError {
             | DestinationPipelineError::PipelinesDb(PipelinesDbError::Database(_))
             | DestinationPipelineError::Database(_)
             | DestinationPipelineError::NoDefaultImageFound
-            | DestinationPipelineError::K8sCore(_) => "Internal server error".to_owned(),
+            | DestinationPipelineError::K8sCore(_)
+            | DestinationPipelineError::Pipeline(_) => "Internal server error".to_owned(),
             DestinationPipelineError::SourceDatabase(_)
             | DestinationPipelineError::SourcePipelineState(_) => {
                 utils::source_database_query_error_message().to_owned()
@@ -165,7 +171,8 @@ impl IntoResponse for DestinationPipelineError {
             | DestinationPipelineError::SourcesDb(_)
             | DestinationPipelineError::PipelinesDb(_)
             | DestinationPipelineError::Database(_)
-            | DestinationPipelineError::K8sCore(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            | DestinationPipelineError::K8sCore(_)
+            | DestinationPipelineError::Pipeline(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DestinationPipelineError::SourceDatabase(error) => {
                 utils::source_database_error_status_code(error)
             }
@@ -339,9 +346,13 @@ pub(crate) async fn create_destination_and_pipeline(
     ),
     tag = "Destinations and Pipelines"
 )]
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn update_destination_and_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
+    Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
+    Extension(api_config): Extension<Arc<ApiConfig>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     destination_and_pipeline_ids: Path<(i64, i64)>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     destination_and_pipeline: Json<UpdateDestinationPipelineRequest>,
@@ -379,7 +390,7 @@ pub(crate) async fn update_destination_and_pipeline(
     }
 
     data::destinations_pipelines::update_destination_and_pipeline(
-        txn,
+        &mut txn,
         tenant_id,
         destination_id,
         pipeline_id,
@@ -399,6 +410,19 @@ pub(crate) async fn update_destination_and_pipeline(
         }
         e => e.into(),
     })?;
+
+    restart_pipeline_replicator_if_running(
+        &mut txn,
+        tenant_id,
+        pipeline_id,
+        &encryption_key,
+        k8s_client.as_ref(),
+        source_tls_config.as_ref(),
+        api_config.as_ref(),
+    )
+    .await?;
+
+    txn.commit().await?;
 
     Ok(StatusCode::OK)
 }

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -746,7 +746,7 @@ pub(crate) async fn update_pipeline(
     Extension(pool): Extension<PgPool>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     pipeline_id: Path<i64>,
     pipeline: Json<UpdatePipelineRequest>,
@@ -783,7 +783,7 @@ pub(crate) async fn update_pipeline(
         tenant_id,
         pipeline_id,
         &encryption_key,
-        k8s_client.as_ref(),
+        k8s_client.as_deref(),
         source_tls_config.as_ref(),
         api_config.as_ref(),
     )
@@ -819,7 +819,7 @@ pub(crate) async fn delete_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     pipeline_id: Path<i64>,
 ) -> Result<impl IntoResponse, PipelineError> {
@@ -829,7 +829,7 @@ pub(crate) async fn delete_pipeline(
     let pipeline = read_pipeline_for_deletion(&pool, tenant_id, pipeline_id)
         .await?
         .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
-    if is_replicator_active(k8s_client.as_ref(), tenant_id, pipeline.replicator_id).await? {
+    if is_replicator_active(k8s_client.as_deref(), tenant_id, pipeline.replicator_id).await? {
         return Err(PipelineError::ActivePipeline(pipeline.id));
     }
 
@@ -943,7 +943,7 @@ pub(crate) async fn start_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     pipeline_id: Path<i64>,
@@ -957,19 +957,20 @@ pub(crate) async fn start_pipeline(
 
     let tls_config = source_tls_config.get_tls_config();
 
-    // We update the pipeline in K8s.
-    create_or_update_pipeline_resources_in_k8s(
-        k8s_client.as_ref(),
-        tenant_id,
-        pipeline,
-        replicator,
-        image,
-        source,
-        destination,
-        api_config.supabase_api_url.as_deref(),
-        tls_config,
-    )
-    .await?;
+    if let Some(k8s_client) = k8s_client.as_deref() {
+        create_or_update_pipeline_resources_in_k8s(
+            k8s_client,
+            tenant_id,
+            pipeline,
+            replicator,
+            image,
+            source,
+            destination,
+            api_config.supabase_api_url.as_deref(),
+            tls_config,
+        )
+        .await?;
+    }
     txn.commit().await?;
 
     Ok(StatusCode::OK)
@@ -995,7 +996,7 @@ pub(crate) async fn start_pipeline(
 pub(crate) async fn stop_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     pipeline_id: Path<i64>,
 ) -> Result<impl IntoResponse, PipelineError> {
     let tenant_id = extract_tenant_id(&headers)?;
@@ -1010,7 +1011,9 @@ pub(crate) async fn stop_pipeline(
             .await?
             .ok_or(PipelineError::ReplicatorNotFound(pipeline_id))?;
 
-    delete_pipeline_resources_in_k8s(k8s_client.as_ref(), tenant_id, replicator).await?;
+    if let Some(k8s_client) = k8s_client.as_deref() {
+        delete_pipeline_resources_in_k8s(k8s_client, tenant_id, replicator).await?;
+    }
     txn.commit().await?;
 
     Ok(StatusCode::OK)
@@ -1034,14 +1037,16 @@ pub(crate) async fn stop_pipeline(
 pub(crate) async fn stop_all_pipelines(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
 ) -> Result<impl IntoResponse, PipelineError> {
     let tenant_id = extract_tenant_id(&headers)?;
 
     let mut txn = pool.begin().await?;
     let replicators = data::replicators::read_replicators(txn.deref_mut(), tenant_id).await?;
     for replicator in replicators {
-        delete_pipeline_resources_in_k8s(k8s_client.as_ref(), tenant_id, replicator).await?;
+        if let Some(k8s_client) = k8s_client.as_deref() {
+            delete_pipeline_resources_in_k8s(k8s_client, tenant_id, replicator).await?;
+        }
     }
     txn.commit().await?;
 
@@ -1129,7 +1134,7 @@ pub(crate) async fn get_pipeline_version(
 pub(crate) async fn get_pipeline_status(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     pipeline_id: Path<i64>,
 ) -> Result<impl IntoResponse, PipelineError> {
     let tenant_id = extract_tenant_id(&headers)?;
@@ -1143,9 +1148,12 @@ pub(crate) async fn get_pipeline_status(
             .await?
             .ok_or(PipelineError::ReplicatorNotFound(pipeline_id))?;
 
-    let prefix = create_k8s_object_prefix(tenant_id, replicator.id);
-    let pod_status = k8s_client.get_replicator_pod_status(&prefix).await?;
-    let status = pod_status.into();
+    let status = if let Some(k8s_client) = k8s_client.as_deref() {
+        let prefix = create_k8s_object_prefix(tenant_id, replicator.id);
+        k8s_client.get_replicator_pod_status(&prefix).await?.into()
+    } else {
+        PipelineStatus::Stopped
+    };
 
     let response = GetPipelineStatusResponse { pipeline_id, status };
 
@@ -1433,7 +1441,7 @@ pub(crate) async fn update_pipeline_version(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     pipeline_id: Path<i64>,
@@ -1490,7 +1498,7 @@ pub(crate) async fn update_pipeline_version(
         tenant_id,
         pipeline_id,
         &encryption_key,
-        k8s_client.as_ref(),
+        k8s_client.as_deref(),
         source_tls_config.as_ref(),
         api_config.as_ref(),
     )

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -42,12 +42,11 @@ use crate::{
         core::{
             create_k8s_object_prefix, create_or_update_pipeline_resources_in_k8s,
             delete_pipeline_resources_in_k8s, is_replicator_active,
-            should_reconcile_replicator_resources,
         },
     },
     routes::{
-        ErrorMessage, IntoInner, TenantIdError, error_response_with_internal_error,
-        extract_tenant_id, utils as route_utils,
+        ErrorMessage, IntoInner, TenantIdError, common::restart_pipeline_replicator_if_running,
+        error_response_with_internal_error, extract_tenant_id, utils as route_utils,
     },
     utils::parse_docker_image_tag,
     validation,
@@ -778,27 +777,14 @@ pub(crate) async fn update_pipeline(
     .await?
     .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
 
-    let (pipeline, replicator, image, source, destination) =
-        read_pipeline_components(&mut txn, tenant_id, pipeline_id, &encryption_key).await?;
-
-    if !should_reconcile_replicator_resources(k8s_client.as_ref(), tenant_id, replicator.id).await?
-    {
-        txn.commit().await?;
-
-        return Ok(StatusCode::OK);
-    }
-
-    let tls_config = source_tls_config.get_tls_config();
-    create_or_update_pipeline_resources_in_k8s(
-        k8s_client.as_ref(),
+    restart_pipeline_replicator_if_running(
+        &mut txn,
         tenant_id,
-        pipeline,
-        replicator,
-        image,
-        source,
-        destination,
-        api_config.supabase_api_url.as_deref(),
-        tls_config,
+        pipeline_id,
+        &encryption_key,
+        k8s_client.as_ref(),
+        source_tls_config.as_ref(),
+        api_config.as_ref(),
     )
     .await?;
 
@@ -1457,7 +1443,7 @@ pub(crate) async fn update_pipeline_version(
     let update_request = update_request.into_inner();
 
     let mut txn = pool.begin().await?;
-    let (pipeline, replicator, current_image, source, destination) =
+    let (_, replicator, current_image, _, destination) =
         read_pipeline_components(&mut txn, tenant_id, pipeline_id, &encryption_key).await?;
 
     // Only allow updating to the current default image. The client must provide the
@@ -1498,28 +1484,14 @@ pub(crate) async fn update_pipeline_version(
         return Ok(StatusCode::OK);
     }
 
-    // If a replicator has no runtime resources, we don't want to create new K8s
-    // resources. If a StatefulSet still exists, reconcile it even when no pod is
-    // currently running so a broken or stale StatefulSet can be repaired.
-    if !should_reconcile_replicator_resources(k8s_client.as_ref(), tenant_id, replicator.id).await?
-    {
-        txn.commit().await?;
-
-        return Ok(StatusCode::OK);
-    }
-
-    let tls_config = source_tls_config.get_tls_config();
-
-    create_or_update_pipeline_resources_in_k8s(
-        k8s_client.as_ref(),
+    restart_pipeline_replicator_if_running(
+        &mut txn,
         tenant_id,
-        pipeline,
-        replicator,
-        target_image,
-        source,
-        destination,
-        api_config.supabase_api_url.as_deref(),
-        tls_config,
+        pipeline_id,
+        &encryption_key,
+        k8s_client.as_ref(),
+        source_tls_config.as_ref(),
+        api_config.as_ref(),
     )
     .await?;
 

--- a/crates/etl-api/src/routes/sources.rs
+++ b/crates/etl-api/src/routes/sources.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 
 use axum::{
     Extension, Json,
@@ -19,7 +19,9 @@ use crate::{
     },
     data,
     data::{
-        pipelines::{PipelinesDbError, read_pipelines_for_source_for_deletion},
+        pipelines::{
+            PipelinesDbError, read_pipeline_ids_for_source, read_pipelines_for_source_for_deletion,
+        },
         sources::{SourcesDbError, source_exists},
     },
     k8s::{
@@ -28,7 +30,7 @@ use crate::{
     },
     routes::{
         ErrorMessage, IntoInner, TenantIdError, common, error_response_with_internal_error,
-        extract_tenant_id, utils,
+        extract_tenant_id, pipelines::PipelineError, utils,
     },
     validation::{FailureType, ValidationError, ValidationFailure},
 };
@@ -64,15 +66,19 @@ pub enum SourceError {
 
     #[error("The source with id {0} is still used by pipelines; delete those pipelines first")]
     SourceInUse(i64),
+
+    #[error(transparent)]
+    Pipeline(#[from] PipelineError),
 }
 
 impl SourceError {
     pub fn to_message(&self) -> String {
         match self {
             // Do not expose internal database details in error messages
-            SourceError::SourcesDb(_) | SourceError::PipelinesDb(_) | SourceError::K8sCore(_) => {
-                "Internal server error".to_owned()
-            }
+            SourceError::SourcesDb(_)
+            | SourceError::PipelinesDb(_)
+            | SourceError::K8sCore(_)
+            | SourceError::Pipeline(_) => "Internal server error".to_owned(),
             SourceError::Validation(error) => utils::validation_error_message(error).to_owned(),
             // Every other message is ok, as they do not divulge sensitive information
             e => e.to_string(),
@@ -85,9 +91,10 @@ impl IntoResponse for SourceError {
         let status_code = match &self {
             SourceError::SourceNotFound(_) => StatusCode::NOT_FOUND,
             SourceError::TenantId(_) => StatusCode::BAD_REQUEST,
-            SourceError::SourcesDb(_) | SourceError::PipelinesDb(_) | SourceError::K8sCore(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            SourceError::SourcesDb(_)
+            | SourceError::PipelinesDb(_)
+            | SourceError::K8sCore(_)
+            | SourceError::Pipeline(_) => StatusCode::INTERNAL_SERVER_ERROR,
             SourceError::Validation(error) => utils::validation_error_status_code(error),
             SourceError::ValidationFailed(_) => StatusCode::UNPROCESSABLE_ENTITY,
             SourceError::ActivePipeline(_) | SourceError::SourceInUse(_) => StatusCode::CONFLICT,
@@ -333,11 +340,13 @@ pub(crate) async fn read_source(
     ),
     tag = "Sources"
 )]
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn update_source(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     source_id: Path<i64>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     source: Json<UpdateSourceRequest>,
@@ -353,8 +362,10 @@ pub(crate) async fn update_source(
     )
     .await?;
 
+    let mut txn = pool.begin().await.map_err(SourcesDbError::from)?;
+
     data::sources::update_source(
-        &pool,
+        txn.deref_mut(),
         tenant_id,
         &source.name,
         source_id,
@@ -363,6 +374,22 @@ pub(crate) async fn update_source(
     )
     .await?
     .ok_or(SourceError::SourceNotFound(source_id))?;
+
+    let pipeline_ids = read_pipeline_ids_for_source(txn.deref_mut(), tenant_id, source_id).await?;
+    for pipeline_id in pipeline_ids {
+        common::restart_pipeline_replicator_if_running(
+            txn.deref_mut(),
+            tenant_id,
+            pipeline_id,
+            &encryption_key,
+            k8s_client.as_ref(),
+            source_tls_config.as_ref(),
+            api_config.as_ref(),
+        )
+        .await?;
+    }
+
+    txn.commit().await.map_err(SourcesDbError::from)?;
 
     Ok(StatusCode::OK)
 }

--- a/crates/etl-api/src/routes/sources.rs
+++ b/crates/etl-api/src/routes/sources.rs
@@ -346,7 +346,7 @@ pub(crate) async fn update_source(
     Extension(pool): Extension<PgPool>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     source_id: Path<i64>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     source: Json<UpdateSourceRequest>,
@@ -382,7 +382,7 @@ pub(crate) async fn update_source(
             tenant_id,
             pipeline_id,
             &encryption_key,
-            k8s_client.as_ref(),
+            k8s_client.as_deref(),
             source_tls_config.as_ref(),
             api_config.as_ref(),
         )
@@ -415,7 +415,7 @@ pub(crate) async fn update_source(
 pub(crate) async fn delete_source(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     source_id: Path<i64>,
 ) -> Result<impl IntoResponse, SourceError> {
     let tenant_id = extract_tenant_id(&headers)?;
@@ -427,7 +427,7 @@ pub(crate) async fn delete_source(
 
     let pipelines = read_pipelines_for_source_for_deletion(&pool, tenant_id, source_id).await?;
     if let Some(pipeline_id) =
-        first_active_pipeline_id(k8s_client.as_ref(), tenant_id, &pipelines).await?
+        first_active_pipeline_id(k8s_client.as_deref(), tenant_id, &pipelines).await?
     {
         return Err(SourceError::ActivePipeline(pipeline_id));
     }

--- a/crates/etl-api/src/routes/tenants.rs
+++ b/crates/etl-api/src/routes/tenants.rs
@@ -324,7 +324,7 @@ pub(crate) async fn update_tenant(
 pub(crate) async fn delete_tenant(
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
     tenant_id: Path<String>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
 ) -> Result<impl IntoResponse, TenantError> {
@@ -335,7 +335,7 @@ pub(crate) async fn delete_tenant(
 
     let pipelines = read_all_pipelines_for_deletion(&pool, &tenant_id).await?;
     if let Some(pipeline_id) =
-        first_active_pipeline_id(k8s_client.as_ref(), &tenant_id, &pipelines).await?
+        first_active_pipeline_id(k8s_client.as_deref(), &tenant_id, &pipelines).await?
     {
         return Err(TenantError::ActivePipeline(pipeline_id));
     }

--- a/crates/etl-api/src/startup.rs
+++ b/crates/etl-api/src/startup.rs
@@ -145,16 +145,22 @@ impl Application {
                     client.preflight().await.context("Checking Kubernetes prerequisites")?;
                     Some(Arc::new(client) as Arc<dyn K8sClient>)
                 }
-                Err(e) => {
+                Err(err) => {
                     warn!(
-                        error = %e,
-                        "failed to create kubernetes client, running without kubernetes support"
+                        error = %err,
+                        "failed to create kubernetes client; etl-api is running in degraded mode \
+                        without full kubernetes capabilities and will skip kubernetes resource \
+                        creation, updates, deletion, status checks, and pod restarts"
                     );
                     None
                 }
             },
             None => {
-                warn!("kubernetes client unavailable, running without kubernetes support");
+                warn!(
+                    "kubernetes client unavailable; etl-api is running in degraded mode without \
+                     full kubernetes capabilities and will skip kubernetes resource creation, \
+                     updates, deletion, status checks, and pod restarts"
+                );
                 None
             }
         };
@@ -494,8 +500,7 @@ pub fn run(
         .layer(sentry_layer)
         .layer(trace_layer);
 
-    let app =
-        if let Some(k8s_client) = k8s_client { app.layer(Extension(k8s_client)) } else { app };
+    let app = app.layer(Extension(k8s_client));
 
     let app = app.layer(Extension(source_tls_config));
 

--- a/crates/etl-api/tests/destinations.rs
+++ b/crates/etl-api/tests/destinations.rs
@@ -159,6 +159,29 @@ async fn an_existing_bigquery_destination_can_be_updated() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn updating_destination_with_running_pipeline_restarts_replicator() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = &create_tenant(&app).await;
+    create_default_image(&app).await;
+
+    let source_id = create_source(&app, tenant_id).await;
+    let (destination_id, _pipeline_id) =
+        create_destination_pipeline_for_source(&app, tenant_id, source_id).await;
+
+    let create_calls_before = app.k8s_state.create_calls();
+    let updated_config = UpdateDestinationRequest {
+        name: updated_name(),
+        config: updated_destination_config().into(),
+    };
+
+    let response = app.update_destination(tenant_id, destination_id, &updated_config).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(app.k8s_state.create_calls() > create_calls_before);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn an_existing_iceberg_supabase_destination_can_be_updated() {
     init_test_tracing();
     // Arrange

--- a/crates/etl-api/tests/destinations_pipelines.rs
+++ b/crates/etl-api/tests/destinations_pipelines.rs
@@ -296,6 +296,7 @@ async fn an_existing_bigquery_destination_and_pipeline_can_be_updated() {
         response.json().await.expect("failed to deserialize response");
     let CreateDestinationPipelineResponse { destination_id, pipeline_id } = response;
     let new_source_id = create_source(&app, tenant_id).await;
+    let create_calls_before = app.k8s_state.create_calls();
 
     // Act
     let destination_pipeline = UpdateDestinationPipelineRequest {
@@ -310,6 +311,7 @@ async fn an_existing_bigquery_destination_and_pipeline_can_be_updated() {
 
     // Assert
     assert!(response.status().is_success());
+    assert!(app.k8s_state.create_calls() > create_calls_before);
 
     let response = app.read_destination(tenant_id, destination_id).await;
     let response: ReadDestinationResponse =

--- a/crates/etl-api/tests/health_check.rs
+++ b/crates/etl-api/tests/health_check.rs
@@ -1,12 +1,32 @@
 use etl_telemetry::tracing::init_test_tracing;
 
-use crate::support::test_app::spawn_test_app;
+use crate::support::test_app::{spawn_test_app, spawn_test_app_without_k8s_client};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn health_check_returns_200() {
     init_test_tracing();
     // Arrange
     let app = spawn_test_app().await;
+
+    let client = reqwest::Client::new();
+
+    // Act
+    let response = client
+        .get(format!("{}/health_check", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert!(response.status().is_success());
+    assert_eq!(Some(2), response.content_length());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn health_check_returns_200_without_k8s_client() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app_without_k8s_client().await;
 
     let client = reqwest::Client::new();
 

--- a/crates/etl-api/tests/metrics.rs
+++ b/crates/etl-api/tests/metrics.rs
@@ -1,13 +1,32 @@
 use etl_telemetry::tracing::init_test_tracing;
 use reqwest::Url;
 
-use crate::support::test_app::spawn_test_app;
+use crate::support::test_app::{spawn_test_app, spawn_test_app_without_k8s_client};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn metrics_endpoint_returns_200() {
     init_test_tracing();
     // Arrange
     let app = spawn_test_app().await;
+
+    let client = reqwest::Client::new();
+
+    // Act
+    let response = client
+        .get(local_test_url(&app.address, "/metrics"))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert!(response.status().is_success());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_endpoint_returns_200_without_k8s_client() {
+    init_test_tracing();
+    // Arrange
+    let app = spawn_test_app_without_k8s_client().await;
 
     let client = reqwest::Client::new();
 

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -30,7 +30,9 @@ use crate::support::{
         sources::create_source,
         tenants::{create_tenant, create_tenant_with_id_and_name},
     },
-    test_app::{TestApp, spawn_test_app, spawn_test_app_with_k8s_state},
+    test_app::{
+        TestApp, spawn_test_app, spawn_test_app_with_k8s_state, spawn_test_app_without_k8s_client,
+    },
 };
 
 /// Creates a basic pipeline setup for tests that don't need source databases.
@@ -49,6 +51,46 @@ async fn setup_basic_pipeline() -> (TestApp, String, i64, i64, i64) {
     )
     .await;
     (app, tenant_id, source_id, destination_id, pipeline_id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pipeline_k8s_endpoints_are_noops_without_k8s_client() {
+    init_test_tracing();
+    let app = spawn_test_app_without_k8s_client().await;
+    create_default_image(&app).await;
+    let tenant_id = create_tenant(&app).await;
+    let source_id = create_source(&app, &tenant_id).await;
+    let destination_id = create_destination(&app, &tenant_id).await;
+    let pipeline_id = create_pipeline_with_config(
+        &app,
+        &tenant_id,
+        source_id,
+        destination_id,
+        new_pipeline_config(),
+    )
+    .await;
+
+    let response = app.start_pipeline(&tenant_id, pipeline_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .api_client
+        .get(format!("{}/v1/pipelines/{pipeline_id}/status", app.address))
+        .bearer_auth(app.api_key.clone())
+        .header("tenant_id", &tenant_id)
+        .send()
+        .await
+        .expect("failed to execute request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response["status"]["name"], "stopped");
+
+    let response = app.stop_pipeline(&tenant_id, pipeline_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app.stop_all_pipelines(&tenant_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 /// Creates a pipeline setup with a real source database for table state

--- a/crates/etl-api/tests/sources.rs
+++ b/crates/etl-api/tests/sources.rs
@@ -149,6 +149,31 @@ async fn an_existing_source_can_be_updated() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn updating_source_with_running_pipeline_restarts_replicator() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = &create_tenant(&app).await;
+
+    let source = CreateSourceRequest { name: new_name(), config: new_source_config() };
+    let response = app.create_source(tenant_id, &source).await;
+    let response: CreateSourceResponse =
+        response.json().await.expect("failed to deserialize response");
+    let source_id = response.id;
+
+    create_default_image(&app).await;
+    create_pipeline_for_source(&app, tenant_id, source_id).await;
+
+    let create_calls_before = app.k8s_state.create_calls();
+    let updated_config =
+        UpdateSourceRequest { name: updated_name(), config: updated_source_config() };
+
+    let response = app.update_source(tenant_id, source_id, &updated_config).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(app.k8s_state.create_calls() > create_calls_before);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn non_existing_source_cannot_be_updated() {
     init_test_tracing();
     // Arrange

--- a/crates/etl-api/tests/sources.rs
+++ b/crates/etl-api/tests/sources.rs
@@ -32,7 +32,10 @@ use crate::support::{
         },
         tenants::create_tenant,
     },
-    test_app::{TestApp, spawn_test_app, spawn_test_app_with_trusted_username},
+    test_app::{
+        TestApp, spawn_test_app, spawn_test_app_with_trusted_username,
+        spawn_test_app_without_k8s_client,
+    },
 };
 
 fn source_config_from_db_config(source_db_config: &PgConnectionConfig) -> FullApiSourceConfig {
@@ -171,6 +174,32 @@ async fn updating_source_with_running_pipeline_restarts_replicator() {
 
     assert_eq!(response.status(), StatusCode::OK);
     assert!(app.k8s_state.create_calls() > create_calls_before);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn updating_source_with_pipeline_succeeds_without_k8s_client() {
+    init_test_tracing();
+    let app = spawn_test_app_without_k8s_client().await;
+    let tenant_id = &create_tenant(&app).await;
+
+    let source = CreateSourceRequest { name: new_name(), config: new_source_config() };
+    let response = app.create_source(tenant_id, &source).await;
+    let response: CreateSourceResponse =
+        response.json().await.expect("failed to deserialize response");
+    let source_id = response.id;
+
+    create_default_image(&app).await;
+    create_pipeline_for_source(&app, tenant_id, source_id).await;
+
+    let updated_config =
+        UpdateSourceRequest { name: updated_name(), config: updated_source_config() };
+    let response = app.update_source(tenant_id, source_id, &updated_config).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = app.read_source(tenant_id, source_id).await;
+    let response: ReadSourceResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(response.name, updated_config.name);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -10,7 +10,8 @@ use base64::prelude::*;
 use etl_api::{
     config::{
         ApiConfig, ApplicationSettings, DefaultReplicatorResourcesConfig,
-        EncryptionKeyConfig as ConfigEncryptionKey, K8sConfig, SourceConfig,
+        DefaultVectorResourcesConfig, EncryptionKeyConfig as ConfigEncryptionKey, K8sConfig,
+        SourceConfig,
     },
     configs::encryption,
     k8s::{K8sClient, SourceTlsConfig},
@@ -580,8 +581,12 @@ async fn spawn_test_app_with_services(
         application: ApplicationSettings { host: base_address.to_owned(), port },
         k8s: K8sConfig {
             replicator_resources: DefaultReplicatorResourcesConfig {
-                replicator_memory_request_mib: 250,
-                replicator_cpu_request_millicores: 125,
+                memory_request_mib: 250,
+                cpu_request_millicores: 125,
+            },
+            vector_resources: DefaultVectorResourcesConfig {
+                memory_request_mib: 192,
+                cpu_request_millicores: 75,
             },
         },
         encryption_keys: vec![ConfigEncryptionKey {

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -549,6 +549,10 @@ pub(crate) async fn spawn_test_app_with_k8s_state(
     spawn_test_app_with_services(trusted_source_username, Some(k8s_client), k8s_state).await
 }
 
+pub(crate) async fn spawn_test_app_without_k8s_client() -> TestApp {
+    spawn_test_app_with_services(None, None, MockK8sState::default()).await
+}
+
 async fn spawn_test_app_with_services(
     trusted_source_username: Option<String>,
     k8s_client: Option<Arc<dyn K8sClient>>,


### PR DESCRIPTION
## Summary

- Centralizes running replicator reconciliation in `restart_pipeline_replicator_if_running` and wires it through update endpoints that can affect an existing pipeline: pipeline updates, pipeline version updates, destination updates, source updates, and combined destination+pipeline updates.
- Documents the restart contract at the shared helper and Kubernetes client boundary: materialize the latest Secrets/ConfigMaps/StatefulSet resources, then intentionally change the StatefulSet pod template restart annotation so pods are recreated and startup-time config/env is picked up.
- Keeps Kubernetes work optional when `etl-api` is running without Kubernetes support: the API always layers an optional Kubernetes client, route handlers still validate and persist database work, and Kubernetes create/update/delete/status/active-check side effects become no-ops when no client is available.
- Uses a consistent server-side apply field manager, `etl-api`, for API-owned Kubernetes resource patches.
- Keeps deletion-specific loaders scoped to deletion paths and adds general pipeline-id loaders for source/destination update restart fan-out.
- Implements new mandatory API-level `vector_resources` config so Vector defaults are configured alongside replicator defaults instead of being hardcoded in the StatefulSet materializer.
- Removes replicator probes for now; we will add a dedicated health endpoint before wiring Kubernetes liveness/readiness back in.
- Tightens container security context intentionally while keeping the current images runnable: the pod gets `seccompProfile: RuntimeDefault`, both replicator and Vector containers disable privilege escalation and drop all Linux capabilities.
- Lets Kubernetes default image pull policy for the pinned Vector image instead of emitting an explicit `imagePullPolicy`; Kubernetes defaults pinned tags to `IfNotPresent`.