### PR TITLE
fix(destinations): streaming uses deferred durability in Snowflake

### DIFF
--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -1,24 +1,190 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use etl::{
     pipeline::PipelineId,
     schema::{ColumnChange, ColumnModification, ColumnSchema, SchemaDiff, TableId},
 };
-use reqwest::StatusCode;
-use tokio::sync::{Mutex, RwLock};
+use metrics::{counter, gauge, histogram};
+use tokio::{
+    sync::{Mutex, RwLock},
+    time::sleep,
+};
 use tracing::warn;
 
 use crate::snowflake::{
-    Config, Error, Result,
+    Config, Error, Result, SnowpipeError,
     auth::{AuthManager, HttpExchanger, TokenProvider},
     config::{HTTP_CONNECT_TIMEOUT, HTTP_REQUEST_TIMEOUT},
+    metrics::{
+        ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_FAILURES_TOTAL,
+        ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_SECONDS, ETL_SNOWFLAKE_STREAMING_PENDING_BYTES,
+        ETL_SNOWFLAKE_STREAMING_PENDING_CHANNELS, ETL_SNOWFLAKE_STREAMING_PENDING_ROW_BATCHES,
+    },
     schema,
     sql::{quote_identifier, quote_string_literal},
     sql_client::SqlClient,
-    streaming::{ChannelHandle, OffsetToken, RestStreamClient, RowBatch, StreamClient},
+    streaming::{
+        AcceptedRowBatch, ChannelHandle, DEFAULT_COMMIT_POLL_INTERVAL, DEFAULT_COMMIT_WAIT_TIMEOUT,
+        OffsetToken, RestStreamClient, RowBatch, StreamClient, validate_committed_status,
+    },
 };
 
 type ChannelMap<C> = Arc<RwLock<HashMap<TableId, Arc<Mutex<ChannelHandle<C>>>>>>;
+
+/// Maximum accepted Snowflake row batches before forcing a durability wait.
+const STREAMING_PENDING_MAX_ROW_BATCHES: usize = 64;
+
+/// Maximum accepted compressed bytes before forcing a durability wait.
+const STREAMING_PENDING_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// Collapsed durability target for one Snowflake streaming channel.
+///
+/// Snowflake committed offsets are cumulative, so multiple accepted row
+/// batches can be represented by the latest target offset plus aggregate row
+/// and byte counts.
+#[derive(Debug, Clone)]
+struct PendingDurabilityTarget {
+    /// Latest accepted offset for this channel.
+    target_offset: OffsetToken,
+    /// Accepted rows since the baseline status.
+    rows: u64,
+    /// Compressed bytes accepted since the baseline status.
+    bytes: usize,
+    /// Snowflake row batches accepted since the baseline status.
+    row_batches: usize,
+    /// Cumulative inserted rows before the pending range began.
+    baseline_rows_inserted: u64,
+    /// Cumulative row errors before the pending range began.
+    baseline_rows_error_count: u64,
+}
+
+impl PendingDurabilityTarget {
+    /// Creates a pending durability target from the first accepted row batch.
+    fn new(batch: AcceptedRowBatch) -> Self {
+        Self {
+            target_offset: batch.target_offset,
+            rows: batch.rows,
+            bytes: batch.bytes,
+            row_batches: 1,
+            baseline_rows_inserted: batch.baseline_rows_inserted,
+            baseline_rows_error_count: batch.baseline_rows_error_count,
+        }
+    }
+
+    /// Extends this target with a later accepted row batch on the same channel.
+    fn record(&mut self, batch: AcceptedRowBatch) -> Result<()> {
+        let rows = self.rows.checked_add(batch.rows).ok_or_else(|| {
+            Error::Channel("Snowflake pending streaming row count overflowed.".into())
+        })?;
+        let bytes = self.bytes.checked_add(batch.bytes).ok_or_else(|| {
+            Error::Channel("Snowflake pending streaming byte count overflowed.".into())
+        })?;
+        let row_batches = self.row_batches.checked_add(1).ok_or_else(|| {
+            Error::Channel("Snowflake pending streaming batch count overflowed.".into())
+        })?;
+
+        self.target_offset = batch.target_offset;
+        self.rows = rows;
+        self.bytes = bytes;
+        self.row_batches = row_batches;
+
+        Ok(())
+    }
+
+    /// Converts this cumulative target into the validation input shape.
+    fn as_accepted_batch(&self) -> AcceptedRowBatch {
+        AcceptedRowBatch {
+            target_offset: self.target_offset.clone(),
+            rows: self.rows,
+            bytes: self.bytes,
+            baseline_rows_inserted: self.baseline_rows_inserted,
+            baseline_rows_error_count: self.baseline_rows_error_count,
+        }
+    }
+}
+
+/// Global accepted-but-not-durable Snowflake streaming state.
+#[derive(Debug, Default)]
+struct PendingDurabilityState {
+    /// Pending durability targets keyed by table/channel id.
+    targets: HashMap<TableId, PendingDurabilityTarget>,
+    /// Total accepted row batches across pending targets.
+    row_batches: usize,
+    /// Total accepted compressed bytes across pending targets.
+    bytes: usize,
+}
+
+impl PendingDurabilityState {
+    /// Records a row batch accepted by Snowflake.
+    fn record(&mut self, table_id: TableId, batch: AcceptedRowBatch) -> Result<()> {
+        let row_batches = self.row_batches.checked_add(1).ok_or_else(|| {
+            Error::Channel("Snowflake pending streaming batch count overflowed.".into())
+        })?;
+        let bytes = self.bytes.checked_add(batch.bytes).ok_or_else(|| {
+            Error::Channel("Snowflake pending streaming byte count overflowed.".into())
+        })?;
+
+        match self.targets.get_mut(&table_id) {
+            Some(target) => target.record(batch)?,
+            None => {
+                self.targets.insert(table_id, PendingDurabilityTarget::new(batch));
+            }
+        }
+
+        self.row_batches = row_batches;
+        self.bytes = bytes;
+        Ok(())
+    }
+
+    /// Returns whether the pending window has reached its configured limit.
+    fn limits_reached(&self) -> bool {
+        self.row_batches >= STREAMING_PENDING_MAX_ROW_BATCHES
+            || self.bytes >= STREAMING_PENDING_MAX_BYTES
+    }
+
+    /// Returns whether adding one row batch would exceed the pending window.
+    fn would_exceed_limits(&self, batch_bytes: usize) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+
+        self.limits_reached()
+            || self.row_batches.saturating_add(1) > STREAMING_PENDING_MAX_ROW_BATCHES
+            || self.bytes.saturating_add(batch_bytes) > STREAMING_PENDING_MAX_BYTES
+    }
+
+    /// Returns whether there is no accepted-but-not-durable streaming work.
+    fn is_empty(&self) -> bool {
+        self.targets.is_empty()
+    }
+
+    /// Clones the current pending targets for status polling.
+    fn targets(&self) -> Vec<(TableId, PendingDurabilityTarget)> {
+        self.targets.iter().map(|(table_id, target)| (*table_id, target.clone())).collect()
+    }
+
+    /// Removes targets whose current offset is covered by the proven target.
+    fn clear_committed(&mut self, committed: &[(TableId, OffsetToken)]) {
+        for (table_id, committed_target) in committed {
+            let should_clear = self
+                .targets
+                .get(table_id)
+                .is_some_and(|target| &target.target_offset <= committed_target);
+
+            if should_clear && let Some(target) = self.targets.remove(table_id) {
+                self.row_batches = self.row_batches.saturating_sub(target.row_batches);
+                self.bytes = self.bytes.saturating_sub(target.bytes);
+            }
+        }
+    }
+
+    /// Records pending-window gauges.
+    fn observe_metrics(&self) {
+        gauge!(ETL_SNOWFLAKE_STREAMING_PENDING_BYTES).set(self.bytes as f64);
+        gauge!(ETL_SNOWFLAKE_STREAMING_PENDING_ROW_BATCHES).set(self.row_batches as f64);
+        gauge!(ETL_SNOWFLAKE_STREAMING_PENDING_CHANNELS).set(self.targets.len() as f64);
+    }
+}
 
 /// Snowflake API client.
 ///
@@ -31,6 +197,7 @@ pub struct Client<T, C = RestStreamClient<T>> {
     schema: String,
     pipeline_id: PipelineId,
     channels: ChannelMap<C>,
+    pending_durability: Arc<Mutex<PendingDurabilityState>>,
 }
 
 impl<T: TokenProvider, C: StreamClient> Clone for Client<T, C> {
@@ -42,6 +209,7 @@ impl<T: TokenProvider, C: StreamClient> Clone for Client<T, C> {
             schema: self.schema.clone(),
             pipeline_id: self.pipeline_id,
             channels: Arc::clone(&self.channels),
+            pending_durability: Arc::clone(&self.pending_durability),
         }
     }
 }
@@ -129,6 +297,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
             schema,
             pipeline_id,
             channels: Arc::new(RwLock::new(HashMap::new())),
+            pending_durability: Arc::new(Mutex::new(PendingDurabilityState::default())),
         }
     }
 
@@ -272,6 +441,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
 
     /// Truncate the table and reset ingestion state so offsets restart.
     pub async fn truncate_table(&self, table_id: TableId, table_name: &str) -> Result<()> {
+        self.wait_for_pending_durability().await?;
         let mut guard = self.get_channel(table_id).await?.lock_owned().await;
         self.sql_client.truncate_table(table_name).await?;
         guard.reset().await
@@ -296,7 +466,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         };
         match drop_channel_result {
             Ok(()) => {}
-            Err(Error::HttpStatus { status: StatusCode::NOT_FOUND, .. }) => {}
+            Err(Error::Snowpipe(SnowpipeError::ChannelNotFound)) => {}
             Err(error) => return Err(error),
         }
 
@@ -307,23 +477,132 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
     ///
     /// Channels must be reopened after ALTER TABLE so Snowpipe picks up the
     /// new column list. Without this, inserts would fail (and fall back to
-    /// the auto-recovery path in `process_batches`, so after one error
+    /// the auto-recovery path in `accept_streaming_batches`, so after one error
     /// round-trip data would still be pushed, but we can avoid that extra
     /// trip).
     ///
     /// Ref: <https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-classic-recommendation>
     pub async fn refresh_table(&self, table_id: &TableId) -> Result<()> {
-        self.get_channel(*table_id).await?.lock().await.open().await
+        self.wait_for_pending_durability().await?;
+        self.get_channel(*table_id).await?.lock().await.open().await.map(|_| ())
     }
 
-    /// Send pre-encoded row batches through the table's channel.
-    pub async fn insert_batches(&self, table_id: TableId, batches: Vec<RowBatch>) -> Result<()> {
-        self.get_channel(table_id).await?.lock().await.process_batches(batches).await
+    /// Send table-copy row batches through the existing append-ack path.
+    pub async fn send_table_copy_batches(
+        &self,
+        table_id: TableId,
+        batches: Vec<RowBatch>,
+    ) -> Result<()> {
+        self.get_channel(table_id).await?.lock().await.send_table_copy_batches(batches).await
     }
 
-    /// Last offset committed by Snowflake for this table's channel.
-    pub async fn committed_offset(&self, table_id: TableId) -> Result<Option<OffsetToken>> {
-        self.get_channel(table_id).await?.lock().await.committed_offset().await
+    /// Send streaming row batches and record accepted-but-not-durable targets.
+    pub async fn send_streaming_batches(
+        &self,
+        table_id: TableId,
+        batches: Vec<RowBatch>,
+    ) -> Result<()> {
+        let channel = self.get_channel(table_id).await?;
+        for batch in batches {
+            if self.pending_durability.lock().await.would_exceed_limits(batch.size()) {
+                self.wait_for_pending_durability().await?;
+            }
+
+            let accepted = channel.lock().await.accept_streaming_batches(vec![batch]).await?;
+            for accepted_batch in accepted {
+                let mut pending = self.pending_durability.lock().await;
+                pending.record(table_id, accepted_batch)?;
+                pending.observe_metrics();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns whether `offset` is already committed for this table's channel.
+    pub async fn is_offset_committed(
+        &self,
+        table_id: TableId,
+        offset: &OffsetToken,
+    ) -> Result<bool> {
+        Ok(self.get_channel(table_id).await?.lock().await.is_offset_committed(offset))
+    }
+
+    /// Returns whether pending streaming work has reached the durability wait
+    /// threshold.
+    pub async fn pending_durability_limits_reached(&self) -> bool {
+        self.pending_durability.lock().await.limits_reached()
+    }
+
+    /// Returns whether there is no accepted-but-not-durable streaming work.
+    pub async fn pending_durability_is_empty(&self) -> bool {
+        self.pending_durability.lock().await.is_empty()
+    }
+
+    /// Wait until all accepted streaming rows have committed.
+    pub async fn wait_for_pending_durability(&self) -> Result<()> {
+        let started = Instant::now();
+        let mut observed_pending = false;
+        let result = self.wait_for_pending_durability_inner(&mut observed_pending).await;
+        if observed_pending {
+            histogram!(ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_SECONDS)
+                .record(started.elapsed().as_secs_f64());
+            if result.is_err() {
+                counter!(ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_FAILURES_TOTAL).increment(1);
+            }
+        }
+
+        result
+    }
+
+    async fn wait_for_pending_durability_inner(&self, observed_pending: &mut bool) -> Result<()> {
+        let deadline = Instant::now() + DEFAULT_COMMIT_WAIT_TIMEOUT;
+
+        loop {
+            let targets = self.pending_durability.lock().await.targets();
+            if targets.is_empty() {
+                return Ok(());
+            }
+            *observed_pending = true;
+
+            let mut committed = Vec::new();
+            for (table_id, target) in targets {
+                let channel = self.get_channel(table_id).await?;
+                let status = channel.lock().await.refresh_status().await?;
+                let accepted_batch = target.as_accepted_batch();
+                validate_committed_status(&status, &accepted_batch)?;
+
+                if status
+                    .offset_token
+                    .as_ref()
+                    .is_some_and(|offset| offset >= &target.target_offset)
+                {
+                    committed.push((table_id, target.target_offset.clone()));
+                }
+            }
+
+            {
+                let mut pending = self.pending_durability.lock().await;
+                pending.clear_committed(&committed);
+                pending.observe_metrics();
+                if pending.is_empty() {
+                    return Ok(());
+                }
+            }
+
+            if Instant::now() >= deadline {
+                return Err(Error::Channel(
+                    "Timed out waiting for Snowflake streaming rows to commit.".into(),
+                ));
+            }
+
+            sleep(DEFAULT_COMMIT_POLL_INTERVAL).await;
+        }
+    }
+
+    /// Fetches the latest committed offset for this table's channel.
+    pub async fn fetch_committed_offset(&self, table_id: TableId) -> Result<Option<OffsetToken>> {
+        self.get_channel(table_id).await?.lock().await.fetch_committed_offset().await
     }
 
     /// Get table-level guard.
@@ -336,5 +615,86 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
             .get(&table_id)
             .cloned()
             .ok_or_else(|| Error::Channel(format!("no open channel for table {table_id}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accepted_batch(lsn: u64, ordinal: u64, rows: u64, bytes: usize) -> AcceptedRowBatch {
+        AcceptedRowBatch {
+            target_offset: OffsetToken::new(lsn.into(), ordinal),
+            rows,
+            bytes,
+            baseline_rows_inserted: 100,
+            baseline_rows_error_count: 1,
+        }
+    }
+
+    #[test]
+    fn pending_state_collapses_targets_per_channel() {
+        let table_id = TableId::new(1);
+        let mut state = PendingDurabilityState::default();
+
+        state.record(table_id, accepted_batch(10, 1, 2, 20)).unwrap();
+        state.record(table_id, accepted_batch(10, 2, 3, 30)).unwrap();
+
+        let target = state.targets.get(&table_id).unwrap();
+        assert_eq!(state.targets.len(), 1);
+        assert_eq!(state.row_batches, 2);
+        assert_eq!(state.bytes, 50);
+        assert_eq!(target.target_offset, OffsetToken::new(10_u64.into(), 2));
+        assert_eq!(target.rows, 5);
+        assert_eq!(target.bytes, 50);
+        assert_eq!(target.baseline_rows_inserted, 100);
+        assert_eq!(target.baseline_rows_error_count, 1);
+    }
+
+    #[test]
+    fn pending_state_clears_committed_channels_from_global_totals() {
+        let first_table_id = TableId::new(1);
+        let second_table_id = TableId::new(2);
+        let mut state = PendingDurabilityState::default();
+
+        state.record(first_table_id, accepted_batch(10, 1, 2, 20)).unwrap();
+        state.record(second_table_id, accepted_batch(11, 1, 3, 30)).unwrap();
+        state.clear_committed(&[(first_table_id, OffsetToken::new(10_u64.into(), 1))]);
+
+        assert_eq!(state.targets.len(), 1);
+        assert!(state.targets.contains_key(&second_table_id));
+        assert_eq!(state.row_batches, 1);
+        assert_eq!(state.bytes, 30);
+    }
+
+    #[test]
+    fn pending_state_keeps_target_that_advanced_after_wait_snapshot() {
+        let table_id = TableId::new(1);
+        let mut state = PendingDurabilityState::default();
+
+        state.record(table_id, accepted_batch(10, 1, 2, 20)).unwrap();
+        let stale_committed_target = (table_id, OffsetToken::new(10_u64.into(), 1));
+        state.record(table_id, accepted_batch(10, 2, 3, 30)).unwrap();
+        state.clear_committed(&[stale_committed_target]);
+
+        let target = state.targets.get(&table_id).unwrap();
+        assert_eq!(target.target_offset, OffsetToken::new(10_u64.into(), 2));
+        assert_eq!(target.rows, 5);
+        assert_eq!(target.bytes, 50);
+        assert_eq!(state.row_batches, 2);
+        assert_eq!(state.bytes, 50);
+    }
+
+    #[test]
+    fn pending_window_allows_single_oversized_batch_when_empty() {
+        let table_id = TableId::new(1);
+        let mut state = PendingDurabilityState::default();
+
+        assert!(!state.would_exceed_limits(STREAMING_PENDING_MAX_BYTES + 1));
+
+        state.record(table_id, accepted_batch(10, 1, 1, STREAMING_PENDING_MAX_BYTES + 1)).unwrap();
+
+        assert!(state.limits_reached());
+        assert!(state.would_exceed_limits(1));
     }
 }

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -118,7 +118,7 @@ where
         }
 
         let batches = builder.finish().map_err(EtlError::from)?;
-        self.client.insert_batches(table_id, batches).await.map_err(EtlError::from)?;
+        self.client.send_table_copy_batches(table_id, batches).await.map_err(EtlError::from)?;
 
         Ok(())
     }
@@ -127,22 +127,34 @@ where
     ///
     /// All events (inserts, updates, deletes, truncates, and schema changes)
     /// from the replication stream are processed here.
-    pub async fn process_events(&self, events: Vec<Event>) -> EtlResult<()> {
+    pub async fn process_events(&self, events: Vec<Event>) -> EtlResult<DestinationWriteStatus> {
         let mut iter = events.into_iter().peekable();
+        // Schema and truncate side effects must close the pending streaming window.
+        let mut requires_durability_wait = false;
 
         while iter.peek().is_some() {
             let builders = self.accumulate_data_events(&mut iter).await?;
             self.flush_batches(builders).await?;
-            self.apply_relation_events(&mut iter).await?;
-            self.apply_truncate_events(&mut iter).await?;
+            requires_durability_wait |= self.apply_relation_events(&mut iter).await?;
+            requires_durability_wait |= self.apply_truncate_events(&mut iter).await?;
         }
 
-        Ok(())
+        if requires_durability_wait || self.client.pending_durability_limits_reached().await {
+            self.client.wait_for_pending_durability().await.map_err(EtlError::from)?;
+            Ok(DestinationWriteStatus::Durable)
+        } else if self.client.pending_durability_is_empty().await {
+            Ok(DestinationWriteStatus::Durable)
+        } else {
+            Ok(DestinationWriteStatus::Accepted)
+        }
     }
 
-    /// Last offset committed by Snowflake for this table's channel.
-    pub async fn committed_offset(&self, table_id: TableId) -> EtlResult<Option<OffsetToken>> {
-        self.client.committed_offset(table_id).await.map_err(EtlError::from)
+    /// Fetches the latest committed offset for this table's channel.
+    pub async fn fetch_committed_offset(
+        &self,
+        table_id: TableId,
+    ) -> EtlResult<Option<OffsetToken>> {
+        self.client.fetch_committed_offset(table_id).await.map_err(EtlError::from)
     }
 
     async fn accumulate_data_events(
@@ -174,21 +186,23 @@ where
     async fn flush_batches(&self, builders: HashMap<TableId, RowBatchBuilder>) -> EtlResult<()> {
         for (table_id, builder) in builders {
             let batches = builder.finish().map_err(EtlError::from)?;
-            self.client.insert_batches(table_id, batches).await.map_err(EtlError::from)?;
+            self.client.send_streaming_batches(table_id, batches).await.map_err(EtlError::from)?;
         }
         Ok(())
     }
 
-    async fn apply_relation_events(&self, iter: &mut EventIter) -> EtlResult<()> {
+    async fn apply_relation_events(&self, iter: &mut EventIter) -> EtlResult<bool> {
+        let mut applied_schema_change = false;
         while matches!(iter.peek(), Some(Event::Relation(_))) {
             if let Some(Event::Relation(rel)) = iter.next() {
-                self.handle_relation_event(&rel.replicated_table_schema).await?;
+                applied_schema_change |=
+                    self.handle_relation_event(&rel.replicated_table_schema).await?;
             }
         }
-        Ok(())
+        Ok(applied_schema_change)
     }
 
-    async fn apply_truncate_events(&self, iter: &mut EventIter) -> EtlResult<()> {
+    async fn apply_truncate_events(&self, iter: &mut EventIter) -> EtlResult<bool> {
         // Collect and dedup tables to be truncated.
         let mut truncated: HashMap<TableId, ReplicatedTableSchema> = HashMap::new();
         while matches!(iter.peek(), Some(Event::Truncate(_))) {
@@ -198,6 +212,7 @@ where
                 }
             }
         }
+        let had_truncates = !truncated.is_empty();
 
         // Truncate tables.
         for (_, schema) in truncated {
@@ -205,7 +220,7 @@ where
             self.client.truncate_table(schema.id(), &table_name).await.map_err(EtlError::from)?;
         }
 
-        Ok(())
+        Ok(had_truncates)
     }
 
     async fn encode_insert(
@@ -219,6 +234,10 @@ where
 
         let cols = &column_cache[&table_id];
         let offset = OffsetToken::new(e.commit_lsn, e.tx_ordinal);
+        if self.client.is_offset_committed(table_id, &offset).await.map_err(EtlError::from)? {
+            return Ok(());
+        }
+
         builders
             .entry(table_id)
             .or_default()
@@ -244,6 +263,10 @@ where
 
         let cols = &column_cache[&table_id];
         let offset = OffsetToken::new(e.commit_lsn, e.tx_ordinal);
+        if self.client.is_offset_committed(table_id, &offset).await.map_err(EtlError::from)? {
+            return Ok(());
+        }
+
         builders
             .entry(table_id)
             .or_default()
@@ -259,11 +282,13 @@ where
     ) -> EtlResult<()> {
         let table_id = e.replicated_table_schema.id();
         let offset = OffsetToken::new(e.commit_lsn, e.tx_ordinal);
+        self.ensure_column_cache(column_cache, table_id, &e.replicated_table_schema).await?;
+        if self.client.is_offset_committed(table_id, &offset).await.map_err(EtlError::from)? {
+            return Ok(());
+        }
 
         match snowflake_delete_row(&e.replicated_table_schema, e.old_table_row)? {
             SnowflakeDeleteRow::Full(row) => {
-                self.ensure_column_cache(column_cache, table_id, &e.replicated_table_schema)
-                    .await?;
                 let cols = &column_cache[&table_id];
                 builders
                     .entry(table_id)
@@ -277,8 +302,6 @@ where
                     .map_err(EtlError::from)
             }
             SnowflakeDeleteRow::Key(key_row) => {
-                self.ensure_column_cache(column_cache, table_id, &e.replicated_table_schema)
-                    .await?;
                 let identity_cols: Vec<_> =
                     e.replicated_table_schema.identity_column_schemas().cloned().collect();
                 builders
@@ -310,7 +333,7 @@ where
         Ok(())
     }
 
-    async fn handle_relation_event(&self, new_schema: &ReplicatedTableSchema) -> EtlResult<()> {
+    async fn handle_relation_event(&self, new_schema: &ReplicatedTableSchema) -> EtlResult<bool> {
         let table_id = new_schema.id();
         let new_snapshot_id = new_schema.inner().snapshot_id;
 
@@ -334,7 +357,7 @@ where
             && current_replication_mask == new_replication_mask
         {
             info!(table_id = ?table_id, "schema unchanged, skipping relation event");
-            return Ok(());
+            return Ok(false);
         }
 
         info!(
@@ -363,6 +386,7 @@ where
         );
 
         let table_name = try_stringify_table_name(new_schema.name())?.to_uppercase();
+        self.client.wait_for_pending_durability().await.map_err(EtlError::from)?;
 
         let updated_metadata = DestinationTableMetadata::new_applied(
             metadata.destination_table_id.clone(),
@@ -397,7 +421,7 @@ where
         self.client.refresh_table(&table_id).await.map_err(EtlError::from)?;
 
         info!(table_id = ?table_id, "schema change applied");
-        Ok(())
+        Ok(true)
     }
 }
 
@@ -503,7 +527,7 @@ where
         self.tasks
             .spawn(async move {
                 let result = destination.process_events(events).await;
-                async_result.send(result.map(|_| DestinationWriteStatus::Durable));
+                async_result.send(result);
             })
             .await;
 

--- a/crates/etl-destinations/src/snowflake/error.rs
+++ b/crates/etl-destinations/src/snowflake/error.rs
@@ -1,5 +1,6 @@
 use etl::error::{ErrorKind, EtlError};
 use reqwest::StatusCode;
+use serde::Deserialize;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -15,8 +16,8 @@ pub enum Error {
     #[error("SQL error{}: {message}", statement_handle.as_ref().map(|h| format!(" (handle {h})")).unwrap_or_default())]
     Sql { statement_handle: Option<String>, message: String },
 
-    #[error("Snowpipe error (code {status_code}): {message}")]
-    Snowpipe { status_code: u32, message: String },
+    #[error(transparent)]
+    Snowpipe(#[from] SnowpipeError),
 
     #[error("Channel error: {0}")]
     Channel(String),
@@ -46,7 +47,7 @@ impl From<Error> for EtlError {
             Error::HttpStatus { .. } => (ErrorKind::DestinationError, "Snowflake HTTP error"),
             Error::Auth(_) => (ErrorKind::DestinationError, "Snowflake authentication failed"),
             Error::Sql { .. } => (ErrorKind::DestinationError, "Snowflake SQL execution failed"),
-            Error::Snowpipe { .. } => (ErrorKind::DestinationError, "Snowpipe streaming error"),
+            Error::Snowpipe(_) => (ErrorKind::DestinationError, "Snowpipe streaming error"),
             Error::Channel(_) => (ErrorKind::DestinationError, "Snowflake channel error"),
             Error::Encoding(_) => (ErrorKind::InvalidData, "Snowflake encoding error"),
             Error::Config(_) => (ErrorKind::ConfigError, "Snowflake configuration error"),
@@ -58,3 +59,87 @@ impl From<Error> for EtlError {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Snowpipe Streaming API failure classified for lifecycle and retry handling.
+#[derive(Debug, thiserror::Error)]
+pub enum SnowpipeError {
+    /// The continuation token is older than Snowflake expects for the channel.
+    #[error("Snowpipe stale continuation token")]
+    StaleContinuation,
+
+    /// A safe open or drop was refused because the channel has uncommitted
+    /// rows.
+    #[error("Snowpipe channel has uncommitted rows")]
+    ChannelHasUncommittedRows,
+
+    /// The requested streaming channel does not exist.
+    #[error("Snowpipe channel not found")]
+    ChannelNotFound,
+
+    /// Snowflake reported that authentication expired for the request.
+    #[error("Snowpipe authentication expired")]
+    AuthenticationExpired,
+
+    /// Snowpipe returned a numeric API status code.
+    #[error("Snowpipe API error code {status_code}: {message}")]
+    ApiStatus { status_code: u32, message: String },
+
+    /// Snowpipe returned an unsuccessful HTTP status without a known API code.
+    #[error("Snowpipe HTTP status {status}")]
+    HttpStatus { status: StatusCode },
+}
+
+impl SnowpipeError {
+    /// Classifies an unsuccessful Snowpipe Streaming HTTP response.
+    pub fn from_response(status: StatusCode, body: String) -> Self {
+        let response = serde_json::from_str::<SnowpipeErrorResponse>(&body).ok();
+        if let Some(status_code) = response.as_ref().and_then(|response| response.status_code) {
+            return Self::from_api_status_code(
+                status_code,
+                "Snowpipe API returned an unsuccessful status.".to_owned(),
+            );
+        }
+
+        match (status, response.and_then(|response| response.code)) {
+            (StatusCode::BAD_REQUEST, Some(code))
+                if code == "STALE_CONTINUATION_TOKEN_SEQUENCER" =>
+            {
+                Self::StaleContinuation
+            }
+            (StatusCode::CONFLICT, Some(code)) if code == "ERR_CHANNEL_HAS_UNCOMMITTED_DATA" => {
+                Self::ChannelHasUncommittedRows
+            }
+            (StatusCode::NOT_FOUND, _) => Self::ChannelNotFound,
+            _ => Self::HttpStatus { status },
+        }
+    }
+
+    fn from_api_status_code(status_code: u32, message: String) -> Self {
+        match status_code {
+            3 => Self::AuthenticationExpired,
+            4 => Self::StaleContinuation,
+            _ => Self::ApiStatus { status_code, message },
+        }
+    }
+
+    /// Returns whether the channel can be reopened for this error.
+    pub fn is_reopenable_channel_error(&self) -> bool {
+        matches!(self, Self::StaleContinuation | Self::ChannelNotFound)
+    }
+
+    /// Returns whether this error is an authentication failure.
+    pub fn is_authentication_expired(&self) -> bool {
+        matches!(self, Self::AuthenticationExpired)
+    }
+}
+
+/// Minimal Snowpipe error response envelope used for classification.
+#[derive(Deserialize)]
+struct SnowpipeErrorResponse {
+    /// String error code, when Snowflake returns one.
+    #[serde(default)]
+    code: Option<String>,
+    /// Numeric Snowpipe API status code, when Snowflake returns one.
+    #[serde(default)]
+    status_code: Option<u32>,
+}

--- a/crates/etl-destinations/src/snowflake/metrics.rs
+++ b/crates/etl-destinations/src/snowflake/metrics.rs
@@ -1,6 +1,6 @@
 use std::sync::Once;
 
-use metrics::{Unit, describe_counter, describe_histogram};
+use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
 static REGISTER_METRICS: Once = Once::new();
 
@@ -9,6 +9,16 @@ pub(super) const ETL_SNOWFLAKE_BATCH_BYTES: &str = "etl_snowflake_batch_bytes";
 pub(super) const ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL: &str = "etl_snowflake_insert_errors_total";
 pub(super) const ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL: &str =
     "etl_snowflake_channel_recoveries_total";
+pub(super) const ETL_SNOWFLAKE_STREAMING_PENDING_BYTES: &str =
+    "etl_snowflake_streaming_pending_bytes";
+pub(super) const ETL_SNOWFLAKE_STREAMING_PENDING_ROW_BATCHES: &str =
+    "etl_snowflake_streaming_pending_row_batches";
+pub(super) const ETL_SNOWFLAKE_STREAMING_PENDING_CHANNELS: &str =
+    "etl_snowflake_streaming_pending_channels";
+pub(super) const ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_SECONDS: &str =
+    "etl_snowflake_streaming_durability_wait_seconds";
+pub(super) const ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_FAILURES_TOTAL: &str =
+    "etl_snowflake_streaming_durability_wait_failures_total";
 
 pub(super) fn register_metrics() {
     REGISTER_METRICS.call_once(|| {
@@ -29,7 +39,37 @@ pub(super) fn register_metrics() {
         describe_counter!(
             ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL,
             Unit::Count,
-            "Channel recovery count (GC'd or errored channels)"
+            "Stale channel recovery count"
+        );
+
+        describe_gauge!(
+            ETL_SNOWFLAKE_STREAMING_PENDING_BYTES,
+            Unit::Bytes,
+            "Accepted Snowflake streaming bytes awaiting durability proof"
+        );
+
+        describe_gauge!(
+            ETL_SNOWFLAKE_STREAMING_PENDING_ROW_BATCHES,
+            Unit::Count,
+            "Accepted Snowflake streaming row batches awaiting durability proof"
+        );
+
+        describe_gauge!(
+            ETL_SNOWFLAKE_STREAMING_PENDING_CHANNELS,
+            Unit::Count,
+            "Snowflake streaming channels with accepted work awaiting durability proof"
+        );
+
+        describe_histogram!(
+            ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_SECONDS,
+            Unit::Seconds,
+            "Snowflake streaming durability wait duration"
+        );
+
+        describe_counter!(
+            ETL_SNOWFLAKE_STREAMING_DURABILITY_WAIT_FAILURES_TOTAL,
+            Unit::Count,
+            "Total Snowflake streaming durability wait failures"
         );
     });
 }

--- a/crates/etl-destinations/src/snowflake/mod.rs
+++ b/crates/etl-destinations/src/snowflake/mod.rs
@@ -19,6 +19,6 @@ pub use auth::{AuthManager, HttpExchanger, TokenProvider};
 pub use client::Client;
 pub use config::Config;
 pub use encoding::{CdcMeta, CdcOperation};
-pub use error::{Error, Result};
+pub use error::{Error, Result, SnowpipeError};
 pub use sql_client::SqlClient;
 pub use streaming::{OffsetToken, RestStreamClient, RowBatch, RowBatchBuilder, StreamClient};

--- a/crates/etl-destinations/src/snowflake/streaming/batch.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/batch.rs
@@ -41,11 +41,37 @@ const SCRATCH_INITIAL_CAPACITY: usize = 4096;
 /// Nice balance between compression and processor time spend compressing.
 const ZSTD_COMPRESSION_LEVEL: i32 = 3;
 
+/// Inclusive `[a, b]` offset range for a non-empty row batch.
+struct OffsetRange {
+    start: OffsetToken,
+    end: OffsetToken,
+}
+
+/// Extension operations for an optional [`OffsetRange`].
+trait OffsetRangeExt {
+    /// Extends the range with `offset`, creating it when empty.
+    fn extend(&mut self, offset: &OffsetToken);
+}
+
+impl OffsetRangeExt for Option<OffsetRange> {
+    fn extend(&mut self, offset: &OffsetToken) {
+        match self {
+            Some(range) => {
+                debug_assert!(offset >= &range.end);
+                range.end = offset.clone();
+            }
+            None => {
+                *self = Some(OffsetRange { start: offset.clone(), end: offset.clone() });
+            }
+        }
+    }
+}
+
 /// Batch of rows ready to be pushed to the Streaming API.
 pub struct RowBatch {
     data: Bytes,
     row_count: usize,
-    offset: OffsetToken,
+    offset_range: OffsetRange,
 }
 
 impl RowBatch {
@@ -64,9 +90,14 @@ impl RowBatch {
         self.row_count
     }
 
+    /// Offset token of the first row in this batch.
+    pub fn start_offset(&self) -> &OffsetToken {
+        &self.offset_range.start
+    }
+
     /// Offset token of the last row in this batch.
-    pub fn offset(&self) -> &OffsetToken {
-        &self.offset
+    pub fn end_offset(&self) -> &OffsetToken {
+        &self.offset_range.end
     }
 }
 
@@ -79,7 +110,7 @@ pub struct RowBatchBuilder {
     encoder: Encoder<'static, Vec<u8>>,
     scratch: Vec<u8>,
     current_row_count: usize,
-    current_offset: OffsetToken,
+    current_offset_range: Option<OffsetRange>,
     input_since_flush: usize,
     batches: Vec<RowBatch>,
 }
@@ -96,7 +127,7 @@ impl RowBatchBuilder {
             encoder: new_encoder(),
             scratch: Vec::with_capacity(SCRATCH_INITIAL_CAPACITY),
             current_row_count: 0,
-            current_offset: OffsetToken::zero(),
+            current_offset_range: None,
             input_since_flush: 0,
             batches: Vec::new(),
         }
@@ -142,7 +173,7 @@ impl RowBatchBuilder {
             .map_err(|e| Error::Encoding(format!("zstd write: {e}")))?;
         self.input_since_flush += self.scratch.len();
         self.current_row_count += 1;
-        self.current_offset = offset.clone();
+        self.current_offset_range.extend(offset);
 
         Ok(())
     }
@@ -150,6 +181,7 @@ impl RowBatchBuilder {
     /// Wrap-up building process, produce list of batches.
     pub fn finish(mut self) -> Result<Vec<RowBatch>> {
         if self.current_row_count > 0 {
+            let offset_range = self.take_current_offset_range()?;
             let compressed =
                 self.encoder.finish().map_err(|e| Error::Encoding(format!("zstd finish: {e}")))?;
 
@@ -164,7 +196,7 @@ impl RowBatchBuilder {
             self.batches.push(RowBatch {
                 data: Bytes::from(compressed),
                 row_count: self.current_row_count,
-                offset: self.current_offset,
+                offset_range,
             });
         }
 
@@ -176,6 +208,7 @@ impl RowBatchBuilder {
     }
 
     fn next_batch(&mut self) -> Result<()> {
+        let offset_range = self.take_current_offset_range()?;
         let old_encoder = mem::replace(&mut self.encoder, new_encoder());
         let compressed =
             old_encoder.finish().map_err(|e| Error::Encoding(format!("zstd finish: {e}")))?;
@@ -183,13 +216,19 @@ impl RowBatchBuilder {
         self.batches.push(RowBatch {
             data: Bytes::from(compressed),
             row_count: self.current_row_count,
-            offset: mem::take(&mut self.current_offset),
+            offset_range,
         });
 
         self.current_row_count = 0;
         self.input_since_flush = 0;
 
         Ok(())
+    }
+
+    fn take_current_offset_range(&mut self) -> Result<OffsetRange> {
+        self.current_offset_range.take().ok_or_else(|| {
+            Error::Encoding("Non-empty Snowflake row batch is missing an offset range.".into())
+        })
     }
 }
 
@@ -305,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn offset_tracks_last_row() {
+    fn end_offset_tracks_last_row() {
         let cols = [col("id")];
         let mut builder = RowBatchBuilder::new();
 
@@ -320,6 +359,6 @@ mod tests {
 
         let batches = builder.finish().unwrap();
         assert_eq!(batches.len(), 1);
-        assert_eq!(batches.first().unwrap().offset().as_ref(), offsets[1]);
+        assert_eq!(batches.first().unwrap().end_offset().as_ref(), offsets[1]);
     }
 }

--- a/crates/etl-destinations/src/snowflake/streaming/channel.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/channel.rs
@@ -1,17 +1,98 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use etl::pipeline::PipelineId;
 use metrics::{counter, histogram};
-use reqwest::StatusCode;
+use tokio::time::{Instant, sleep};
 use tracing::warn;
 
 use crate::snowflake::{
-    Error, OffsetToken, Result, RowBatch, StreamClient,
+    Error, OffsetToken, Result, RowBatch, SnowpipeError, StreamClient,
     metrics::{
         ETL_SNOWFLAKE_BATCH_BYTES, ETL_SNOWFLAKE_BATCH_SIZE,
         ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL, ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL,
     },
+    streaming::ChannelStatusResponse,
 };
+
+/// Interval between Snowflake channel commit-status checks.
+///
+/// Defines how often do we retry/check.
+/// Durability barriers use this between status polls. Safe open/drop uses it
+/// between retries after Snowflake reports uncommitted channel data.
+pub(crate) const DEFAULT_COMMIT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Total wall-clock budget for waiting until accepted rows become committed.
+///
+/// If this deadline is reached, the destination returns an error instead of
+/// reporting durability or reopening/dropping a channel destructively.
+pub(crate) const DEFAULT_COMMIT_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Row batch accepted by a streaming channel.
+#[derive(Debug, Clone)]
+pub(crate) struct AcceptedRowBatch {
+    /// Final offset accepted by Snowflake for this row batch.
+    pub target_offset: OffsetToken,
+    /// Number of rows accepted in this row batch.
+    pub rows: u64,
+    /// Compressed payload bytes accepted in this row batch.
+    pub bytes: usize,
+    /// Cumulative inserted rows before the pending range began.
+    pub baseline_rows_inserted: u64,
+    /// Cumulative row errors before the pending range began.
+    pub baseline_rows_error_count: u64,
+}
+
+impl AcceptedRowBatch {
+    fn from_row_batch(
+        batch: &RowBatch,
+        baseline_rows_inserted: u64,
+        baseline_rows_error_count: u64,
+    ) -> Result<Self> {
+        Ok(Self {
+            target_offset: batch.end_offset().clone(),
+            rows: u64::try_from(batch.row_count()).map_err(|_| {
+                Error::Channel("Snowflake row batch row count overflowed u64.".into())
+            })?,
+            bytes: batch.size(),
+            baseline_rows_inserted,
+            baseline_rows_error_count,
+        })
+    }
+}
+
+/// Last durable status observed for a Snowflake channel.
+#[derive(Debug, Clone, Default)]
+struct ChannelProgress {
+    /// Last committed offset reported by Snowflake.
+    committed_offset: Option<OffsetToken>,
+    /// Cumulative inserted rows reported by Snowflake.
+    rows_inserted: u64,
+    /// Cumulative row errors reported by Snowflake.
+    rows_error_count: u64,
+}
+
+impl ChannelProgress {
+    /// Updates progress from a channel status response.
+    fn observe(&mut self, status: &ChannelStatusResponse) {
+        self.committed_offset = status.offset_token.clone();
+        self.rows_inserted = status.rows_inserted;
+        self.rows_error_count = status.rows_error_count;
+    }
+
+    /// Returns whether `offset` has already committed.
+    fn is_committed(&self, offset: &OffsetToken) -> bool {
+        self.committed_offset.as_ref().is_some_and(|committed| committed >= offset)
+    }
+}
+
+/// Result of sending one batch to Snowflake.
+#[derive(Debug)]
+enum BatchAcceptance {
+    /// Snowflake accepted ownership of the batch.
+    Accepted(AcceptedRowBatch),
+    /// The batch was already committed before the retry path resent it.
+    AlreadyCommitted,
+}
 
 /// Manages the state and lifecycle of a single Snowpipe Streaming channel.
 ///
@@ -33,11 +114,17 @@ pub(crate) struct ChannelHandle<C> {
     /// Derived channel name.
     channel: String,
 
-    /// Last offset token returned by Snowflake API (on open or insert).
-    last_offset_token: Option<OffsetToken>,
+    /// Last durable status observed for this channel.
+    progress: ChannelProgress,
 
     /// Continuation token for the next API call on this channel.
     continuation_token: Option<String>,
+
+    /// Interval between Snowflake channel commit-status checks.
+    poll_interval: Duration,
+
+    /// Maximum time to wait for Snowflake commit proof.
+    wait_timeout: Duration,
 }
 
 impl<C> Clone for ChannelHandle<C> {
@@ -48,8 +135,10 @@ impl<C> Clone for ChannelHandle<C> {
             schema: self.schema.clone(),
             table: self.table.clone(),
             channel: self.channel.clone(),
-            last_offset_token: self.last_offset_token.clone(),
+            progress: self.progress.clone(),
             continuation_token: self.continuation_token.clone(),
+            poll_interval: self.poll_interval,
+            wait_timeout: self.wait_timeout,
         }
     }
 }
@@ -70,76 +159,243 @@ impl<C: StreamClient> ChannelHandle<C> {
             schema,
             table,
             channel,
-            last_offset_token: None,
+            progress: ChannelProgress::default(),
             continuation_token: None,
+            poll_interval: DEFAULT_COMMIT_POLL_INTERVAL,
+            wait_timeout: DEFAULT_COMMIT_WAIT_TIMEOUT,
         }
     }
 
-    /// Open (or reopen) the channel.
-    ///
-    /// Idempotent, reopening preserves offset history.
-    pub async fn open(&mut self) -> Result<()> {
-        let response = self
-            .client
-            .open_channel(&self.database, &self.schema, &self.table, &self.channel)
-            .await?;
-
-        self.last_offset_token = response.offset_token;
-        self.continuation_token = Some(response.continuation_token);
-
-        Ok(())
+    #[cfg(test)]
+    fn with_wait_policy(mut self, poll_interval: Duration, wait_timeout: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self.wait_timeout = wait_timeout;
+        self
     }
 
-    /// Drop the channel.
-    ///
-    /// Committed data remains in the table.
+    /// Open or reopen the channel without discarding uncommitted rows.
+    pub async fn open(&mut self) -> Result<ChannelStatusResponse> {
+        let deadline = Instant::now() + self.wait_timeout;
+
+        loop {
+            match self
+                .client
+                .open_channel(&self.database, &self.schema, &self.table, &self.channel)
+                .await
+            {
+                Ok(response) => {
+                    self.progress.observe(&response.status);
+                    self.continuation_token = Some(response.continuation_token);
+                    return Ok(response.status);
+                }
+                Err(error @ Error::Snowpipe(SnowpipeError::ChannelHasUncommittedRows)) => {
+                    if Instant::now() >= deadline {
+                        return Err(error);
+                    }
+
+                    warn!(
+                        table = %self.table,
+                        channel = %self.channel,
+                        "waiting for Snowflake channel rows to commit before reopening"
+                    );
+                    sleep(self.poll_interval).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    /// Drop the channel without discarding uncommitted rows.
     pub async fn drop_channel(&mut self) -> Result<()> {
-        self.client.drop_channel(&self.database, &self.schema, &self.table, &self.channel).await?;
+        let deadline = Instant::now() + self.wait_timeout;
 
-        self.last_offset_token = None;
-        self.continuation_token = None;
+        loop {
+            match self
+                .client
+                .drop_channel(&self.database, &self.schema, &self.table, &self.channel)
+                .await
+            {
+                Ok(()) => {
+                    self.progress = ChannelProgress::default();
+                    self.continuation_token = None;
+                    return Ok(());
+                }
+                Err(error @ Error::Snowpipe(SnowpipeError::ChannelHasUncommittedRows)) => {
+                    if Instant::now() >= deadline {
+                        return Err(error);
+                    }
 
-        Ok(())
+                    warn!(
+                        table = %self.table,
+                        channel = %self.channel,
+                        "waiting for Snowflake channel rows to commit before dropping"
+                    );
+                    sleep(self.poll_interval).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     /// Drop and reopen the channel, resetting offsets.
     pub async fn reset(&mut self) -> Result<()> {
         self.drop_channel().await?;
-        self.open().await
+        self.open().await?;
+        Ok(())
     }
 
-    /// Send all batches, recovering from channel GC errors.
-    pub async fn process_batches(&mut self, batches: Vec<RowBatch>) -> Result<()> {
-        fn is_stale_channel(e: &Error) -> bool {
-            matches!(e, Error::Snowpipe { status_code: 4, .. })
-                || matches!(e, Error::HttpStatus { status: StatusCode::NOT_FOUND, .. })
-        }
+    /// Returns whether `offset` has already been committed.
+    pub fn is_offset_committed(&self, offset: &OffsetToken) -> bool {
+        self.progress.is_committed(offset)
+    }
 
+    /// Refreshes channel status and returns the latest status.
+    pub async fn refresh_status(&mut self) -> Result<ChannelStatusResponse> {
+        let status = self
+            .client
+            .channel_status(&self.database, &self.schema, &self.table, &self.channel)
+            .await?;
+        self.progress.observe(&status);
+        Ok(status)
+    }
+
+    /// Fetches the latest committed offset and updates cached channel progress.
+    pub async fn fetch_committed_offset(&mut self) -> Result<Option<OffsetToken>> {
+        self.refresh_status().await.map(|status| status.offset_token)
+    }
+
+    /// Send all batches with immediate append-ack semantics.
+    ///
+    /// This is kept for table-copy callers. Copy rows do not carry stable WAL
+    /// offsets, so streaming committed-offset filtering and deferred
+    /// durability tracking must not be applied here (just yet).
+    pub async fn send_table_copy_batches(&mut self, batches: Vec<RowBatch>) -> Result<()> {
         for batch in &batches {
             histogram!(ETL_SNOWFLAKE_BATCH_SIZE).record(batch.row_count() as f64);
             histogram!(ETL_SNOWFLAKE_BATCH_BYTES).record(batch.size() as f64);
 
-            match self.send_batch(batch).await {
+            match self.append_batch(batch).await {
                 Ok(()) => {}
-                // If channel is stale, try to reopen it, once.
-                Err(e) if is_stale_channel(&e) => {
+                Err(Error::Snowpipe(error)) if error.is_reopenable_channel_error() => {
                     counter!(ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL).increment(1);
-                    warn!(table = %self.table, "channel was closed, reopenning and retrying insert");
+                    warn!(
+                        table = %self.table,
+                        channel = %self.channel,
+                        "channel was stale, reopening and retrying insert"
+                    );
                     self.open().await?;
-                    self.send_batch(batch).await?;
+                    self.append_batch(batch).await?;
                 }
-                Err(e) => {
+                Err(error) => {
                     counter!(ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL).increment(1);
-                    return Err(e);
+                    return Err(error);
                 }
             }
         }
+
         Ok(())
     }
 
-    async fn send_batch(&mut self, batch: &RowBatch) -> Result<()> {
+    /// Accept streaming batches, returning accepted-but-not-durable metadata.
+    pub async fn accept_streaming_batches(
+        &mut self,
+        batches: Vec<RowBatch>,
+    ) -> Result<Vec<AcceptedRowBatch>> {
+        let mut accepted = Vec::new();
+        for batch in &batches {
+            match self.accept_streaming_batch(batch).await? {
+                BatchAcceptance::Accepted(batch) => accepted.push(batch),
+                BatchAcceptance::AlreadyCommitted => {}
+            }
+        }
+
+        Ok(accepted)
+    }
+
+    async fn accept_streaming_batch(&mut self, batch: &RowBatch) -> Result<BatchAcceptance> {
+        if self.progress.is_committed(batch.end_offset()) {
+            return Ok(BatchAcceptance::AlreadyCommitted);
+        }
+
+        if self.progress.is_committed(batch.start_offset()) {
+            return Err(Error::Channel(format!(
+                "Snowflake batch {}..={} overlaps committed offset {:?}; replay filtering should \
+                 remove committed rows before batching.",
+                batch.start_offset(),
+                batch.end_offset(),
+                self.progress.committed_offset
+            )));
+        }
+
+        let baseline_rows_inserted = self.progress.rows_inserted;
+        let baseline_rows_error_count = self.progress.rows_error_count;
+
+        histogram!(ETL_SNOWFLAKE_BATCH_SIZE).record(batch.row_count() as f64);
+        histogram!(ETL_SNOWFLAKE_BATCH_BYTES).record(batch.size() as f64);
+
+        match self.append_batch(batch).await {
+            Ok(()) => Ok(BatchAcceptance::Accepted(AcceptedRowBatch::from_row_batch(
+                batch,
+                baseline_rows_inserted,
+                baseline_rows_error_count,
+            )?)),
+            Err(Error::Snowpipe(SnowpipeError::StaleContinuation)) => {
+                counter!(ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL).increment(1);
+                warn!(
+                    table = %self.table,
+                    channel = %self.channel,
+                    "channel was stale, reopening and retrying insert"
+                );
+                let status = self.open().await?;
+
+                if status
+                    .offset_token
+                    .as_ref()
+                    .is_some_and(|committed| committed >= batch.end_offset())
+                {
+                    let accepted = AcceptedRowBatch::from_row_batch(
+                        batch,
+                        baseline_rows_inserted,
+                        baseline_rows_error_count,
+                    )?;
+                    validate_committed_status(&status, &accepted)?;
+                    return Ok(BatchAcceptance::AlreadyCommitted);
+                }
+
+                if status
+                    .offset_token
+                    .as_ref()
+                    .is_some_and(|committed| committed >= batch.start_offset())
+                {
+                    return Err(Error::Channel(format!(
+                        "Snowflake stale-channel recovery found committed offset {:?} inside \
+                         batch {}..={}; failing closed for upstream replay.",
+                        self.progress.committed_offset,
+                        batch.start_offset(),
+                        batch.end_offset()
+                    )));
+                }
+
+                let baseline_rows_inserted = self.progress.rows_inserted;
+                let baseline_rows_error_count = self.progress.rows_error_count;
+                self.append_batch(batch).await?;
+
+                Ok(BatchAcceptance::Accepted(AcceptedRowBatch::from_row_batch(
+                    batch,
+                    baseline_rows_inserted,
+                    baseline_rows_error_count,
+                )?))
+            }
+            Err(error) => {
+                counter!(ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL).increment(1);
+                Err(error)
+            }
+        }
+    }
+
+    async fn append_batch(&mut self, batch: &RowBatch) -> Result<()> {
         let ct = self.continuation_token.as_deref().ok_or_else(|| {
-            Error::Channel("send_batch called on channel without continuation token".into())
+            Error::Channel("append_batch called on channel without continuation token".into())
         })?;
 
         let response = self
@@ -148,18 +404,36 @@ impl<C: StreamClient> ChannelHandle<C> {
             .await?;
 
         self.continuation_token = Some(response.continuation_token);
-        self.last_offset_token = Some(batch.offset().clone());
 
         Ok(())
     }
+}
 
-    /// Last offset token committed by Snowflake for this channel.
-    pub async fn committed_offset(&self) -> Result<Option<OffsetToken>> {
-        let status = self
-            .client
-            .channel_status(&self.database, &self.schema, &self.table, &self.channel)
-            .await?;
-
-        Ok(status.offset_token)
+/// Validates that a channel status has not rejected rows for an accepted range.
+pub(crate) fn validate_committed_status(
+    status: &ChannelStatusResponse,
+    accepted: &AcceptedRowBatch,
+) -> Result<()> {
+    if status.rows_error_count > accepted.baseline_rows_error_count {
+        return Err(Error::Channel(format!(
+            "Snowflake channel {} rejected rows while committing offset {}.",
+            status.channel, accepted.target_offset
+        )));
     }
+
+    if status.offset_token.as_ref().is_some_and(|committed| committed >= &accepted.target_offset) {
+        let expected_rows_inserted =
+            accepted.baseline_rows_inserted.checked_add(accepted.rows).ok_or_else(|| {
+                Error::Channel("Snowflake expected inserted row count overflowed.".into())
+            })?;
+        if status.rows_inserted < expected_rows_inserted {
+            return Err(Error::Channel(format!(
+                "Snowflake channel {} committed offset {} without inserting all accepted rows: \
+                 expected at least {expected_rows_inserted}, got {}.",
+                status.channel, accepted.target_offset, status.rows_inserted
+            )));
+        }
+    }
+
+    Ok(())
 }

--- a/crates/etl-destinations/src/snowflake/streaming/channel.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/channel.rs
@@ -166,13 +166,6 @@ impl<C: StreamClient> ChannelHandle<C> {
         }
     }
 
-    #[cfg(test)]
-    fn with_wait_policy(mut self, poll_interval: Duration, wait_timeout: Duration) -> Self {
-        self.poll_interval = poll_interval;
-        self.wait_timeout = wait_timeout;
-        self
-    }
-
     /// Open or reopen the channel without discarding uncommitted rows.
     pub async fn open(&mut self) -> Result<ChannelStatusResponse> {
         let deadline = Instant::now() + self.wait_timeout;

--- a/crates/etl-destinations/src/snowflake/streaming/mod.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/mod.rs
@@ -7,7 +7,10 @@ mod rest_client;
 use std::future::Future;
 
 pub use batch::{RowBatch, RowBatchBuilder};
-pub(crate) use channel::ChannelHandle;
+pub(crate) use channel::{
+    AcceptedRowBatch, ChannelHandle, DEFAULT_COMMIT_POLL_INTERVAL, DEFAULT_COMMIT_WAIT_TIMEOUT,
+    validate_committed_status,
+};
 pub use offset_token::OffsetToken;
 pub use rest_client::RestStreamClient;
 
@@ -25,6 +28,9 @@ pub struct OpenChannelResponse {
     ///
     /// `None` if the channel has never committed data.
     pub offset_token: Option<OffsetToken>,
+
+    /// Channel status returned by Snowflake when the channel was opened.
+    pub status: ChannelStatusResponse,
 }
 
 /// Response from inserting rows into a channel.
@@ -35,7 +41,7 @@ pub struct InsertRowsResponse {
 }
 
 /// Per-channel status from a bulk status check.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ChannelStatusResponse {
     /// Channel name.
     pub channel: String,
@@ -45,6 +51,21 @@ pub struct ChannelStatusResponse {
 
     /// Last committed offset token, or `None` if no data has been committed.
     pub offset_token: Option<OffsetToken>,
+
+    /// Total rows successfully inserted through this channel.
+    pub rows_inserted: u64,
+
+    /// Total rows parsed through this channel.
+    pub rows_parsed: u64,
+
+    /// Total rows rejected by this channel.
+    pub rows_error_count: u64,
+
+    /// Upper bound of the offset range containing the latest row error.
+    pub last_error_offset_upper_bound: Option<OffsetToken>,
+
+    /// Message for the latest row error, when Snowflake reports one.
+    pub last_error_message: Option<String>,
 }
 
 /// Abstraction over Snowpipe Streaming ingestion backends.

--- a/crates/etl-destinations/src/snowflake/streaming/offset_token.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/offset_token.rs
@@ -7,7 +7,7 @@ use crate::snowflake::{Error, Result};
 /// An offset token encoding a WAL position as a hex string.
 ///
 /// Format: `{commit_lsn:016x}/{tx_ordinal:016x}`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OffsetToken(String);
 
 impl OffsetToken {
@@ -61,8 +61,43 @@ impl FromStr for OffsetToken {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
+        if !is_canonical_offset_token(s) {
+            return Err(Error::Channel(format!("invalid offset token format: {s}")));
+        }
+
         let token = OffsetToken(s.to_owned());
         token.decode()?;
         Ok(token)
+    }
+}
+
+fn is_canonical_offset_token(s: &str) -> bool {
+    let Some((lsn_hex, ordinal_hex)) = s.split_once('/') else {
+        return false;
+    };
+
+    lsn_hex.len() == 16
+        && ordinal_hex.len() == 16
+        && lsn_hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && ordinal_hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use etl::schema::PgLsn;
+
+    use super::*;
+
+    #[test]
+    fn orders_by_lsn_then_transaction_ordinal() {
+        let low_lsn_high_ordinal = OffsetToken::new(PgLsn::from(10), 99);
+        let high_lsn_low_ordinal = OffsetToken::new(PgLsn::from(11), 0);
+        let same_lsn_low_ordinal = OffsetToken::new(PgLsn::from(11), 1);
+        let same_lsn_high_ordinal = OffsetToken::new(PgLsn::from(11), 2);
+
+        assert!(high_lsn_low_ordinal > low_lsn_high_ordinal);
+        assert!(same_lsn_high_ordinal > same_lsn_low_ordinal);
+        assert!(same_lsn_high_ordinal >= same_lsn_low_ordinal);
+        assert!(same_lsn_low_ordinal < same_lsn_high_ordinal);
     }
 }

--- a/crates/etl-destinations/src/snowflake/streaming/rest_client.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/rest_client.rs
@@ -8,7 +8,7 @@ use tracing::{debug, warn};
 use crate::{
     retry::{RetryDecision, RetryPolicy, retry_with_backoff},
     snowflake::{
-        Error, Result,
+        Error, Result, SnowpipeError,
         auth::TokenProvider,
         streaming::{
             ChannelStatusResponse, InsertRowsResponse, OffsetToken, OpenChannelResponse, RowBatch,
@@ -133,7 +133,7 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
                         .bearer_auth(&token)
                         .header("User-Agent", USER_AGENT)
                         .header("Content-Type", "application/json")
-                        .body("{}")
+                        .json(&ChannelLifecycleRequest::new())
                         .send()
                         .await
                         .map_err(Error::HttpTransport)?;
@@ -145,30 +145,32 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
                             warn!("received 401 from Snowpipe Streaming API, invalidating token");
                             auth.invalidate_token().await;
                         }
-                        return Err(Error::HttpStatus { status, body });
+                        return Err(SnowpipeError::from_response(status, body).into());
                     }
 
                     let response: OpenChannelApiResponse = resp.json().await.map_err(|e| {
                         Error::Encoding(format!("failed to parse open_channel response: {e}"))
                     })?;
 
-                    if let Some(ref status) = response.channel_status
-                        && let Some(ref code) = status.channel_status_code
-                    {
+                    let status = response.channel_status.ok_or_else(|| {
+                        Error::Encoding("open_channel response missing channel_status".into())
+                    })?;
+
+                    if let Some(ref code) = status.channel_status_code {
                         let is_ok = code == "SUCCESS" || code == "ACTIVE" || code == "0";
                         if !is_ok {
                             let msg = format!("open_channel returned unexpected status: {code}");
-                            return Err(Error::Snowpipe { status_code: 1, message: msg });
+                            return Err(
+                                SnowpipeError::ApiStatus { status_code: 1, message: msg }.into()
+                            );
                         }
                     }
 
+                    let status = status.into_channel_status(channel)?;
                     Ok(OpenChannelResponse {
                         continuation_token: response.next_continuation_token,
-                        offset_token: response
-                            .channel_status
-                            .and_then(|cs| cs.last_committed_offset_token)
-                            .map(|s| s.parse::<OffsetToken>())
-                            .transpose()?,
+                        offset_token: status.offset_token.clone(),
+                        status,
                     })
                 }
             },
@@ -190,10 +192,7 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
         let base_url = insert_url(host, database, schema, table, channel);
 
         let compressed = batch.bytes().clone();
-        let query_params = [
-            ("continuationToken", continuation_token.to_owned()),
-            ("offsetToken", batch.offset().as_ref().to_owned()),
-        ];
+        let query_params = insert_query_params(batch, continuation_token);
 
         let auth = Arc::clone(&self.auth);
         let http = self.http.clone();
@@ -203,7 +202,7 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
             should_retry,
             |d| d,
             |attempt| {
-                if matches!(attempt.error, Error::Snowpipe { status_code: 3, .. }) {
+                if matches!(attempt.error, Error::Snowpipe(SnowpipeError::AuthenticationExpired)) {
                     debug!("auth error on insert_rows, token will be refreshed on retry");
                 }
                 warn!(
@@ -237,19 +236,15 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
                     let status = resp.status();
                     if status != StatusCode::OK {
                         let body = resp.text().await.unwrap_or_default();
+                        let error = SnowpipeError::from_response(status, body);
                         if status == StatusCode::UNAUTHORIZED {
                             warn!("received 401 from Snowpipe Streaming API, invalidating token");
                             auth.invalidate_token().await;
                         }
-                        if let Ok(err_resp) = serde_json::from_str::<SnowpipeErrorResponse>(&body)
-                            && let Some(code) = err_resp.status_code
-                        {
-                            if code == 3 {
-                                auth.invalidate_token().await;
-                            }
-                            return Err(Error::Snowpipe { status_code: code, message: body });
+                        if error.is_authentication_expired() {
+                            auth.invalidate_token().await;
                         }
-                        return Err(Error::HttpStatus { status, body });
+                        return Err(error.into());
                     }
 
                     let response: InsertRowsApiResponse = resp.json().await.map_err(|e| {
@@ -300,6 +295,7 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
                         .delete(&url)
                         .bearer_auth(&token)
                         .header("User-Agent", USER_AGENT)
+                        .json(&ChannelLifecycleRequest::new())
                         .send()
                         .await
                         .map_err(Error::HttpTransport)?;
@@ -311,7 +307,7 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
                             warn!("received 401 from Snowpipe Streaming API, invalidating token");
                             auth.invalidate_token().await;
                         }
-                        return Err(Error::HttpStatus { status, body });
+                        return Err(SnowpipeError::from_response(status, body).into());
                     }
                     Ok(())
                 }
@@ -372,7 +368,7 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
                             warn!("received 401 from Snowpipe Streaming API, invalidating token");
                             auth.invalidate_token().await;
                         }
-                        return Err(Error::HttpStatus { status, body });
+                        return Err(SnowpipeError::from_response(status, body).into());
                     }
 
                     let response: BulkStatusApiResponse = resp.json().await.map_err(|e| {
@@ -381,16 +377,7 @@ impl<T: TokenProvider + 'static> StreamClient for RestStreamClient<T> {
 
                     response.channel_statuses.into_iter().next().map_or_else(
                         || Err(Error::Channel("channel not found in status response".into())),
-                        |(name, ch)| {
-                            Ok(ChannelStatusResponse {
-                                channel: name,
-                                status_code: ch.channel_status_code.unwrap_or_default(),
-                                offset_token: ch
-                                    .last_committed_offset_token
-                                    .map(|s| s.parse::<OffsetToken>())
-                                    .transpose()?,
-                            })
-                        },
+                        |(name, ch)| ch.into_channel_status(&name),
                     )
                 }
             },
@@ -422,34 +409,60 @@ fn channel_status_url(host: &str, db: &str, schema: &str, table: &str) -> String
     format!("{host}/v2/streaming/databases/{db}/schemas/{schema}/pipes/{pipe}:bulk-channel-status")
 }
 
+fn insert_query_params(batch: &RowBatch, continuation_token: &str) -> [(&'static str, String); 3] {
+    [
+        ("continuationToken", continuation_token.to_owned()),
+        ("startOffsetToken", batch.start_offset().as_ref().to_owned()),
+        ("endOffsetToken", batch.end_offset().as_ref().to_owned()),
+    ]
+}
+
 fn should_retry(error: &Error) -> RetryDecision {
     match error {
-        Error::Snowpipe { status_code, .. } => match *status_code {
-            0 => RetryDecision::Stop,
-            1 | 5 | 6 => RetryDecision::Retry,
-            3 => RetryDecision::Retry,
-            2 | 4 => RetryDecision::Stop,
-            _ => RetryDecision::Retry,
+        Error::Snowpipe(error) => match error {
+            SnowpipeError::AuthenticationExpired => RetryDecision::Retry,
+            SnowpipeError::StaleContinuation
+            | SnowpipeError::ChannelHasUncommittedRows
+            | SnowpipeError::ChannelNotFound => RetryDecision::Stop,
+            SnowpipeError::ApiStatus { status_code, .. } => match *status_code {
+                0 | 2 | 4 => RetryDecision::Stop,
+                1 | 3 | 5 | 6 => RetryDecision::Retry,
+                _ => RetryDecision::Retry,
+            },
+            SnowpipeError::HttpStatus { status, .. } => http_status_retry_decision(*status),
         },
         Error::HttpTransport(_) => RetryDecision::Retry,
-        Error::HttpStatus { status, .. } => {
-            if *status == StatusCode::UNAUTHORIZED
-                || *status == StatusCode::REQUEST_TIMEOUT
-                || *status == StatusCode::TOO_MANY_REQUESTS
-                || status.is_server_error()
-            {
-                RetryDecision::Retry
-            } else {
-                RetryDecision::Stop
-            }
-        }
+        Error::HttpStatus { status, .. } => http_status_retry_decision(*status),
         _ => RetryDecision::Stop,
+    }
+}
+
+fn http_status_retry_decision(status: StatusCode) -> RetryDecision {
+    if status == StatusCode::UNAUTHORIZED
+        || status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+    {
+        RetryDecision::Retry
+    } else {
+        RetryDecision::Stop
     }
 }
 
 #[derive(Deserialize)]
 struct HostnameResponse {
     hostname: String,
+}
+
+#[derive(Serialize)]
+struct ChannelLifecycleRequest {
+    fail_on_uncommitted_rows: bool,
+}
+
+impl ChannelLifecycleRequest {
+    fn new() -> Self {
+        Self { fail_on_uncommitted_rows: true }
+    }
 }
 
 #[derive(Deserialize)]
@@ -462,20 +475,43 @@ struct OpenChannelApiResponse {
 #[derive(Deserialize)]
 struct ChannelStatusDetail {
     #[serde(default)]
+    channel_name: Option<String>,
+    #[serde(default)]
     channel_status_code: Option<String>,
     #[serde(default)]
     last_committed_offset_token: Option<String>,
+    #[serde(default)]
+    rows_inserted: u64,
+    #[serde(default)]
+    rows_parsed: u64,
+    #[serde(default, alias = "rows_errors")]
+    rows_error_count: u64,
+    #[serde(default)]
+    last_error_offset_upper_bound: Option<String>,
+    #[serde(default)]
+    last_error_message: Option<String>,
+}
+
+impl ChannelStatusDetail {
+    fn into_channel_status(self, fallback_channel: &str) -> Result<ChannelStatusResponse> {
+        Ok(ChannelStatusResponse {
+            channel: self.channel_name.unwrap_or_else(|| fallback_channel.to_owned()),
+            status_code: self.channel_status_code.unwrap_or_default(),
+            offset_token: parse_optional_offset_token(self.last_committed_offset_token)?,
+            rows_inserted: self.rows_inserted,
+            rows_parsed: self.rows_parsed,
+            rows_error_count: self.rows_error_count,
+            last_error_offset_upper_bound: parse_optional_offset_token(
+                self.last_error_offset_upper_bound,
+            )?,
+            last_error_message: self.last_error_message,
+        })
+    }
 }
 
 #[derive(Deserialize)]
 struct InsertRowsApiResponse {
     next_continuation_token: String,
-}
-
-#[derive(Deserialize)]
-struct SnowpipeErrorResponse {
-    #[serde(default)]
-    status_code: Option<u32>,
 }
 
 #[derive(Serialize)]
@@ -495,6 +531,39 @@ struct BulkStatusChannel {
     channel_status_code: Option<String>,
     #[serde(default)]
     last_committed_offset_token: Option<String>,
+    #[serde(default)]
+    channel_name: Option<String>,
+    #[serde(default)]
+    rows_inserted: u64,
+    #[serde(default)]
+    rows_parsed: u64,
+    #[serde(default, alias = "rows_errors")]
+    rows_error_count: u64,
+    #[serde(default)]
+    last_error_offset_upper_bound: Option<String>,
+    #[serde(default)]
+    last_error_message: Option<String>,
+}
+
+impl BulkStatusChannel {
+    fn into_channel_status(self, fallback_channel: &str) -> Result<ChannelStatusResponse> {
+        Ok(ChannelStatusResponse {
+            channel: self.channel_name.unwrap_or_else(|| fallback_channel.to_owned()),
+            status_code: self.channel_status_code.unwrap_or_default(),
+            offset_token: parse_optional_offset_token(self.last_committed_offset_token)?,
+            rows_inserted: self.rows_inserted,
+            rows_parsed: self.rows_parsed,
+            rows_error_count: self.rows_error_count,
+            last_error_offset_upper_bound: parse_optional_offset_token(
+                self.last_error_offset_upper_bound,
+            )?,
+            last_error_message: self.last_error_message,
+        })
+    }
+}
+
+fn parse_optional_offset_token(token: Option<String>) -> Result<Option<OffsetToken>> {
+    token.filter(|token| !token.is_empty()).map(|token| token.parse::<OffsetToken>()).transpose()
 }
 
 #[cfg(test)]
@@ -503,6 +572,7 @@ mod tests {
         data::{Cell, TableRow},
         schema::{ColumnSchema, Type},
     };
+    use serde_json::json;
 
     use super::*;
     use crate::snowflake::{
@@ -512,7 +582,9 @@ mod tests {
 
     #[test]
     fn should_retry_decision() {
-        let snowpipe = |code| Error::Snowpipe { status_code: code, message: "test".into() };
+        let snowpipe = |code| {
+            Error::Snowpipe(SnowpipeError::ApiStatus { status_code: code, message: "test".into() })
+        };
 
         assert_eq!(should_retry(&snowpipe(0)), RetryDecision::Stop);
         assert_eq!(should_retry(&snowpipe(1)), RetryDecision::Retry);
@@ -531,6 +603,14 @@ mod tests {
         assert_eq!(should_retry(&http(StatusCode::UNAUTHORIZED)), RetryDecision::Retry);
         assert_eq!(should_retry(&http(StatusCode::BAD_REQUEST)), RetryDecision::Stop);
 
+        assert_eq!(
+            should_retry(&Error::Snowpipe(SnowpipeError::AuthenticationExpired)),
+            RetryDecision::Retry
+        );
+        assert_eq!(
+            should_retry(&Error::Snowpipe(SnowpipeError::StaleContinuation)),
+            RetryDecision::Stop
+        );
         assert_eq!(should_retry(&Error::Auth("expired".into())), RetryDecision::Stop);
     }
 
@@ -592,5 +672,87 @@ mod tests {
         let line = text.trim();
         let val: serde_json::Value = serde_json::from_str(line).unwrap();
         assert_eq!(val["id"], 42);
+    }
+
+    #[test]
+    fn insert_query_params_include_start_and_end_offsets() {
+        let cols = [ColumnSchema::new("id".into(), Type::INT4, -1, 1, true)];
+        let start: OffsetToken = "000000000000000a/0000000000000001".parse().unwrap();
+        let end: OffsetToken = "000000000000000a/0000000000000002".parse().unwrap();
+        let mut builder = RowBatchBuilder::new();
+        builder
+            .push_row(
+                &cols,
+                &TableRow::new(vec![Cell::I32(1)]),
+                CdcMeta::new(CdcOperation::Insert, start.as_ref()),
+                &start,
+            )
+            .unwrap();
+        builder
+            .push_row(
+                &cols,
+                &TableRow::new(vec![Cell::I32(2)]),
+                CdcMeta::new(CdcOperation::Insert, end.as_ref()),
+                &end,
+            )
+            .unwrap();
+        let batch = builder.finish().unwrap().pop().unwrap();
+
+        let params = insert_query_params(&batch, "ct0");
+
+        assert_eq!(
+            params,
+            [
+                ("continuationToken", "ct0".to_owned()),
+                ("startOffsetToken", start.as_ref().to_owned()),
+                ("endOffsetToken", end.as_ref().to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn channel_status_parsers_accept_documented_status_fields() {
+        // Open Channel has row errors as `rows_error_count` in Snowflake API docs.
+        let detail: ChannelStatusDetail = serde_json::from_value(json!({
+            "channel_name": "ch0",
+            "channel_status_code": "ACTIVE",
+            "last_committed_offset_token": "000000000000000a/0000000000000002",
+            "rows_inserted": 12,
+            "rows_parsed": 13,
+            "rows_error_count": 1,
+            "last_error_offset_upper_bound": "000000000000000a/0000000000000003",
+            "last_error_message": "row rejected"
+        }))
+        .unwrap();
+
+        let status = detail.into_channel_status("fallback").unwrap();
+
+        assert_eq!(status.channel, "ch0");
+        assert_eq!(status.status_code, "ACTIVE");
+        assert_eq!(status.offset_token, Some("000000000000000a/0000000000000002".parse().unwrap()));
+        assert_eq!(status.rows_inserted, 12);
+        assert_eq!(status.rows_parsed, 13);
+        assert_eq!(status.rows_error_count, 1);
+        assert_eq!(
+            status.last_error_offset_upper_bound,
+            Some("000000000000000a/0000000000000003".parse().unwrap())
+        );
+        assert_eq!(status.last_error_message.as_deref(), Some("row rejected"));
+
+        // Bulk Get Channel Status documents the same counter as `rows_errors`.
+        let detail: BulkStatusChannel = serde_json::from_value(json!({
+            "last_committed_offset_token": "000000000000000a/0000000000000002",
+            "rows_inserted": 12,
+            "rows_parsed": 13,
+            "rows_errors": 2
+        }))
+        .unwrap();
+
+        let status = detail.into_channel_status("fallback").unwrap();
+
+        assert_eq!(status.channel, "fallback");
+        assert_eq!(status.rows_inserted, 12);
+        assert_eq!(status.rows_parsed, 13);
+        assert_eq!(status.rows_error_count, 2);
     }
 }

--- a/crates/etl-destinations/tests/snowflake/common.rs
+++ b/crates/etl-destinations/tests/snowflake/common.rs
@@ -46,7 +46,7 @@ where
             tokio::time::sleep(interval).await;
         }
 
-        if let Ok(Some(offset)) = destination.committed_offset(table_id).await
+        if let Ok(Some(offset)) = destination.fetch_committed_offset(table_id).await
             && &offset == expected
         {
             return Some(offset);


### PR DESCRIPTION
## Summary

- implement Snowflake streaming deferred durability using `Accepted` until Snowpipe channel status proves commit
- track compact pending durability targets per channel instead of retaining accepted rows
- add safe channel lifecycle handling with `fail_on_uncommitted_rows=true` (so, that channel re/openning is non-destructive)
- add cumulative offset handling, replay filtering, stale continuation recovery, and row/error counter validation
- force durability barriers for real schema changes and truncates

## Notes

Table-copy durability is intentionally unchanged.