### PR TITLE
feat(performance): Improve core performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,8 @@
 - Do not add imports solely to make rustdoc links shorter.
 - Keep comments and docs precise, short, and punctuated.
 - Normal comments should always end with `.`.
+- Prefer normal comments on the line above the code they explain instead of
+  trailing comments at the end of a code line.
 - Do not add code examples in rustdoc for this repository.
 
 ## Metrics And Observability

--- a/crates/etl-postgres/src/numeric.rs
+++ b/crates/etl-postgres/src/numeric.rs
@@ -411,14 +411,30 @@ fn convert_to_base_10000(
 
     // Calculate offset for proper alignment
     let offset = (weight + 1) * 4 - (dweight + 1);
-    let total_decimal_digits = decimal_digits.len() as i32 + offset;
-    let ndigits = (total_decimal_digits + 3) / 4; // Round up to nearest multiple of 4
+    let Some(first_nonzero_decimal_index) = decimal_digits.iter().position(|&digit| digit != 0)
+    else {
+        return Ok(PgNumeric::Value { sign: Sign::Positive, weight: 0, scale, digits: vec![] });
+    };
+    let last_nonzero_decimal_index = decimal_digits
+        .iter()
+        .rposition(|&digit| digit != 0)
+        .expect("nonzero decimal digit should have a last position");
+
+    let first_nonzero_group = (offset + first_nonzero_decimal_index as i32) / 4;
+    let last_nonzero_group = (offset + last_nonzero_decimal_index as i32) / 4;
+    let final_weight = weight - first_nonzero_group;
+    if !(POSTGRES_NUMERIC_MIN_WEIGHT..=POSTGRES_NUMERIC_MAX_WEIGHT).contains(&final_weight) {
+        return Err(ParseNumericError::ValueOutOfRange);
+    }
 
     // Convert groups of 4 decimal digits to base-10000 digits, reading each
     // decimal digit at its aligned position and treating positions outside the
-    // input as zero padding.
-    let mut base_10000_digits = Vec::with_capacity(ndigits as usize);
-    for group in 0..ndigits {
+    // input as zero padding. Leading and trailing zero groups are skipped up
+    // front, so obviously out-of-range exponents are rejected before allocating
+    // a vector sized by the exponent.
+    let retained_groups = last_nonzero_group - first_nonzero_group + 1;
+    let mut base_10000_digits = Vec::with_capacity(retained_groups as usize);
+    for group in first_nonzero_group..=last_nonzero_group {
         let mut digit = 0i16;
         for position in group * 4..group * 4 + 4 {
             let decimal_digit = usize::try_from(position - offset)
@@ -428,29 +444,6 @@ fn convert_to_base_10000(
             digit = digit * 10 + decimal_digit as i16;
         }
         base_10000_digits.push(digit);
-    }
-
-    // If all groups are zero, normalize to PostgreSQL canonical zero:
-    // weight = 0, digits = [], positive sign; preserve scale.
-    if base_10000_digits.iter().all(|&d| d == 0) {
-        return Ok(PgNumeric::Value { sign: Sign::Positive, weight: 0, scale, digits: vec![] });
-    }
-
-    // Strip leading zeros first and record how many we removed so we can
-    // adjust the weight correctly. Trailing zeros should NOT influence
-    // the weight because they are fractional groups after the decimal point.
-    // At least one group is nonzero here, so neither strip can empty the
-    // digits.
-    let leading_zeros = base_10000_digits.iter().take_while(|&&d| d == 0).count();
-    base_10000_digits.drain(..leading_zeros);
-
-    let trailing_zeros = base_10000_digits.iter().rev().take_while(|&&d| d == 0).count();
-    base_10000_digits.truncate(base_10000_digits.len() - trailing_zeros);
-
-    // Adjust weight only by the number of leading zeros that were removed.
-    let final_weight = weight - leading_zeros as i32;
-    if !(POSTGRES_NUMERIC_MIN_WEIGHT..=POSTGRES_NUMERIC_MAX_WEIGHT).contains(&final_weight) {
-        return Err(ParseNumericError::ValueOutOfRange);
     }
 
     Ok(PgNumeric::Value { sign, weight: final_weight as i16, scale, digits: base_10000_digits })

--- a/crates/etl-postgres/src/numeric.rs
+++ b/crates/etl-postgres/src/numeric.rs
@@ -109,9 +109,6 @@ impl FromStr for PgNumeric {
     type Err = ParseNumericError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        // Surrounding whitespace is allowed; `str::trim` uses the same Unicode
-        // whitespace predicate the previous char-based skip used. All accepted
-        // syntax beyond that is ASCII, so the value is parsed as bytes.
         let trimmed = input.trim();
 
         if trimmed.is_empty() {

--- a/crates/etl-postgres/src/numeric.rs
+++ b/crates/etl-postgres/src/numeric.rs
@@ -1,10 +1,6 @@
 //! Postgres `NUMERIC` value support.
 
-use std::{
-    io::Cursor,
-    iter::Peekable,
-    str::{Chars, FromStr},
-};
+use std::{io::Cursor, str::FromStr};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use tokio_postgres::types::{FromSql, IsNull, ToSql, Type};
@@ -102,35 +98,34 @@ impl FromStr for PgNumeric {
     type Err = ParseNumericError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let mut chars = input.chars().peekable();
+        // Surrounding whitespace is allowed; `str::trim` uses the same Unicode
+        // whitespace predicate the previous char-based skip used. All accepted
+        // syntax beyond that is ASCII, so the value is parsed as bytes.
+        let trimmed = input.trim();
 
-        // Skip leading spaces
-        skip_whitespace(&mut chars);
-
-        if chars.peek().is_none() {
+        if trimmed.is_empty() {
             return Err(ParseNumericError::InvalidSyntax);
         }
 
+        let bytes = trimmed.as_bytes();
+
         // Handle sign
-        let (sign, has_explicit_sign) = match chars.peek() {
-            Some('+') => {
-                chars.next();
-                (Sign::Positive, true)
-            }
-            Some('-') => {
-                chars.next();
-                (Sign::Negative, true)
-            }
-            _ => (Sign::Positive, false),
+        let (sign, rest, has_explicit_sign) = match bytes[0] {
+            b'+' => (Sign::Positive, &bytes[1..], true),
+            b'-' => (Sign::Negative, &bytes[1..], true),
+            _ => (Sign::Positive, bytes, false),
         };
 
         // Check for special values (NaN, infinity)
-        if !matches!(chars.peek(), Some('0'..='9' | '.')) {
-            return parse_special_value(&mut chars, &sign, has_explicit_sign);
+        if !matches!(rest.first(), Some(b'0'..=b'9' | b'.')) {
+            // The sign byte is ASCII, so slicing past it stays on a char
+            // boundary.
+            let rest = &trimmed[trimmed.len() - rest.len()..];
+            return parse_special_value(rest, &sign, has_explicit_sign);
         }
 
         // Parse regular numeric value
-        parse_numeric_value(&mut chars, sign)
+        parse_numeric_value(rest, sign)
     }
 }
 
@@ -225,20 +220,6 @@ pub enum ParseNumericError {
     ValueOutOfRange,
 }
 
-/// Skips whitespace characters from a peekable character iterator.
-///
-/// This helper function advances the iterator past all consecutive whitespace
-/// characters, stopping at the first non-whitespace character or end of input.
-fn skip_whitespace(chars: &mut Peekable<Chars>) {
-    while let Some(&ch) = chars.peek() {
-        if ch.is_whitespace() {
-            chars.next();
-        } else {
-            break;
-        }
-    }
-}
-
 impl std::fmt::Display for ParseNumericError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -254,22 +235,23 @@ impl std::error::Error for ParseNumericError {}
 ///
 /// This function handles Postgres's special numeric values when they appear
 /// in string format. NaN cannot have a negative sign, while infinity values
-/// respect the sign parameter.
+/// respect the sign parameter. The candidates are ASCII, so case-insensitive
+/// ASCII comparison accepts and rejects the same inputs the previous
+/// Unicode-lowercasing comparison did, without allocating.
 fn parse_special_value(
-    chars: &mut Peekable<Chars>,
+    rest: &str,
     sign: &Sign,
     has_explicit_sign: bool,
 ) -> Result<PgNumeric, ParseNumericError> {
-    let remaining: String = chars.collect();
-    let remaining_lower = remaining.trim_end().to_lowercase();
+    let rest = rest.trim_end();
 
-    if remaining_lower == "nan" {
+    if rest.eq_ignore_ascii_case("nan") {
         // NaN must not have a sign.
         if has_explicit_sign {
             return Err(ParseNumericError::InvalidSyntax);
         }
         Ok(PgNumeric::NaN)
-    } else if remaining_lower == "infinity" || remaining_lower == "inf" {
+    } else if rest.eq_ignore_ascii_case("infinity") || rest.eq_ignore_ascii_case("inf") {
         match sign {
             Sign::Positive => Ok(PgNumeric::PositiveInfinity),
             Sign::Negative => Ok(PgNumeric::NegativeInfinity),
@@ -279,58 +261,58 @@ fn parse_special_value(
     }
 }
 
-/// Parses a regular numeric value from character input.
+/// Parses a regular numeric value from trimmed byte input.
 ///
 /// This function processes decimal digits, decimal points, underscores (digit
 /// separators), and scientific notation to construct a numeric value. It
-/// handles both integer and fractional parts with arbitrary precision.
-fn parse_numeric_value(
-    chars: &mut Peekable<Chars>,
-    sign: Sign,
-) -> Result<PgNumeric, ParseNumericError> {
-    let mut decimal_digits = Vec::new();
+/// handles both integer and fractional parts with arbitrary precision. All
+/// accepted syntax is ASCII, so a non-ASCII byte simply fails to match and
+/// rejects the input, exactly as the previous char-based parser did.
+fn parse_numeric_value(bytes: &[u8], sign: Sign) -> Result<PgNumeric, ParseNumericError> {
+    let mut decimal_digits = Vec::with_capacity(bytes.len());
     let mut have_decimal_point = false;
     let mut dweight = -1i32; // Decimal weight (number of digits before decimal point - 1)
     let mut dscale = 0u32; // Number of digits after decimal point
+    let mut pos = 0;
 
     // Check for initial decimal point
-    if chars.peek() == Some(&'.') {
+    if bytes.first() == Some(&b'.') {
         have_decimal_point = true;
-        chars.next();
+        pos += 1;
     }
 
     // Must have at least one digit
-    if !matches!(chars.peek(), Some('0'..='9')) {
+    if !matches!(bytes.get(pos), Some(b'0'..=b'9')) {
         return Err(ParseNumericError::InvalidSyntax);
     }
 
     // Parse digits and decimal point
-    while let Some(&ch) = chars.peek() {
-        match ch {
-            '0'..='9' => {
-                chars.next();
-                decimal_digits.push(ch as u8 - b'0');
+    while let Some(&byte) = bytes.get(pos) {
+        match byte {
+            b'0'..=b'9' => {
+                pos += 1;
+                decimal_digits.push(byte - b'0');
                 if !have_decimal_point {
                     dweight += 1;
                 } else {
                     dscale += 1;
                 }
             }
-            '.' => {
+            b'.' => {
                 if have_decimal_point {
                     return Err(ParseNumericError::InvalidSyntax);
                 }
                 have_decimal_point = true;
-                chars.next();
+                pos += 1;
                 // Decimal point must not be followed by underscore
-                if chars.peek() == Some(&'_') {
+                if bytes.get(pos) == Some(&b'_') {
                     return Err(ParseNumericError::InvalidSyntax);
                 }
             }
-            '_' => {
-                chars.next();
+            b'_' => {
+                pos += 1;
                 // Underscore must be followed by more digits
-                if !matches!(chars.peek(), Some('0'..='9')) {
+                if !matches!(bytes.get(pos), Some(b'0'..=b'9')) {
                     return Err(ParseNumericError::InvalidSyntax);
                 }
             }
@@ -339,40 +321,44 @@ fn parse_numeric_value(
     }
 
     // Handle scientific notation
-    if matches!(chars.peek(), Some('e' | 'E')) {
-        chars.next();
+    if matches!(bytes.get(pos), Some(b'e' | b'E')) {
+        pos += 1;
         let mut exponent = 0i64;
         let mut exp_negative = false;
 
         // Handle exponent sign
-        match chars.peek() {
-            Some('+') => {
-                chars.next();
+        match bytes.get(pos) {
+            Some(b'+') => {
+                pos += 1;
             }
-            Some('-') => {
+            Some(b'-') => {
                 exp_negative = true;
-                chars.next();
+                pos += 1;
             }
             _ => {}
         }
 
         // Parse exponent digits
-        if !matches!(chars.peek(), Some('0'..='9')) {
+        if !matches!(bytes.get(pos), Some(b'0'..=b'9')) {
             return Err(ParseNumericError::InvalidSyntax);
         }
 
-        while let Some(&ch) = chars.peek() {
-            match ch {
-                '0'..='9' => {
-                    chars.next();
-                    exponent = exponent * 10 + (ch as u8 - b'0') as i64;
+        while let Some(&byte) = bytes.get(pos) {
+            match byte {
+                b'0'..=b'9' => {
+                    pos += 1;
+                    exponent = exponent * 10 + i64::from(byte - b'0');
+                    // This is an arithmetic overflow guard, not the Postgres
+                    // numeric range check. Weight and scale bounds are
+                    // enforced below after the exponent is applied to the
+                    // parsed decimal shape.
                     if exponent > i32::MAX as i64 / 2 {
                         return Err(ParseNumericError::ValueOutOfRange);
                     }
                 }
-                '_' => {
-                    chars.next();
-                    if !matches!(chars.peek(), Some('0'..='9')) {
+                b'_' => {
+                    pos += 1;
+                    if !matches!(bytes.get(pos), Some(b'0'..=b'9')) {
                         return Err(ParseNumericError::InvalidSyntax);
                     }
                 }
@@ -388,9 +374,8 @@ fn parse_numeric_value(
         dscale = if (dscale as i64 - exponent) < 0 { 0 } else { (dscale as i64 - exponent) as u32 };
     }
 
-    // Check for trailing whitespace/junk
-    skip_whitespace(chars);
-    if chars.peek().is_some() {
+    // The caller trims surrounding whitespace, so any remaining byte is junk.
+    if pos != bytes.len() {
         return Err(ParseNumericError::InvalidSyntax);
     }
 
@@ -399,7 +384,7 @@ fn parse_numeric_value(
     }
 
     // Convert to base-10000 representation
-    convert_to_base_10000(decimal_digits, dweight, dscale, sign)
+    convert_to_base_10000(&decimal_digits, dweight, dscale, sign)
 }
 
 /// Converts decimal digits to Postgres's base-10000 internal format.
@@ -409,7 +394,7 @@ fn parse_numeric_value(
 /// up to 10000 in decimal. This format balances storage efficiency with
 /// calculation performance.
 fn convert_to_base_10000(
-    decimal_digits: Vec<u8>,
+    decimal_digits: &[u8],
     dweight: i32,
     dscale: u32,
     sign: Sign,
@@ -429,22 +414,18 @@ fn convert_to_base_10000(
     let total_decimal_digits = decimal_digits.len() as i32 + offset;
     let ndigits = (total_decimal_digits + 3) / 4; // Round up to nearest multiple of 4
 
-    // Create padded decimal digits array
-    let mut padded_digits = vec![0u8; ndigits as usize * 4];
-    let start_idx = offset as usize;
-
-    for (i, &digit) in decimal_digits.iter().enumerate() {
-        if start_idx + i < padded_digits.len() {
-            padded_digits[start_idx + i] = digit;
-        }
-    }
-
-    // Convert groups of 4 decimal digits to base-10000 digits
-    let mut base_10000_digits = Vec::new();
-    for chunk in padded_digits.chunks(4) {
+    // Convert groups of 4 decimal digits to base-10000 digits, reading each
+    // decimal digit at its aligned position and treating positions outside the
+    // input as zero padding.
+    let mut base_10000_digits = Vec::with_capacity(ndigits as usize);
+    for group in 0..ndigits {
         let mut digit = 0i16;
-        for &d in chunk {
-            digit = digit * 10 + d as i16;
+        for position in group * 4..group * 4 + 4 {
+            let decimal_digit = usize::try_from(position - offset)
+                .ok()
+                .and_then(|index| decimal_digits.get(index).copied())
+                .unwrap_or(0);
+            digit = digit * 10 + decimal_digit as i16;
         }
         base_10000_digits.push(digit);
     }
@@ -458,47 +439,21 @@ fn convert_to_base_10000(
     // Strip leading zeros first and record how many we removed so we can
     // adjust the weight correctly. Trailing zeros should NOT influence
     // the weight because they are fractional groups after the decimal point.
-    let leading_zeros_before_strip =
-        base_10000_digits.iter().take_while(|&&d| d == 0).count() as i32;
+    // At least one group is nonzero here, so neither strip can empty the
+    // digits.
+    let leading_zeros = base_10000_digits.iter().take_while(|&&d| d == 0).count();
+    base_10000_digits.drain(..leading_zeros);
 
-    strip_leading_zeros(&mut base_10000_digits);
-    strip_trailing_zeros(&mut base_10000_digits);
+    let trailing_zeros = base_10000_digits.iter().rev().take_while(|&&d| d == 0).count();
+    base_10000_digits.truncate(base_10000_digits.len() - trailing_zeros);
 
     // Adjust weight only by the number of leading zeros that were removed.
-    let final_weight = weight - leading_zeros_before_strip;
+    let final_weight = weight - leading_zeros as i32;
     if !(POSTGRES_NUMERIC_MIN_WEIGHT..=POSTGRES_NUMERIC_MAX_WEIGHT).contains(&final_weight) {
         return Err(ParseNumericError::ValueOutOfRange);
     }
 
     Ok(PgNumeric::Value { sign, weight: final_weight as i16, scale, digits: base_10000_digits })
-}
-
-/// Removes leading zero digits from a base-10000 digit sequence.
-///
-/// This function strips unnecessary leading zeros while preserving at least
-/// one digit to represent zero values correctly.
-fn strip_leading_zeros(digits: &mut Vec<i16>) {
-    while let Some(&first) = digits.first() {
-        if first == 0 && digits.len() > 1 {
-            digits.remove(0);
-        } else {
-            break;
-        }
-    }
-}
-
-/// Removes trailing zero digits from a base-10000 digit sequence.
-///
-/// This function strips unnecessary trailing zeros while preserving at least
-/// one digit to represent zero values correctly.
-fn strip_trailing_zeros(digits: &mut Vec<i16>) {
-    while let Some(&last) = digits.last() {
-        if last == 0 && digits.len() > 1 {
-            digits.pop();
-        } else {
-            break;
-        }
-    }
 }
 
 impl std::fmt::Display for PgNumeric {
@@ -675,6 +630,14 @@ mod tests {
         );
         assert_eq!(
             PgNumeric::from_str("1e-16384").unwrap_err(),
+            ParseNumericError::ValueOutOfRange
+        );
+        assert_eq!(
+            PgNumeric::from_str("1e1000000000").unwrap_err(),
+            ParseNumericError::ValueOutOfRange
+        );
+        assert_eq!(
+            PgNumeric::from_str("1e-1000000000").unwrap_err(),
             ParseNumericError::ValueOutOfRange
         );
     }

--- a/crates/etl-postgres/src/numeric.rs
+++ b/crates/etl-postgres/src/numeric.rs
@@ -5,14 +5,24 @@ use std::{io::Cursor, str::FromStr};
 use byteorder::{BigEndian, ReadBytesExt};
 use tokio_postgres::types::{FromSql, IsNull, ToSql, Type};
 
+/// Postgres positive numeric sign marker.
 const POSITIVE_SIGN: u16 = 0x0000;
+/// Postgres negative numeric sign marker.
 const NEGATIVE_SIGN: u16 = 0x4000;
-const NAN_SIGN: u16 = 0xC000; // NUMERIC_NAN
-const POSITIVE_INFINITY_SIGN: u16 = 0xD000; // NUMERIC_PINF
-const NEGATIVE_INFINITY_SIGN: u16 = 0xF000; // NUMERIC_NINF
+/// Postgres `NUMERIC_NAN` sign marker.
+const NAN_SIGN: u16 = 0xC000;
+/// Postgres `NUMERIC_PINF` sign marker.
+const POSITIVE_INFINITY_SIGN: u16 = 0xD000;
+/// Postgres `NUMERIC_NINF` sign marker.
+const NEGATIVE_INFINITY_SIGN: u16 = 0xF000;
+/// Maximum display scale accepted by Postgres `NUMERIC`.
 const POSTGRES_NUMERIC_MAX_SCALE: u32 = 16_383;
+/// Minimum base-10000 weight representable by Postgres `NUMERIC`.
 const POSTGRES_NUMERIC_MIN_WEIGHT: i32 = i16::MIN as i32;
+/// Maximum base-10000 weight representable by Postgres `NUMERIC`.
 const POSTGRES_NUMERIC_MAX_WEIGHT: i32 = i16::MAX as i32;
+/// Maximum decimal digit buffer capacity reserved before parsing.
+const MAX_INITIAL_DECIMAL_DIGITS_CAPACITY: usize = 1024;
 
 /// Sign indicator for Postgres numeric values.
 ///
@@ -63,11 +73,11 @@ impl From<Sign> for u16 {
 /// and calculation while maintaining exact decimal precision.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub enum PgNumeric {
-    /// Not a number (NaN) - result of invalid operations.
+    /// Not a number, produced by invalid numeric operations.
     NaN,
-    /// Positive infinity - result of overflow in a positive direction.
+    /// Positive infinity, produced by overflow in a positive direction.
     PositiveInfinity,
-    /// Negative infinity - result of overflow in a negative direction.
+    /// Negative infinity, produced by overflow in a negative direction.
     NegativeInfinity,
     /// Regular numeric value with arbitrary precision.
     Value {
@@ -85,6 +95,7 @@ pub enum PgNumeric {
     },
 }
 
+/// Canonical zero value.
 const ZERO: PgNumeric =
     PgNumeric::Value { sign: Sign::Positive, weight: 0, scale: 0, digits: vec![] };
 
@@ -109,14 +120,14 @@ impl FromStr for PgNumeric {
 
         let bytes = trimmed.as_bytes();
 
-        // Handle sign
+        // Handle sign.
         let (sign, rest, has_explicit_sign) = match bytes[0] {
             b'+' => (Sign::Positive, &bytes[1..], true),
             b'-' => (Sign::Negative, &bytes[1..], true),
             _ => (Sign::Positive, bytes, false),
         };
 
-        // Check for special values (NaN, infinity)
+        // Check for special values (NaN, infinity).
         if !matches!(rest.first(), Some(b'0'..=b'9' | b'.')) {
             // The sign byte is ASCII, so slicing past it stays on a char
             // boundary.
@@ -124,7 +135,7 @@ impl FromStr for PgNumeric {
             return parse_special_value(rest, &sign, has_explicit_sign);
         }
 
-        // Parse regular numeric value
+        // Parse regular numeric value.
         parse_numeric_value(rest, sign)
     }
 }
@@ -269,24 +280,27 @@ fn parse_special_value(
 /// accepted syntax is ASCII, so a non-ASCII byte simply fails to match and
 /// rejects the input, exactly as the previous char-based parser did.
 fn parse_numeric_value(bytes: &[u8], sign: Sign) -> Result<PgNumeric, ParseNumericError> {
-    let mut decimal_digits = Vec::with_capacity(bytes.len());
+    let mut decimal_digits =
+        Vec::with_capacity(bytes.len().min(MAX_INITIAL_DECIMAL_DIGITS_CAPACITY));
     let mut have_decimal_point = false;
-    let mut dweight = -1i32; // Decimal weight (number of digits before decimal point - 1)
-    let mut dscale = 0u32; // Number of digits after decimal point
+    // Decimal weight is the number of digits before the decimal point minus one.
+    let mut dweight = -1i32;
+    // Decimal scale is the number of digits after the decimal point.
+    let mut dscale = 0u32;
     let mut pos = 0;
 
-    // Check for initial decimal point
+    // Check for initial decimal point.
     if bytes.first() == Some(&b'.') {
         have_decimal_point = true;
         pos += 1;
     }
 
-    // Must have at least one digit
+    // The mantissa must contain at least one digit.
     if !matches!(bytes.get(pos), Some(b'0'..=b'9')) {
         return Err(ParseNumericError::InvalidSyntax);
     }
 
-    // Parse digits and decimal point
+    // Parse digits and decimal point.
     while let Some(&byte) = bytes.get(pos) {
         match byte {
             b'0'..=b'9' => {
@@ -304,14 +318,14 @@ fn parse_numeric_value(bytes: &[u8], sign: Sign) -> Result<PgNumeric, ParseNumer
                 }
                 have_decimal_point = true;
                 pos += 1;
-                // Decimal point must not be followed by underscore
+                // A decimal point must not be followed by an underscore.
                 if bytes.get(pos) == Some(&b'_') {
                     return Err(ParseNumericError::InvalidSyntax);
                 }
             }
             b'_' => {
                 pos += 1;
-                // Underscore must be followed by more digits
+                // An underscore must be followed by more digits.
                 if !matches!(bytes.get(pos), Some(b'0'..=b'9')) {
                     return Err(ParseNumericError::InvalidSyntax);
                 }
@@ -320,13 +334,13 @@ fn parse_numeric_value(bytes: &[u8], sign: Sign) -> Result<PgNumeric, ParseNumer
         }
     }
 
-    // Handle scientific notation
+    // Handle scientific notation.
     if matches!(bytes.get(pos), Some(b'e' | b'E')) {
         pos += 1;
         let mut exponent = 0i64;
         let mut exp_negative = false;
 
-        // Handle exponent sign
+        // Handle exponent sign.
         match bytes.get(pos) {
             Some(b'+') => {
                 pos += 1;
@@ -338,7 +352,7 @@ fn parse_numeric_value(bytes: &[u8], sign: Sign) -> Result<PgNumeric, ParseNumer
             _ => {}
         }
 
-        // Parse exponent digits
+        // Parse exponent digits.
         if !matches!(bytes.get(pos), Some(b'0'..=b'9')) {
             return Err(ParseNumericError::InvalidSyntax);
         }
@@ -383,7 +397,7 @@ fn parse_numeric_value(bytes: &[u8], sign: Sign) -> Result<PgNumeric, ParseNumer
         return Err(ParseNumericError::ValueOutOfRange);
     }
 
-    // Convert to base-10000 representation
+    // Convert to base-10000 representation.
     convert_to_base_10000(&decimal_digits, dweight, dscale, sign)
 }
 
@@ -405,11 +419,11 @@ fn convert_to_base_10000(
         return Ok(PgNumeric::Value { sign: Sign::Positive, weight: 0, scale, digits: vec![] });
     }
 
-    // Calculate weight in base-10000 terms
-    // Each base-10000 digit represents 4 decimal digits
+    // Calculate weight in base-10000 terms. Each base-10000 digit represents 4
+    // decimal digits.
     let weight = if dweight >= 0 { (dweight + 4) / 4 - 1 } else { -((-dweight - 1) / 4 + 1) };
 
-    // Calculate offset for proper alignment
+    // Calculate offset for proper alignment.
     let offset = (weight + 1) * 4 - (dweight + 1);
     let Some(first_nonzero_decimal_index) = decimal_digits.iter().position(|&digit| digit != 0)
     else {
@@ -474,29 +488,29 @@ fn format_numeric_value(
     scale: u16,
     digits: &[i16],
 ) -> std::fmt::Result {
-    // Handle zero case
+    // Handle zero case.
     if digits.is_empty() {
         return write!(f, "0");
     }
 
-    // Output negative sign if needed
+    // Output negative sign if needed.
     if matches!(sign, Sign::Negative) {
         write!(f, "-")?;
     }
 
     if weight < 0 {
-        // Number is less than 1, start with "0."
+        // Number is less than 1, start with zero before the decimal point.
         write!(f, "0")?;
     } else {
-        // Output digits before the decimal point
+        // Output digits before the decimal point.
         for d in 0..=weight {
             let base_10000_digit = if (d as usize) < digits.len() { digits[d as usize] } else { 0 };
 
-            // Convert base-10000 digit to 4 decimal digits
+            // Convert base-10000 digit to 4 decimal digits.
             let decimal_digits = format!("{base_10000_digit:04}");
 
             if d == 0 {
-                // For the first digit, suppress leading zeros
+                // For the first digit, suppress leading zeros.
                 let trimmed = decimal_digits.trim_start_matches('0');
                 if trimmed.is_empty() {
                     write!(f, "0")?;
@@ -504,13 +518,13 @@ fn format_numeric_value(
                     write!(f, "{trimmed}")?;
                 }
             } else {
-                // For subsequent digits, always output all 4 digits
+                // For subsequent digits, always output all 4 digits.
                 write!(f, "{decimal_digits}")?;
             }
         }
     }
 
-    // Output decimal point and fractional digits if scale > 0
+    // Output decimal point and fractional digits if scale is positive.
     if scale > 0 {
         write!(f, ".")?;
 
@@ -521,10 +535,10 @@ fn format_numeric_value(
             let base_10000_digit =
                 if d >= 0 && (d as usize) < digits.len() { digits[d as usize] } else { 0 };
 
-            // Convert base-10000 digit to 4 decimal digits
+            // Convert base-10000 digit to 4 decimal digits.
             let decimal_digits = format!("{base_10000_digit:04}");
 
-            // Output up to remaining_scale digits
+            // Output up to remaining scale digits.
             let digits_to_output = std::cmp::min(4, remaining_scale);
             for i in 0..digits_to_output {
                 if let Some(ch) = decimal_digits.chars().nth(i as usize) {
@@ -673,6 +687,10 @@ mod tests {
         } else {
             panic!("Expected Value variant");
         }
+
+        assert_eq!(PgNumeric::from_str("1e-2").unwrap().to_string(), "0.01");
+        assert_eq!(PgNumeric::from_str("1.23e-2").unwrap().to_string(), "0.0123");
+        assert_eq!(PgNumeric::from_str("123e-2").unwrap().to_string(), "1.23");
     }
 
     #[test]
@@ -680,7 +698,19 @@ mod tests {
         assert!(PgNumeric::from_str("").is_err());
         assert!(PgNumeric::from_str("abc").is_err());
         assert!(PgNumeric::from_str("1.2.3").is_err());
-        assert!(PgNumeric::from_str("-NaN").is_err()); // NaN cannot have a sign
+        // NaN cannot have a sign.
+        assert!(PgNumeric::from_str("-NaN").is_err());
+
+        for input in [
+            "+", "-", ".", "+.", "-.", "1e", "1e+", "1e-", "1e_", "1e1_", "_1", "1_", "1__2",
+            "1._2", "1é",
+        ] {
+            assert_eq!(
+                PgNumeric::from_str(input).unwrap_err(),
+                ParseNumericError::InvalidSyntax,
+                "input: {input}"
+            );
+        }
     }
 
     #[test]
@@ -739,7 +769,7 @@ mod tests {
             assert_eq!(num.to_string(), "0");
 
             if let PgNumeric::Value { sign, weight, scale: _, digits } = num {
-                // Normalize to positive zero
+                // Normalize to positive zero.
                 assert_eq!(sign, Sign::Positive);
                 assert_eq!(weight, 0);
                 assert!(digits.is_empty());
@@ -756,7 +786,7 @@ mod tests {
             let mut buf = BytesMut::new();
             ToSql::to_sql(&num, &Type::NUMERIC, &mut buf).unwrap();
             let round = PgNumeric::from_sql(&Type::NUMERIC, &buf).unwrap();
-            // Internal representation should be canonical-zero with same scale
+            // Internal representation should be canonical zero with same scale.
             assert_eq!(num, round);
             if let PgNumeric::Value { sign, weight, digits, .. } = round {
                 assert_eq!(sign, Sign::Positive);
@@ -792,9 +822,11 @@ mod tests {
             sign: Sign::Positive,
             weight: 0,
             scale: 0,
-            digits: vec![123], // First digit has leading zeros when formatted as 4 digits
+            // The first digit has leading zeros when formatted as 4 digits.
+            digits: vec![123],
         };
-        assert_eq!(format!("{num}"), "123"); // Should not display as "0123"
+        // Formatting should suppress those leading zeros.
+        assert_eq!(format!("{num}"), "123");
     }
 
     #[test]
@@ -803,16 +835,17 @@ mod tests {
             sign: Sign::Positive,
             weight: 0,
             scale: 4,
-            digits: vec![1200, 0], // Represents 120.0000
+            // This represents 120.0000.
+            digits: vec![1200, 0],
         };
         let output = format!("{num}");
-        // Should display trailing zeros according to scale
+        // Display should preserve trailing zeros according to scale.
         assert!(output.ends_with("0000"));
     }
 
     #[test]
     fn weight_ignores_trailing_fraction_groups() {
-        // 0.0012000 → groups: [12, 0], weight must stay at -1 after stripping
+        // 0.0012000 has groups [12, 0], and weight must stay at -1 after stripping.
         let num = PgNumeric::from_str("0.0012000").unwrap();
         assert_eq!(num.to_string(), "0.0012000");
 
@@ -828,7 +861,7 @@ mod tests {
 
     #[test]
     fn weight_and_groups_boundary_cases() {
-        // 9999.9999 is exactly two full groups: [9999, 9999], weight 0
+        // 9999.9999 is exactly two full groups with weight 0.
         let num_1 = PgNumeric::from_str("9999.9999").unwrap();
         assert_eq!(num_1.to_string(), "9999.9999");
 
@@ -841,7 +874,7 @@ mod tests {
             panic!("Expected Value variant");
         }
 
-        // 10000.0001 crosses the 10^4 boundary
+        // 10000.0001 crosses the 10^4 boundary.
         let num_2 = PgNumeric::from_str("10000.0001").unwrap();
         assert_eq!(num_2.to_string(), "10000.0001");
 
@@ -849,7 +882,7 @@ mod tests {
             assert_eq!(sign, Sign::Positive);
             assert_eq!(weight, 1);
             assert_eq!(scale, 4);
-            // Two integer groups [1, 0] and one fractional group [1]
+            // The value has two integer groups and one fractional group.
             assert_eq!(digits.as_slice(), &[1, 0, 1]);
         } else {
             panic!("Expected Value variant");
@@ -880,17 +913,17 @@ mod tests {
             let printed = parsed.to_string();
             let reparsed = PgNumeric::from_str(&printed).unwrap();
 
-            // String should be stable across two parses
+            // String form should be stable across two parses.
             assert_eq!(printed, reparsed.to_string(), "unstable print for {case}");
 
-            // Value representation should be equal across parse/print/parse
+            // Value representation should be equal across parse, print, and parse.
             assert_eq!(parsed, reparsed, "unstable internal value for {case}");
         }
     }
 
     #[test]
     fn large_integer_weight() {
-        // 1,200,000 = 120*10000 + 0 → digits [120, 0] before strip trailing zero
+        // 1,200,000 is 120 * 10000 + 0, giving digits [120, 0] before stripping.
         // We expect trailing zero group to be stripped, weight stays 1.
         let num = PgNumeric::from_str("1200000").unwrap();
         assert_eq!(num.to_string(), "1200000");

--- a/crates/etl-postgres/src/numeric.rs
+++ b/crates/etl-postgres/src/numeric.rs
@@ -115,25 +115,22 @@ impl FromStr for PgNumeric {
             return Err(ParseNumericError::InvalidSyntax);
         }
 
-        let bytes = trimmed.as_bytes();
-
         // Handle sign.
-        let (sign, rest, has_explicit_sign) = match bytes[0] {
-            b'+' => (Sign::Positive, &bytes[1..], true),
-            b'-' => (Sign::Negative, &bytes[1..], true),
-            _ => (Sign::Positive, bytes, false),
+        let (sign, rest, has_explicit_sign) = if let Some(rest) = trimmed.strip_prefix('+') {
+            (Sign::Positive, rest, true)
+        } else if let Some(rest) = trimmed.strip_prefix('-') {
+            (Sign::Negative, rest, true)
+        } else {
+            (Sign::Positive, trimmed, false)
         };
 
         // Check for special values (NaN, infinity).
-        if !matches!(rest.first(), Some(b'0'..=b'9' | b'.')) {
-            // The sign byte is ASCII, so slicing past it stays on a char
-            // boundary.
-            let rest = &trimmed[trimmed.len() - rest.len()..];
+        if !matches!(rest.as_bytes().first(), Some(b'0'..=b'9' | b'.')) {
             return parse_special_value(rest, &sign, has_explicit_sign);
         }
 
         // Parse regular numeric value.
-        parse_numeric_value(rest, sign)
+        parse_numeric_value(rest.as_bytes(), sign)
     }
 }
 

--- a/crates/etl/src/data/table_row.rs
+++ b/crates/etl/src/data/table_row.rs
@@ -1,7 +1,5 @@
 use std::mem::size_of;
 
-use tracing::warn;
-
 use crate::data::{
     PgNumeric, PgTimeTz, SizeHint,
     cell::{ArrayCell, Cell},
@@ -248,23 +246,11 @@ impl SizeHint for OldTableRow {
 
 /// Returns an estimate of allocated bytes for a table row payload.
 fn estimate_table_row_allocated_bytes(values: &[Cell], values_capacity: usize) -> usize {
-    let mut total = size_of::<TableRow>();
-    total = checked_add_or_saturating(
-        total,
-        checked_mul_or_saturating(
-            values_capacity,
-            size_of::<Cell>(),
-            "table_row.values_capacity_mul_cell_size",
-        ),
-        "table_row.base_add_values_capacity",
-    );
+    let mut total =
+        size_of::<TableRow>().saturating_add(values_capacity.saturating_mul(size_of::<Cell>()));
 
     for cell in values {
-        total = checked_add_or_saturating(
-            total,
-            estimate_cell_allocated_bytes(cell),
-            "table_row.add_cell_heap_bytes",
-        );
+        total = total.saturating_add(estimate_cell_allocated_bytes(cell));
     }
 
     total
@@ -277,16 +263,9 @@ fn estimate_partial_table_row_allocated_bytes(
     missing_column_indexes_capacity: usize,
     _total_columns: usize,
 ) -> usize {
-    let mut total = size_of::<PartialTableRow>() + table_row.size_hint();
-    total = checked_add_or_saturating(
-        total,
-        checked_mul_or_saturating(
-            missing_column_indexes_capacity,
-            size_of::<usize>(),
-            "partial_table_row.missing_indexes_capacity_mul_usize_size",
-        ),
-        "partial_table_row.base_add_missing_indexes_capacity",
-    );
+    let mut total = size_of::<PartialTableRow>().saturating_add(table_row.size_hint());
+    total =
+        total.saturating_add(missing_column_indexes_capacity.saturating_mul(size_of::<usize>()));
     let _ = missing_column_indexes;
 
     total
@@ -320,11 +299,7 @@ fn estimate_cell_allocated_bytes(cell: &Cell) -> usize {
 /// Returns an estimate of additional heap bytes owned by a [`PgNumeric`].
 fn estimated_pg_numeric_allocated_bytes(value: &PgNumeric) -> usize {
     match &value {
-        PgNumeric::Value { digits, .. } => checked_mul_or_saturating(
-            digits.capacity(),
-            size_of::<i16>(),
-            "pg_numeric.digits_capacity_mul_i16_size",
-        ),
+        PgNumeric::Value { digits, .. } => digits.capacity().saturating_mul(size_of::<i16>()),
         PgNumeric::NaN | PgNumeric::PositiveInfinity | PgNumeric::NegativeInfinity => 0,
     }
 }
@@ -335,28 +310,15 @@ fn estimate_json_allocated_bytes(value: &serde_json::Value) -> usize {
         serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => 0,
         serde_json::Value::String(value) => value.capacity(),
         serde_json::Value::Array(values) => {
-            let mut total = checked_mul_or_saturating(
-                values.capacity(),
-                size_of::<serde_json::Value>(),
-                "json.array_capacity_mul_value_size",
-            );
+            let mut total = values.capacity().saturating_mul(size_of::<serde_json::Value>());
             for value in values {
-                total = checked_add_or_saturating(
-                    total,
-                    estimate_json_allocated_bytes(value),
-                    "json.add_nested_value_bytes",
-                );
+                total = total.saturating_add(estimate_json_allocated_bytes(value));
             }
             total
         }
         serde_json::Value::Object(values) => values.iter().fold(0usize, |acc, (key, value)| {
-            let with_key =
-                checked_add_or_saturating(acc, key.capacity(), "json.object_add_key_capacity");
-            checked_add_or_saturating(
-                with_key,
-                estimate_json_allocated_bytes(value),
-                "json.object_add_nested_value_bytes",
-            )
+            let with_key = acc.saturating_add(key.capacity());
+            with_key.saturating_add(estimate_json_allocated_bytes(value))
         }),
     }
 }
@@ -364,157 +326,59 @@ fn estimate_json_allocated_bytes(value: &serde_json::Value) -> usize {
 /// Returns an estimate of additional heap bytes owned by an [`ArrayCell`].
 fn estimate_array_allocated_bytes(value: &ArrayCell) -> usize {
     match value {
-        ArrayCell::Bool(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<bool>>(),
-            "array.bool_capacity_mul_option_size",
-        ),
-        ArrayCell::I16(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<i16>>(),
-            "array.i16_capacity_mul_option_size",
-        ),
-        ArrayCell::I32(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<i32>>(),
-            "array.i32_capacity_mul_option_size",
-        ),
-        ArrayCell::U32(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<u32>>(),
-            "array.u32_capacity_mul_option_size",
-        ),
-        ArrayCell::I64(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<i64>>(),
-            "array.i64_capacity_mul_option_size",
-        ),
-        ArrayCell::F32(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<f32>>(),
-            "array.f32_capacity_mul_option_size",
-        ),
-        ArrayCell::F64(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<f64>>(),
-            "array.f64_capacity_mul_option_size",
-        ),
+        ArrayCell::Bool(values) => values.capacity().saturating_mul(size_of::<Option<bool>>()),
+        ArrayCell::I16(values) => values.capacity().saturating_mul(size_of::<Option<i16>>()),
+        ArrayCell::I32(values) => values.capacity().saturating_mul(size_of::<Option<i32>>()),
+        ArrayCell::U32(values) => values.capacity().saturating_mul(size_of::<Option<u32>>()),
+        ArrayCell::I64(values) => values.capacity().saturating_mul(size_of::<Option<i64>>()),
+        ArrayCell::F32(values) => values.capacity().saturating_mul(size_of::<Option<f32>>()),
+        ArrayCell::F64(values) => values.capacity().saturating_mul(size_of::<Option<f64>>()),
         ArrayCell::Numeric(values) => {
-            let mut total = checked_mul_or_saturating(
-                values.capacity(),
-                size_of::<Option<PgNumeric>>(),
-                "array.numeric_capacity_mul_option_size",
-            );
+            let mut total = values.capacity().saturating_mul(size_of::<Option<PgNumeric>>());
             for value in values.iter().flatten() {
-                total = checked_add_or_saturating(
-                    total,
-                    estimated_pg_numeric_allocated_bytes(value),
-                    "array.numeric_add_element_heap_bytes",
-                );
+                total = total.saturating_add(estimated_pg_numeric_allocated_bytes(value));
             }
             total
         }
-        ArrayCell::Date(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<chrono::NaiveDate>>(),
-            "array.date_capacity_mul_option_size",
-        ),
-        ArrayCell::Time(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<chrono::NaiveTime>>(),
-            "array.time_capacity_mul_option_size",
-        ),
-        ArrayCell::TimeTz(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<PgTimeTz>>(),
-            "array.timetz_capacity_mul_option_size",
-        ),
-        ArrayCell::Timestamp(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<chrono::NaiveDateTime>>(),
-            "array.timestamp_capacity_mul_option_size",
-        ),
-        ArrayCell::TimestampTz(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<chrono::DateTime<chrono::Utc>>>(),
-            "array.timestamptz_capacity_mul_option_size",
-        ),
-        ArrayCell::Uuid(values) => checked_mul_or_saturating(
-            values.capacity(),
-            size_of::<Option<uuid::Uuid>>(),
-            "array.uuid_capacity_mul_option_size",
-        ),
+        ArrayCell::Date(values) => {
+            values.capacity().saturating_mul(size_of::<Option<chrono::NaiveDate>>())
+        }
+        ArrayCell::Time(values) => {
+            values.capacity().saturating_mul(size_of::<Option<chrono::NaiveTime>>())
+        }
+        ArrayCell::TimeTz(values) => {
+            values.capacity().saturating_mul(size_of::<Option<PgTimeTz>>())
+        }
+        ArrayCell::Timestamp(values) => {
+            values.capacity().saturating_mul(size_of::<Option<chrono::NaiveDateTime>>())
+        }
+        ArrayCell::TimestampTz(values) => {
+            values.capacity().saturating_mul(size_of::<Option<chrono::DateTime<chrono::Utc>>>())
+        }
+        ArrayCell::Uuid(values) => {
+            values.capacity().saturating_mul(size_of::<Option<uuid::Uuid>>())
+        }
         ArrayCell::String(values) => {
-            let mut total = checked_mul_or_saturating(
-                values.capacity(),
-                size_of::<Option<String>>(),
-                "array.string_capacity_mul_option_size",
-            );
+            let mut total = values.capacity().saturating_mul(size_of::<Option<String>>());
             for value in values.iter().flatten() {
-                total = checked_add_or_saturating(
-                    total,
-                    value.capacity(),
-                    "array.string_add_element_capacity",
-                );
+                total = total.saturating_add(value.capacity());
             }
             total
         }
         ArrayCell::Json(values) => {
-            let mut total = checked_mul_or_saturating(
-                values.capacity(),
-                size_of::<Option<serde_json::Value>>(),
-                "array.json_capacity_mul_option_size",
-            );
+            let mut total =
+                values.capacity().saturating_mul(size_of::<Option<serde_json::Value>>());
             for value in values.iter().flatten() {
-                total = checked_add_or_saturating(
-                    total,
-                    estimate_json_allocated_bytes(value),
-                    "array.json_add_element_heap_bytes",
-                );
+                total = total.saturating_add(estimate_json_allocated_bytes(value));
             }
             total
         }
         ArrayCell::Bytes(values) => {
-            let mut total = checked_mul_or_saturating(
-                values.capacity(),
-                size_of::<Option<Vec<u8>>>(),
-                "array.bytes_capacity_mul_option_size",
-            );
+            let mut total = values.capacity().saturating_mul(size_of::<Option<Vec<u8>>>());
             for value in values.iter().flatten() {
-                total = checked_add_or_saturating(
-                    total,
-                    value.capacity(),
-                    "array.bytes_add_element_capacity",
-                );
+                total = total.saturating_add(value.capacity());
             }
             total
-        }
-    }
-}
-
-/// Returns `left + right`, saturating on overflow while emitting a warning.
-fn checked_add_or_saturating(left: usize, right: usize, context: &'static str) -> usize {
-    match left.checked_add(right) {
-        Some(value) => value,
-        None => {
-            warn!(context, left, right, "size hint addition overflowed, saturating to usize::MAX");
-
-            usize::MAX
-        }
-    }
-}
-
-/// Returns `left * right`, saturating on overflow while emitting a warning.
-fn checked_mul_or_saturating(left: usize, right: usize, context: &'static str) -> usize {
-    match left.checked_mul(right) {
-        Some(value) => value,
-        None => {
-            warn!(
-                context,
-                left, right, "size hint multiplication overflowed, saturating to usize::MAX"
-            );
-
-            usize::MAX
         }
     }
 }

--- a/crates/etl/src/postgres/codec/event.rs
+++ b/crates/etl/src/postgres/codec/event.rs
@@ -790,14 +790,15 @@ impl<'a> OldRowResolver<'a> {
 
 /// Converts a dense key-image tuple into a dense row containing only
 /// replica-identity columns in replicated table-column order.
-fn convert_dense_key_tuple_to_row(
-    identity_column_schemas: &[&ColumnSchema],
+fn convert_dense_key_tuple_to_row<'a>(
+    identity_column_schemas: impl ExactSizeIterator<Item = &'a ColumnSchema>,
     tuple_data: &[protocol::TupleData],
 ) -> EtlResult<TableRow> {
-    let mut values = Vec::with_capacity(identity_column_schemas.len());
+    let identity_column_count = identity_column_schemas.len();
+    let mut values = Vec::with_capacity(identity_column_count);
 
     for (i, (column_schema, tuple_data)) in
-        identity_column_schemas.iter().zip(tuple_data.iter()).enumerate()
+        identity_column_schemas.zip(tuple_data.iter()).enumerate()
     {
         let ConvertedTupleCell::Present(value) =
             convert_tuple_data_to_cell(i, column_schema, tuple_data, None)?
@@ -819,16 +820,17 @@ fn convert_dense_key_tuple_to_row(
 
 /// Converts a full-width key-image tuple into a dense row containing only
 /// replica-identity columns in replicated table-column order.
-fn convert_full_width_key_tuple_to_row(
-    identity_column_schemas: &[&ColumnSchema],
-    replicated_column_schemas: &[&ColumnSchema],
+fn convert_full_width_key_tuple_to_row<'a>(
+    identity_column_schemas: impl ExactSizeIterator<Item = &'a ColumnSchema>,
+    replicated_column_schemas: impl Iterator<Item = &'a ColumnSchema>,
     tuple_data: &[protocol::TupleData],
 ) -> EtlResult<TableRow> {
-    let mut values = Vec::with_capacity(identity_column_schemas.len());
-    let mut identity_columns = identity_column_schemas.iter().peekable();
+    let identity_column_count = identity_column_schemas.len();
+    let mut values = Vec::with_capacity(identity_column_count);
+    let mut identity_columns = identity_column_schemas.peekable();
 
     for (i, (column_schema, tuple_data)) in
-        replicated_column_schemas.iter().zip(tuple_data.iter()).enumerate()
+        replicated_column_schemas.zip(tuple_data.iter()).enumerate()
     {
         if !identity_columns.peek().is_some_and(|identity_column| {
             identity_column.ordinal_position == column_schema.ordinal_position
@@ -882,11 +884,8 @@ fn normalize_key_tuple_to_row(
     replicated_table_schema: &ReplicatedTableSchema,
     tuple_data: &[protocol::TupleData],
 ) -> EtlResult<TableRow> {
-    let identity_column_schemas: Vec<_> =
-        replicated_table_schema.identity_column_schemas().collect();
-    let identity_column_count = identity_column_schemas.len();
-    let replicated_column_schemas: Vec<_> = replicated_table_schema.column_schemas().collect();
-    let replicated_column_count = replicated_column_schemas.len();
+    let identity_column_count = replicated_table_schema.identity_column_schemas().len();
+    let replicated_column_count = replicated_table_schema.column_schemas().len();
 
     if identity_column_count == 0 {
         bail!(
@@ -897,12 +896,13 @@ fn normalize_key_tuple_to_row(
     }
 
     match tuple_data.len() {
-        len if len == identity_column_count => {
-            convert_dense_key_tuple_to_row(&identity_column_schemas, tuple_data)
-        }
+        len if len == identity_column_count => convert_dense_key_tuple_to_row(
+            replicated_table_schema.identity_column_schemas(),
+            tuple_data,
+        ),
         len if len == replicated_column_count => convert_full_width_key_tuple_to_row(
-            &identity_column_schemas,
-            &replicated_column_schemas,
+            replicated_table_schema.identity_column_schemas(),
+            replicated_table_schema.column_schemas(),
             tuple_data,
         ),
         _ => {

--- a/crates/etl/src/postgres/codec/table_row.rs
+++ b/crates/etl/src/postgres/codec/table_row.rs
@@ -43,47 +43,44 @@ fn find_next_special(haystack: &[u8]) -> Option<usize> {
 /// Returns an error if the row data is not valid UTF-8, the column count
 /// doesn't match the schema, the row is not properly terminated, or a cell
 /// value cannot be parsed according to its column type.
-pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
+pub(crate) fn parse_table_row_from_postgres_copy_bytes(
     row: &[u8],
-    mut column_schemas: impl ExactSizeIterator<Item = &'a ColumnSchema>,
+    column_schemas: &[ColumnSchema],
 ) -> EtlResult<TableRow> {
     let expected_column_count = column_schemas.len();
-    let mut values = Vec::with_capacity(column_schemas.len());
-
     let row_str = str::from_utf8(row)?;
     let bytes = row_str.as_bytes();
+
+    // Parsed cells in schema order.
+    let mut values = Vec::with_capacity(expected_column_count);
+    // Scratch value for escaped fields; unescaped fields borrow from `row_str`.
+    let mut field_buffer = String::new();
+
+    // Row-level cursor and termination state.
     let mut pos = 0;
-    let mut val_str = String::new();
+    let mut column_index = 0;
     let mut row_terminated = false;
     let mut done = false;
 
     // Main parsing loop - continues until the whole row has been consumed.
     while !done {
-        // Byte offset of the start of the literal run not yet appended to `val_str`.
-        // Postgres COPY text format only ever backslash-escapes ASCII bytes (the
-        // delimiter, backslash itself, newline, and carriage return), so scanning
-        // for those bytes and bulk-appending everything in between never splits a
-        // multibyte UTF-8 character: an ASCII byte can never appear as part of a
-        // multibyte sequence, so `literal_start` and `pos` always land on a valid
-        // char boundary.
-        let mut literal_start = pos;
+        // Field bounds and escape state for the current column.
+        let field_start = pos;
+        // First unbuffered byte after the previous escape. COPY escapes are
+        // ASCII, so these offsets stay on UTF-8 boundaries.
+        let mut literal_start = field_start;
+        let mut field_end = field_start;
+        let mut field_escaped = false;
 
         // Inner loop parses a single field value until tab, newline, or end of input.
-        // `memchr3` scans for the next occurrence of any of the three bytes using
-        // vectorized comparisons across many bytes at once, rather than checking
-        // one byte at a time, so long literal runs (the common case for large
-        // `text`/`bytea` payloads) are skipped over in bulk. Fields with escapes
-        // packed only a few bytes apart would otherwise pay `memchr3`'s per-call
-        // setup cost far more often than a plain byte scan would, so
-        // `find_next_special` only calls into it once the remaining slice is long
-        // enough for that cost to pay off.
+        // `find_next_special` uses vectorized search for long literal runs.
         loop {
             let Some(offset) = find_next_special(&bytes[pos..]) else {
                 // No delimiter, terminator, or escape anywhere in the rest of the
                 // row. A properly terminated row always has an unescaped newline
                 // remaining at this point, so this means the row is incomplete.
-                if bytes.len() > literal_start {
-                    val_str.push_str(&row_str[literal_start..]);
+                if field_escaped && bytes.len() > literal_start {
+                    field_buffer.push_str(&row_str[literal_start..]);
                 }
 
                 if !row_terminated {
@@ -99,18 +96,20 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
             // Escapes packed only a byte or two apart (or consecutive delimiters,
             // like an empty field) make this run empty most of the time; skip the
             // slice and its UTF-8 boundary check rather than appending nothing.
-            if special_pos > literal_start {
-                val_str.push_str(&row_str[literal_start..special_pos]);
+            if field_escaped && special_pos > literal_start {
+                field_buffer.push_str(&row_str[literal_start..special_pos]);
             }
 
             match bytes[special_pos] {
                 // Field separator - end current field parsing.
                 b'\t' => {
+                    field_end = special_pos;
                     pos = special_pos + 1;
                     break;
                 }
                 // Row terminator - end current field and mark row complete.
                 b'\n' => {
+                    field_end = special_pos;
                     pos = special_pos + 1;
                     row_terminated = true;
                     break;
@@ -118,6 +117,11 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
                 // Escape character - decode the following character and keep scanning
                 // this same field.
                 _ => {
+                    if !field_escaped {
+                        field_buffer.push_str(&row_str[field_start..special_pos]);
+                        field_escaped = true;
+                    }
+
                     pos = special_pos + 1;
 
                     match bytes.get(pos) {
@@ -128,16 +132,16 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
                         Some(&escaped) if escaped.is_ascii() => {
                             match escaped {
                                 // Special case: \N when escaped becomes literal \N (not NULL)
-                                b'N' => val_str.push_str("\\N"),
+                                b'N' => field_buffer.push_str("\\N"),
                                 // Standard Postgres escape sequences
-                                b'b' => val_str.push(8 as char), // backspace
-                                b'f' => val_str.push(12 as char), // form feed
-                                b'n' => val_str.push('\n'),
-                                b'r' => val_str.push('\r'),
-                                b't' => val_str.push('\t'),
-                                b'v' => val_str.push(11 as char), // vertical tab
+                                b'b' => field_buffer.push(8 as char), // backspace
+                                b'f' => field_buffer.push(12 as char), // form feed
+                                b'n' => field_buffer.push('\n'),
+                                b'r' => field_buffer.push('\r'),
+                                b't' => field_buffer.push('\t'),
+                                b'v' => field_buffer.push(11 as char), // vertical tab
                                 // Any other byte: strip backslash, keep the byte
-                                other => val_str.push(other as char),
+                                other => field_buffer.push(other as char),
                             }
                             pos += 1;
                         }
@@ -149,7 +153,7 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
                                 .chars()
                                 .next()
                                 .expect("validated UTF-8 has a char at a valid boundary");
-                            val_str.push(escaped);
+                            field_buffer.push(escaped);
                             pos += escaped.len_utf8();
                         }
                         // Trailing backslash with no following byte at all. The row
@@ -169,8 +173,8 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
         }
 
         // Get the next column schema - error if we have more fields than expected.
-        let Some(column_schema) = column_schemas.next() else {
-            let actual_column_count = values.len() + 1;
+        let Some(column_schema) = column_schemas.get(column_index) else {
+            let actual_column_count = column_index + 1;
             bail!(
                 ErrorKind::ConversionError,
                 "Postgres COPY row contains more columns than the table schema",
@@ -181,9 +185,13 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
                 )
             );
         };
+        column_index += 1;
+
+        let field_value =
+            if field_escaped { field_buffer.as_str() } else { &row_str[field_start..field_end] };
 
         // Convert the parsed string value to appropriate Cell type.
-        let value = if val_str == "\\N" {
+        let value = if field_value == "\\N" {
             // Postgres NULL marker: \N represents a NULL value
             // We preserve this as Cell::Null rather than converting to a typed null
             // so that downstream code can handle null semantics appropriately.
@@ -192,13 +200,13 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
             // Convert non-null field value to the appropriate Cell type based on the
             // column's Postgres type, covering all supported data types (integers,
             // floats, strings, booleans, etc.).
-            match parse_cell_from_postgres_text(&column_schema.typ, &val_str) {
+            match parse_cell_from_postgres_text(&column_schema.typ, field_value) {
                 Ok(value) => value,
                 Err(e) => {
                     error!(
                         column_name = %column_schema.name,
                         column_type = %column_schema.typ,
-                        value_length = val_str.len(),
+                        value_length = field_value.len(),
                         "error parsing column from postgres text",
                     );
 
@@ -211,15 +219,17 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes<'a>(
         values.push(value);
 
         // Reset the buffer for the next field.
-        val_str.clear();
+        if field_escaped {
+            field_buffer.clear();
+        }
     }
 
     // Validate that all expected columns were present in the row.
     //
-    // If there are still columns left in the schema iterator, it means the row
+    // If there are still columns left in the schema slice, it means the row
     // had fewer fields than expected, which is an error.
-    if let Some(missing_column_schema) = column_schemas.next() {
-        let actual_column_count = values.len();
+    if let Some(missing_column_schema) = column_schemas.get(column_index) {
+        let actual_column_count = column_index;
         bail!(
             ErrorKind::ConversionError,
             "Postgres COPY row contains fewer columns than the table schema",
@@ -273,8 +283,7 @@ mod tests {
         let column_schemas = create_test_column_schemas();
         let row_data = b"123\tJohn Doe\tt\n";
 
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values().len(), 3);
         assert_eq!(result.values()[0], Cell::I32(123));
@@ -287,8 +296,7 @@ mod tests {
         let column_schemas = create_test_column_schemas();
         let row_data = b"456\t\\N\tf\n";
 
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values().len(), 3);
         assert_eq!(result.values()[0], Cell::I32(456));
@@ -301,8 +309,7 @@ mod tests {
         let column_schemas = create_test_column_schemas();
         let row_data = b"0\t\tf\n";
 
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values().len(), 3);
         assert_eq!(result.values()[0], Cell::I32(0));
@@ -315,8 +322,7 @@ mod tests {
         let column_schemas = create_single_column_schema("value", Type::INT4);
         let row_data = b"42\n";
 
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values().len(), 1);
         assert_eq!(result.values()[0], Cell::I32(42));
@@ -333,8 +339,7 @@ mod tests {
 
         let row_data = b"123\t3.15\tHello World\tt\n";
 
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values().len(), 4);
         assert_eq!(result.values()[0], Cell::I32(123));
@@ -348,7 +353,7 @@ mod tests {
         let column_schemas = create_single_column_schema("value", Type::INT4);
         let row_data = b"42"; // Missing newline
 
-        let result = parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas);
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -361,7 +366,7 @@ mod tests {
         let column_schemas = create_single_column_schema("value", Type::TEXT);
         let row_data = b"text\\"; // Dangling escape byte, no following character at all
 
-        let result = parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas);
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -374,8 +379,7 @@ mod tests {
         let column_schemas = create_test_column_schemas();
         let row_data = b"123\tJohn\n";
 
-        let result_empty =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
+        let result_empty = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas);
         assert!(result_empty.is_err());
         let err = result_empty.unwrap_err();
         assert_eq!(
@@ -396,7 +400,7 @@ mod tests {
         let column_schemas = create_test_column_schemas();
         let row_data = b"123\tJohn\tt\textra\n";
 
-        let result = parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas);
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -418,7 +422,7 @@ mod tests {
         let column_schemas = create_single_column_schema("value", Type::TEXT);
         let row_data = &[0xFF, 0xFE, 0xFD, b'\n']; // Invalid UTF-8
 
-        let result = parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas);
 
         assert!(result.is_err());
     }
@@ -428,7 +432,7 @@ mod tests {
         let column_schemas = create_single_column_schema("number", Type::INT4);
         let row_data = b"not_a_number\n";
 
-        let result = parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas);
 
         assert!(result.is_err());
     }
@@ -438,8 +442,7 @@ mod tests {
         let column_schemas = create_single_column_schema("data", Type::TEXT);
 
         let row_data = b"Text\\\\\n";
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values().len(), 1);
         assert_eq!(result.values()[0], Cell::String("Text\\".to_owned()));
@@ -450,18 +453,17 @@ mod tests {
         let column_schemas = create_single_column_schema("value", Type::TEXT);
 
         let row_data = b"\\N\n";
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
         assert_eq!(result.values()[0], Cell::Null);
 
         let row_data = b"\\\\N\n";
         let result_test =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+            parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
         assert_eq!(result_test.values()[0], Cell::Null);
 
         let row_data = b"\\\\A\n";
         let result_test =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+            parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
         assert_eq!(result_test.values()[0], Cell::String("\\A".to_owned()));
     }
 
@@ -470,8 +472,7 @@ mod tests {
         let column_schemas = create_test_column_schemas();
 
         let row_data = b"123\t John Doe \tt\n";
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values().len(), 3);
         assert_eq!(result.values()[0], Cell::I32(123));
@@ -493,11 +494,9 @@ mod tests {
         }
         expected_row.push('\n');
 
-        let result = parse_table_row_from_postgres_copy_bytes(
-            expected_row.as_bytes(),
-            column_schemas.iter(),
-        )
-        .unwrap();
+        let result =
+            parse_table_row_from_postgres_copy_bytes(expected_row.as_bytes(), &column_schemas)
+                .unwrap();
 
         assert_eq!(result.values().len(), 50);
         for i in 0..50 {
@@ -510,7 +509,7 @@ mod tests {
         let column_schemas = create_test_column_schemas();
         let row_data = b"\t\t\n"; // Empty values but correct number of tabs
 
-        let result = parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter());
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas);
 
         assert!(result.is_err());
     }
@@ -524,8 +523,7 @@ mod tests {
 
         // Postgres escapes tab characters in data with \\t
         let row_data = b"value\\twith\\ttabs\tnormal\\tvalue\n";
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values()[0], Cell::String("value\twith\ttabs".to_owned()));
         assert_eq!(result.values()[1], Cell::String("normal\tvalue".to_owned()));
@@ -541,8 +539,7 @@ mod tests {
 
         // Escapes at the beginning, middle, and end of fields
         let row_data = b"\\tstart\tmiddle\\nvalue\tend\\r\n";
-        let result =
-            parse_table_row_from_postgres_copy_bytes(row_data, column_schemas.iter()).unwrap();
+        let result = parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
 
         assert_eq!(result.values()[0], Cell::String("\tstart".to_owned()));
         assert_eq!(result.values()[1], Cell::String("middle\nvalue".to_owned()));
@@ -559,8 +556,7 @@ mod tests {
         row_with_newline.push(b'\n');
 
         let result =
-            parse_table_row_from_postgres_copy_bytes(&row_with_newline, column_schemas.iter())
-                .unwrap();
+            parse_table_row_from_postgres_copy_bytes(&row_with_newline, &column_schemas).unwrap();
 
         assert_eq!(result.values()[0], Cell::String("Hello\t🌍\nWorld\r测试".to_owned()));
     }
@@ -596,8 +592,7 @@ mod tests {
         ];
 
         for (input, expected) in test_cases {
-            let result =
-                parse_table_row_from_postgres_copy_bytes(input, column_schemas.iter()).unwrap();
+            let result = parse_table_row_from_postgres_copy_bytes(input, &column_schemas).unwrap();
             assert_eq!(
                 result.values()[0],
                 Cell::String(expected.to_owned()),
@@ -619,8 +614,7 @@ mod tests {
         ];
 
         for (input, expected) in test_cases {
-            let result =
-                parse_table_row_from_postgres_copy_bytes(input, column_schemas.iter()).unwrap();
+            let result = parse_table_row_from_postgres_copy_bytes(input, &column_schemas).unwrap();
             assert_eq!(
                 result.values()[0],
                 expected,

--- a/crates/etl/src/postgres/codec/table_row.rs
+++ b/crates/etl/src/postgres/codec/table_row.rs
@@ -125,22 +125,19 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes(
                     pos = special_pos + 1;
 
                     match bytes.get(pos) {
-                        // Postgres COPY TO only ever escapes ASCII bytes (the
-                        // delimiter, backslash, newline, and carriage return), so
-                        // this fast path handles every real escape without going
-                        // through the pricier `chars()` decode below.
+                        // Postgres COPY TO emits ASCII escape sequences for
+                        // delimiters, backslashes, and supported control bytes.
+                        // This fast path handles those without `chars()` decoding.
                         Some(&escaped) if escaped.is_ascii() => {
                             match escaped {
-                                // Special case: \N when escaped becomes literal \N (not NULL)
-                                b'N' => field_buffer.push_str("\\N"),
-                                // Standard Postgres escape sequences
+                                // Standard Postgres escape sequences.
                                 b'b' => field_buffer.push(8 as char), // backspace
                                 b'f' => field_buffer.push(12 as char), // form feed
                                 b'n' => field_buffer.push('\n'),
                                 b'r' => field_buffer.push('\r'),
                                 b't' => field_buffer.push('\t'),
                                 b'v' => field_buffer.push(11 as char), // vertical tab
-                                // Any other byte: strip backslash, keep the byte
+                                // Any other byte strips the backslash and keeps the byte.
                                 other => field_buffer.push(other as char),
                             }
                             pos += 1;
@@ -187,16 +184,15 @@ pub(crate) fn parse_table_row_from_postgres_copy_bytes(
         };
         column_index += 1;
 
-        let field_value =
-            if field_escaped { field_buffer.as_str() } else { &row_str[field_start..field_end] };
+        let raw_field_value = &row_str[field_start..field_end];
 
-        // Convert the parsed string value to appropriate Cell type.
-        let value = if field_value == "\\N" {
-            // Postgres NULL marker: \N represents a NULL value
-            // We preserve this as Cell::Null rather than converting to a typed null
-            // so that downstream code can handle null semantics appropriately.
+        // Postgres matches the null marker before removing backslashes, so
+        // `\\N` remains a literal `\N`.
+        let value = if raw_field_value == "\\N" {
             Cell::Null
         } else {
+            let field_value = if field_escaped { field_buffer.as_str() } else { raw_field_value };
+
             // Convert non-null field value to the appropriate Cell type based on the
             // column's Postgres type, covering all supported data types (integers,
             // floats, strings, booleans, etc.).
@@ -459,7 +455,7 @@ mod tests {
         let row_data = b"\\\\N\n";
         let result_test =
             parse_table_row_from_postgres_copy_bytes(row_data, &column_schemas).unwrap();
-        assert_eq!(result_test.values()[0], Cell::Null);
+        assert_eq!(result_test.values()[0], Cell::String("\\N".to_owned()));
 
         let row_data = b"\\\\A\n";
         let result_test =
@@ -581,6 +577,7 @@ mod tests {
             (b"\\!\n", "!"),   // punctuation
             (b"\\@\n", "@"),   // symbol
             (b"\\\"\n", "\""), // quote
+            (b"value\\Ntail\n", "valueNtail"),
             // Complex patterns
             ("Text\\bwith\\bbackspaces\n".as_bytes(), "Text\u{0008}with\u{0008}backspaces"),
             ("Form\\ffeed\\ftest\n".as_bytes(), "Form\u{000C}feed\u{000C}test"),
@@ -608,9 +605,9 @@ mod tests {
 
         // Test NULL marker vs empty string vs literal \N
         let test_cases: Vec<(&[u8], Cell)> = vec![
-            (b"\\N\n", Cell::Null),               // NULL marker
-            (b"\n", Cell::String("".to_owned())), // empty string
-            ("\\\\N\n".as_bytes(), Cell::Null),   // NULL marker
+            (b"\\N\n", Cell::Null),                                 // NULL marker
+            (b"\n", Cell::String("".to_owned())),                   // empty string
+            ("\\\\N\n".as_bytes(), Cell::String("\\N".to_owned())), // literal \N
         ];
 
         for (input, expected) in test_cases {

--- a/crates/etl/src/postgres/codec/text.rs
+++ b/crates/etl/src/postgres/codec/text.rs
@@ -1,10 +1,6 @@
 use core::str;
 
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-use etl_postgres::{
-    time::{DATE_FORMAT, TIME_FORMAT, TIMESTAMP_FORMAT},
-    type_utils::is_array_type,
-};
+use etl_postgres::type_utils::is_array_type;
 use tokio_postgres::types::Type;
 use uuid::Uuid;
 
@@ -15,7 +11,10 @@ use crate::{
     postgres::codec::{
         bool::parse_bool,
         hex,
-        time::{parse_postgres_timestamptz, parse_postgres_timetz},
+        time::{
+            parse_postgres_date, parse_postgres_time, parse_postgres_timestamp,
+            parse_postgres_timestamptz, parse_postgres_timetz,
+        },
     },
 };
 
@@ -70,21 +69,21 @@ pub(crate) fn parse_cell_from_postgres_text(typ: &Type, str: &str) -> EtlResult<
             ArrayCell::Bytes,
         ),
         Type::DATE => {
-            let val = NaiveDate::parse_from_str(str, DATE_FORMAT)?;
+            let val = parse_postgres_date(str)?;
             Ok(Cell::Date(val))
         }
         Type::DATE_ARRAY => parse_cell_from_postgres_text_array(
             str,
-            |str| Ok(Some(NaiveDate::parse_from_str(str, DATE_FORMAT)?)),
+            |str| Ok(Some(parse_postgres_date(str)?)),
             ArrayCell::Date,
         ),
         Type::TIME => {
-            let val = NaiveTime::parse_from_str(str, TIME_FORMAT)?;
+            let val = parse_postgres_time(str)?;
             Ok(Cell::Time(val))
         }
         Type::TIME_ARRAY => parse_cell_from_postgres_text_array(
             str,
-            |str| Ok(Some(NaiveTime::parse_from_str(str, TIME_FORMAT)?)),
+            |str| Ok(Some(parse_postgres_time(str)?)),
             ArrayCell::Time,
         ),
         Type::TIMETZ => {
@@ -97,12 +96,12 @@ pub(crate) fn parse_cell_from_postgres_text(typ: &Type, str: &str) -> EtlResult<
             ArrayCell::TimeTz,
         ),
         Type::TIMESTAMP => {
-            let val = NaiveDateTime::parse_from_str(str, TIMESTAMP_FORMAT)?;
+            let val = parse_postgres_timestamp(str)?;
             Ok(Cell::Timestamp(val))
         }
         Type::TIMESTAMP_ARRAY => parse_cell_from_postgres_text_array(
             str,
-            |str| Ok(Some(NaiveDateTime::parse_from_str(str, TIMESTAMP_FORMAT)?)),
+            |str| Ok(Some(parse_postgres_timestamp(str)?)),
             ArrayCell::Timestamp,
         ),
         Type::TIMESTAMPTZ => {

--- a/crates/etl/src/postgres/codec/text.rs
+++ b/crates/etl/src/postgres/codec/text.rs
@@ -237,8 +237,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use chrono::{Datelike, Timelike};
-    use etl_postgres::numeric::PgNumeric;
+    use chrono::{Datelike, NaiveDateTime, NaiveTime, Timelike};
+    use etl_postgres::{
+        numeric::PgNumeric,
+        time::{TIME_FORMAT, TIMESTAMP_FORMAT},
+    };
 
     use super::*;
 
@@ -599,6 +602,42 @@ mod tests {
             parse_cell_from_postgres_text(&Type::TIMESTAMPTZ, "2023-12-25 14:30:45.123+00:00:15")
                 .unwrap();
         assert!(matches!(cell, Cell::TimestampTz(_)));
+    }
+
+    #[test]
+    fn try_from_str_temporal_arrays() {
+        assert_eq!(
+            parse_cell_from_postgres_text(&Type::DATE_ARRAY, "{2023-12-25,NULL,2024-02-29}")
+                .unwrap(),
+            Cell::Array(ArrayCell::Date(vec![
+                Some("2023-12-25".parse().unwrap()),
+                None,
+                Some("2024-02-29".parse().unwrap()),
+            ]))
+        );
+
+        assert_eq!(
+            parse_cell_from_postgres_text(&Type::TIME_ARRAY, r#"{"14:30:45.123",NULL}"#).unwrap(),
+            Cell::Array(ArrayCell::Time(vec![
+                Some(NaiveTime::parse_from_str("14:30:45.123", TIME_FORMAT).unwrap()),
+                None,
+            ]))
+        );
+
+        assert_eq!(
+            parse_cell_from_postgres_text(
+                &Type::TIMESTAMP_ARRAY,
+                r#"{"2023-12-25 14:30:45.123",NULL}"#,
+            )
+            .unwrap(),
+            Cell::Array(ArrayCell::Timestamp(vec![
+                Some(
+                    NaiveDateTime::parse_from_str("2023-12-25 14:30:45.123", TIMESTAMP_FORMAT,)
+                        .unwrap(),
+                ),
+                None,
+            ]))
+        );
     }
 
     #[test]

--- a/crates/etl/src/postgres/codec/time.rs
+++ b/crates/etl/src/postgres/codec/time.rs
@@ -1,7 +1,9 @@
 //! Date and time conversion helpers for Postgres text output.
 
-use chrono::{DateTime, FixedOffset, NaiveDateTime, TimeZone};
-use etl_postgres::time::{ParseTimeError, PgTimeTz, TIMESTAMP_FORMAT, parse_postgres_utc_offset};
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone};
+use etl_postgres::time::{
+    DATE_FORMAT, ParseTimeError, PgTimeTz, TIME_FORMAT, TIMESTAMP_FORMAT, parse_postgres_utc_offset,
+};
 
 /// Minimum byte index after `YYYY-MM-DD` where a UTC offset sign can appear.
 const MIN_TIMESTAMP_OFFSET_INDEX: usize = 10;
@@ -9,6 +11,47 @@ const MIN_TIMESTAMP_OFFSET_INDEX: usize = 10;
 /// Parses a Postgres `time with time zone` text value.
 pub(crate) fn parse_postgres_timetz(value: &str) -> Result<PgTimeTz, ParseTimeError> {
     value.parse()
+}
+
+/// Parses a Postgres `date` text value.
+///
+/// Postgres emits ISO dates as `YYYY-MM-DD` on replication connections. That
+/// shape is decoded with a fixed-layout byte parser; anything else falls back
+/// to chrono's format machinery so accepted and rejected inputs stay identical.
+pub(crate) fn parse_postgres_date(value: &str) -> Result<NaiveDate, chrono::ParseError> {
+    if let Some(date) = parse_iso_date_fast(value.as_bytes()) {
+        return Ok(date);
+    }
+
+    NaiveDate::parse_from_str(value, DATE_FORMAT)
+}
+
+/// Parses a Postgres `time` text value.
+///
+/// Postgres emits ISO times as `HH:MM:SS[.ffffff]` on replication connections.
+/// That shape is decoded with a fixed-layout byte parser; anything else falls
+/// back to chrono's format machinery so accepted and rejected inputs stay
+/// identical.
+pub(crate) fn parse_postgres_time(value: &str) -> Result<NaiveTime, chrono::ParseError> {
+    if let Some(time) = parse_iso_time_fast(value.as_bytes()) {
+        return Ok(time);
+    }
+
+    NaiveTime::parse_from_str(value, TIME_FORMAT)
+}
+
+/// Parses a Postgres `timestamp` text value.
+///
+/// Postgres emits ISO timestamps as `YYYY-MM-DD HH:MM:SS[.ffffff]` on
+/// replication connections. That shape is decoded with a fixed-layout byte
+/// parser; anything else falls back to chrono's format machinery so accepted
+/// and rejected inputs stay identical.
+pub(crate) fn parse_postgres_timestamp(value: &str) -> Result<NaiveDateTime, chrono::ParseError> {
+    if let Some(timestamp) = parse_iso_timestamp_fast(value.as_bytes()) {
+        return Ok(timestamp);
+    }
+
+    NaiveDateTime::parse_from_str(value, TIMESTAMP_FORMAT)
 }
 
 /// Parses a Postgres `timestamp with time zone` text value.
@@ -21,10 +64,92 @@ pub(crate) fn parse_postgres_timestamptz(
     value: &str,
 ) -> Result<DateTime<FixedOffset>, ParseTimeError> {
     let (timestamp, offset) = split_timestamp_offset(value).ok_or(ParseTimeError::InvalidSyntax)?;
-    let timestamp = NaiveDateTime::parse_from_str(timestamp.trim_end(), TIMESTAMP_FORMAT)?;
+    let timestamp = parse_postgres_timestamp(timestamp.trim_end())?;
     let offset = parse_postgres_utc_offset(offset).ok_or(ParseTimeError::InvalidSyntax)?;
 
     offset.from_local_datetime(&timestamp).single().ok_or(ParseTimeError::InvalidSyntax)
+}
+
+/// Parses two ASCII decimal digits into a number.
+#[inline]
+fn parse_two_digits(bytes: &[u8]) -> Option<u32> {
+    let high = bytes[0].wrapping_sub(b'0');
+    let low = bytes[1].wrapping_sub(b'0');
+    if high > 9 || low > 9 {
+        return None;
+    }
+
+    Some(u32::from(high) * 10 + u32::from(low))
+}
+
+/// Parses a strict `YYYY-MM-DD` byte layout into a [`NaiveDate`].
+///
+/// Returns [`None`] for any deviation, including out-of-range components, so
+/// the caller can defer to chrono for the exact accept/reject decision.
+fn parse_iso_date_fast(bytes: &[u8]) -> Option<NaiveDate> {
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+
+    let year = parse_two_digits(&bytes[0..2])? * 100 + parse_two_digits(&bytes[2..4])?;
+    let month = parse_two_digits(&bytes[5..7])?;
+    let day = parse_two_digits(&bytes[8..10])?;
+
+    NaiveDate::from_ymd_opt(year as i32, month, day)
+}
+
+/// Parses a strict `HH:MM:SS[.f{1,9}]` byte layout into a [`NaiveTime`].
+///
+/// Returns [`None`] for any deviation, including out-of-range components and
+/// leap seconds, so the caller can defer to chrono for the exact accept/reject
+/// decision.
+fn parse_iso_time_fast(bytes: &[u8]) -> Option<NaiveTime> {
+    if bytes.len() < 8 || bytes[2] != b':' || bytes[5] != b':' {
+        return None;
+    }
+
+    let hour = parse_two_digits(&bytes[0..2])?;
+    let minute = parse_two_digits(&bytes[3..5])?;
+    let second = parse_two_digits(&bytes[6..8])?;
+
+    let nanos = if bytes.len() == 8 {
+        0
+    } else {
+        if bytes[8] != b'.' {
+            return None;
+        }
+
+        let fraction = &bytes[9..];
+        if fraction.is_empty() || fraction.len() > 9 {
+            return None;
+        }
+
+        let mut nanos: u32 = 0;
+        for &byte in fraction {
+            let digit = byte.wrapping_sub(b'0');
+            if digit > 9 {
+                return None;
+            }
+            nanos = nanos * 10 + u32::from(digit);
+        }
+
+        nanos * 10u32.pow(9 - fraction.len() as u32)
+    };
+
+    NaiveTime::from_hms_nano_opt(hour, minute, second, nanos)
+}
+
+/// Parses a strict `YYYY-MM-DD HH:MM:SS[.f{1,9}]` byte layout into a
+/// [`NaiveDateTime`].
+fn parse_iso_timestamp_fast(bytes: &[u8]) -> Option<NaiveDateTime> {
+    if bytes.len() < 19 || bytes[10] != b' ' {
+        return None;
+    }
+
+    let date = parse_iso_date_fast(&bytes[..10])?;
+    let time = parse_iso_time_fast(&bytes[11..])?;
+
+    Some(NaiveDateTime::new(date, time))
 }
 
 /// Splits a timestamp string into timestamp and numeric UTC offset parts.
@@ -39,6 +164,95 @@ mod tests {
     use chrono::{NaiveTime, Timelike};
 
     use super::*;
+
+    #[test]
+    fn date_fast_path_matches_chrono_for_iso_dates() {
+        for value in ["2023-12-25", "0001-01-01", "9999-12-31", "2024-02-29"] {
+            assert_eq!(
+                parse_postgres_date(value).unwrap(),
+                NaiveDate::parse_from_str(value, DATE_FORMAT).unwrap(),
+                "value: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn date_falls_back_for_non_iso_shapes() {
+        // Single-digit components are chrono-only shapes.
+        assert_eq!(
+            parse_postgres_date("2023-1-01").unwrap(),
+            NaiveDate::parse_from_str("2023-1-01", DATE_FORMAT).unwrap()
+        );
+
+        // Chrono's `%Y` requires a `+` prefix for years above 4 digits, so the
+        // fallback rejects this exactly like the previous direct parse did.
+        assert!(parse_postgres_date("12023-01-01").is_err());
+        assert!(parse_postgres_date("2023-13-01").is_err());
+        assert!(parse_postgres_date("2023-02-30").is_err());
+        assert!(parse_postgres_date("2023-12-25 BC").is_err());
+        assert!(parse_postgres_date("not-a-date").is_err());
+        assert!(parse_postgres_date("").is_err());
+    }
+
+    #[test]
+    fn time_fast_path_matches_chrono_for_iso_times() {
+        for value in
+            ["00:00:00", "23:59:59", "14:30:45.1", "14:30:45.123", "14:30:45.123456", "12:00:00.5"]
+        {
+            assert_eq!(
+                parse_postgres_time(value).unwrap(),
+                NaiveTime::parse_from_str(value, TIME_FORMAT).unwrap(),
+                "value: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn time_falls_back_for_non_iso_shapes() {
+        // Leap seconds only parse through chrono.
+        assert_eq!(
+            parse_postgres_time("23:59:60").unwrap(),
+            NaiveTime::parse_from_str("23:59:60", TIME_FORMAT).unwrap()
+        );
+
+        // Chrono's `%.f` accepts more than nine fractional digits, so the
+        // fallback keeps accepting them exactly like the previous direct
+        // parse did.
+        assert_eq!(
+            parse_postgres_time("12:30:45.1234567890").unwrap(),
+            NaiveTime::parse_from_str("12:30:45.1234567890", TIME_FORMAT).unwrap()
+        );
+
+        assert!(parse_postgres_time("24:00:00").is_err());
+        assert!(parse_postgres_time("12:61:00").is_err());
+        assert!(parse_postgres_time("12:30:45.").is_err());
+        assert!(parse_postgres_time("12:30:45extra").is_err());
+        assert!(parse_postgres_time("invalid").is_err());
+    }
+
+    #[test]
+    fn timestamp_fast_path_matches_chrono_for_iso_timestamps() {
+        for value in [
+            "2023-12-25 14:30:45",
+            "2023-12-25 14:30:45.123",
+            "2023-12-25 14:30:45.123456",
+            "1970-01-01 00:00:00",
+        ] {
+            assert_eq!(
+                parse_postgres_timestamp(value).unwrap(),
+                NaiveDateTime::parse_from_str(value, TIMESTAMP_FORMAT).unwrap(),
+                "value: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn timestamp_falls_back_for_non_iso_shapes() {
+        assert!(parse_postgres_timestamp("2023-12-25T14:30:45").is_err());
+        assert!(parse_postgres_timestamp("2023-12-25 14:30").is_err());
+        assert!(parse_postgres_timestamp("2023-12-25 14:30:45 tail").is_err());
+        assert!(parse_postgres_timestamp("").is_err());
+    }
 
     #[test]
     fn timetz_parses_via_shared_type() {

--- a/crates/etl/src/postgres/codec/time.rs
+++ b/crates/etl/src/postgres/codec/time.rs
@@ -72,9 +72,9 @@ pub(crate) fn parse_postgres_timestamptz(
 
 /// Parses two ASCII decimal digits into a number.
 #[inline]
-fn parse_two_digits(bytes: &[u8]) -> Option<u32> {
-    let high = bytes[0].wrapping_sub(b'0');
-    let low = bytes[1].wrapping_sub(b'0');
+fn parse_two_digits([high, low]: [u8; 2]) -> Option<u32> {
+    let high = high.wrapping_sub(b'0');
+    let low = low.wrapping_sub(b'0');
     if high > 9 || low > 9 {
         return None;
     }
@@ -91,9 +91,10 @@ fn parse_iso_date_fast(bytes: &[u8]) -> Option<NaiveDate> {
         return None;
     }
 
-    let year = parse_two_digits(&bytes[0..2])? * 100 + parse_two_digits(&bytes[2..4])?;
-    let month = parse_two_digits(&bytes[5..7])?;
-    let day = parse_two_digits(&bytes[8..10])?;
+    let year =
+        parse_two_digits([bytes[0], bytes[1]])? * 100 + parse_two_digits([bytes[2], bytes[3]])?;
+    let month = parse_two_digits([bytes[5], bytes[6]])?;
+    let day = parse_two_digits([bytes[8], bytes[9]])?;
 
     NaiveDate::from_ymd_opt(year as i32, month, day)
 }
@@ -108,9 +109,9 @@ fn parse_iso_time_fast(bytes: &[u8]) -> Option<NaiveTime> {
         return None;
     }
 
-    let hour = parse_two_digits(&bytes[0..2])?;
-    let minute = parse_two_digits(&bytes[3..5])?;
-    let second = parse_two_digits(&bytes[6..8])?;
+    let hour = parse_two_digits([bytes[0], bytes[1]])?;
+    let minute = parse_two_digits([bytes[3], bytes[4]])?;
+    let second = parse_two_digits([bytes[6], bytes[7]])?;
 
     let nanos = if bytes.len() == 8 {
         0

--- a/crates/etl/src/postgres/codec/time.rs
+++ b/crates/etl/src/postgres/codec/time.rs
@@ -190,6 +190,7 @@ mod tests {
         assert!(parse_postgres_date("2023-13-01").is_err());
         assert!(parse_postgres_date("2023-02-30").is_err());
         assert!(parse_postgres_date("2023-12-25 BC").is_err());
+        assert!(parse_postgres_date("2023-1é-01").is_err());
         assert!(parse_postgres_date("not-a-date").is_err());
         assert!(parse_postgres_date("").is_err());
     }
@@ -227,6 +228,7 @@ mod tests {
         assert!(parse_postgres_time("12:61:00").is_err());
         assert!(parse_postgres_time("12:30:45.").is_err());
         assert!(parse_postgres_time("12:30:45extra").is_err());
+        assert!(parse_postgres_time("12:30:4é").is_err());
         assert!(parse_postgres_time("invalid").is_err());
     }
 
@@ -248,9 +250,20 @@ mod tests {
 
     #[test]
     fn timestamp_falls_back_for_non_iso_shapes() {
+        assert_eq!(
+            parse_postgres_timestamp("2023-12-25 23:59:60").unwrap(),
+            NaiveDateTime::parse_from_str("2023-12-25 23:59:60", TIMESTAMP_FORMAT).unwrap()
+        );
+        assert_eq!(
+            parse_postgres_timestamp("2023-12-25 12:30:45.1234567890").unwrap(),
+            NaiveDateTime::parse_from_str("2023-12-25 12:30:45.1234567890", TIMESTAMP_FORMAT)
+                .unwrap()
+        );
+
         assert!(parse_postgres_timestamp("2023-12-25T14:30:45").is_err());
         assert!(parse_postgres_timestamp("2023-12-25 14:30").is_err());
         assert!(parse_postgres_timestamp("2023-12-25 14:30:45 tail").is_err());
+        assert!(parse_postgres_timestamp("2023-12-25 12:30:4é").is_err());
         assert!(parse_postgres_timestamp("").is_err());
     }
 

--- a/crates/etl/src/postgres/stream/events.rs
+++ b/crates/etl/src/postgres/stream/events.rs
@@ -66,15 +66,20 @@ impl StatusUpdateType {
             Self::ShutdownFlush => true,
         }
     }
+
+    /// Returns the metric label for this status update type.
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::KeepAlive => "keep_alive",
+            Self::PeriodicKeepAlive => "periodic_keep_alive",
+            Self::ShutdownFlush => "shutdown_flush",
+        }
+    }
 }
 
 impl Display for StatusUpdateType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::KeepAlive => write!(f, "keep_alive"),
-            Self::PeriodicKeepAlive => write!(f, "periodic_keep_alive"),
-            Self::ShutdownFlush => write!(f, "shutdown_flush"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
@@ -161,7 +166,7 @@ impl EventsStream {
             if flush_lsn == *last_flush && last_update.elapsed() < STATUS_UPDATE_INTERVAL {
                 counter!(
                     ETL_STATUS_UPDATES_SKIPPED_TOTAL,
-                    STATUS_UPDATE_TYPE_LABEL => status_update_type.to_string(),
+                    STATUS_UPDATE_TYPE_LABEL => status_update_type.as_str(),
                 )
                 .increment(1);
 
@@ -197,8 +202,8 @@ impl EventsStream {
 
         counter!(
             ETL_STATUS_UPDATES_TOTAL,
-            FORCED_LABEL => force.to_string(),
-            STATUS_UPDATE_TYPE_LABEL => status_update_type.to_string(),
+            FORCED_LABEL => if force { "true" } else { "false" },
+            STATUS_UPDATE_TYPE_LABEL => status_update_type.as_str(),
         )
         .increment(1);
 

--- a/crates/etl/src/postgres/stream/table_copy.rs
+++ b/crates/etl/src/postgres/stream/table_copy.rs
@@ -20,74 +20,6 @@ use crate::{
     schema::ColumnSchema,
 };
 
-/// Number of COPY rows to aggregate before emitting metrics.
-const COPY_METRICS_FLUSH_ROWS: u64 = 1024;
-
-/// Pending COPY metrics waiting to be emitted.
-#[derive(Debug, Default)]
-struct CopyMetricsBatch {
-    /// Number of rows seen since the last flush.
-    rows: u64,
-    /// Number of raw COPY bytes seen since the last flush.
-    bytes: u64,
-    /// Row sizes buffered for the row-size histogram.
-    ///
-    /// Buffering preserves every histogram sample while paying the
-    /// metrics-registry lookup once per flush instead of once per row.
-    row_size_samples: Vec<f64>,
-}
-
-impl CopyMetricsBatch {
-    /// Records one COPY row and flushes metrics when the batch is full.
-    fn record_row(&mut self, row_size_bytes: u64) {
-        self.rows = self.rows.saturating_add(1);
-        self.bytes = self.bytes.saturating_add(row_size_bytes);
-        self.row_size_samples.push(row_size_bytes as f64);
-
-        if self.rows >= COPY_METRICS_FLUSH_ROWS {
-            self.flush();
-        }
-    }
-
-    /// Flushes pending metric deltas to the metrics recorder.
-    fn flush(&mut self) {
-        if self.rows == 0 {
-            return;
-        }
-
-        counter!(
-            ETL_EVENTS_RECEIVED_TOTAL,
-            WORKER_TYPE_LABEL => "table_sync",
-            ACTION_LABEL => "table_copy",
-        )
-        .increment(self.rows);
-
-        counter!(
-            ETL_EVENTS_PROCESSED_TOTAL,
-            WORKER_TYPE_LABEL => "table_sync",
-            ACTION_LABEL => "table_copy",
-        )
-        .increment(self.rows);
-
-        counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(self.bytes);
-        counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(self.bytes);
-
-        let row_size_histogram = histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => "copy");
-        for sample in self.row_size_samples.drain(..) {
-            row_size_histogram.record(sample);
-        }
-
-        self.rows = 0;
-        self.bytes = 0;
-    }
-}
-
-impl Drop for CopyMetricsBatch {
-    fn drop(&mut self) {
-        self.flush();
-    }
-}
-
 pin_project! {
     /// A stream that yields rows from a Postgres COPY operation.
     ///
@@ -99,7 +31,6 @@ pin_project! {
         #[pin]
         stream: CopyOutStream,
         column_schemas: Vec<ColumnSchema>,
-        metrics_batch: CopyMetricsBatch,
     }
 }
 
@@ -110,7 +41,33 @@ impl TableCopyStream {
     /// The column schemas are used to convert the raw Postgres data into
     /// [`TableRow`]s.
     pub(crate) fn wrap(stream: CopyOutStream, column_schemas: Vec<ColumnSchema>) -> Self {
-        Self { stream, column_schemas, metrics_batch: CopyMetricsBatch::default() }
+        Self { stream, column_schemas }
+    }
+
+    /// Records source-side metrics for a COPY row received from Postgres.
+    fn record_row_received(row_size_bytes: u64) {
+        counter!(
+            ETL_EVENTS_RECEIVED_TOTAL,
+            WORKER_TYPE_LABEL => "table_sync",
+            ACTION_LABEL => "table_copy",
+        )
+        .increment(1);
+
+        counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(row_size_bytes);
+    }
+
+    /// Records pipeline-side metrics for a COPY row read from the stream.
+    fn record_row_processed(row_size_bytes: u64) {
+        counter!(
+            ETL_EVENTS_PROCESSED_TOTAL,
+            WORKER_TYPE_LABEL => "table_sync",
+            ACTION_LABEL => "table_copy",
+        )
+        .increment(1);
+
+        counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(row_size_bytes);
+
+        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => "copy").record(row_size_bytes as f64);
     }
 }
 
@@ -127,41 +84,26 @@ impl Stream for TableCopyStream {
         let this = self.project();
 
         match this.stream.poll_next(cx) {
-            Poll::Pending => {
-                this.metrics_batch.flush();
-
-                Poll::Pending
-            }
+            Poll::Pending => Poll::Pending,
             // Row copy received.
             Poll::Ready(Some(Ok(row))) => {
                 let row_size_bytes = row.len() as u64;
 
-                this.metrics_batch.record_row(row_size_bytes);
+                Self::record_row_received(row_size_bytes);
+                Self::record_row_processed(row_size_bytes);
 
                 // Conversion step: transform raw bytes into structured TableRow.
                 // This is where most errors occur due to data format or type issues.
                 match parse_table_row_from_postgres_copy_bytes(&row, this.column_schemas.as_slice())
                 {
                     Ok(row) => Poll::Ready(Some(Ok(row))),
-                    Err(err) => {
-                        this.metrics_batch.flush();
-
-                        Poll::Ready(Some(Err(err)))
-                    }
+                    Err(err) => Poll::Ready(Some(Err(err))),
                 }
             }
             // Postgres connection or protocol-level failure.
-            Poll::Ready(Some(Err(err))) => {
-                this.metrics_batch.flush();
-
-                Poll::Ready(Some(Err(err.into())))
-            }
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err.into()))),
             // Normal completion, no more rows available.
-            Poll::Ready(None) => {
-                this.metrics_batch.flush();
-
-                Poll::Ready(None)
-            }
+            Poll::Ready(None) => Poll::Ready(None),
         }
     }
 }

--- a/crates/etl/src/postgres/stream/table_copy.rs
+++ b/crates/etl/src/postgres/stream/table_copy.rs
@@ -3,7 +3,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{Stream, ready};
+use futures::Stream;
 use metrics::{counter, histogram};
 use pin_project_lite::pin_project;
 use tokio_postgres::CopyOutStream;
@@ -20,6 +20,62 @@ use crate::{
     schema::ColumnSchema,
 };
 
+/// Number of COPY rows to aggregate before emitting counter metrics.
+///
+/// Row-size histograms are still recorded per row so their distribution keeps
+/// the same meaning.
+const COPY_METRICS_FLUSH_ROWS: u64 = 1024;
+
+/// Pending COPY metrics waiting to be emitted.
+#[derive(Debug, Default)]
+struct CopyMetricsBatch {
+    /// Number of rows seen since the last flush.
+    rows: u64,
+    /// Number of raw COPY bytes seen since the last flush.
+    bytes: u64,
+}
+
+impl CopyMetricsBatch {
+    /// Records one COPY row and flushes counters when the batch is full.
+    fn record_row(&mut self, row_size_bytes: u64) {
+        self.rows = self.rows.saturating_add(1);
+        self.bytes = self.bytes.saturating_add(row_size_bytes);
+
+        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => "copy").record(row_size_bytes as f64);
+
+        if self.rows >= COPY_METRICS_FLUSH_ROWS {
+            self.flush();
+        }
+    }
+
+    /// Flushes pending metric deltas to the metrics recorder.
+    fn flush(&mut self) {
+        if self.rows == 0 {
+            return;
+        }
+
+        counter!(
+            ETL_EVENTS_RECEIVED_TOTAL,
+            WORKER_TYPE_LABEL => "table_sync",
+            ACTION_LABEL => "table_copy",
+        )
+        .increment(self.rows);
+
+        counter!(
+            ETL_EVENTS_PROCESSED_TOTAL,
+            WORKER_TYPE_LABEL => "table_sync",
+            ACTION_LABEL => "table_copy",
+        )
+        .increment(self.rows);
+
+        counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(self.bytes);
+        counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(self.bytes);
+
+        self.rows = 0;
+        self.bytes = 0;
+    }
+}
+
 pin_project! {
     /// A stream that yields rows from a Postgres COPY operation.
     ///
@@ -31,6 +87,7 @@ pin_project! {
         #[pin]
         stream: CopyOutStream,
         column_schemas: I,
+        metrics_batch: CopyMetricsBatch,
     }
 }
 
@@ -41,33 +98,7 @@ impl<I> TableCopyStream<I> {
     /// The column schemas are used to convert the raw Postgres data into
     /// [`TableRow`]s.
     pub(crate) fn wrap(stream: CopyOutStream, column_schemas: I) -> Self {
-        Self { stream, column_schemas }
-    }
-
-    /// Records source-side metrics for a COPY row received from Postgres.
-    fn record_row_received(row_size_bytes: u64) {
-        counter!(
-            ETL_EVENTS_RECEIVED_TOTAL,
-            WORKER_TYPE_LABEL => "table_sync",
-            ACTION_LABEL => "table_copy",
-        )
-        .increment(1);
-
-        counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(row_size_bytes);
-    }
-
-    /// Records pipeline-side metrics for a COPY row read from the stream.
-    fn record_row_processed(row_size_bytes: u64) {
-        counter!(
-            ETL_EVENTS_PROCESSED_TOTAL,
-            WORKER_TYPE_LABEL => "table_sync",
-            ACTION_LABEL => "table_copy",
-        )
-        .increment(1);
-
-        counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(row_size_bytes);
-
-        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => "copy").record(row_size_bytes as f64);
+        Self { stream, column_schemas, metrics_batch: CopyMetricsBatch::default() }
     }
 }
 
@@ -86,25 +117,41 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
 
-        match ready!(this.stream.poll_next(cx)) {
+        match this.stream.poll_next(cx) {
+            Poll::Pending => {
+                this.metrics_batch.flush();
+
+                Poll::Pending
+            }
             // Row copy received.
-            Some(Ok(row)) => {
+            Poll::Ready(Some(Ok(row))) => {
                 let row_size_bytes = row.len() as u64;
 
-                Self::record_row_received(row_size_bytes);
-                Self::record_row_processed(row_size_bytes);
+                this.metrics_batch.record_row(row_size_bytes);
 
                 // Conversion step: transform raw bytes into structured TableRow.
                 // This is where most errors occur due to data format or type issues.
                 match parse_table_row_from_postgres_copy_bytes(&row, this.column_schemas.clone()) {
                     Ok(row) => Poll::Ready(Some(Ok(row))),
-                    Err(err) => Poll::Ready(Some(Err(err))),
+                    Err(err) => {
+                        this.metrics_batch.flush();
+
+                        Poll::Ready(Some(Err(err)))
+                    }
                 }
             }
             // Postgres connection or protocol-level failure.
-            Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
+            Poll::Ready(Some(Err(err))) => {
+                this.metrics_batch.flush();
+
+                Poll::Ready(Some(Err(err.into())))
+            }
             // Normal completion, no more rows available.
-            None => Poll::Ready(None),
+            Poll::Ready(None) => {
+                this.metrics_batch.flush();
+
+                Poll::Ready(None)
+            }
         }
     }
 }

--- a/crates/etl/src/postgres/stream/table_copy.rs
+++ b/crates/etl/src/postgres/stream/table_copy.rs
@@ -83,29 +83,26 @@ pin_project! {
     /// using the provided column schemas. The conversion process handles both text and
     /// binary format data.
     #[must_use = "streams do nothing unless polled"]
-    pub(crate) struct TableCopyStream<I> {
+    pub(crate) struct TableCopyStream {
         #[pin]
         stream: CopyOutStream,
-        column_schemas: I,
+        column_schemas: Vec<ColumnSchema>,
         metrics_batch: CopyMetricsBatch,
     }
 }
 
-impl<I> TableCopyStream<I> {
+impl TableCopyStream {
     /// Creates a new [`TableCopyStream`] from a [`CopyOutStream`] and column
     /// schemas.
     ///
     /// The column schemas are used to convert the raw Postgres data into
     /// [`TableRow`]s.
-    pub(crate) fn wrap(stream: CopyOutStream, column_schemas: I) -> Self {
+    pub(crate) fn wrap(stream: CopyOutStream, column_schemas: Vec<ColumnSchema>) -> Self {
         Self { stream, column_schemas, metrics_batch: CopyMetricsBatch::default() }
     }
 }
 
-impl<'a, I> Stream for TableCopyStream<I>
-where
-    I: ExactSizeIterator<Item = &'a ColumnSchema> + Clone,
-{
+impl Stream for TableCopyStream {
     type Item = EtlResult<TableRow>;
 
     /// Polls the stream for the next converted table row with comprehensive
@@ -131,7 +128,8 @@ where
 
                 // Conversion step: transform raw bytes into structured TableRow.
                 // This is where most errors occur due to data format or type issues.
-                match parse_table_row_from_postgres_copy_bytes(&row, this.column_schemas.clone()) {
+                match parse_table_row_from_postgres_copy_bytes(&row, this.column_schemas.as_slice())
+                {
                     Ok(row) => Poll::Ready(Some(Ok(row))),
                     Err(err) => {
                         this.metrics_batch.flush();

--- a/crates/etl/src/postgres/stream/table_copy.rs
+++ b/crates/etl/src/postgres/stream/table_copy.rs
@@ -20,10 +20,7 @@ use crate::{
     schema::ColumnSchema,
 };
 
-/// Number of COPY rows to aggregate before emitting counter metrics.
-///
-/// Row-size histograms are still recorded per row so their distribution keeps
-/// the same meaning.
+/// Number of COPY rows to aggregate before emitting metrics.
 const COPY_METRICS_FLUSH_ROWS: u64 = 1024;
 
 /// Pending COPY metrics waiting to be emitted.
@@ -33,15 +30,19 @@ struct CopyMetricsBatch {
     rows: u64,
     /// Number of raw COPY bytes seen since the last flush.
     bytes: u64,
+    /// Row sizes buffered for the row-size histogram.
+    ///
+    /// Buffering preserves every histogram sample while paying the
+    /// metrics-registry lookup once per flush instead of once per row.
+    row_size_samples: Vec<f64>,
 }
 
 impl CopyMetricsBatch {
-    /// Records one COPY row and flushes counters when the batch is full.
+    /// Records one COPY row and flushes metrics when the batch is full.
     fn record_row(&mut self, row_size_bytes: u64) {
         self.rows = self.rows.saturating_add(1);
         self.bytes = self.bytes.saturating_add(row_size_bytes);
-
-        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => "copy").record(row_size_bytes as f64);
+        self.row_size_samples.push(row_size_bytes as f64);
 
         if self.rows >= COPY_METRICS_FLUSH_ROWS {
             self.flush();
@@ -71,8 +72,19 @@ impl CopyMetricsBatch {
         counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(self.bytes);
         counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => "copy").increment(self.bytes);
 
+        let row_size_histogram = histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => "copy");
+        for sample in self.row_size_samples.drain(..) {
+            row_size_histogram.record(sample);
+        }
+
         self.rows = 0;
         self.bytes = 0;
+    }
+}
+
+impl Drop for CopyMetricsBatch {
+    fn drop(&mut self) {
+        self.flush();
     }
 }
 

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -395,196 +395,6 @@ impl HandleMessageResult {
     }
 }
 
-/// Logical replication row event types that carry payload bytes.
-#[derive(Debug, Copy, Clone)]
-enum StreamingDataEventType {
-    /// An `INSERT` row event.
-    Insert,
-    /// An `UPDATE` row event.
-    Update,
-    /// A `DELETE` row event.
-    Delete,
-}
-
-impl StreamingDataEventType {
-    /// Returns the metric label for this event type.
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Insert => "insert",
-            Self::Update => "update",
-            Self::Delete => "delete",
-        }
-    }
-}
-
-/// Maximum row-size histogram samples buffered per event type before an
-/// inline flush.
-///
-/// This bounds batch memory when many row events arrive between the normal
-/// flush points at status updates and batch dispatches.
-const MAX_BUFFERED_ROW_SIZE_SAMPLES: usize = 4096;
-
-/// Batched streaming metrics waiting to be flushed to the metrics recorder.
-#[derive(Debug, Default)]
-struct StreamingMetricsBatch {
-    /// Number of replication protocol messages received.
-    messages_received: u64,
-    /// Number of logical replication messages received.
-    events_received: u64,
-    /// Bytes received for `INSERT` row payloads.
-    insert_bytes_received: u64,
-    /// Bytes received for `UPDATE` row payloads.
-    update_bytes_received: u64,
-    /// Bytes received for `DELETE` row payloads.
-    delete_bytes_received: u64,
-    /// Bytes processed for `INSERT` row payloads after ownership filtering.
-    insert_bytes_processed: u64,
-    /// Bytes processed for `UPDATE` row payloads after ownership filtering.
-    update_bytes_processed: u64,
-    /// Bytes processed for `DELETE` row payloads after ownership filtering.
-    delete_bytes_processed: u64,
-    /// Row sizes buffered for the `INSERT` row-size histogram.
-    ///
-    /// Buffering preserves every histogram sample while paying the
-    /// metrics-registry lookup once per flush instead of once per row event.
-    insert_row_size_samples: Vec<f64>,
-    /// Row sizes buffered for the `UPDATE` row-size histogram.
-    update_row_size_samples: Vec<f64>,
-    /// Row sizes buffered for the `DELETE` row-size histogram.
-    delete_row_size_samples: Vec<f64>,
-}
-
-impl StreamingMetricsBatch {
-    /// Records one replication protocol message received.
-    fn record_message_received(&mut self) {
-        self.messages_received = self.messages_received.saturating_add(1);
-    }
-
-    /// Records one source event received by the table streaming path.
-    fn record_event_received(&mut self) {
-        self.events_received = self.events_received.saturating_add(1);
-    }
-
-    /// Records row payload bytes received from logical replication.
-    fn record_bytes_received(&mut self, event_type: StreamingDataEventType, payload_bytes: u64) {
-        match event_type {
-            StreamingDataEventType::Insert => {
-                self.insert_bytes_received =
-                    self.insert_bytes_received.saturating_add(payload_bytes);
-            }
-            StreamingDataEventType::Update => {
-                self.update_bytes_received =
-                    self.update_bytes_received.saturating_add(payload_bytes);
-            }
-            StreamingDataEventType::Delete => {
-                self.delete_bytes_received =
-                    self.delete_bytes_received.saturating_add(payload_bytes);
-            }
-        }
-    }
-
-    /// Records row payload bytes processed after table ownership filtering.
-    fn record_bytes_processed(&mut self, event_type: StreamingDataEventType, payload_bytes: u64) {
-        let (bytes_processed, row_size_samples) = match event_type {
-            StreamingDataEventType::Insert => {
-                (&mut self.insert_bytes_processed, &mut self.insert_row_size_samples)
-            }
-            StreamingDataEventType::Update => {
-                (&mut self.update_bytes_processed, &mut self.update_row_size_samples)
-            }
-            StreamingDataEventType::Delete => {
-                (&mut self.delete_bytes_processed, &mut self.delete_row_size_samples)
-            }
-        };
-
-        *bytes_processed = bytes_processed.saturating_add(payload_bytes);
-        row_size_samples.push(payload_bytes as f64);
-
-        if row_size_samples.len() >= MAX_BUFFERED_ROW_SIZE_SAMPLES {
-            Self::flush_row_size_histogram(event_type.as_str(), row_size_samples);
-        }
-    }
-
-    /// Flushes pending metric deltas to the metrics recorder.
-    fn flush(&mut self, worker_type: WorkerType) {
-        if self.messages_received > 0 {
-            counter!(
-                ETL_REPLICATION_MESSAGES_TOTAL,
-                WORKER_TYPE_LABEL => worker_type.as_str(),
-            )
-            .increment(self.messages_received);
-            self.messages_received = 0;
-        }
-
-        if self.events_received > 0 {
-            counter!(
-                ETL_EVENTS_RECEIVED_TOTAL,
-                WORKER_TYPE_LABEL => worker_type.as_str(),
-                ACTION_LABEL => "table_streaming",
-            )
-            .increment(self.events_received);
-            self.events_received = 0;
-        }
-
-        Self::flush_bytes_counter(
-            ETL_BYTES_RECEIVED_TOTAL,
-            "insert",
-            &mut self.insert_bytes_received,
-        );
-        Self::flush_bytes_counter(
-            ETL_BYTES_RECEIVED_TOTAL,
-            "update",
-            &mut self.update_bytes_received,
-        );
-        Self::flush_bytes_counter(
-            ETL_BYTES_RECEIVED_TOTAL,
-            "delete",
-            &mut self.delete_bytes_received,
-        );
-        Self::flush_bytes_counter(
-            ETL_BYTES_PROCESSED_TOTAL,
-            "insert",
-            &mut self.insert_bytes_processed,
-        );
-        Self::flush_bytes_counter(
-            ETL_BYTES_PROCESSED_TOTAL,
-            "update",
-            &mut self.update_bytes_processed,
-        );
-        Self::flush_bytes_counter(
-            ETL_BYTES_PROCESSED_TOTAL,
-            "delete",
-            &mut self.delete_bytes_processed,
-        );
-
-        Self::flush_row_size_histogram("insert", &mut self.insert_row_size_samples);
-        Self::flush_row_size_histogram("update", &mut self.update_row_size_samples);
-        Self::flush_row_size_histogram("delete", &mut self.delete_row_size_samples);
-    }
-
-    /// Flushes a single byte counter if it has a pending delta.
-    fn flush_bytes_counter(metric_name: &'static str, event_type: &'static str, bytes: &mut u64) {
-        if *bytes == 0 {
-            return;
-        }
-
-        counter!(metric_name, EVENT_TYPE_LABEL => event_type).increment(*bytes);
-        *bytes = 0;
-    }
-
-    /// Flushes buffered row-size histogram samples for one event type.
-    fn flush_row_size_histogram(event_type: &'static str, samples: &mut Vec<f64>) {
-        if samples.is_empty() {
-            return;
-        }
-
-        let row_size_histogram = histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => event_type);
-        for sample in samples.drain(..) {
-            row_size_histogram.record(sample);
-        }
-    }
-}
-
 /// Running schema cleanup marker.
 ///
 /// Finishing the marker schedules the next cleanup deadline. This keeps the
@@ -837,8 +647,6 @@ struct ApplyLoopState {
     events_batch: Vec<Event>,
     /// Approximate total size in bytes of events currently in the batch.
     events_batch_bytes: usize,
-    /// Streaming metrics accumulated between flush points.
-    streaming_metrics_batch: StreamingMetricsBatch,
     /// Instant from when a transaction began.
     current_tx_begin_ts: Option<Instant>,
     /// Number of events observed in the current transaction (excluding
@@ -900,7 +708,6 @@ impl ApplyLoopState {
             replication_lag_metrics,
             events_batch: Vec::new(),
             events_batch_bytes: 0,
-            streaming_metrics_batch: StreamingMetricsBatch::default(),
             current_tx_begin_ts: None,
             current_tx_events: 0,
             next_tx_ordinal: 0,
@@ -940,39 +747,6 @@ impl ApplyLoopState {
         self.events_batch_bytes = 0;
 
         (events_batch, events_batch_bytes)
-    }
-
-    /// Records one replication protocol message received.
-    fn record_streaming_message_received(&mut self) {
-        self.streaming_metrics_batch.record_message_received();
-    }
-
-    /// Records one source event received by the table streaming path.
-    fn record_streaming_event_received(&mut self) {
-        self.streaming_metrics_batch.record_event_received();
-    }
-
-    /// Records row payload bytes received from logical replication.
-    fn record_streaming_bytes_received(
-        &mut self,
-        event_type: StreamingDataEventType,
-        payload_bytes: u64,
-    ) {
-        self.streaming_metrics_batch.record_bytes_received(event_type, payload_bytes);
-    }
-
-    /// Records row payload bytes processed after table ownership filtering.
-    fn record_streaming_bytes_processed(
-        &mut self,
-        event_type: StreamingDataEventType,
-        payload_bytes: u64,
-    ) {
-        self.streaming_metrics_batch.record_bytes_processed(event_type, payload_bytes);
-    }
-
-    /// Flushes pending streaming metric deltas to the metrics recorder.
-    fn flush_streaming_metrics(&mut self, worker_type: WorkerType) {
-        self.streaming_metrics_batch.flush(worker_type);
     }
 
     /// Returns the bootstrap snapshot used before a table has shared protocol
@@ -1360,8 +1134,6 @@ where
         start_lsn: PgLsn,
     ) -> EtlResult<ApplyLoopResult> {
         let result = self.run(replication_client, start_lsn).await;
-
-        self.flush_streaming_metrics();
 
         self.tasks
             .teardown(self.worker_context.worker_type(), &self.state.schema_cleanup_deadline)
@@ -1760,8 +1532,6 @@ where
         force: bool,
         status_update_type: StatusUpdateType,
     ) -> EtlResult<()> {
-        self.flush_streaming_metrics();
-
         let status_update_result = events_stream
             .as_mut()
             .stream_mut()
@@ -2062,11 +1832,7 @@ where
     ) -> EtlResult<()> {
         let result = match self.handle_replication_message(events_stream.as_mut(), message).await {
             Ok(result) => result,
-            Err(err) => {
-                self.flush_streaming_metrics();
-
-                return Err(err);
-            }
+            Err(err) => return Err(err),
         };
 
         if let Some(event) = result.event {
@@ -2108,8 +1874,6 @@ where
     /// processed. The queued batch is then retried from
     /// [`Self::handle_flush_result`] when that in-flight flush resolves.
     async fn flush_batch(&mut self, reason: &str) -> EtlResult<()> {
-        self.flush_streaming_metrics();
-
         // If the batch is empty, we don't need to do anything.
         if !self.state.has_pending_batch() {
             return Ok(());
@@ -2166,7 +1930,7 @@ where
         mut events_stream: Pin<&mut BackpressureStream<EventsStream>>,
         message: ReplicationMessage<LogicalReplicationMessage>,
     ) -> EtlResult<HandleMessageResult> {
-        self.state.record_streaming_message_received();
+        self.record_streaming_message_received();
 
         match message {
             ReplicationMessage::XLogData(message) => {
@@ -2260,32 +2024,36 @@ where
         }
     }
 
+    /// Records one replication protocol message received.
+    fn record_streaming_message_received(&mut self) {
+        counter!(
+            ETL_REPLICATION_MESSAGES_TOTAL,
+            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+        )
+        .increment(1);
+    }
+
     /// Records a source event received by the table streaming path.
     fn record_streaming_event_received(&mut self) {
-        self.state.record_streaming_event_received();
+        counter!(
+            ETL_EVENTS_RECEIVED_TOTAL,
+            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+            ACTION_LABEL => "table_streaming",
+        )
+        .increment(1);
     }
 
     /// Records row payload bytes received from logical replication.
-    fn record_streaming_bytes_received(
-        &mut self,
-        event_type: StreamingDataEventType,
-        payload_bytes: u64,
-    ) {
-        self.state.record_streaming_bytes_received(event_type, payload_bytes);
+    fn record_streaming_bytes_received(&self, event_type: &'static str, payload_bytes: u64) {
+        counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => event_type).increment(payload_bytes);
     }
 
     /// Records row payload bytes processed after table ownership filtering.
-    fn record_streaming_bytes_processed(
-        &mut self,
-        event_type: StreamingDataEventType,
-        payload_bytes: u64,
-    ) {
-        self.state.record_streaming_bytes_processed(event_type, payload_bytes);
-    }
+    fn record_streaming_bytes_processed(&self, event_type: &'static str, payload_bytes: u64) {
+        counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => event_type)
+            .increment(payload_bytes);
 
-    /// Flushes pending streaming metrics for this worker.
-    fn flush_streaming_metrics(&mut self) {
-        self.state.flush_streaming_metrics(self.worker_context.worker_type());
+        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => event_type).record(payload_bytes as f64);
     }
 
     /// Handles Postgres MESSAGE messages (pg_logical_emit_message).
@@ -2611,14 +2379,14 @@ where
 
         let payload_bytes = insert_message_payload_bytes(message);
 
-        self.record_streaming_bytes_received(StreamingDataEventType::Insert, payload_bytes);
+        self.record_streaming_bytes_received("insert", payload_bytes);
 
         let Some(replicated_table_schema) =
             self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
         else {
             return Ok(HandleMessageResult::no_event());
         };
-        self.record_streaming_bytes_processed(StreamingDataEventType::Insert, payload_bytes);
+        self.record_streaming_bytes_processed("insert", payload_bytes);
 
         let event = parse_event_from_insert_message(
             replicated_table_schema,
@@ -2650,14 +2418,14 @@ where
 
         let payload_bytes = update_message_payload_bytes(message);
 
-        self.record_streaming_bytes_received(StreamingDataEventType::Update, payload_bytes);
+        self.record_streaming_bytes_received("update", payload_bytes);
 
         let Some(replicated_table_schema) =
             self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
         else {
             return Ok(HandleMessageResult::no_event());
         };
-        self.record_streaming_bytes_processed(StreamingDataEventType::Update, payload_bytes);
+        self.record_streaming_bytes_processed("update", payload_bytes);
 
         let event = parse_event_from_update_message(
             replicated_table_schema,
@@ -2689,14 +2457,14 @@ where
 
         let payload_bytes = delete_message_payload_bytes(message);
 
-        self.record_streaming_bytes_received(StreamingDataEventType::Delete, payload_bytes);
+        self.record_streaming_bytes_received("delete", payload_bytes);
 
         let Some(replicated_table_schema) =
             self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
         else {
             return Ok(HandleMessageResult::no_event());
         };
-        self.record_streaming_bytes_processed(StreamingDataEventType::Delete, payload_bytes);
+        self.record_streaming_bytes_processed("delete", payload_bytes);
 
         let event = parse_event_from_delete_message(
             replicated_table_schema,

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -121,12 +121,6 @@ const MIN_KEEP_ALIVE_DEADLINE_DURATION: Duration = Duration::from_millis(100);
 /// progress points where durable ETL progress may have advanced. The next
 /// deadline is scheduled when the previous cleanup task finishes.
 const SCHEMA_CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
-/// Maximum event-vector capacity retained after dispatching a destination
-/// batch.
-///
-/// This keeps normal batches from reallocating on every flush while bounding
-/// the memory retained after an unusually large batch.
-const MAX_RETAINED_EVENTS_BATCH_CAPACITY: usize = 16 * 1024;
 
 /// Result type for the apply loop execution.
 ///
@@ -739,8 +733,10 @@ impl ApplyLoopState {
     fn take_events_batch(&mut self) -> (Vec<Event>, usize) {
         debug_assert!(self.has_pending_batch());
 
-        let replacement_capacity =
-            self.events_batch.capacity().min(MAX_RETAINED_EVENTS_BATCH_CAPACITY);
+        // We replace the old vector with a new one of the same length, under the
+        // assumption that we do mostly steady-state streaming, so it's highly
+        // likely that the next batch will need the same memory footprint.
+        let replacement_capacity = self.events_batch.len();
         let events_batch =
             std::mem::replace(&mut self.events_batch, Vec::with_capacity(replacement_capacity));
         let events_batch_bytes = self.events_batch_bytes;
@@ -1830,10 +1826,7 @@ where
         mut events_stream: Pin<&mut BackpressureStream<EventsStream>>,
         message: ReplicationMessage<LogicalReplicationMessage>,
     ) -> EtlResult<()> {
-        let result = match self.handle_replication_message(events_stream.as_mut(), message).await {
-            Ok(result) => result,
-            Err(err) => return Err(err),
-        };
+        let result = self.handle_replication_message(events_stream.as_mut(), message).await?;
 
         if let Some(event) = result.event {
             // We add the element to the pending batch.
@@ -1930,16 +1923,19 @@ where
         mut events_stream: Pin<&mut BackpressureStream<EventsStream>>,
         message: ReplicationMessage<LogicalReplicationMessage>,
     ) -> EtlResult<HandleMessageResult> {
-        self.record_streaming_message_received();
+        counter!(
+            ETL_REPLICATION_MESSAGES_TOTAL,
+            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+        )
+        .increment(1);
 
         match message {
             ReplicationMessage::XLogData(message) => {
                 let start_lsn = PgLsn::from(message.wal_start());
-                let end_lsn = PgLsn::from(message.wal_end());
+                self.state.update_last_received_lsn(start_lsn);
 
-                // The received LSN tracks the maximum, so one update covers
-                // both positions.
-                self.state.update_last_received_lsn(start_lsn.max(end_lsn));
+                let end_lsn = PgLsn::from(message.wal_end());
+                self.state.update_last_received_lsn(end_lsn);
 
                 debug!(
                     %start_lsn,
@@ -2024,17 +2020,8 @@ where
         }
     }
 
-    /// Records one replication protocol message received.
-    fn record_streaming_message_received(&mut self) {
-        counter!(
-            ETL_REPLICATION_MESSAGES_TOTAL,
-            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-        )
-        .increment(1);
-    }
-
     /// Records a source event received by the table streaming path.
-    fn record_streaming_event_received(&mut self) {
+    fn record_streaming_event_received(&self) {
         counter!(
             ETL_EVENTS_RECEIVED_TOTAL,
             WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
@@ -2044,12 +2031,12 @@ where
     }
 
     /// Records row payload bytes received from logical replication.
-    fn record_streaming_bytes_received(&self, event_type: &'static str, payload_bytes: u64) {
+    fn record_streaming_bytes_received(event_type: &'static str, payload_bytes: u64) {
         counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => event_type).increment(payload_bytes);
     }
 
     /// Records row payload bytes processed after table ownership filtering.
-    fn record_streaming_bytes_processed(&self, event_type: &'static str, payload_bytes: u64) {
+    fn record_streaming_bytes_processed(event_type: &'static str, payload_bytes: u64) {
         counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => event_type)
             .increment(payload_bytes);
 
@@ -2379,14 +2366,19 @@ where
 
         let payload_bytes = insert_message_payload_bytes(message);
 
-        self.record_streaming_bytes_received("insert", payload_bytes);
+        Self::record_streaming_bytes_received("insert", payload_bytes);
 
-        let Some(replicated_table_schema) =
-            self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
-        else {
+        // Exactly one worker owns protocol interpretation for a table at a time, so
+        // non-owning workers skip row decoding and leave the shared table state
+        // untouched.
+        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
             return Ok(HandleMessageResult::no_event());
-        };
-        self.record_streaming_bytes_processed("insert", payload_bytes);
+        }
+
+        Self::record_streaming_bytes_processed("insert", payload_bytes);
+
+        let replicated_table_schema =
+            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
 
         let event = parse_event_from_insert_message(
             replicated_table_schema,
@@ -2418,14 +2410,19 @@ where
 
         let payload_bytes = update_message_payload_bytes(message);
 
-        self.record_streaming_bytes_received("update", payload_bytes);
+        Self::record_streaming_bytes_received("update", payload_bytes);
 
-        let Some(replicated_table_schema) =
-            self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
-        else {
+        // Exactly one worker owns protocol interpretation for a table at a time, so
+        // non-owning workers skip row decoding and leave the shared table state
+        // untouched.
+        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
             return Ok(HandleMessageResult::no_event());
-        };
-        self.record_streaming_bytes_processed("update", payload_bytes);
+        }
+
+        Self::record_streaming_bytes_processed("update", payload_bytes);
+
+        let replicated_table_schema =
+            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
 
         let event = parse_event_from_update_message(
             replicated_table_schema,
@@ -2457,14 +2454,19 @@ where
 
         let payload_bytes = delete_message_payload_bytes(message);
 
-        self.record_streaming_bytes_received("delete", payload_bytes);
+        Self::record_streaming_bytes_received("delete", payload_bytes);
 
-        let Some(replicated_table_schema) =
-            self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
-        else {
+        // Exactly one worker owns protocol interpretation for a table at a time, so
+        // non-owning workers skip row decoding and leave the shared table state
+        // untouched.
+        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
             return Ok(HandleMessageResult::no_event());
-        };
-        self.record_streaming_bytes_processed("delete", payload_bytes);
+        }
+
+        Self::record_streaming_bytes_processed("delete", payload_bytes);
+
+        let replicated_table_schema =
+            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
 
         let event = parse_event_from_delete_message(
             replicated_table_schema,
@@ -2499,9 +2501,9 @@ where
 
             // Exactly one worker owns protocol interpretation for a table at a time, so
             // non-owning workers skip truncation handling for that table as well.
-            if let Some(replicated_table_schema) =
-                self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
-            {
+            if self.should_apply_changes(table_id, remote_final_lsn).await? {
+                let replicated_table_schema =
+                    get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
                 truncated_tables.push(replicated_table_schema);
             }
         }
@@ -2542,26 +2544,6 @@ where
                 Ok(table_sync_worker::should_apply_changes(ctx, table_id))
             }
         }
-    }
-
-    /// Returns the replicated schema when this worker should decode a row for
-    /// `table_id`.
-    async fn get_replicated_table_schema_for_row(
-        &mut self,
-        table_id: TableId,
-        remote_final_lsn: PgLsn,
-    ) -> EtlResult<Option<ReplicatedTableSchema>> {
-        // Exactly one worker owns protocol interpretation for a table at a
-        // time, so non-owning workers skip row decoding and leave the shared
-        // table state untouched.
-        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
-            return Ok(None);
-        }
-
-        let replicated_table_schema =
-            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
-
-        Ok(Some(replicated_table_schema))
     }
 
     /// Processes syncing tables after a commit message.

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -127,6 +127,7 @@ const SCHEMA_CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
 /// This keeps normal batches from reallocating on every flush while bounding
 /// the memory retained after an unusually large batch.
 const MAX_RETAINED_EVENTS_BATCH_CAPACITY: usize = 16 * 1024;
+
 /// Result type for the apply loop execution.
 ///
 /// Indicates the reason why the apply loop terminated, enabling appropriate
@@ -416,9 +417,18 @@ impl StreamingDataEventType {
     }
 }
 
+/// Maximum row-size histogram samples buffered per event type before an
+/// inline flush.
+///
+/// This bounds batch memory when many row events arrive between the normal
+/// flush points at status updates and batch dispatches.
+const MAX_BUFFERED_ROW_SIZE_SAMPLES: usize = 4096;
+
 /// Batched streaming metrics waiting to be flushed to the metrics recorder.
 #[derive(Debug, Default)]
 struct StreamingMetricsBatch {
+    /// Number of replication protocol messages received.
+    messages_received: u64,
     /// Number of logical replication messages received.
     events_received: u64,
     /// Bytes received for `INSERT` row payloads.
@@ -433,9 +443,23 @@ struct StreamingMetricsBatch {
     update_bytes_processed: u64,
     /// Bytes processed for `DELETE` row payloads after ownership filtering.
     delete_bytes_processed: u64,
+    /// Row sizes buffered for the `INSERT` row-size histogram.
+    ///
+    /// Buffering preserves every histogram sample while paying the
+    /// metrics-registry lookup once per flush instead of once per row event.
+    insert_row_size_samples: Vec<f64>,
+    /// Row sizes buffered for the `UPDATE` row-size histogram.
+    update_row_size_samples: Vec<f64>,
+    /// Row sizes buffered for the `DELETE` row-size histogram.
+    delete_row_size_samples: Vec<f64>,
 }
 
 impl StreamingMetricsBatch {
+    /// Records one replication protocol message received.
+    fn record_message_received(&mut self) {
+        self.messages_received = self.messages_received.saturating_add(1);
+    }
+
     /// Records one source event received by the table streaming path.
     fn record_event_received(&mut self) {
         self.events_received = self.events_received.saturating_add(1);
@@ -461,27 +485,37 @@ impl StreamingMetricsBatch {
 
     /// Records row payload bytes processed after table ownership filtering.
     fn record_bytes_processed(&mut self, event_type: StreamingDataEventType, payload_bytes: u64) {
-        match event_type {
+        let (bytes_processed, row_size_samples) = match event_type {
             StreamingDataEventType::Insert => {
-                self.insert_bytes_processed =
-                    self.insert_bytes_processed.saturating_add(payload_bytes);
+                (&mut self.insert_bytes_processed, &mut self.insert_row_size_samples)
             }
             StreamingDataEventType::Update => {
-                self.update_bytes_processed =
-                    self.update_bytes_processed.saturating_add(payload_bytes);
+                (&mut self.update_bytes_processed, &mut self.update_row_size_samples)
             }
             StreamingDataEventType::Delete => {
-                self.delete_bytes_processed =
-                    self.delete_bytes_processed.saturating_add(payload_bytes);
+                (&mut self.delete_bytes_processed, &mut self.delete_row_size_samples)
             }
-        }
+        };
 
-        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => event_type.as_str())
-            .record(payload_bytes as f64);
+        *bytes_processed = bytes_processed.saturating_add(payload_bytes);
+        row_size_samples.push(payload_bytes as f64);
+
+        if row_size_samples.len() >= MAX_BUFFERED_ROW_SIZE_SAMPLES {
+            Self::flush_row_size_histogram(event_type.as_str(), row_size_samples);
+        }
     }
 
     /// Flushes pending metric deltas to the metrics recorder.
     fn flush(&mut self, worker_type: WorkerType) {
+        if self.messages_received > 0 {
+            counter!(
+                ETL_REPLICATION_MESSAGES_TOTAL,
+                WORKER_TYPE_LABEL => worker_type.as_str(),
+            )
+            .increment(self.messages_received);
+            self.messages_received = 0;
+        }
+
         if self.events_received > 0 {
             counter!(
                 ETL_EVENTS_RECEIVED_TOTAL,
@@ -522,6 +556,10 @@ impl StreamingMetricsBatch {
             "delete",
             &mut self.delete_bytes_processed,
         );
+
+        Self::flush_row_size_histogram("insert", &mut self.insert_row_size_samples);
+        Self::flush_row_size_histogram("update", &mut self.update_row_size_samples);
+        Self::flush_row_size_histogram("delete", &mut self.delete_row_size_samples);
     }
 
     /// Flushes a single byte counter if it has a pending delta.
@@ -532,6 +570,18 @@ impl StreamingMetricsBatch {
 
         counter!(metric_name, EVENT_TYPE_LABEL => event_type).increment(*bytes);
         *bytes = 0;
+    }
+
+    /// Flushes buffered row-size histogram samples for one event type.
+    fn flush_row_size_histogram(event_type: &'static str, samples: &mut Vec<f64>) {
+        if samples.is_empty() {
+            return;
+        }
+
+        let row_size_histogram = histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => event_type);
+        for sample in samples.drain(..) {
+            row_size_histogram.record(sample);
+        }
     }
 }
 
@@ -789,14 +839,6 @@ struct ApplyLoopState {
     events_batch_bytes: usize,
     /// Streaming metrics accumulated between flush points.
     streaming_metrics_batch: StreamingMetricsBatch,
-    /// Replicated schemas proven ready for this worker within the current
-    /// transaction.
-    ///
-    /// The cache is cleared at transaction and table-state coordination
-    /// boundaries. It is intentionally not a cross-transaction ownership
-    /// cache, because table sync handoff and DDL can change who is allowed to
-    /// interpret a table.
-    ready_table_schemas_in_tx: HashMap<TableId, ReplicatedTableSchema>,
     /// Instant from when a transaction began.
     current_tx_begin_ts: Option<Instant>,
     /// Number of events observed in the current transaction (excluding
@@ -859,7 +901,6 @@ impl ApplyLoopState {
             events_batch: Vec::new(),
             events_batch_bytes: 0,
             streaming_metrics_batch: StreamingMetricsBatch::default(),
-            ready_table_schemas_in_tx: HashMap::new(),
             current_tx_begin_ts: None,
             current_tx_events: 0,
             next_tx_ordinal: 0,
@@ -901,6 +942,11 @@ impl ApplyLoopState {
         (events_batch, events_batch_bytes)
     }
 
+    /// Records one replication protocol message received.
+    fn record_streaming_message_received(&mut self) {
+        self.streaming_metrics_batch.record_message_received();
+    }
+
     /// Records one source event received by the table streaming path.
     fn record_streaming_event_received(&mut self) {
         self.streaming_metrics_batch.record_event_received();
@@ -927,30 +973,6 @@ impl ApplyLoopState {
     /// Flushes pending streaming metric deltas to the metrics recorder.
     fn flush_streaming_metrics(&mut self, worker_type: WorkerType) {
         self.streaming_metrics_batch.flush(worker_type);
-    }
-
-    /// Returns a transaction-local ready schema for `table_id`, if present.
-    fn ready_table_schema_in_tx(&self, table_id: TableId) -> Option<ReplicatedTableSchema> {
-        self.ready_table_schemas_in_tx.get(&table_id).cloned()
-    }
-
-    /// Caches a ready schema for reuse during the current transaction.
-    fn cache_ready_table_schema_in_tx(
-        &mut self,
-        table_id: TableId,
-        replicated_table_schema: ReplicatedTableSchema,
-    ) {
-        self.ready_table_schemas_in_tx.insert(table_id, replicated_table_schema);
-    }
-
-    /// Removes any transaction-local ready schema for `table_id`.
-    fn remove_ready_table_schema_in_tx(&mut self, table_id: TableId) {
-        self.ready_table_schemas_in_tx.remove(&table_id);
-    }
-
-    /// Clears all transaction-local ready schemas.
-    fn clear_ready_table_schemas_in_tx(&mut self) {
-        self.ready_table_schemas_in_tx.clear();
     }
 
     /// Returns the bootstrap snapshot used before a table has shared protocol
@@ -1338,6 +1360,8 @@ where
         start_lsn: PgLsn,
     ) -> EtlResult<ApplyLoopResult> {
         let result = self.run(replication_client, start_lsn).await;
+
+        self.flush_streaming_metrics();
 
         self.tasks
             .teardown(self.worker_context.worker_type(), &self.state.schema_cleanup_deadline)
@@ -2142,19 +2166,16 @@ where
         mut events_stream: Pin<&mut BackpressureStream<EventsStream>>,
         message: ReplicationMessage<LogicalReplicationMessage>,
     ) -> EtlResult<HandleMessageResult> {
-        counter!(
-            ETL_REPLICATION_MESSAGES_TOTAL,
-            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-        )
-        .increment(1);
+        self.state.record_streaming_message_received();
 
         match message {
             ReplicationMessage::XLogData(message) => {
                 let start_lsn = PgLsn::from(message.wal_start());
-                self.state.update_last_received_lsn(start_lsn);
-
                 let end_lsn = PgLsn::from(message.wal_end());
-                self.state.update_last_received_lsn(end_lsn);
+
+                // The received LSN tracks the maximum, so one update covers
+                // both positions.
+                self.state.update_last_received_lsn(start_lsn.max(end_lsn));
 
                 debug!(
                     %start_lsn,
@@ -2334,7 +2355,6 @@ where
         let table_id = schema_change_message.table_id();
         let command_tag = schema_change_message.command_tag.clone();
         let columns_count = schema_change_message.columns.len();
-        self.state.remove_ready_table_schema_in_tx(table_id);
 
         // Exactly one worker owns protocol interpretation for a table at a time. If
         // this worker is not the owner, it must skip the DDL so the owning
@@ -2420,7 +2440,6 @@ where
         self.state.current_tx_begin_ts = Some(Instant::now());
         self.state.current_tx_events = 0;
         self.state.reset_tx_ordinal();
-        self.state.clear_ready_table_schemas_in_tx();
 
         let tx_ordinal = self.state.next_tx_ordinal();
         let event = parse_event_from_begin_message(start_lsn, final_lsn, tx_ordinal, message);
@@ -2441,7 +2460,6 @@ where
                 "Transaction must be active before processing COMMIT message"
             );
         };
-        self.state.clear_ready_table_schemas_in_tx();
 
         let commit_lsn = PgLsn::from(message.commit_lsn());
         if commit_lsn != remote_final_lsn {
@@ -2510,7 +2528,6 @@ where
 
         let table_id = TableId::new(message.rel_id());
         let tx_ordinal = self.state.next_tx_ordinal();
-        self.state.remove_ready_table_schema_in_tx(table_id);
 
         // Exactly one worker owns protocol interpretation for a table at a time.
         // Non-owning workers skip `RELATION` handling and rely on the owner to
@@ -2564,7 +2581,6 @@ where
             ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask);
 
         self.shared_table_cache.note_ready(table_id, replicated_table_schema.clone()).await;
-        self.state.cache_ready_table_schema_in_tx(table_id, replicated_table_schema.clone());
 
         let relation_event = RelationEvent {
             start_lsn,
@@ -2762,21 +2778,11 @@ where
 
     /// Returns the replicated schema when this worker should decode a row for
     /// `table_id`.
-    ///
-    /// The transaction-local cache avoids repeating the ownership and shared
-    /// schema lookups for multiple row events from the same table in the same
-    /// transaction. It is populated only after the normal ownership check has
-    /// passed and is cleared at transaction, relation, DDL, and table-state
-    /// coordination boundaries.
     async fn get_replicated_table_schema_for_row(
         &mut self,
         table_id: TableId,
         remote_final_lsn: PgLsn,
     ) -> EtlResult<Option<ReplicatedTableSchema>> {
-        if let Some(replicated_table_schema) = self.state.ready_table_schema_in_tx(table_id) {
-            return Ok(Some(replicated_table_schema));
-        }
-
         // Exactly one worker owns protocol interpretation for a table at a
         // time, so non-owning workers skip row decoding and leave the shared
         // table state untouched.
@@ -2786,7 +2792,6 @@ where
 
         let replicated_table_schema =
             get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
-        self.state.cache_ready_table_schema_in_tx(table_id, replicated_table_schema.clone());
 
         Ok(Some(replicated_table_schema))
     }
@@ -2796,8 +2801,6 @@ where
     /// Dispatches to worker-specific implementation based on the worker
     /// context.
     async fn process_syncing_tables_after_commit_event(&mut self, lsn: PgLsn) -> EtlResult<bool> {
-        self.state.clear_ready_table_schemas_in_tx();
-
         let exit_intent = match &mut self.worker_context {
             WorkerContext::Apply(ctx) => {
                 apply_worker::process_syncing_tables_after_commit_event(ctx, lsn).await
@@ -2821,8 +2824,6 @@ where
         &mut self,
         last_commit_end_lsn: PgLsn,
     ) -> EtlResult<()> {
-        self.state.clear_ready_table_schemas_in_tx();
-
         // Store durable replication progress at commit boundaries after the
         // destination acknowledges the batch. This gives restarts a durable
         // lower-bound resume point: once startup chooses this point, no event
@@ -2905,8 +2906,6 @@ where
 
             return Ok(());
         }
-
-        self.state.clear_ready_table_schemas_in_tx();
 
         let current_lsn = self.state.last_received_lsn();
 

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -729,7 +729,7 @@ impl ApplyLoopState {
     }
 
     /// Takes the events batch for further processing and leaves behind a
-    /// bounded-capacity replacement.
+    /// replacement sized for the emitted batch.
     fn take_events_batch(&mut self) -> (Vec<Event>, usize) {
         debug_assert!(self.has_pending_batch());
 

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -121,6 +121,12 @@ const MIN_KEEP_ALIVE_DEADLINE_DURATION: Duration = Duration::from_millis(100);
 /// progress points where durable ETL progress may have advanced. The next
 /// deadline is scheduled when the previous cleanup task finishes.
 const SCHEMA_CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
+/// Maximum event-vector capacity retained after dispatching a destination
+/// batch.
+///
+/// This keeps normal batches from reallocating on every flush while bounding
+/// the memory retained after an unusually large batch.
+const MAX_RETAINED_EVENTS_BATCH_CAPACITY: usize = 16 * 1024;
 /// Result type for the apply loop execution.
 ///
 /// Indicates the reason why the apply loop terminated, enabling appropriate
@@ -388,6 +394,147 @@ impl HandleMessageResult {
     }
 }
 
+/// Logical replication row event types that carry payload bytes.
+#[derive(Debug, Copy, Clone)]
+enum StreamingDataEventType {
+    /// An `INSERT` row event.
+    Insert,
+    /// An `UPDATE` row event.
+    Update,
+    /// A `DELETE` row event.
+    Delete,
+}
+
+impl StreamingDataEventType {
+    /// Returns the metric label for this event type.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Insert => "insert",
+            Self::Update => "update",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+/// Batched streaming metrics waiting to be flushed to the metrics recorder.
+#[derive(Debug, Default)]
+struct StreamingMetricsBatch {
+    /// Number of logical replication messages received.
+    events_received: u64,
+    /// Bytes received for `INSERT` row payloads.
+    insert_bytes_received: u64,
+    /// Bytes received for `UPDATE` row payloads.
+    update_bytes_received: u64,
+    /// Bytes received for `DELETE` row payloads.
+    delete_bytes_received: u64,
+    /// Bytes processed for `INSERT` row payloads after ownership filtering.
+    insert_bytes_processed: u64,
+    /// Bytes processed for `UPDATE` row payloads after ownership filtering.
+    update_bytes_processed: u64,
+    /// Bytes processed for `DELETE` row payloads after ownership filtering.
+    delete_bytes_processed: u64,
+}
+
+impl StreamingMetricsBatch {
+    /// Records one source event received by the table streaming path.
+    fn record_event_received(&mut self) {
+        self.events_received = self.events_received.saturating_add(1);
+    }
+
+    /// Records row payload bytes received from logical replication.
+    fn record_bytes_received(&mut self, event_type: StreamingDataEventType, payload_bytes: u64) {
+        match event_type {
+            StreamingDataEventType::Insert => {
+                self.insert_bytes_received =
+                    self.insert_bytes_received.saturating_add(payload_bytes);
+            }
+            StreamingDataEventType::Update => {
+                self.update_bytes_received =
+                    self.update_bytes_received.saturating_add(payload_bytes);
+            }
+            StreamingDataEventType::Delete => {
+                self.delete_bytes_received =
+                    self.delete_bytes_received.saturating_add(payload_bytes);
+            }
+        }
+    }
+
+    /// Records row payload bytes processed after table ownership filtering.
+    fn record_bytes_processed(&mut self, event_type: StreamingDataEventType, payload_bytes: u64) {
+        match event_type {
+            StreamingDataEventType::Insert => {
+                self.insert_bytes_processed =
+                    self.insert_bytes_processed.saturating_add(payload_bytes);
+            }
+            StreamingDataEventType::Update => {
+                self.update_bytes_processed =
+                    self.update_bytes_processed.saturating_add(payload_bytes);
+            }
+            StreamingDataEventType::Delete => {
+                self.delete_bytes_processed =
+                    self.delete_bytes_processed.saturating_add(payload_bytes);
+            }
+        }
+
+        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => event_type.as_str())
+            .record(payload_bytes as f64);
+    }
+
+    /// Flushes pending metric deltas to the metrics recorder.
+    fn flush(&mut self, worker_type: WorkerType) {
+        if self.events_received > 0 {
+            counter!(
+                ETL_EVENTS_RECEIVED_TOTAL,
+                WORKER_TYPE_LABEL => worker_type.as_str(),
+                ACTION_LABEL => "table_streaming",
+            )
+            .increment(self.events_received);
+            self.events_received = 0;
+        }
+
+        Self::flush_bytes_counter(
+            ETL_BYTES_RECEIVED_TOTAL,
+            "insert",
+            &mut self.insert_bytes_received,
+        );
+        Self::flush_bytes_counter(
+            ETL_BYTES_RECEIVED_TOTAL,
+            "update",
+            &mut self.update_bytes_received,
+        );
+        Self::flush_bytes_counter(
+            ETL_BYTES_RECEIVED_TOTAL,
+            "delete",
+            &mut self.delete_bytes_received,
+        );
+        Self::flush_bytes_counter(
+            ETL_BYTES_PROCESSED_TOTAL,
+            "insert",
+            &mut self.insert_bytes_processed,
+        );
+        Self::flush_bytes_counter(
+            ETL_BYTES_PROCESSED_TOTAL,
+            "update",
+            &mut self.update_bytes_processed,
+        );
+        Self::flush_bytes_counter(
+            ETL_BYTES_PROCESSED_TOTAL,
+            "delete",
+            &mut self.delete_bytes_processed,
+        );
+    }
+
+    /// Flushes a single byte counter if it has a pending delta.
+    fn flush_bytes_counter(metric_name: &'static str, event_type: &'static str, bytes: &mut u64) {
+        if *bytes == 0 {
+            return;
+        }
+
+        counter!(metric_name, EVENT_TYPE_LABEL => event_type).increment(*bytes);
+        *bytes = 0;
+    }
+}
+
 /// Running schema cleanup marker.
 ///
 /// Finishing the marker schedules the next cleanup deadline. This keeps the
@@ -640,6 +787,16 @@ struct ApplyLoopState {
     events_batch: Vec<Event>,
     /// Approximate total size in bytes of events currently in the batch.
     events_batch_bytes: usize,
+    /// Streaming metrics accumulated between flush points.
+    streaming_metrics_batch: StreamingMetricsBatch,
+    /// Replicated schemas proven ready for this worker within the current
+    /// transaction.
+    ///
+    /// The cache is cleared at transaction and table-state coordination
+    /// boundaries. It is intentionally not a cross-transaction ownership
+    /// cache, because table sync handoff and DDL can change who is allowed to
+    /// interpret a table.
+    ready_table_schemas_in_tx: HashMap<TableId, ReplicatedTableSchema>,
     /// Instant from when a transaction began.
     current_tx_begin_ts: Option<Instant>,
     /// Number of events observed in the current transaction (excluding
@@ -701,6 +858,8 @@ impl ApplyLoopState {
             replication_lag_metrics,
             events_batch: Vec::new(),
             events_batch_bytes: 0,
+            streaming_metrics_batch: StreamingMetricsBatch::default(),
+            ready_table_schemas_in_tx: HashMap::new(),
             current_tx_begin_ts: None,
             current_tx_events: 0,
             next_tx_ordinal: 0,
@@ -727,16 +886,71 @@ impl ApplyLoopState {
         self.events_batch.push(event);
     }
 
-    /// Takes the events batch for further processing. Replacing it with a new
-    /// empty batch.
+    /// Takes the events batch for further processing and leaves behind a
+    /// bounded-capacity replacement.
     fn take_events_batch(&mut self) -> (Vec<Event>, usize) {
         debug_assert!(self.has_pending_batch());
 
-        let events_batch = std::mem::take(&mut self.events_batch);
+        let replacement_capacity =
+            self.events_batch.capacity().min(MAX_RETAINED_EVENTS_BATCH_CAPACITY);
+        let events_batch =
+            std::mem::replace(&mut self.events_batch, Vec::with_capacity(replacement_capacity));
         let events_batch_bytes = self.events_batch_bytes;
         self.events_batch_bytes = 0;
 
         (events_batch, events_batch_bytes)
+    }
+
+    /// Records one source event received by the table streaming path.
+    fn record_streaming_event_received(&mut self) {
+        self.streaming_metrics_batch.record_event_received();
+    }
+
+    /// Records row payload bytes received from logical replication.
+    fn record_streaming_bytes_received(
+        &mut self,
+        event_type: StreamingDataEventType,
+        payload_bytes: u64,
+    ) {
+        self.streaming_metrics_batch.record_bytes_received(event_type, payload_bytes);
+    }
+
+    /// Records row payload bytes processed after table ownership filtering.
+    fn record_streaming_bytes_processed(
+        &mut self,
+        event_type: StreamingDataEventType,
+        payload_bytes: u64,
+    ) {
+        self.streaming_metrics_batch.record_bytes_processed(event_type, payload_bytes);
+    }
+
+    /// Flushes pending streaming metric deltas to the metrics recorder.
+    fn flush_streaming_metrics(&mut self, worker_type: WorkerType) {
+        self.streaming_metrics_batch.flush(worker_type);
+    }
+
+    /// Returns a transaction-local ready schema for `table_id`, if present.
+    fn ready_table_schema_in_tx(&self, table_id: TableId) -> Option<ReplicatedTableSchema> {
+        self.ready_table_schemas_in_tx.get(&table_id).cloned()
+    }
+
+    /// Caches a ready schema for reuse during the current transaction.
+    fn cache_ready_table_schema_in_tx(
+        &mut self,
+        table_id: TableId,
+        replicated_table_schema: ReplicatedTableSchema,
+    ) {
+        self.ready_table_schemas_in_tx.insert(table_id, replicated_table_schema);
+    }
+
+    /// Removes any transaction-local ready schema for `table_id`.
+    fn remove_ready_table_schema_in_tx(&mut self, table_id: TableId) {
+        self.ready_table_schemas_in_tx.remove(&table_id);
+    }
+
+    /// Clears all transaction-local ready schemas.
+    fn clear_ready_table_schemas_in_tx(&mut self) {
+        self.ready_table_schemas_in_tx.clear();
     }
 
     /// Returns the bootstrap snapshot used before a table has shared protocol
@@ -1522,6 +1736,8 @@ where
         force: bool,
         status_update_type: StatusUpdateType,
     ) -> EtlResult<()> {
+        self.flush_streaming_metrics();
+
         let status_update_result = events_stream
             .as_mut()
             .stream_mut()
@@ -1820,7 +2036,14 @@ where
         mut events_stream: Pin<&mut BackpressureStream<EventsStream>>,
         message: ReplicationMessage<LogicalReplicationMessage>,
     ) -> EtlResult<()> {
-        let result = self.handle_replication_message(events_stream.as_mut(), message).await?;
+        let result = match self.handle_replication_message(events_stream.as_mut(), message).await {
+            Ok(result) => result,
+            Err(err) => {
+                self.flush_streaming_metrics();
+
+                return Err(err);
+            }
+        };
 
         if let Some(event) = result.event {
             // We add the element to the pending batch.
@@ -1861,6 +2084,8 @@ where
     /// processed. The queued batch is then retried from
     /// [`Self::handle_flush_result`] when that in-flight flush resolves.
     async fn flush_batch(&mut self, reason: &str) -> EtlResult<()> {
+        self.flush_streaming_metrics();
+
         // If the batch is empty, we don't need to do anything.
         if !self.state.has_pending_batch() {
             return Ok(());
@@ -2015,26 +2240,31 @@ where
     }
 
     /// Records a source event received by the table streaming path.
-    fn record_streaming_event_received(&self) {
-        counter!(
-            ETL_EVENTS_RECEIVED_TOTAL,
-            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-            ACTION_LABEL => "table_streaming",
-        )
-        .increment(1);
+    fn record_streaming_event_received(&mut self) {
+        self.state.record_streaming_event_received();
     }
 
     /// Records row payload bytes received from logical replication.
-    fn record_streaming_bytes_received(event_type: &'static str, payload_bytes: u64) {
-        counter!(ETL_BYTES_RECEIVED_TOTAL, EVENT_TYPE_LABEL => event_type).increment(payload_bytes);
+    fn record_streaming_bytes_received(
+        &mut self,
+        event_type: StreamingDataEventType,
+        payload_bytes: u64,
+    ) {
+        self.state.record_streaming_bytes_received(event_type, payload_bytes);
     }
 
     /// Records row payload bytes processed after table ownership filtering.
-    fn record_streaming_bytes_processed(event_type: &'static str, payload_bytes: u64) {
-        counter!(ETL_BYTES_PROCESSED_TOTAL, EVENT_TYPE_LABEL => event_type)
-            .increment(payload_bytes);
+    fn record_streaming_bytes_processed(
+        &mut self,
+        event_type: StreamingDataEventType,
+        payload_bytes: u64,
+    ) {
+        self.state.record_streaming_bytes_processed(event_type, payload_bytes);
+    }
 
-        histogram!(ETL_ROW_SIZE_BYTES, EVENT_TYPE_LABEL => event_type).record(payload_bytes as f64);
+    /// Flushes pending streaming metrics for this worker.
+    fn flush_streaming_metrics(&mut self) {
+        self.state.flush_streaming_metrics(self.worker_context.worker_type());
     }
 
     /// Handles Postgres MESSAGE messages (pg_logical_emit_message).
@@ -2104,6 +2334,7 @@ where
         let table_id = schema_change_message.table_id();
         let command_tag = schema_change_message.command_tag.clone();
         let columns_count = schema_change_message.columns.len();
+        self.state.remove_ready_table_schema_in_tx(table_id);
 
         // Exactly one worker owns protocol interpretation for a table at a time. If
         // this worker is not the owner, it must skip the DDL so the owning
@@ -2189,6 +2420,7 @@ where
         self.state.current_tx_begin_ts = Some(Instant::now());
         self.state.current_tx_events = 0;
         self.state.reset_tx_ordinal();
+        self.state.clear_ready_table_schemas_in_tx();
 
         let tx_ordinal = self.state.next_tx_ordinal();
         let event = parse_event_from_begin_message(start_lsn, final_lsn, tx_ordinal, message);
@@ -2209,6 +2441,7 @@ where
                 "Transaction must be active before processing COMMIT message"
             );
         };
+        self.state.clear_ready_table_schemas_in_tx();
 
         let commit_lsn = PgLsn::from(message.commit_lsn());
         if commit_lsn != remote_final_lsn {
@@ -2277,6 +2510,7 @@ where
 
         let table_id = TableId::new(message.rel_id());
         let tx_ordinal = self.state.next_tx_ordinal();
+        self.state.remove_ready_table_schema_in_tx(table_id);
 
         // Exactly one worker owns protocol interpretation for a table at a time.
         // Non-owning workers skip `RELATION` handling and rely on the owner to
@@ -2330,6 +2564,7 @@ where
             ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask);
 
         self.shared_table_cache.note_ready(table_id, replicated_table_schema.clone()).await;
+        self.state.cache_ready_table_schema_in_tx(table_id, replicated_table_schema.clone());
 
         let relation_event = RelationEvent {
             start_lsn,
@@ -2360,19 +2595,14 @@ where
 
         let payload_bytes = insert_message_payload_bytes(message);
 
-        Self::record_streaming_bytes_received("insert", payload_bytes);
+        self.record_streaming_bytes_received(StreamingDataEventType::Insert, payload_bytes);
 
-        // Exactly one worker owns protocol interpretation for a table at a time, so
-        // non-owning workers skip row decoding and leave the shared table state
-        // untouched.
-        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
+        let Some(replicated_table_schema) =
+            self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
+        else {
             return Ok(HandleMessageResult::no_event());
-        }
-
-        Self::record_streaming_bytes_processed("insert", payload_bytes);
-
-        let replicated_table_schema =
-            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
+        };
+        self.record_streaming_bytes_processed(StreamingDataEventType::Insert, payload_bytes);
 
         let event = parse_event_from_insert_message(
             replicated_table_schema,
@@ -2404,19 +2634,14 @@ where
 
         let payload_bytes = update_message_payload_bytes(message);
 
-        Self::record_streaming_bytes_received("update", payload_bytes);
+        self.record_streaming_bytes_received(StreamingDataEventType::Update, payload_bytes);
 
-        // Exactly one worker owns protocol interpretation for a table at a time, so
-        // non-owning workers skip row decoding and leave the shared table state
-        // untouched.
-        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
+        let Some(replicated_table_schema) =
+            self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
+        else {
             return Ok(HandleMessageResult::no_event());
-        }
-
-        Self::record_streaming_bytes_processed("update", payload_bytes);
-
-        let replicated_table_schema =
-            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
+        };
+        self.record_streaming_bytes_processed(StreamingDataEventType::Update, payload_bytes);
 
         let event = parse_event_from_update_message(
             replicated_table_schema,
@@ -2448,19 +2673,14 @@ where
 
         let payload_bytes = delete_message_payload_bytes(message);
 
-        Self::record_streaming_bytes_received("delete", payload_bytes);
+        self.record_streaming_bytes_received(StreamingDataEventType::Delete, payload_bytes);
 
-        // Exactly one worker owns protocol interpretation for a table at a time, so
-        // non-owning workers skip row decoding and leave the shared table state
-        // untouched.
-        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
+        let Some(replicated_table_schema) =
+            self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
+        else {
             return Ok(HandleMessageResult::no_event());
-        }
-
-        Self::record_streaming_bytes_processed("delete", payload_bytes);
-
-        let replicated_table_schema =
-            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
+        };
+        self.record_streaming_bytes_processed(StreamingDataEventType::Delete, payload_bytes);
 
         let event = parse_event_from_delete_message(
             replicated_table_schema,
@@ -2495,9 +2715,9 @@ where
 
             // Exactly one worker owns protocol interpretation for a table at a time, so
             // non-owning workers skip truncation handling for that table as well.
-            if self.should_apply_changes(table_id, remote_final_lsn).await? {
-                let replicated_table_schema =
-                    get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
+            if let Some(replicated_table_schema) =
+                self.get_replicated_table_schema_for_row(table_id, remote_final_lsn).await?
+            {
                 truncated_tables.push(replicated_table_schema);
             }
         }
@@ -2540,11 +2760,44 @@ where
         }
     }
 
+    /// Returns the replicated schema when this worker should decode a row for
+    /// `table_id`.
+    ///
+    /// The transaction-local cache avoids repeating the ownership and shared
+    /// schema lookups for multiple row events from the same table in the same
+    /// transaction. It is populated only after the normal ownership check has
+    /// passed and is cleared at transaction, relation, DDL, and table-state
+    /// coordination boundaries.
+    async fn get_replicated_table_schema_for_row(
+        &mut self,
+        table_id: TableId,
+        remote_final_lsn: PgLsn,
+    ) -> EtlResult<Option<ReplicatedTableSchema>> {
+        if let Some(replicated_table_schema) = self.state.ready_table_schema_in_tx(table_id) {
+            return Ok(Some(replicated_table_schema));
+        }
+
+        // Exactly one worker owns protocol interpretation for a table at a
+        // time, so non-owning workers skip row decoding and leave the shared
+        // table state untouched.
+        if !self.should_apply_changes(table_id, remote_final_lsn).await? {
+            return Ok(None);
+        }
+
+        let replicated_table_schema =
+            get_replicated_table_schema(&table_id, &self.shared_table_cache).await?;
+        self.state.cache_ready_table_schema_in_tx(table_id, replicated_table_schema.clone());
+
+        Ok(Some(replicated_table_schema))
+    }
+
     /// Processes syncing tables after a commit message.
     ///
     /// Dispatches to worker-specific implementation based on the worker
     /// context.
     async fn process_syncing_tables_after_commit_event(&mut self, lsn: PgLsn) -> EtlResult<bool> {
+        self.state.clear_ready_table_schemas_in_tx();
+
         let exit_intent = match &mut self.worker_context {
             WorkerContext::Apply(ctx) => {
                 apply_worker::process_syncing_tables_after_commit_event(ctx, lsn).await
@@ -2568,6 +2821,8 @@ where
         &mut self,
         last_commit_end_lsn: PgLsn,
     ) -> EtlResult<()> {
+        self.state.clear_ready_table_schemas_in_tx();
+
         // Store durable replication progress at commit boundaries after the
         // destination acknowledges the batch. This gives restarts a durable
         // lower-bound resume point: once startup chooses this point, no event
@@ -2650,6 +2905,8 @@ where
 
             return Ok(());
         }
+
+        self.state.clear_ready_table_schemas_in_tx();
 
         let current_lsn = self.state.last_received_lsn();
 

--- a/crates/etl/src/replication/table_sync/copy.rs
+++ b/crates/etl/src/replication/table_sync/copy.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Reverse,
     collections::VecDeque,
     pin::Pin,
     sync::Arc,
@@ -73,6 +74,8 @@ struct CopyPartition {
     filter_table_id: TableId,
     /// The physical ctid range for `source_table_id`.
     ctid_partition: CtidPartition,
+    /// Estimated heap blocks covered by this range.
+    planned_blocks: u64,
 }
 
 /// Rows copied by a completed worker.
@@ -496,9 +499,14 @@ async fn plan_copy_partitions(
                 source_table_id,
                 filter_table_id: table_id,
                 ctid_partition,
+                planned_blocks,
             });
         }
     }
+
+    // Start larger estimated ranges first so long copy tasks overlap while all
+    // workers are active, leaving smaller ranges to drain at the tail.
+    copy_partitions.sort_unstable_by_key(|partition| Reverse(partition.planned_blocks));
 
     histogram!(ETL_TABLE_COPY_PLANNED_PARTITIONS).record(f64::from(target_partitions));
     histogram!(ETL_TABLE_COPY_EFFECTIVE_PARTITIONS).record(copy_partitions.len() as f64);
@@ -608,7 +616,7 @@ where
         )
         .await?;
 
-    let table_copy_stream = TableCopyStream::wrap(copy_stream, replicated_column_schemas.iter());
+    let table_copy_stream = TableCopyStream::wrap(copy_stream, replicated_column_schemas);
     let connection_updates_rx = child_replication_transaction.connection_updates_rx();
     let _table_copy_stream_guard = batch_budget.register_stream_load(1);
     let cached_batch_budget = batch_budget.cached();

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -198,97 +198,115 @@ where
             return Poll::Ready(None);
         }
 
-        loop {
-            // PRIORITY 1: Memory backpressure.
-            // If memory backpressure is active and there are buffered items, flush
-            // immediately to avoid accumulating more memory in this stream.
-            let was_paused = *this.paused_for_memory;
-            if let Some(memory_subscription) = this.memory_subscription.as_mut() {
-                // Drain all currently queued watch updates and only stop at `Pending`.
-                // Hitting `Pending` is important because it registers this task's waker for the
-                // next backpressure transition, so returning `Pending` below
-                // cannot miss a wakeup.
-                loop {
-                    match Pin::new(&mut *memory_subscription).poll_next(cx) {
-                        Poll::Ready(Some(backpressure_active)) => {
-                            *this.paused_for_memory = backpressure_active;
-                        }
-                        Poll::Ready(None) => {
-                            // If the was channel was dropped, we assume that memory is fine, to be
-                            // resilient.
-                            *this.paused_for_memory = false;
+        // PRIORITY 1: Memory backpressure.
+        // If memory backpressure is active and there are buffered items, flush
+        // immediately to avoid accumulating more memory in this stream.
+        //
+        // The subscription stream is polled once per outer poll rather than
+        // once per item. The hot loop below still reads the current watch value
+        // after each item so a memory transition during a ready-drain can flush
+        // the partial batch without paying watch-stream polling overhead for
+        // every row.
+        let was_paused = *this.paused_for_memory;
+        if let Some(memory_subscription) = this.memory_subscription.as_mut() {
+            // Drain all currently queued watch updates and only stop at `Pending`.
+            // Hitting `Pending` is important because it registers this task's waker for the
+            // next backpressure transition, so returning `Pending` below
+            // cannot miss a wakeup.
+            loop {
+                match Pin::new(&mut *memory_subscription).poll_next(cx) {
+                    Poll::Ready(Some(backpressure_active)) => {
+                        *this.paused_for_memory = backpressure_active;
+                    }
+                    Poll::Ready(None) => {
+                        // If the was channel was dropped, we assume that memory is fine, to be
+                        // resilient.
+                        *this.paused_for_memory = false;
 
-                            break;
+                        break;
+                    }
+                    Poll::Pending => {
+                        // If the memory state didn't change, we just use the current state that
+                        // is on the watch.
+                        let currently_backpressure_active =
+                            memory_subscription.current_backpressure_active();
+                        if *this.paused_for_memory != currently_backpressure_active {
+                            *this.paused_for_memory = currently_backpressure_active;
                         }
-                        Poll::Pending => {
-                            // If the memory state didn't change, we just use the current state that
-                            // is on the watch.
-                            let currently_backpressure_active =
-                                memory_subscription.current_backpressure_active();
-                            if *this.paused_for_memory != currently_backpressure_active {
-                                *this.paused_for_memory = currently_backpressure_active;
-                            }
 
-                            break;
-                        }
+                        break;
                     }
                 }
-            } else {
-                *this.paused_for_memory = false;
             }
+        } else {
+            *this.paused_for_memory = false;
+        }
 
-            if !was_paused && *this.paused_for_memory {
+        if !was_paused && *this.paused_for_memory {
+            info!(
+                stream_id = %this.stream_id,
+                "backpressure active, batch stream paused"
+            );
+        } else if was_paused && !*this.paused_for_memory {
+            info!(
+                stream_id = %this.stream_id,
+                "backpressure released, batch stream resumed"
+            );
+        }
+
+        if *this.paused_for_memory {
+            if !this.items.is_empty() {
                 info!(
                     stream_id = %this.stream_id,
-                    "backpressure active, batch stream paused"
+                    buffered_items = this.items.len(),
+                    buffered_bytes = *this.current_batch_bytes,
+                    "backpressure active, flushing buffered batch"
                 );
-            } else if was_paused && !*this.paused_for_memory {
-                info!(
-                    stream_id = %this.stream_id,
-                    "backpressure released, batch stream resumed"
-                );
+                *this.reset_timer = true;
+                *this.current_batch_bytes = 0;
+
+                return Poll::Ready(Some(Ok(std::mem::take(this.items))));
             }
 
-            if *this.paused_for_memory {
-                if !this.items.is_empty() {
-                    info!(
-                        stream_id = %this.stream_id,
-                        buffered_items = this.items.len(),
-                        buffered_bytes = *this.current_batch_bytes,
-                        "backpressure active, flushing buffered batch"
-                    );
-                    *this.reset_timer = true;
-                    *this.current_batch_bytes = 0;
+            return Poll::Pending;
+        }
 
-                    return Poll::Ready(Some(Ok(std::mem::take(this.items))));
-                }
+        // Snapshot the byte budget once per poll; it refreshes on its own
+        // 100ms cadence, so a per-item read only adds clock lookups.
+        let max_batch_size_bytes = this.cached_batch_budget.current_batch_size_bytes();
 
-                return Poll::Pending;
-            }
-
-            // PRIORITY 2: Timer management.
-            // Reset the timeout timer when starting a new batch or after emitting a batch.
-            if *this.reset_timer {
-                this.deadline.set(Some(tokio::time::sleep(Duration::from_millis(
-                    this.batch_config.max_fill_ms,
-                ))));
-                *this.reset_timer = false;
-            }
-
-            // PRIORITY 3: Poll underlying stream for new items.
+        // PRIORITY 2: Poll underlying stream for new items.
+        loop {
             match this.stream.as_mut().poll_next(cx) {
-                Poll::Pending => {
-                    // No more items available right now, check if we should emit due to timeout.
-                    break;
-                }
                 Poll::Ready(Some(Ok(item))) => {
+                    // Start the fill timer only when a batch becomes non-empty.
+                    // Otherwise an idle stream could expire the timer before
+                    // the first item arrives and flush that item immediately.
+                    if this.items.is_empty() && *this.reset_timer {
+                        this.deadline.set(Some(tokio::time::sleep(Duration::from_millis(
+                            this.batch_config.max_fill_ms,
+                        ))));
+                        *this.reset_timer = false;
+                    }
+
                     *this.current_batch_bytes =
                         this.current_batch_bytes.saturating_add(item.size_hint());
                     this.items.push(item);
 
+                    if let Some(memory_subscription) = this.memory_subscription.as_mut()
+                        && memory_subscription.current_backpressure_active()
+                    {
+                        *this.paused_for_memory = true;
+                        *this.reset_timer = true;
+                        *this.current_batch_bytes = 0;
+
+                        return Poll::Ready(Some(Ok(take_items_with_retained_capacity(
+                            this.items,
+                        ))));
+                    }
+
                     // If byte budget is reached, emit immediately.
-                    let max_batch_bytes_reached = *this.current_batch_bytes
-                        >= this.cached_batch_budget.current_batch_size_bytes();
+                    let max_batch_bytes_reached = *this.current_batch_bytes >= max_batch_size_bytes;
                     if max_batch_bytes_reached {
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
@@ -318,10 +336,14 @@ where
 
                     return Poll::Ready(last);
                 }
+                Poll::Pending => {
+                    // No more items available right now, check if we should emit due to timeout.
+                    break;
+                }
             }
         }
 
-        // PRIORITY 4: Time-based emission check.
+        // PRIORITY 3: Time-based emission check.
         if !this.items.is_empty()
             && let Some(deadline) = this.deadline.as_pin_mut()
         {
@@ -342,6 +364,7 @@ mod tests {
 
     use futures::{StreamExt, future::poll_fn};
     use pin_project_lite::pin_project;
+    use tokio_stream::wrappers::ReceiverStream;
 
     use super::*;
     use crate::{
@@ -369,6 +392,38 @@ mod tests {
             match self.emitted {
                 0 => {
                     self.emitted = 1;
+                    Poll::Ready(Some(Ok(1)))
+                }
+                1 => {
+                    self.emitted = 2;
+                    Poll::Ready(Some(Ok(2)))
+                }
+                _ => Poll::Pending,
+            }
+        }
+    }
+
+    pin_project! {
+        struct ActivatesBackpressureAfterFirst {
+            emitted: usize,
+            memory: MemoryMonitor,
+        }
+    }
+
+    impl ActivatesBackpressureAfterFirst {
+        fn new(memory: MemoryMonitor) -> Self {
+            Self { emitted: 0, memory }
+        }
+    }
+
+    impl Stream for ActivatesBackpressureAfterFirst {
+        type Item = Result<i32, &'static str>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match self.emitted {
+                0 => {
+                    self.emitted = 1;
+                    self.memory.set_backpressure_active_for_test(true);
                     Poll::Ready(Some(Ok(1)))
                 }
                 1 => {
@@ -569,6 +624,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn flushes_current_batch_when_memory_blocks_during_ready_drain() {
+        let memory = MemoryMonitor::new_for_test();
+        let memory_sub = memory.subscribe();
+
+        let batch_config = test_batch_config(10_000);
+        let mut stream = Box::pin(TryBatchBackpressureStream::wrap(
+            ActivatesBackpressureAfterFirst::new(memory.clone()),
+            "test_stream",
+            batch_config,
+            memory_sub,
+            test_cached_budget(&memory),
+        ));
+
+        let batch = poll_fn(|cx| stream.as_mut().poll_next(cx)).await;
+        assert_eq!(batch, Some(Ok(vec![1])));
+
+        poll_fn(|cx| match stream.as_mut().poll_next(cx) {
+            Poll::Pending => Poll::Ready(()),
+            _ => panic!("expected pending while backpressure is active"),
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn returns_pending_while_blocked_then_resumes_after_unblock() {
         let memory = MemoryMonitor::new_for_test();
         memory.set_backpressure_active_for_test(true);
@@ -749,6 +828,41 @@ mod tests {
 
         let flushed = poll_fn(|cx| stream.as_mut().poll_next(cx)).await;
         assert_eq!(flushed, Some(Ok(vec![1, 2])));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_starts_when_first_item_arrives_after_idle() {
+        let memory = MemoryMonitor::new_for_test();
+        let memory_sub = memory.subscribe();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let batch_config = test_batch_config(100);
+        let mut stream = Box::pin(TryBatchBackpressureStream::wrap(
+            ReceiverStream::new(rx),
+            "test_stream",
+            batch_config,
+            memory_sub,
+            test_cached_budget(&memory),
+        ));
+
+        poll_fn(|cx| match stream.as_mut().poll_next(cx) {
+            Poll::Pending => Poll::Ready(()),
+            _ => panic!("expected pending while idle"),
+        })
+        .await;
+
+        tokio::time::advance(Duration::from_millis(120)).await;
+        tx.send(Ok::<i32, &'static str>(1)).await.unwrap();
+
+        poll_fn(|cx| match stream.as_mut().poll_next(cx) {
+            Poll::Pending => Poll::Ready(()),
+            _ => panic!("expected pending before first item's timeout elapses"),
+        })
+        .await;
+
+        tokio::time::advance(Duration::from_millis(120)).await;
+        let flushed = poll_fn(|cx| stream.as_mut().poll_next(cx)).await;
+        assert_eq!(flushed, Some(Ok(vec![1])));
     }
 
     #[tokio::test]

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -302,8 +302,9 @@ where
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 
-                        // If we are paused for memory, we don't want to reallocate a batch of the same
-                        // size as before, to avoid increasing memory usage even more.
+                        // If we are paused for memory, we don't want to reallocate a batch of the
+                        // same size as before, to avoid increasing memory
+                        // usage even more.
                         return Poll::Ready(Some(Ok(std::mem::take(this.items))));
                     }
 

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -262,6 +262,8 @@ where
                 *this.reset_timer = true;
                 *this.current_batch_bytes = 0;
 
+                // If we are paused for memory, we don't want to reallocate a batch of the same
+                // size as before, to avoid increasing memory usage even more.
                 return Poll::Ready(Some(Ok(std::mem::take(this.items))));
             }
 
@@ -300,6 +302,8 @@ where
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 
+                        // If we are paused for memory, we don't want to reallocate a batch of the same
+                        // size as before, to avoid increasing memory usage even more.
                         return Poll::Ready(Some(Ok(std::mem::take(this.items))));
                     }
 

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -262,7 +262,7 @@ where
                 *this.reset_timer = true;
                 *this.current_batch_bytes = 0;
 
-                return Poll::Ready(Some(Ok(take_and_replace_items(this.items))));
+                return Poll::Ready(Some(Ok(std::mem::take(this.items))));
             }
 
             return Poll::Pending;
@@ -300,7 +300,7 @@ where
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 
-                        return Poll::Ready(Some(Ok(take_and_replace_items(this.items))));
+                        return Poll::Ready(Some(Ok(std::mem::take(this.items))));
                     }
 
                     // If byte budget is reached we want to return the accumulated data.
@@ -506,7 +506,6 @@ mod tests {
         assert_eq!(apply_worker_apply_stream_id(), "apply_worker_apply_stream");
     }
 
-    // BackpressureStream tests.
     #[tokio::test]
     async fn backpressure_stream_pauses_while_blocked_then_resumes() {
         let memory = MemoryMonitor::new_for_test();
@@ -591,7 +590,6 @@ mod tests {
         unblocker.await.unwrap();
     }
 
-    // TryBatchBackpressureStream tests.
     #[tokio::test]
     async fn flushes_buffered_items_immediately_when_memory_blocks() {
         let memory = MemoryMonitor::new_for_test();

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -15,12 +15,6 @@ use crate::{
     schema::TableId,
 };
 
-/// Maximum item-vector capacity retained after emitting a stream batch.
-///
-/// This avoids reallocating for normal batch sizes while bounding memory after
-/// a transiently large batch.
-const MAX_RETAINED_BATCH_ITEMS: usize = 16 * 1024;
-
 /// Builds the stream id for a table sync worker's initial table-copy stream.
 pub(crate) fn table_sync_worker_copy_stream_id(table_id: TableId) -> String {
     format!("table_sync_worker_copy_{}_stream", table_id.0)
@@ -36,11 +30,11 @@ pub(crate) fn apply_worker_apply_stream_id() -> String {
     "apply_worker_apply_stream".to_owned()
 }
 
-/// Takes buffered items and leaves behind a bounded retained-capacity
-/// replacement.
-fn take_items_with_retained_capacity<T>(items: &mut Vec<T>) -> Vec<T> {
-    let replacement_capacity = items.capacity().min(MAX_RETAINED_BATCH_ITEMS);
-
+/// Takes buffered items and leaves behind a replacement sized for the emitted
+/// batch under the assumption that next batches are likely going to need a
+/// similar amount of memory.
+fn take_and_replace_items<T>(items: &mut Vec<T>) -> Vec<T> {
+    let replacement_capacity = items.len();
     std::mem::replace(items, Vec::with_capacity(replacement_capacity))
 }
 
@@ -265,7 +259,7 @@ where
                 *this.reset_timer = true;
                 *this.current_batch_bytes = 0;
 
-                return Poll::Ready(Some(Ok(take_items_with_retained_capacity(this.items))));
+                return Poll::Ready(Some(Ok(take_and_replace_items(this.items))));
             }
 
             return Poll::Pending;
@@ -301,9 +295,7 @@ where
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 
-                        return Poll::Ready(Some(Ok(take_items_with_retained_capacity(
-                            this.items,
-                        ))));
+                        return Poll::Ready(Some(Ok(take_and_replace_items(this.items))));
                     }
 
                     // If byte budget is reached, emit immediately.
@@ -312,9 +304,7 @@ where
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 
-                        return Poll::Ready(Some(Ok(take_items_with_retained_capacity(
-                            this.items,
-                        ))));
+                        return Poll::Ready(Some(Ok(take_and_replace_items(this.items))));
                     }
                 }
                 Poll::Ready(Some(Err(err))) => {
@@ -356,7 +346,7 @@ where
             *this.reset_timer = true;
             *this.current_batch_bytes = 0;
 
-            return Poll::Ready(Some(Ok(take_items_with_retained_capacity(this.items))));
+            return Poll::Ready(Some(Ok(take_and_replace_items(this.items))));
         }
 
         Poll::Pending

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -265,7 +265,7 @@ where
                 *this.reset_timer = true;
                 *this.current_batch_bytes = 0;
 
-                return Poll::Ready(Some(Ok(std::mem::take(this.items))));
+                return Poll::Ready(Some(Ok(take_items_with_retained_capacity(this.items))));
             }
 
             return Poll::Pending;
@@ -280,7 +280,7 @@ where
             match this.stream.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(item))) => {
                     // Start the fill timer only when a batch becomes non-empty.
-                    // Otherwise an idle stream could expire the timer before
+                    // Otherwise, an idle stream could expire the timer before
                     // the first item arrives and flush that item immediately.
                     if this.items.is_empty() && *this.reset_timer {
                         this.deadline.set(Some(tokio::time::sleep(Duration::from_millis(
@@ -289,6 +289,7 @@ where
                         *this.reset_timer = false;
                     }
 
+                    // Add the new item to the batch and track its size.
                     *this.current_batch_bytes =
                         this.current_batch_bytes.saturating_add(item.size_hint());
                     this.items.push(item);
@@ -329,6 +330,10 @@ where
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 
+                        // The inner stream is ending, so no future batch can
+                        // reuse retained capacity. `mem::take` replaces the
+                        // buffer with `Vec::new()`, which keeps zero capacity
+                        // and avoids allocating a replacement vector.
                         Some(Ok(std::mem::take(this.items)))
                     };
 
@@ -628,6 +633,9 @@ mod tests {
         let memory = MemoryMonitor::new_for_test();
         let memory_sub = memory.subscribe();
 
+        // This covers the ready-drain path specifically: the inner stream does
+        // not return `Pending` between items, so memory pressure must be
+        // observed from the current watch value inside the drain loop.
         let batch_config = test_batch_config(10_000);
         let mut stream = Box::pin(TryBatchBackpressureStream::wrap(
             ActivatesBackpressureAfterFirst::new(memory.clone()),
@@ -835,6 +843,7 @@ mod tests {
         let memory = MemoryMonitor::new_for_test();
         let memory_sub = memory.subscribe();
 
+        // This guards against arming the fill timer while the stream is idle.
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let batch_config = test_batch_config(100);
         let mut stream = Box::pin(TryBatchBackpressureStream::wrap(

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -15,6 +15,12 @@ use crate::{
     schema::TableId,
 };
 
+/// Maximum item-vector capacity retained after emitting a stream batch.
+///
+/// This avoids reallocating for normal batch sizes while bounding memory after
+/// a transiently large batch.
+const MAX_RETAINED_BATCH_ITEMS: usize = 16 * 1024;
+
 /// Builds the stream id for a table sync worker's initial table-copy stream.
 pub(crate) fn table_sync_worker_copy_stream_id(table_id: TableId) -> String {
     format!("table_sync_worker_copy_{}_stream", table_id.0)
@@ -28,6 +34,14 @@ pub(crate) fn table_sync_worker_apply_stream_id(table_id: TableId) -> String {
 /// Builds the stream id for the apply worker's apply stream.
 pub(crate) fn apply_worker_apply_stream_id() -> String {
     "apply_worker_apply_stream".to_owned()
+}
+
+/// Takes buffered items and leaves behind a bounded retained-capacity
+/// replacement.
+fn take_items_with_retained_capacity<T>(items: &mut Vec<T>) -> Vec<T> {
+    let replacement_capacity = items.capacity().min(MAX_RETAINED_BATCH_ITEMS);
+
+    std::mem::replace(items, Vec::with_capacity(replacement_capacity))
 }
 
 pin_project! {
@@ -279,7 +293,9 @@ where
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 
-                        return Poll::Ready(Some(Ok(std::mem::take(this.items))));
+                        return Poll::Ready(Some(Ok(take_items_with_retained_capacity(
+                            this.items,
+                        ))));
                     }
                 }
                 Poll::Ready(Some(Err(err))) => {
@@ -313,7 +329,7 @@ where
             *this.reset_timer = true;
             *this.current_batch_bytes = 0;
 
-            return Poll::Ready(Some(Ok(std::mem::take(this.items))));
+            return Poll::Ready(Some(Ok(take_items_with_retained_capacity(this.items))));
         }
 
         Poll::Pending

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -236,6 +236,7 @@ where
             *this.paused_for_memory = false;
         }
 
+        // We log the backpressure state changes, for better observability.
         if !was_paused && *this.paused_for_memory {
             info!(
                 stream_id = %this.stream_id,
@@ -248,6 +249,8 @@ where
             );
         }
 
+        // If the stream is paused due to memory backpressure, we want to return the
+        // accumulated data.
         if *this.paused_for_memory {
             if !this.items.is_empty() {
                 info!(
@@ -288,6 +291,8 @@ where
                         this.current_batch_bytes.saturating_add(item.size_hint());
                     this.items.push(item);
 
+                    // Check if the memory backpressure was activated in the meanwhile, in such case
+                    // we want to pause and return the accumulated data.
                     if let Some(memory_subscription) = this.memory_subscription.as_mut()
                         && memory_subscription.current_backpressure_active()
                     {
@@ -298,9 +303,8 @@ where
                         return Poll::Ready(Some(Ok(take_and_replace_items(this.items))));
                     }
 
-                    // If byte budget is reached, emit immediately.
-                    let max_batch_bytes_reached = *this.current_batch_bytes >= max_batch_size_bytes;
-                    if max_batch_bytes_reached {
+                    // If byte budget is reached we want to return the accumulated data.
+                    if *this.current_batch_bytes >= max_batch_size_bytes {
                         *this.reset_timer = true;
                         *this.current_batch_bytes = 0;
 

--- a/crates/etl/src/test_utils/replication_stream.rs
+++ b/crates/etl/src/test_utils/replication_stream.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Parses a raw Postgres COPY row with the production conversion path.
 pub fn parse_copy_row(row: &[u8], column_schemas: &[ColumnSchema]) -> EtlResult<TableRow> {
-    parse_table_row_from_postgres_copy_bytes(row, column_schemas.iter())
+    parse_table_row_from_postgres_copy_bytes(row, column_schemas)
 }
 
 /// Parses a logical replication tuple with the production conversion path.

--- a/crates/etl/tests/replication_stream.rs
+++ b/crates/etl/tests/replication_stream.rs
@@ -198,6 +198,9 @@ async fn create_type_matrix_table_in(
                 ("varchar_col", "varchar(16) not null"),
                 ("name_col", "name not null"),
                 ("text_col", "text not null"),
+                ("text_null_col", "text"),
+                ("text_null_marker_literal_col", "text not null"),
+                ("text_embedded_null_marker_col", "text not null"),
                 ("money_col", "money not null"),
                 ("int2_col", "smallint not null"),
                 ("int4_col", "integer not null"),
@@ -312,6 +315,9 @@ async fn insert_type_matrix_row(
                 'varchar',
                 'pg_name'::name,
                 'hello world',
+                null::text,
+                $$\N$$::text,
+                $$value\Ntail$$::text,
                 '12.34'::money,
                 -123::smallint,
                 456::integer,
@@ -612,6 +618,9 @@ fn assert_type_matrix_row(row: &TableRow, column_schemas: &[ColumnSchema]) {
     assert_string_cell(row, column_schemas, "varchar_col", "varchar");
     assert_string_cell(row, column_schemas, "name_col", "pg_name");
     assert_string_cell(row, column_schemas, "text_col", "hello world");
+    assert_eq!(cell(row, column_schemas, "text_null_col"), &Cell::Null);
+    assert_string_cell(row, column_schemas, "text_null_marker_literal_col", "\\N");
+    assert_string_cell(row, column_schemas, "text_embedded_null_marker_col", "value\\Ntail");
     assert_money_cell(row, column_schemas);
     assert_eq!(cell(row, column_schemas, "int2_col"), &Cell::I16(-123));
     assert_eq!(cell(row, column_schemas, "int4_col"), &Cell::I32(456));


### PR DESCRIPTION
## Summary

Improve ETL hot-path parsing and batching behavior for Postgres replication and copy workloads.

This PR focuses on reducing avoidable allocation, iterator, formatting, and metrics overhead in high-volume paths while preserving parser correctness with targeted regression coverage.

## What changed

- Reworked Postgres `NUMERIC` text parsing to use byte-oriented parsing instead of a `char` iterator.
  - Avoids allocating and lowercasing strings for special values.
  - Caps the initial decimal-digit reservation.
  - Converts decimal digits to PostgreSQL's base-10000 representation without allocating a large, zero-padded intermediate buffer.
  - Rejects obviously out-of-range exponents before performing exponent-derived allocation.

- Added fast paths for common Postgres temporal text shapes.
  - `date`: `YYYY-MM-DD`
  - `time`: `HH:MM:SS[.fraction]`
  - `timestamp`: `YYYY-MM-DD HH:MM:SS[.fraction]`
  - Inputs outside these common shapes still fall back to the existing Chrono parsers, preserving previous behavior.

- Optimized row parsing.
  - Uses schema slices instead of cloned iterators.
  - Borrows unescaped fields directly from the input instead of allocating a field string.
  - Preserves correct COPY null-marker behavior: raw `\N` is `NULL`, while escaped `\\N` is literal text.

- Reduced hot-loop overhead in batch and backpressure streams.
  - Polls the memory watch stream once per outer poll.
  - Still checks the current memory state while draining ready rows so backpressure can flush promptly.
  - Starts the batch fill timer only after the first row arrives.
  - Replaces emitted batch vectors with a new vector sized from the emitted batch length, without an artificial minimum capacity.

- Reduced avoidable allocation in metric labels.
  - Uses static strings for status-update and boolean labels instead of calling `to_string()` in hot paths.

- Kept apply-loop changes narrow.
  - The apply loop only retains event-batch vector capacity based on the emitted batch length.
  - Broader experimental apply-loop changes were removed when they did not justify their added complexity.

- Sorts table-copy partitions by estimated block count.
  - Larger copy ranges start first so long-running partitions overlap while workers remain available instead of becoming a slow tail.

## Correctness coverage

Added or updated tests for:

- Malformed numeric inputs and large positive or negative scientific exponents;
- Negative scientific notation around decimal scaling;
- Temporal fast-path and fallback parity with Chrono;
- Date, time, and timestamp arrays;
- COPY `\N` null markers versus escaped literal `\\N`;
- Batch-stream timeout behavior after an idle period;
- Memory backpressure while draining ready rows.