### PR TITLE
feat(etl): Add scripted fault injection for destination tests

### DIFF
--- a/crates/etl/src/test_utils/faults.rs
+++ b/crates/etl/src/test_utils/faults.rs
@@ -28,17 +28,19 @@ use crate::{
 /// Destination operation a fault applies to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FaultyOp {
+    /// The `startup` hook during pipeline startup.
     Startup,
+    /// The `drop_table_for_copy` call before a table copy restarts.
     DropTableForCopy,
+    /// The `write_table_rows` calls of the initial table copy.
     WriteTableRows,
+    /// The `write_events` calls of streaming replication.
     WriteEvents,
+    /// The `shutdown` call at pipeline shutdown.
     Shutdown,
 }
 
 /// Error details injected by a fault, materialized at fire time.
-///
-/// Stored as kind plus message because [`EtlError`] is not reusable across
-/// firings. The kind matters: retry policy derives from it.
 #[derive(Debug, Clone)]
 pub struct InjectedError {
     kind: ErrorKind,
@@ -225,17 +227,17 @@ mod tests {
 
     #[tokio::test]
     async fn injector_returns_none_without_scripted_faults() {
-        // --- GIVEN: an injector with no faults ---
+        // GIVEN: an injector with no faults
         let injector = FaultInjector::new();
 
-        // --- THEN: every operation passes through ---
+        // THEN: every operation passes through
         assert!(injector.next(FaultyOp::WriteEvents).await.is_none());
         assert!(injector.next(FaultyOp::Shutdown).await.is_none());
     }
 
     #[tokio::test]
     async fn injector_consumes_faults_in_fifo_order_per_operation() {
-        // --- GIVEN: two faults on write_events and one on shutdown ---
+        // GIVEN: two faults on write_events and one on shutdown
         let injector = FaultInjector::new();
         injector
             .inject(
@@ -256,64 +258,64 @@ mod tests {
             )
             .await;
 
-        // --- WHEN: write_events faults are consumed ---
+        // WHEN: write_events faults are consumed
         let first = injector.next(FaultyOp::WriteEvents).await;
         let second = injector.next(FaultyOp::WriteEvents).await;
         let third = injector.next(FaultyOp::WriteEvents).await;
 
-        // --- THEN: they fire in injection order, then the queue is empty ---
+        // THEN: they fire in injection order, then the queue is empty
         assert!(matches!(first, Some(FaultAction::FailDispatch(_))));
         assert!(matches!(second, Some(FaultAction::FailResult(_))));
         assert!(third.is_none());
 
-        // --- THEN: the shutdown queue is independent ---
+        // THEN: the shutdown queue is independent
         assert!(injector.next(FaultyOp::Shutdown).await.is_some());
     }
 
     #[tokio::test]
     async fn injected_error_carries_kind_and_message() {
-        // --- GIVEN: an injected error ---
+        // GIVEN: an injected error
         let injected = InjectedError::new(ErrorKind::DestinationTimeout, "boom");
 
-        // --- WHEN: it fires ---
+        // WHEN: it fires
         let err = injected.to_etl_error();
 
-        // --- THEN: the error carries the injected kind and message ---
+        // THEN: the error carries the injected kind and message
         assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
         assert_eq!(err.detail(), Some("boom"));
     }
 
     #[tokio::test]
     async fn hold_gate_passes_captured_result_through_on_release_ok() {
-        // --- GIVEN: a held operation whose inner result is Ok(42) ---
+        // GIVEN: a held operation whose inner result is Ok(42)
         let (action, handle) = FaultAction::hold();
         let FaultAction::HoldResult(gate) = action else {
             panic!("hold() must produce a HoldResult action");
         };
         let held = tokio::spawn(gate.apply(Ok::<_, EtlError>(42)));
 
-        // --- WHEN: the test observes the hold and releases it ---
+        // WHEN: the test observes the hold and releases it
         handle.wait_reached().await;
         handle.release_ok();
 
-        // --- THEN: the captured inner result passes through unchanged ---
+        // THEN: the captured inner result passes through unchanged
         assert_eq!(held.await.unwrap().unwrap(), 42);
     }
 
     #[tokio::test]
     async fn hold_gate_replaces_result_on_release_err() {
-        // --- GIVEN: a held operation whose inner result is Ok ---
+        // GIVEN: a held operation whose inner result is Ok
         let (action, handle) = FaultAction::hold();
         let FaultAction::HoldResult(gate) = action else {
             panic!("hold() must produce a HoldResult action");
         };
         let held = tokio::spawn(gate.apply(Ok::<_, EtlError>(())));
 
-        // --- WHEN: the test releases it with an injected error ---
+        // WHEN: the test releases it with an injected error
         handle.wait_reached().await;
         handle.release_err(ErrorKind::DestinationConnectionFailed, "lost response");
 
-        // --- THEN: the injected error replaces the inner result ---
+        // THEN: the injected error replaces the inner result
         let err = held.await.unwrap().unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationConnectionFailed);
         assert_eq!(err.detail(), Some("lost response"));
@@ -321,21 +323,21 @@ mod tests {
 
     #[tokio::test]
     async fn apply_result_fault_passes_through_or_replaces_the_inner_result() {
-        // --- GIVEN: an inner result of Ok(7) ---
-        // --- WHEN: no fault is scripted ---
+        // GIVEN: an inner result of Ok(7)
+        // WHEN: no fault is scripted
         let ok = apply_result_fault(None, Ok::<_, EtlError>(7)).await;
 
-        // --- THEN: the inner result passes through unchanged ---
+        // THEN: the inner result passes through unchanged
         assert_eq!(ok.unwrap(), 7);
 
-        // --- WHEN: a result failure is scripted ---
+        // WHEN: a result failure is scripted
         let failed = apply_result_fault(
             Some(FaultAction::fail_result(ErrorKind::DestinationTimeout, "late boom")),
             Ok::<_, EtlError>(7),
         )
         .await;
 
-        // --- THEN: the injected error replaces the inner result ---
+        // THEN: the injected error replaces the inner result
         let err = failed.unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
         assert_eq!(err.detail(), Some("late boom"));
@@ -343,17 +345,17 @@ mod tests {
 
     #[tokio::test]
     async fn hold_gate_fails_loudly_when_handle_dropped_without_release() {
-        // --- GIVEN: a hold whose handle is dropped without releasing ---
+        // GIVEN: a hold whose handle is dropped without releasing
         let (action, handle) = FaultAction::hold();
         let FaultAction::HoldResult(gate) = action else {
             panic!("hold() must produce a HoldResult action");
         };
         drop(handle);
 
-        // --- WHEN: the held operation applies ---
+        // WHEN: the held operation applies
         let result = gate.apply(Ok::<_, EtlError>(())).await;
 
-        // --- THEN: it fails instead of unblocking silently ---
+        // THEN: it fails instead of unblocking silently
         assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidState);
     }
 }

--- a/crates/etl/src/test_utils/faults.rs
+++ b/crates/etl/src/test_utils/faults.rs
@@ -2,11 +2,11 @@
 //!
 //! Destinations report through two channels: the method return value
 //! (dispatch) and the async result handle (completion). Faults target either
-//! channel: [`FaultAction::FailDispatch`] rejects work before the inner
-//! destination runs, while the result actions let the inner destination run
-//! and then fail, hold, or delay what the apply loop observes. Faults are
-//! queued FIFO per operation and consumed one per call; an empty queue means
-//! fully transparent behavior.
+//! channel: [`FaultAction::Reject`] refuses work before the inner destination
+//! runs, while the response actions let the inner destination run and then
+//! fail, hold, or delay what the apply loop observes. Faults are queued FIFO
+//! per operation and consumed one per call; an empty queue means fully
+//! transparent behavior.
 
 use std::{
     collections::{HashMap, VecDeque},
@@ -62,37 +62,44 @@ impl InjectedError {
 /// Scripted fault behavior, consumed FIFO per operation.
 #[derive(Debug)]
 pub enum FaultAction {
-    /// The method returns `Err` immediately; the inner destination never runs.
-    FailDispatch(InjectedError),
-    /// The inner destination runs; its async result is replaced with `Err`.
+    /// The destination refuses the work; the method returns `Err` and the
+    /// inner destination never runs.
+    Reject(InjectedError),
+    /// The inner destination does the work, then reports failure.
     ///
     /// This models the lost-response ambiguity: the destination applied the
     /// write but the apply loop observes a failure.
-    FailResult(InjectedError),
-    /// The inner destination runs; its async result is withheld until the
-    /// paired [`HoldHandle`] releases it.
-    HoldResult(HoldGate),
-    /// The inner destination runs; its async result is delayed.
-    DelayResult(Duration),
+    FailAfterWrite(InjectedError),
+    /// The inner destination does the work, then never answers until the
+    /// paired [`HoldHandle`] releases the response.
+    HoldResponse(HoldGate),
+    /// The inner destination does the work; its response is delayed by the
+    /// duration and then passes through unchanged.
+    RespondSlowly(Duration),
 }
 
 impl FaultAction {
-    /// Creates a dispatch failure with the given error kind and message.
-    pub fn fail_dispatch(kind: ErrorKind, message: impl Into<String>) -> Self {
-        Self::FailDispatch(InjectedError::new(kind, message))
+    /// Creates a rejection with the given error kind and message.
+    pub fn reject(kind: ErrorKind, message: impl Into<String>) -> Self {
+        Self::Reject(InjectedError::new(kind, message))
     }
 
-    /// Creates a result failure with the given error kind and message.
-    pub fn fail_result(kind: ErrorKind, message: impl Into<String>) -> Self {
-        Self::FailResult(InjectedError::new(kind, message))
+    /// Creates a failure reported after the work with the given error kind and
+    /// message.
+    pub fn fail_after_write(kind: ErrorKind, message: impl Into<String>) -> Self {
+        Self::FailAfterWrite(InjectedError::new(kind, message))
     }
 
     /// Creates a hold action and the handle that releases it.
+    ///
+    /// Unlike [`FaultAction::RespondSlowly`], a hold is indefinite and
+    /// test-controlled: the handle observes when the operation is held and
+    /// chooses the outcome on release.
     pub fn hold() -> (Self, HoldHandle) {
         let (reached_tx, reached_rx) = watch::channel(false);
         let (release_tx, release_rx) = oneshot::channel();
 
-        let action = Self::HoldResult(HoldGate { reached_tx, release_rx });
+        let action = Self::HoldResponse(HoldGate { reached_tx, release_rx });
         let handle = HoldHandle { reached_rx: Mutex::new(reached_rx), release_tx };
 
         (action, handle)
@@ -171,22 +178,21 @@ impl HoldHandle {
     }
 }
 
-/// Applies a consumed fault to an operation's completion result.
+/// Applies a consumed fault to an operation's response.
 ///
-/// [`FaultAction::FailDispatch`] is normally handled before the inner
-/// destination runs; if it reaches the completion phase it fails the result
-/// defensively.
-pub async fn apply_result_fault<T>(
+/// [`FaultAction::Reject`] is normally handled before the inner destination
+/// runs; if it reaches the response phase it fails the response defensively.
+pub async fn apply_response_fault<T>(
     fault: Option<FaultAction>,
     inner_result: EtlResult<T>,
 ) -> EtlResult<T> {
     match fault {
         None => inner_result,
-        Some(FaultAction::FailDispatch(injected) | FaultAction::FailResult(injected)) => {
+        Some(FaultAction::Reject(injected) | FaultAction::FailAfterWrite(injected)) => {
             Err(injected.to_etl_error())
         }
-        Some(FaultAction::HoldResult(gate)) => gate.apply(inner_result).await,
-        Some(FaultAction::DelayResult(duration)) => {
+        Some(FaultAction::HoldResponse(gate)) => gate.apply(inner_result).await,
+        Some(FaultAction::RespondSlowly(duration)) => {
             sleep(duration).await;
             inner_result
         }
@@ -197,7 +203,7 @@ pub async fn apply_result_fault<T>(
 ///
 /// Cloning shares the underlying queues, so a clone held by a test scripts
 /// faults for the wrapper that owns the original.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct FaultInjector {
     queues: Arc<Mutex<HashMap<FaultyOp, VecDeque<FaultAction>>>>,
 }
@@ -205,7 +211,7 @@ pub struct FaultInjector {
 impl FaultInjector {
     /// Creates an injector with no scripted faults.
     pub fn new() -> Self {
-        Self::default()
+        Self { queues: Arc::new(Mutex::new(HashMap::new())) }
     }
 
     /// Queues a fault for the next unconsumed call of the operation.
@@ -218,6 +224,12 @@ impl FaultInjector {
     pub async fn next(&self, op: FaultyOp) -> Option<FaultAction> {
         let mut queues = self.queues.lock().await;
         queues.get_mut(&op)?.pop_front()
+    }
+}
+
+impl Default for FaultInjector {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -242,19 +254,19 @@ mod tests {
         injector
             .inject(
                 FaultyOp::WriteEvents,
-                FaultAction::fail_dispatch(ErrorKind::DestinationQueryFailed, "first"),
+                FaultAction::reject(ErrorKind::DestinationQueryFailed, "first"),
             )
             .await;
         injector
             .inject(
                 FaultyOp::WriteEvents,
-                FaultAction::fail_result(ErrorKind::DestinationTimeout, "second"),
+                FaultAction::fail_after_write(ErrorKind::DestinationTimeout, "second"),
             )
             .await;
         injector
             .inject(
                 FaultyOp::Shutdown,
-                FaultAction::fail_dispatch(ErrorKind::DestinationQueryFailed, "shutdown"),
+                FaultAction::reject(ErrorKind::DestinationQueryFailed, "shutdown"),
             )
             .await;
 
@@ -264,8 +276,8 @@ mod tests {
         let third = injector.next(FaultyOp::WriteEvents).await;
 
         // THEN: they fire in injection order, then the queue is empty
-        assert!(matches!(first, Some(FaultAction::FailDispatch(_))));
-        assert!(matches!(second, Some(FaultAction::FailResult(_))));
+        assert!(matches!(first, Some(FaultAction::Reject(_))));
+        assert!(matches!(second, Some(FaultAction::FailAfterWrite(_))));
         assert!(third.is_none());
 
         // THEN: the shutdown queue is independent
@@ -289,8 +301,8 @@ mod tests {
     async fn hold_gate_passes_captured_result_through_on_release_ok() {
         // GIVEN: a held operation whose inner result is Ok(42)
         let (action, handle) = FaultAction::hold();
-        let FaultAction::HoldResult(gate) = action else {
-            panic!("hold() must produce a HoldResult action");
+        let FaultAction::HoldResponse(gate) = action else {
+            panic!("hold() must produce a HoldResponse action");
         };
         let held = tokio::spawn(gate.apply(Ok::<_, EtlError>(42)));
 
@@ -306,8 +318,8 @@ mod tests {
     async fn hold_gate_replaces_result_on_release_err() {
         // GIVEN: a held operation whose inner result is Ok
         let (action, handle) = FaultAction::hold();
-        let FaultAction::HoldResult(gate) = action else {
-            panic!("hold() must produce a HoldResult action");
+        let FaultAction::HoldResponse(gate) = action else {
+            panic!("hold() must produce a HoldResponse action");
         };
         let held = tokio::spawn(gate.apply(Ok::<_, EtlError>(())));
 
@@ -322,17 +334,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn apply_result_fault_passes_through_or_replaces_the_inner_result() {
+    async fn apply_response_fault_passes_through_or_replaces_the_inner_result() {
         // GIVEN: an inner result of Ok(7)
         // WHEN: no fault is scripted
-        let ok = apply_result_fault(None, Ok::<_, EtlError>(7)).await;
+        let ok = apply_response_fault(None, Ok::<_, EtlError>(7)).await;
 
         // THEN: the inner result passes through unchanged
         assert_eq!(ok.unwrap(), 7);
 
-        // WHEN: a result failure is scripted
-        let failed = apply_result_fault(
-            Some(FaultAction::fail_result(ErrorKind::DestinationTimeout, "late boom")),
+        // WHEN: a failure after write is scripted
+        let failed = apply_response_fault(
+            Some(FaultAction::fail_after_write(ErrorKind::DestinationTimeout, "late boom")),
             Ok::<_, EtlError>(7),
         )
         .await;
@@ -347,8 +359,8 @@ mod tests {
     async fn hold_gate_fails_loudly_when_handle_dropped_without_release() {
         // GIVEN: a hold whose handle is dropped without releasing
         let (action, handle) = FaultAction::hold();
-        let FaultAction::HoldResult(gate) = action else {
-            panic!("hold() must produce a HoldResult action");
+        let FaultAction::HoldResponse(gate) = action else {
+            panic!("hold() must produce a HoldResponse action");
         };
         drop(handle);
 

--- a/crates/etl/src/test_utils/faults.rs
+++ b/crates/etl/src/test_utils/faults.rs
@@ -16,7 +16,7 @@ use std::{
 
 use tokio::{
     sync::{Mutex, oneshot, watch},
-    time::timeout,
+    time::{sleep, timeout},
 };
 
 use crate::{
@@ -169,6 +169,28 @@ impl HoldHandle {
     }
 }
 
+/// Applies a consumed fault to an operation's completion result.
+///
+/// [`FaultAction::FailDispatch`] is normally handled before the inner
+/// destination runs; if it reaches the completion phase it fails the result
+/// defensively.
+pub async fn apply_result_fault<T>(
+    fault: Option<FaultAction>,
+    inner_result: EtlResult<T>,
+) -> EtlResult<T> {
+    match fault {
+        None => inner_result,
+        Some(FaultAction::FailDispatch(injected) | FaultAction::FailResult(injected)) => {
+            Err(injected.to_etl_error())
+        }
+        Some(FaultAction::HoldResult(gate)) => gate.apply(inner_result).await,
+        Some(FaultAction::DelayResult(duration)) => {
+            sleep(duration).await;
+            inner_result
+        }
+    }
+}
+
 /// Per-operation FIFO queues of scripted faults.
 ///
 /// Cloning shares the underlying queues, so a clone held by a test scripts
@@ -295,6 +317,28 @@ mod tests {
         let err = held.await.unwrap().unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationConnectionFailed);
         assert_eq!(err.detail(), Some("lost response"));
+    }
+
+    #[tokio::test]
+    async fn apply_result_fault_passes_through_or_replaces_the_inner_result() {
+        // --- GIVEN: an inner result of Ok(7) ---
+        // --- WHEN: no fault is scripted ---
+        let ok = apply_result_fault(None, Ok::<_, EtlError>(7)).await;
+
+        // --- THEN: the inner result passes through unchanged ---
+        assert_eq!(ok.unwrap(), 7);
+
+        // --- WHEN: a result failure is scripted ---
+        let failed = apply_result_fault(
+            Some(FaultAction::fail_result(ErrorKind::DestinationTimeout, "late boom")),
+            Ok::<_, EtlError>(7),
+        )
+        .await;
+
+        // --- THEN: the injected error replaces the inner result ---
+        let err = failed.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
+        assert_eq!(err.detail(), Some("late boom"));
     }
 
     #[tokio::test]

--- a/crates/etl/src/test_utils/faults.rs
+++ b/crates/etl/src/test_utils/faults.rs
@@ -1,0 +1,315 @@
+//! Fault injection primitives for destination test wrappers.
+//!
+//! Destinations report through two channels: the method return value
+//! (dispatch) and the async result handle (completion). Faults target either
+//! channel: [`FaultAction::FailDispatch`] rejects work before the inner
+//! destination runs, while the result actions let the inner destination run
+//! and then fail, hold, or delay what the apply loop observes. Faults are
+//! queued FIFO per operation and consumed one per call; an empty queue means
+//! fully transparent behavior.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+    time::Duration,
+};
+
+use tokio::{
+    sync::{Mutex, oneshot, watch},
+    time::timeout,
+};
+
+use crate::{
+    error::{ErrorKind, EtlError, EtlResult},
+    etl_error,
+    test_utils::notify::DEFAULT_NOTIFY_TIMEOUT,
+};
+
+/// Destination operation a fault applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FaultyOp {
+    Startup,
+    DropTableForCopy,
+    WriteTableRows,
+    WriteEvents,
+    Shutdown,
+}
+
+/// Error details injected by a fault, materialized at fire time.
+///
+/// Stored as kind plus message because [`EtlError`] is not reusable across
+/// firings. The kind matters: retry policy derives from it.
+#[derive(Debug, Clone)]
+pub struct InjectedError {
+    kind: ErrorKind,
+    message: String,
+}
+
+impl InjectedError {
+    /// Creates injected error details with the given kind and message.
+    pub fn new(kind: ErrorKind, message: impl Into<String>) -> Self {
+        Self { kind, message: message.into() }
+    }
+
+    /// Builds the [`EtlError`] this injection fires with.
+    pub fn to_etl_error(&self) -> EtlError {
+        etl_error!(self.kind, "Injected destination fault", self.message.clone())
+    }
+}
+
+/// Scripted fault behavior, consumed FIFO per operation.
+#[derive(Debug)]
+pub enum FaultAction {
+    /// The method returns `Err` immediately; the inner destination never runs.
+    FailDispatch(InjectedError),
+    /// The inner destination runs; its async result is replaced with `Err`.
+    ///
+    /// This models the lost-response ambiguity: the destination applied the
+    /// write but the apply loop observes a failure.
+    FailResult(InjectedError),
+    /// The inner destination runs; its async result is withheld until the
+    /// paired [`HoldHandle`] releases it.
+    HoldResult(HoldGate),
+    /// The inner destination runs; its async result is delayed.
+    DelayResult(Duration),
+}
+
+impl FaultAction {
+    /// Creates a dispatch failure with the given error kind and message.
+    pub fn fail_dispatch(kind: ErrorKind, message: impl Into<String>) -> Self {
+        Self::FailDispatch(InjectedError::new(kind, message))
+    }
+
+    /// Creates a result failure with the given error kind and message.
+    pub fn fail_result(kind: ErrorKind, message: impl Into<String>) -> Self {
+        Self::FailResult(InjectedError::new(kind, message))
+    }
+
+    /// Creates a hold action and the handle that releases it.
+    pub fn hold() -> (Self, HoldHandle) {
+        let (reached_tx, reached_rx) = watch::channel(false);
+        let (release_tx, release_rx) = oneshot::channel();
+
+        let action = Self::HoldResult(HoldGate { reached_tx, release_rx });
+        let handle = HoldHandle { reached_rx: Mutex::new(reached_rx), release_tx };
+
+        (action, handle)
+    }
+}
+
+/// Release decision sent from a [`HoldHandle`] to its [`HoldGate`].
+#[derive(Debug)]
+enum Release {
+    Ok,
+    Err(InjectedError),
+}
+
+/// Wrapper-side half of a hold: blocks an async result until released.
+#[derive(Debug)]
+pub struct HoldGate {
+    reached_tx: watch::Sender<bool>,
+    release_rx: oneshot::Receiver<Release>,
+}
+
+impl HoldGate {
+    /// Holds `inner_result` until the paired handle releases it.
+    ///
+    /// On [`HoldHandle::release_ok`] the inner destination's captured result
+    /// passes through unchanged, preserving its genuine write status. On
+    /// [`HoldHandle::release_err`] the injected error replaces it. A handle
+    /// dropped without releasing fails loudly instead of unblocking silently.
+    pub async fn apply<T>(self, inner_result: EtlResult<T>) -> EtlResult<T> {
+        let _ = self.reached_tx.send(true);
+
+        match self.release_rx.await {
+            Ok(Release::Ok) => inner_result,
+            Ok(Release::Err(injected)) => Err(injected.to_etl_error()),
+            Err(_) => Err(etl_error!(
+                ErrorKind::InvalidState,
+                "Fault hold handle dropped without release",
+                "A HoldHandle was dropped before release_ok or release_err was called"
+            )),
+        }
+    }
+}
+
+/// Test-side half of a hold: observes and releases a held async result.
+#[derive(Debug)]
+pub struct HoldHandle {
+    reached_rx: Mutex<watch::Receiver<bool>>,
+    release_tx: oneshot::Sender<Release>,
+}
+
+impl HoldHandle {
+    /// Waits until the held operation has completed on the inner destination
+    /// and its result is being withheld.
+    ///
+    /// # Panics
+    ///
+    /// Panics after [`DEFAULT_NOTIFY_TIMEOUT`] if the hold point is never
+    /// reached, mirroring [`crate::test_utils::notify::TimedNotify`].
+    pub async fn wait_reached(&self) {
+        let mut reached_rx = self.reached_rx.lock().await;
+
+        timeout(DEFAULT_NOTIFY_TIMEOUT, reached_rx.wait_for(|reached| *reached))
+            .await
+            .expect("timed out waiting for a held destination operation to be reached")
+            .expect("hold gate dropped before the hold point was reached");
+    }
+
+    /// Releases the held result, passing the inner destination's captured
+    /// result through unchanged.
+    pub fn release_ok(self) {
+        let _ = self.release_tx.send(Release::Ok);
+    }
+
+    /// Releases the held result, replacing it with an injected error.
+    pub fn release_err(self, kind: ErrorKind, message: impl Into<String>) {
+        let _ = self.release_tx.send(Release::Err(InjectedError::new(kind, message)));
+    }
+}
+
+/// Per-operation FIFO queues of scripted faults.
+///
+/// Cloning shares the underlying queues, so a clone held by a test scripts
+/// faults for the wrapper that owns the original.
+#[derive(Debug, Clone, Default)]
+pub struct FaultInjector {
+    queues: Arc<Mutex<HashMap<FaultyOp, VecDeque<FaultAction>>>>,
+}
+
+impl FaultInjector {
+    /// Creates an injector with no scripted faults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Queues a fault for the next unconsumed call of the operation.
+    pub async fn inject(&self, op: FaultyOp, action: FaultAction) {
+        let mut queues = self.queues.lock().await;
+        queues.entry(op).or_default().push_back(action);
+    }
+
+    /// Consumes the next queued fault for the operation, if any.
+    pub async fn next(&self, op: FaultyOp) -> Option<FaultAction> {
+        let mut queues = self.queues.lock().await;
+        queues.get_mut(&op)?.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn injector_returns_none_without_scripted_faults() {
+        // --- GIVEN: an injector with no faults ---
+        let injector = FaultInjector::new();
+
+        // --- THEN: every operation passes through ---
+        assert!(injector.next(FaultyOp::WriteEvents).await.is_none());
+        assert!(injector.next(FaultyOp::Shutdown).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn injector_consumes_faults_in_fifo_order_per_operation() {
+        // --- GIVEN: two faults on write_events and one on shutdown ---
+        let injector = FaultInjector::new();
+        injector
+            .inject(
+                FaultyOp::WriteEvents,
+                FaultAction::fail_dispatch(ErrorKind::DestinationQueryFailed, "first"),
+            )
+            .await;
+        injector
+            .inject(
+                FaultyOp::WriteEvents,
+                FaultAction::fail_result(ErrorKind::DestinationTimeout, "second"),
+            )
+            .await;
+        injector
+            .inject(
+                FaultyOp::Shutdown,
+                FaultAction::fail_dispatch(ErrorKind::DestinationQueryFailed, "shutdown"),
+            )
+            .await;
+
+        // --- WHEN: write_events faults are consumed ---
+        let first = injector.next(FaultyOp::WriteEvents).await;
+        let second = injector.next(FaultyOp::WriteEvents).await;
+        let third = injector.next(FaultyOp::WriteEvents).await;
+
+        // --- THEN: they fire in injection order, then the queue is empty ---
+        assert!(matches!(first, Some(FaultAction::FailDispatch(_))));
+        assert!(matches!(second, Some(FaultAction::FailResult(_))));
+        assert!(third.is_none());
+
+        // --- THEN: the shutdown queue is independent ---
+        assert!(injector.next(FaultyOp::Shutdown).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn injected_error_carries_kind_and_message() {
+        // --- GIVEN: an injected error ---
+        let injected = InjectedError::new(ErrorKind::DestinationTimeout, "boom");
+
+        // --- WHEN: it fires ---
+        let err = injected.to_etl_error();
+
+        // --- THEN: the error carries the injected kind and message ---
+        assert_eq!(err.kind(), ErrorKind::DestinationTimeout);
+        assert_eq!(err.detail(), Some("boom"));
+    }
+
+    #[tokio::test]
+    async fn hold_gate_passes_captured_result_through_on_release_ok() {
+        // --- GIVEN: a held operation whose inner result is Ok(42) ---
+        let (action, handle) = FaultAction::hold();
+        let FaultAction::HoldResult(gate) = action else {
+            panic!("hold() must produce a HoldResult action");
+        };
+        let held = tokio::spawn(gate.apply(Ok::<_, EtlError>(42)));
+
+        // --- WHEN: the test observes the hold and releases it ---
+        handle.wait_reached().await;
+        handle.release_ok();
+
+        // --- THEN: the captured inner result passes through unchanged ---
+        assert_eq!(held.await.unwrap().unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn hold_gate_replaces_result_on_release_err() {
+        // --- GIVEN: a held operation whose inner result is Ok ---
+        let (action, handle) = FaultAction::hold();
+        let FaultAction::HoldResult(gate) = action else {
+            panic!("hold() must produce a HoldResult action");
+        };
+        let held = tokio::spawn(gate.apply(Ok::<_, EtlError>(())));
+
+        // --- WHEN: the test releases it with an injected error ---
+        handle.wait_reached().await;
+        handle.release_err(ErrorKind::DestinationConnectionFailed, "lost response");
+
+        // --- THEN: the injected error replaces the inner result ---
+        let err = held.await.unwrap().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DestinationConnectionFailed);
+        assert_eq!(err.detail(), Some("lost response"));
+    }
+
+    #[tokio::test]
+    async fn hold_gate_fails_loudly_when_handle_dropped_without_release() {
+        // --- GIVEN: a hold whose handle is dropped without releasing ---
+        let (action, handle) = FaultAction::hold();
+        let FaultAction::HoldResult(gate) = action else {
+            panic!("hold() must produce a HoldResult action");
+        };
+        drop(handle);
+
+        // --- WHEN: the held operation applies ---
+        let result = gate.apply(Ok::<_, EtlError>(())).await;
+
+        // --- THEN: it fails instead of unblocking silently ---
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidState);
+    }
+}

--- a/crates/etl/src/test_utils/mod.rs
+++ b/crates/etl/src/test_utils/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod database;
 pub mod event;
+pub mod faults;
 pub mod materialize;
 pub mod memory_destination;
 pub mod notify;

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -22,7 +22,7 @@ use crate::{
     schema::{ReplicatedTableSchema, TableId},
     test_utils::{
         event::{EventCondition, check_all_events_count, group_events_by_type},
-        faults::{FaultAction, FaultInjector, FaultyOp, HoldHandle, apply_result_fault},
+        faults::{FaultAction, FaultInjector, FaultyOp, HoldHandle, apply_response_fault},
         notify::TimedNotify,
     },
 };
@@ -92,10 +92,10 @@ impl<D> Inner<D> {
 ///
 /// Faults from [`crate::test_utils::faults`] can be scripted per operation
 /// through [`TestDestinationWrapper::inject_fault`]. The wrapper records what
-/// was acknowledged to the apply loop: on an injected result failure the inner
-/// destination has applied the write but the wrapper does not record it, so
-/// ground truth for what the destination actually holds is read from the inner
-/// destination directly.
+/// was acknowledged to the apply loop: on an injected failure after write the
+/// inner destination has applied the write but the wrapper does not record it,
+/// so ground truth for what the destination actually holds is read from the
+/// inner destination directly.
 #[derive(Clone)]
 pub struct TestDestinationWrapper<D> {
     inner: Arc<RwLock<Inner<D>>>,
@@ -251,10 +251,10 @@ impl<D> TestDestinationWrapper<D> {
         handle
     }
 
-    /// Consumes the next fault for the operation, failing dispatch faults here.
+    /// Consumes the next fault for the operation, applying rejections here.
     async fn take_fault(&self, op: FaultyOp) -> EtlResult<Option<FaultAction>> {
         match self.faults.next(op).await {
-            Some(FaultAction::FailDispatch(injected)) => Err(injected.to_etl_error()),
+            Some(FaultAction::Reject(injected)) => Err(injected.to_etl_error()),
             fault => Ok(fault),
         }
     }
@@ -277,7 +277,7 @@ where
         };
         let result = destination.startup().await;
 
-        apply_result_fault(fault, result).await
+        apply_response_fault(fault, result).await
     }
 
     async fn drop_table_for_copy(
@@ -297,7 +297,7 @@ where
 
         // We send the result back before doing the internal checks for this utility, to
         // avoid checking before the apply loop received the result.
-        let result = apply_result_fault(fault, pending_drop_result.await.into_result()).await;
+        let result = apply_response_fault(fault, pending_drop_result.await.into_result()).await;
         let should_record_drop = result.is_ok();
         async_result.send(result);
 
@@ -348,7 +348,7 @@ where
 
         // We send the result back before doing the internal checks for this utility, to
         // avoid checking before the apply loop received the result.
-        let result = apply_result_fault(fault, pending_flush_result.await.into_result()).await;
+        let result = apply_response_fault(fault, pending_flush_result.await.into_result()).await;
         let should_record_table_rows = result.is_ok();
         async_result.send(result);
 
@@ -404,7 +404,7 @@ where
                 // We send the result back before doing the internal checks for this utility, to
                 // avoid checking before the apply loop received the result.
                 let result =
-                    apply_result_fault(fault, pending_flush_result.await.into_result()).await;
+                    apply_response_fault(fault, pending_flush_result.await.into_result()).await;
                 let should_record_events = result.is_ok();
                 async_result.send(result);
 
@@ -447,6 +447,6 @@ where
         }
 
         let result = if errors.is_empty() { Ok(()) } else { Err(errors.into()) };
-        apply_result_fault(fault, result).await
+        apply_response_fault(fault, result).await
     }
 }

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -22,6 +22,7 @@ use crate::{
     schema::{ReplicatedTableSchema, TableId},
     test_utils::{
         event::{EventCondition, check_all_events_count, group_events_by_type},
+        faults::{FaultAction, FaultInjector, FaultyOp, HoldHandle, apply_result_fault},
         notify::TimedNotify,
     },
 };
@@ -88,10 +89,18 @@ impl<D> Inner<D> {
 /// Notification helpers only observe writes that happen after registration.
 /// Register the returned [`TimedNotify`] before starting the producer that is
 /// expected to satisfy it.
+///
+/// Faults from [`crate::test_utils::faults`] can be scripted per operation
+/// through [`TestDestinationWrapper::inject_fault`]. The wrapper records what
+/// was acknowledged to the apply loop: on an injected result failure the inner
+/// destination has applied the write but the wrapper does not record it, so
+/// ground truth for what the destination actually holds is read from the inner
+/// destination directly.
 #[derive(Clone)]
 pub struct TestDestinationWrapper<D> {
     inner: Arc<RwLock<Inner<D>>>,
     tasks: TaskSet,
+    faults: FaultInjector,
 }
 
 impl<D: fmt::Debug> fmt::Debug for TestDestinationWrapper<D> {
@@ -125,7 +134,11 @@ impl<D> TestDestinationWrapper<D> {
             shutdown_called: false,
         };
 
-        Self { inner: Arc::new(RwLock::new(inner)), tasks: TaskSet::new() }
+        Self {
+            inner: Arc::new(RwLock::new(inner)),
+            tasks: TaskSet::new(),
+            faults: FaultInjector::new(),
+        }
     }
 
     /// Returns all table rows written through the wrapper.
@@ -224,6 +237,27 @@ impl<D> TestDestinationWrapper<D> {
     pub async fn shutdown_called(&self) -> bool {
         self.inner.read().await.shutdown_called
     }
+
+    /// Queues a fault for the next call of the given destination operation.
+    pub async fn inject_fault(&self, op: FaultyOp, action: FaultAction) {
+        self.faults.inject(op, action).await;
+    }
+
+    /// Holds the next call of the given operation and returns the handle that
+    /// observes and releases it.
+    pub async fn hold_next(&self, op: FaultyOp) -> HoldHandle {
+        let (action, handle) = FaultAction::hold();
+        self.faults.inject(op, action).await;
+        handle
+    }
+
+    /// Consumes the next fault for the operation, failing dispatch faults here.
+    async fn take_fault(&self, op: FaultyOp) -> EtlResult<Option<FaultAction>> {
+        match self.faults.next(op).await {
+            Some(FaultAction::FailDispatch(injected)) => Err(injected.to_etl_error()),
+            fault => Ok(fault),
+        }
+    }
 }
 
 impl<D> Destination for TestDestinationWrapper<D>
@@ -234,11 +268,25 @@ where
         "wrapper"
     }
 
+    async fn startup(&self) -> EtlResult<()> {
+        let fault = self.take_fault(FaultyOp::Startup).await?;
+
+        let destination = {
+            let inner = self.inner.read().await;
+            inner.wrapped_destination.clone()
+        };
+        let result = destination.startup().await;
+
+        apply_result_fault(fault, result).await
+    }
+
     async fn drop_table_for_copy(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
+        let fault = self.take_fault(FaultyOp::DropTableForCopy).await?;
+
         let destination = {
             let inner = self.inner.read().await;
             inner.wrapped_destination.clone()
@@ -249,7 +297,7 @@ where
 
         // We send the result back before doing the internal checks for this utility, to
         // avoid checking before the apply loop received the result.
-        let result = pending_drop_result.await.into_result();
+        let result = apply_result_fault(fault, pending_drop_result.await.into_result()).await;
         let should_record_drop = result.is_ok();
         async_result.send(result);
 
@@ -285,6 +333,8 @@ where
         table_rows: Vec<TableRow>,
         async_result: WriteTableRowsResult<()>,
     ) -> EtlResult<()> {
+        let fault = self.take_fault(FaultyOp::WriteTableRows).await?;
+
         let destination = {
             let mut inner = self.inner.write().await;
             inner.write_table_rows_called += 1;
@@ -298,7 +348,7 @@ where
 
         // We send the result back before doing the internal checks for this utility, to
         // avoid checking before the apply loop received the result.
-        let result = pending_flush_result.await.into_result();
+        let result = apply_result_fault(fault, pending_flush_result.await.into_result()).await;
         let should_record_table_rows = result.is_ok();
         async_result.send(result);
 
@@ -321,6 +371,8 @@ where
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;
+
+        let fault = self.take_fault(FaultyOp::WriteEvents).await?;
 
         let destination = {
             let inner = self.inner.read().await;
@@ -351,7 +403,8 @@ where
             .spawn(async move {
                 // We send the result back before doing the internal checks for this utility, to
                 // avoid checking before the apply loop received the result.
-                let result = pending_flush_result.await.into_result();
+                let result =
+                    apply_result_fault(fault, pending_flush_result.await.into_result()).await;
                 let should_record_events = result.is_ok();
                 async_result.send(result);
 
@@ -370,6 +423,15 @@ where
     }
 
     async fn shutdown(&self) -> EtlResult<()> {
+        // Record the invocation before applying faults so tests can assert the
+        // pipeline called shutdown even when the shutdown itself fails.
+        {
+            let mut inner = self.inner.write().await;
+            inner.shutdown_called = true;
+        }
+
+        let fault = self.take_fault(FaultyOp::Shutdown).await?;
+
         let destination = {
             let inner = self.inner.read().await;
             inner.wrapped_destination.clone()
@@ -384,11 +446,7 @@ where
             errors.push(err);
         }
 
-        {
-            let mut inner = self.inner.write().await;
-            inner.shutdown_called = true;
-        }
-
-        if errors.is_empty() { Ok(()) } else { Err(errors.into()) }
+        let result = if errors.is_empty() { Ok(()) } else { Err(errors.into()) };
+        apply_result_fault(fault, result).await
     }
 }

--- a/crates/etl/tests/main.rs
+++ b/crates/etl/tests/main.rs
@@ -6,6 +6,7 @@ mod pipeline_read_replica;
 mod pipeline_replica_identity;
 #[cfg(feature = "failpoints")]
 mod pipeline_with_failpoints;
+mod pipeline_with_faulty_destination;
 mod pipeline_with_partitioned_table;
 mod pipelines_with_schema_changes;
 mod postgres_store;

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -1,7 +1,7 @@
 use etl::{
     error::ErrorKind,
     pipeline::PipelineId,
-    store::TableStateType,
+    store::{StateStore, TableRetryPolicy, TableState, TableStateType},
     test_utils::{
         database::spawn_source_database,
         faults::{FaultAction, FaultyOp},
@@ -9,7 +9,7 @@ use etl::{
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
-        test_schema::{TableSelection, setup_test_database_schema},
+        test_schema::{TableSelection, insert_users_data, setup_test_database_schema},
     },
 };
 use etl_telemetry::tracing::init_test_tracing;
@@ -60,4 +60,153 @@ async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
     let err = result.unwrap_err();
     assert!(err.kinds().contains(&ErrorKind::DestinationQueryFailed));
     assert!(destination.shutdown_called().await);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retry() {
+    init_test_tracing();
+
+    // --- GIVEN: a pipeline that has copied a table to Ready ---
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+
+    let initial_rows = 2;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=initial_rows).await;
+
+    let store = NotifyingStore::new();
+    let memory_destination = MemoryDestination::new(store.clone());
+    let destination = TestDestinationWrapper::wrap(memory_destination.clone());
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    // --- WHEN: a resync starts and the destination refuses the drop at dispatch
+    // ---
+    destination
+        .inject_fault(
+            FaultyOp::DropTableForCopy,
+            FaultAction::fail_dispatch(
+                ErrorKind::DestinationConnectionFailed,
+                "injected drop dispatch failure",
+            ),
+        )
+        .await;
+
+    let users_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+
+    store.reset_table_state(table_id).await.unwrap();
+
+    users_errored.notified().await;
+
+    // --- THEN: the table errors with a timed retry and nothing was torn down ---
+    let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
+    assert!(matches!(
+        table_state,
+        TableState::Errored { retry_policy: TableRetryPolicy::TimedRetry { .. }, .. }
+    ));
+    assert!(!destination.was_table_dropped_for_copy(table_id).await);
+    assert!(store.get_latest_table_schemas().await.contains_key(&table_id));
+
+    // The drop was refused before the inner destination ran, so its rows are
+    // untouched.
+    assert_eq!(memory_destination.table_rows().await.get(&table_id).unwrap().len(), initial_rows);
+
+    // --- THEN: the timed retry drops and recopies the table cleanly ---
+    let users_ready_again = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    users_ready_again.notified().await;
+
+    assert!(destination.was_table_dropped_for_copy(table_id).await);
+    let table_rows = destination.get_table_rows().await;
+    assert_eq!(table_rows.get(&table_id).unwrap().len(), initial_rows);
+
+    pipeline.shutdown_and_wait().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry() {
+    init_test_tracing();
+
+    // --- GIVEN: a pipeline that has copied a table to Ready ---
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+
+    let initial_rows = 2;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=initial_rows).await;
+
+    let store = NotifyingStore::new();
+    let memory_destination = MemoryDestination::new(store.clone());
+    let destination = TestDestinationWrapper::wrap(memory_destination.clone());
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    // --- WHEN: a resync starts and the drop result reports failure after the inner
+    // destination applied it ---
+    destination
+        .inject_fault(
+            FaultyOp::DropTableForCopy,
+            FaultAction::fail_result(
+                ErrorKind::DestinationConnectionFailed,
+                "injected drop result failure",
+            ),
+        )
+        .await;
+
+    let users_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+
+    store.reset_table_state(table_id).await.unwrap();
+
+    users_errored.notified().await;
+
+    // --- THEN: the table errors with a timed retry and ETL state was not cleared
+    // ---
+    let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
+    assert!(matches!(
+        table_state,
+        TableState::Errored { retry_policy: TableRetryPolicy::TimedRetry { .. }, .. }
+    ));
+    assert!(store.get_latest_table_schemas().await.contains_key(&table_id));
+
+    // Lost-response semantics: the inner destination applied the drop, but the
+    // apply loop observed a failure, so the wrapper acknowledged nothing.
+    assert!(!destination.was_table_dropped_for_copy(table_id).await);
+    assert!(!memory_destination.table_rows().await.contains_key(&table_id));
+
+    // --- THEN: the timed retry replays the drop and recopies the table cleanly ---
+    let users_ready_again = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    users_ready_again.notified().await;
+
+    assert!(destination.was_table_dropped_for_copy(table_id).await);
+    let table_rows = destination.get_table_rows().await;
+    assert_eq!(table_rows.get(&table_id).unwrap().len(), initial_rows);
+
+    pipeline.shutdown_and_wait().await.unwrap();
 }

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -28,10 +28,7 @@ async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
     destination
         .inject_fault(
             FaultyOp::Shutdown,
-            FaultAction::fail_dispatch(
-                ErrorKind::DestinationQueryFailed,
-                "injected shutdown failure",
-            ),
+            FaultAction::reject(ErrorKind::DestinationQueryFailed, "injected shutdown failure"),
         )
         .await;
 
@@ -55,14 +52,14 @@ async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
     // WHEN: the pipeline shuts down
     let result = pipeline.shutdown_and_wait().await;
 
-    // THEN: the injected shutdown error is propagated and shutdown was invoked
+    // THEN: the injected shutdown error surfaces and shutdown was invoked
     let err = result.unwrap_err();
     assert!(err.kinds().contains(&ErrorKind::DestinationQueryFailed));
     assert!(destination.shutdown_called().await);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retry() {
+async fn drop_table_for_copy_rejection_keeps_table_restartable_until_retry() {
     init_test_tracing();
 
     // GIVEN: a pipeline that has copied a table to Ready
@@ -92,14 +89,11 @@ async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retr
 
     users_ready.notified().await;
 
-    // WHEN: a resync starts and the destination refuses the drop at dispatch
+    // WHEN: a resync starts and the destination rejects the drop
     destination
         .inject_fault(
             FaultyOp::DropTableForCopy,
-            FaultAction::fail_dispatch(
-                ErrorKind::DestinationConnectionFailed,
-                "injected drop dispatch failure",
-            ),
+            FaultAction::reject(ErrorKind::DestinationConnectionFailed, "injected drop rejection"),
         )
         .await;
 
@@ -118,8 +112,7 @@ async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retr
     assert!(!destination.was_table_dropped_for_copy(table_id).await);
     assert!(store.get_latest_table_schemas().await.contains_key(&table_id));
 
-    // The drop was refused before the inner destination ran, so its rows are
-    // untouched.
+    // The drop never ran on the inner destination, so its rows are untouched.
     assert_eq!(memory_destination.table_rows().await.get(&table_id).unwrap().len(), initial_rows);
 
     // THEN: the timed retry drops and recopies the table cleanly
@@ -135,7 +128,7 @@ async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retr
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry() {
+async fn drop_table_for_copy_failure_after_write_keeps_table_restartable_until_retry() {
     init_test_tracing();
 
     // GIVEN: a pipeline that has copied a table to Ready
@@ -165,14 +158,13 @@ async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry(
 
     users_ready.notified().await;
 
-    // WHEN: a resync starts and the drop result fails after the inner destination
-    // applied it
+    // WHEN: a resync starts and the drop fails after being applied
     destination
         .inject_fault(
             FaultyOp::DropTableForCopy,
-            FaultAction::fail_result(
+            FaultAction::fail_after_write(
                 ErrorKind::DestinationConnectionFailed,
-                "injected drop result failure",
+                "injected drop failure after write",
             ),
         )
         .await;
@@ -191,8 +183,7 @@ async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry(
     ));
     assert!(store.get_latest_table_schemas().await.contains_key(&table_id));
 
-    // The inner destination applied the drop, but the apply loop observed a
-    // failure.
+    // The inner destination applied the drop; the apply loop saw a failure.
     assert!(!destination.was_table_dropped_for_copy(table_id).await);
     assert!(!memory_destination.table_rows().await.contains_key(&table_id));
 

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -19,7 +19,7 @@ use rand::random;
 async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
     init_test_tracing();
 
-    // --- GIVEN: a healthy pipeline whose destination fails on shutdown ---
+    // GIVEN: a healthy pipeline whose destination fails on shutdown
     let database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
 
@@ -52,11 +52,10 @@ async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
 
     users_ready.notified().await;
 
-    // --- WHEN: the pipeline shuts down ---
+    // WHEN: the pipeline shuts down
     let result = pipeline.shutdown_and_wait().await;
 
-    // --- THEN: the injected destination shutdown error is propagated and shutdown
-    // was still invoked ---
+    // THEN: the injected shutdown error is propagated and shutdown was invoked
     let err = result.unwrap_err();
     assert!(err.kinds().contains(&ErrorKind::DestinationQueryFailed));
     assert!(destination.shutdown_called().await);
@@ -66,7 +65,7 @@ async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
 async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retry() {
     init_test_tracing();
 
-    // --- GIVEN: a pipeline that has copied a table to Ready ---
+    // GIVEN: a pipeline that has copied a table to Ready
     let mut database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
     let table_id = database_schema.users_schema().id;
@@ -93,8 +92,7 @@ async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retr
 
     users_ready.notified().await;
 
-    // --- WHEN: a resync starts and the destination refuses the drop at dispatch
-    // ---
+    // WHEN: a resync starts and the destination refuses the drop at dispatch
     destination
         .inject_fault(
             FaultyOp::DropTableForCopy,
@@ -111,7 +109,7 @@ async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retr
 
     users_errored.notified().await;
 
-    // --- THEN: the table errors with a timed retry and nothing was torn down ---
+    // THEN: the table errors with a timed retry and nothing was torn down
     let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
     assert!(matches!(
         table_state,
@@ -124,7 +122,7 @@ async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retr
     // untouched.
     assert_eq!(memory_destination.table_rows().await.get(&table_id).unwrap().len(), initial_rows);
 
-    // --- THEN: the timed retry drops and recopies the table cleanly ---
+    // THEN: the timed retry drops and recopies the table cleanly
     let users_ready_again = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     users_ready_again.notified().await;
@@ -140,7 +138,7 @@ async fn drop_table_for_copy_dispatch_failure_keeps_table_restartable_until_retr
 async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry() {
     init_test_tracing();
 
-    // --- GIVEN: a pipeline that has copied a table to Ready ---
+    // GIVEN: a pipeline that has copied a table to Ready
     let mut database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
     let table_id = database_schema.users_schema().id;
@@ -167,8 +165,8 @@ async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry(
 
     users_ready.notified().await;
 
-    // --- WHEN: a resync starts and the drop result reports failure after the inner
-    // destination applied it ---
+    // WHEN: a resync starts and the drop result fails after the inner destination
+    // applied it
     destination
         .inject_fault(
             FaultyOp::DropTableForCopy,
@@ -185,8 +183,7 @@ async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry(
 
     users_errored.notified().await;
 
-    // --- THEN: the table errors with a timed retry and ETL state was not cleared
-    // ---
+    // THEN: the table errors with a timed retry and ETL state was not cleared
     let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
     assert!(matches!(
         table_state,
@@ -194,12 +191,12 @@ async fn drop_table_for_copy_result_failure_keeps_table_restartable_until_retry(
     ));
     assert!(store.get_latest_table_schemas().await.contains_key(&table_id));
 
-    // Lost-response semantics: the inner destination applied the drop, but the
-    // apply loop observed a failure, so the wrapper acknowledged nothing.
+    // The inner destination applied the drop, but the apply loop observed a
+    // failure.
     assert!(!destination.was_table_dropped_for_copy(table_id).await);
     assert!(!memory_destination.table_rows().await.contains_key(&table_id));
 
-    // --- THEN: the timed retry replays the drop and recopies the table cleanly ---
+    // THEN: the timed retry replays the drop and recopies the table cleanly
     let users_ready_again = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     users_ready_again.notified().await;

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -1,0 +1,63 @@
+use etl::{
+    error::ErrorKind,
+    pipeline::PipelineId,
+    store::TableStateType,
+    test_utils::{
+        database::spawn_source_database,
+        faults::{FaultAction, FaultyOp},
+        memory_destination::MemoryDestination,
+        notifying_store::NotifyingStore,
+        pipeline::create_pipeline,
+        test_destination_wrapper::TestDestinationWrapper,
+        test_schema::{TableSelection, setup_test_database_schema},
+    },
+};
+use etl_telemetry::tracing::init_test_tracing;
+use rand::random;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
+    init_test_tracing();
+
+    // --- GIVEN: a healthy pipeline whose destination fails on shutdown ---
+    let database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+
+    let store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    destination
+        .inject_fault(
+            FaultyOp::Shutdown,
+            FaultAction::fail_dispatch(
+                ErrorKind::DestinationQueryFailed,
+                "injected shutdown failure",
+            ),
+        )
+        .await;
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready = store
+        .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
+        .await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    // --- WHEN: the pipeline shuts down ---
+    let result = pipeline.shutdown_and_wait().await;
+
+    // --- THEN: the injected destination shutdown error is propagated and shutdown
+    // was still invoked ---
+    let err = result.unwrap_err();
+    assert!(err.kinds().contains(&ErrorKind::DestinationQueryFailed));
+    assert!(destination.shutdown_called().await);
+}


### PR DESCRIPTION
Destination failures are currently untestable at the core-runtime level: `MemoryDestination` has no error paths and `TestDestinationWrapper` only records successful operations. Every "what does the pipeline do when the destination misbehaves" question was unanswered by tests.

This adds a fault vocabulary to TestDestinationWrapper, scripted per operation and consumed FIFO:

```
FaultAction::Reject(..)          // refuses the work; inner destination never runs
FaultAction::FailAfterWrite(..)  // does the work, then reports failure (lost response)
FaultAction::HoldResponse(..)    // does the work, never answers until the test releases it
FaultAction::RespondSlowly(..)   // does the work, answers late
```

Tests inject faults with one line (`destination.inject_fault(op, action)`) or hold an in-flight operation with `hold_next(op)`, which returns a handle to observe the hold and choose the outcome. Errors are injected as `ErrorKind` + message, so tests control retry-policy classification. An empty queue means fully transparent behavior -- all existing tests pass unchanged.

First consumers, included here:

- `destination_shutdown_error_is_returned_by_shutdown_and_wait`: locks in that destination shutdown errors surface from Pipeline::shutdown_and_wait.
- `drop_table_for_copy_rejection_...` and `drop_table_for_copy_failure_after_write_...`: a failed pre-copy drop must leave the table `Errored` and restartable, keep stored schemas intact, and recopy cleanly on the timed retry.

Follow-up (no new machinery needed): `shutdown-drain and disconnect-while-write-pending` tests.