### PR TITLE
feat(etl): support deferred table-copy write durability

### DIFF
--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -390,7 +390,7 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         let row_count = table_rows.len() as u64;
         let row_bytes = table_rows.iter().map(SizeHint::size_hint).sum::<usize>() as u64;
@@ -445,9 +445,9 @@ impl Destination for NullDestination {
         &self,
         _replicated_table_schema: &ReplicatedTableSchema,
         _table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
-        async_result.send(Ok(()));
+        async_result.send(Ok(DestinationWriteStatus::Durable));
         Ok(())
     }
 
@@ -688,7 +688,7 @@ impl Destination for BenchDestination {
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         match self {
             Self::Null(destination) => {

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1378,13 +1378,13 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;
 
         let result =
             BigQueryDestination::write_table_rows(self, replicated_table_schema, table_rows).await;
-        async_result.send(result);
+        async_result.send(result.map(|_| DestinationWriteStatus::Durable));
 
         Ok(())
     }

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -1466,10 +1466,10 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         let result = self.write_table_rows_inner(replicated_table_schema, table_rows).await;
-        async_result.send(result);
+        async_result.send(result.map(|_| DestinationWriteStatus::Durable));
         Ok(())
     }
 

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -292,10 +292,10 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         let result = self.write_table_rows(replicated_table_schema, table_rows).await;
-        async_result.send(result);
+        async_result.send(result.map(|_| DestinationWriteStatus::Durable));
 
         Ok(())
     }

--- a/crates/etl-destinations/src/iceberg/core.rs
+++ b/crates/etl-destinations/src/iceberg/core.rs
@@ -611,11 +611,11 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         let result =
             IcebergDestination::write_table_rows(self, replicated_table_schema, table_rows).await;
-        async_result.send(result);
+        async_result.send(result.map(|_| DestinationWriteStatus::Durable));
 
         Ok(())
     }

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -509,10 +509,10 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         let result = self.write_table_rows(replicated_table_schema, table_rows).await;
-        async_result.send(result);
+        async_result.send(result.map(|_| DestinationWriteStatus::Durable));
         Ok(())
     }
 

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -15,29 +15,47 @@ use crate::{
     etl_error,
 };
 
-/// Status reported by a streaming destination write.
+/// Durability status reported by streaming and table-copy destination writes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DestinationWriteStatus {
     /// The destination accepted ownership of the write, but ETL must not
-    /// advance durable replication progress for it yet.
+    /// consider it durable yet.
     ///
     /// Completing a result as `Accepted` consumes that result. After that
     /// point, ETL cannot wait on the same result for a later durability signal.
-    /// ETL carries the write's commit end LSN into the next streaming write and
-    /// advances durable progress only when a later cumulative
-    /// [`DestinationWriteStatus::Durable`] result proves it durable.
     ///
-    /// If no later streaming write is dispatched before shutdown, ETL exits
-    /// without acknowledging the accepted write as durable. Restart then
-    /// replays from the last durable checkpoint.
+    /// For streaming writes through
+    /// [`crate::destination::Destination::write_events`], ETL does not advance
+    /// the batch's commit end LSN. It carries that LSN into the next streaming
+    /// write and advances durable progress only when a later cumulative
+    /// [`DestinationWriteStatus::Durable`] result covers it. If no later write
+    /// is dispatched before shutdown, ETL leaves progress at the last durable
+    /// checkpoint so restart can replay the accepted write.
+    ///
+    /// For table-copy writes through
+    /// [`crate::destination::Destination::write_table_rows`], ETL may request
+    /// the next batch for the same copy partition, but records that the table
+    /// requires a terminal durability barrier. After all copy workers finish,
+    /// ETL sends an empty table-copy write and refuses to store `FinishedCopy`
+    /// until that barrier returns [`DestinationWriteStatus::Durable`].
+    /// Returning `Accepted` from the terminal barrier fails the table copy.
     Accepted,
-    /// This write and all earlier accepted writes in the same ordered
-    /// apply-loop stream are durable according to the destination contract.
+    /// The destination confirms the write is durable.
     ///
-    /// The cumulative meaning is required for deferred destinations. When the
-    /// apply loop observes this status, it may advance durable progress through
-    /// the greatest commit end LSN carried by this write or by earlier accepted
-    /// writes that were attached to this write.
+    /// For streaming writes through
+    /// [`crate::destination::Destination::write_events`], this write and all
+    /// earlier `Accepted` writes in the same ordered apply-loop stream are
+    /// durable. ETL may advance through the greatest commit end LSN carried by
+    /// this write or reattached from those earlier writes.
+    ///
+    /// For a nonempty table-copy write through
+    /// [`crate::destination::Destination::write_table_rows`], this status
+    /// confirms that batch is durable. If any table-copy batch returned
+    /// `Accepted`, ETL still sends a terminal empty write after every copy
+    /// worker finishes. `Durable` from that barrier must cover every accepted
+    /// write in the current table-copy attempt before ETL stores
+    /// `FinishedCopy`. Empty and skipped tables must also return `Durable`
+    /// from their empty initialization write before the copy can finish.
     Durable,
 }
 
@@ -45,10 +63,12 @@ pub enum DestinationWriteStatus {
 /// [`crate::destination::Destination::write_table_rows`].
 ///
 /// ETL waits for this result before requesting the next row batch for the same
-/// copy partition. The handle exists mostly to keep the destination API aligned
-/// with [`WriteEventsResult`], so destinations may still choose to structure
-/// their internal write paths in a similar way.
-pub type WriteTableRowsResult<T = ()> = AsyncResult<T>;
+/// copy partition. A destination may report
+/// [`DestinationWriteStatus::Accepted`] to continue copying before the batch is
+/// durable. ETL then issues a terminal empty write as a table-wide durability
+/// barrier and requires [`DestinationWriteStatus::Durable`] before completing
+/// the copy.
+pub type WriteTableRowsResult<T = DestinationWriteStatus> = AsyncResult<T>;
 
 /// Async completion handle used for
 /// [`crate::destination::Destination::drop_table_for_copy`].

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -57,6 +57,11 @@ pub trait Destination {
     /// object and any destination-private replay markers for the table so the
     /// next copy can recreate it from the fresh source schema.
     ///
+    /// Before reporting success, the destination must ensure that writes
+    /// accepted during an earlier copy attempt can no longer modify the
+    /// destination table. It may do this by waiting for them, cancelling
+    /// them, or rejecting them as stale.
+    ///
     /// The supplied schema describes the previously known destination table and
     /// exists only so the destination can locate what should be removed. ETL
     /// clears its own destination metadata and stored schemas only after this
@@ -81,23 +86,43 @@ pub trait Destination {
     /// batches; it just provides the data that should be written for the
     /// initial snapshot.
     ///
-    /// Implementations report asynchronous completion through `async_result`.
+    /// Implementations report asynchronous write status through `async_result`.
     /// The method return value is reserved for immediate dispatch/setup
     /// failures before the work has been accepted.
     ///
     /// ETL waits for each table-copy batch to finish before reading the next
     /// batch for the same copy partition. When multiple copy workers are
     /// configured, this method can still run concurrently across different
-    /// partitions, so the asynchronous result is mostly an API consistency tool
-    /// rather than a way to queue all copy batches and wait at the end.
+    /// partitions.
     ///
-    /// This immediate waiting is intentional: it preserves backpressure and
-    /// avoids accumulating too many in-flight row batches in memory.
+    /// [`crate::destination::DestinationWriteStatus::Durable`] means the batch
+    /// and all earlier accepted writes it covers are durable.
+    /// [`crate::destination::DestinationWriteStatus::Accepted`] transfers
+    /// ownership of the batch to the destination and permits ETL to continue
+    /// copying, but does not permit ETL to complete the table copy.
+    ///
+    /// If any nonempty batch returns
+    /// [`crate::destination::DestinationWriteStatus::Accepted`], ETL calls this
+    /// method once more with an empty batch after every copy worker has
+    /// finished and the source copy transaction has committed. That empty
+    /// write is a table-wide durability barrier: it must return
+    /// [`crate::destination::DestinationWriteStatus::Durable`] and cumulatively
+    /// cover every accepted write for the table copy. Returning
+    /// [`crate::destination::DestinationWriteStatus::Accepted`] from the
+    /// barrier fails the copy without advancing its durable state. Empty
+    /// and skipped tables also receive an empty write so the destination
+    /// can prepare their initial state.
+    ///
+    /// Awaiting each result before requesting the next batch bounds ETL-owned
+    /// row batches per copy partition. A deferred destination must separately
+    /// bound its accepted-but-not-durable work and delay reporting
+    /// [`crate::destination::DestinationWriteStatus::Accepted`] until it has
+    /// reserved ownership and capacity for the batch.
     fn write_table_rows(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 
     /// Writes streaming replication events to the destination.

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -101,9 +101,9 @@
 //!         &self,
 //!         _replicated_table_schema: &ReplicatedTableSchema,
 //!         _table_rows: Vec<TableRow>,
-//!         async_result: WriteTableRowsResult<()>,
+//!         async_result: WriteTableRowsResult,
 //!     ) -> EtlResult<()> {
-//!         async_result.send(Ok(()));
+//!         async_result.send(Ok(DestinationWriteStatus::Durable));
 //!         Ok(())
 //!     }
 //!     async fn write_events(

--- a/crates/etl/src/replication/table_sync/copy.rs
+++ b/crates/etl/src/replication/table_sync/copy.rs
@@ -22,7 +22,7 @@ use tracing::{debug, info, warn};
 use crate::failpoints::{START_TABLE_SYNC_DURING_DATA_SYNC_FP, etl_fail_point};
 use crate::{
     data::TableRow,
-    destination::{Destination, WriteTableRowsResult},
+    destination::{Destination, DestinationWriteStatus, WriteTableRowsResult},
     error::{ErrorKind, EtlResult},
     etl_error,
     observability::{
@@ -56,11 +56,41 @@ const CTID_COPY_ROWS_PER_PARTITION: u128 = 250_000;
 /// Maximum CTID ranges planned for one tracked table.
 const MAX_CTID_COPY_PARTITIONS: u16 = 1024;
 
+/// Mergeable progress accumulated across concurrent table-copy work.
+#[derive(Debug, Default)]
+struct CopyProgress {
+    /// Total number of rows copied.
+    total_rows: u64,
+    /// Whether any row batch was accepted without being durable.
+    barrier_required: bool,
+}
+
+impl CopyProgress {
+    /// Records one successfully accepted or durable row batch.
+    fn record_batch(&mut self, row_count: u64, status: DestinationWriteStatus) {
+        self.total_rows += row_count;
+        self.barrier_required |= status == DestinationWriteStatus::Accepted;
+    }
+
+    /// Merges progress from another copy stream, partition, or worker.
+    fn merge(&mut self, other: Self) {
+        self.total_rows += other.total_rows;
+        self.barrier_required |= other.barrier_required;
+    }
+}
+
 /// Result of a table copy operation.
 #[derive(Debug)]
 pub(crate) enum TableCopyResult {
     /// All rows copied successfully.
-    Completed { total_rows: u64, total_duration_secs: f64 },
+    Completed {
+        /// Total number of rows copied.
+        total_rows: u64,
+        /// Total copy duration in seconds.
+        total_duration_secs: f64,
+        /// Whether the copy requires a terminal durability barrier.
+        barrier_required: bool,
+    },
     /// Copy was interrupted by a shutdown signal.
     Shutdown,
 }
@@ -78,18 +108,11 @@ struct CopyPartition {
     planned_blocks: u64,
 }
 
-/// Rows copied by a completed worker.
-#[derive(Debug)]
-struct CompletedCopyWorker {
-    /// Rows copied by this worker.
-    total_rows: u64,
-}
-
 /// Outcome of one worker connection.
 #[derive(Debug)]
 enum CopyWorkerOutcome {
     /// The worker drained all available work and committed its transaction.
-    Completed(CompletedCopyWorker),
+    Completed(CopyProgress),
     /// The worker observed shutdown before committing its transaction.
     Shutdown,
 }
@@ -302,7 +325,11 @@ async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
         counter!(ETL_TABLE_COPY_ROWS_TOTAL).increment(0);
         histogram!(ETL_TABLE_COPY_DURATION_SECONDS).record(0.0);
 
-        return Ok(TableCopyResult::Completed { total_rows: 0, total_duration_secs: 0.0 });
+        return Ok(TableCopyResult::Completed {
+            total_rows: 0,
+            total_duration_secs: 0.0,
+            barrier_required: false,
+        });
     }
 
     info!(
@@ -372,11 +399,11 @@ async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
         });
     }
 
-    let mut total_rows = 0;
+    let mut progress = CopyProgress::default();
     while let Some(result) = join_set.join_next().await {
         match result {
-            Ok(Ok(CopyWorkerOutcome::Completed(worker_result))) => {
-                total_rows += worker_result.total_rows;
+            Ok(Ok(CopyWorkerOutcome::Completed(worker_progress))) => {
+                progress.merge(worker_progress);
             }
             Ok(Ok(CopyWorkerOutcome::Shutdown)) => {
                 info!(
@@ -415,10 +442,14 @@ async fn worker_table_copy<D: Destination + Clone + Send + 'static>(
     stop_table_copy_lag_reporter(&mut lag_reporter).await;
 
     let total_duration_secs = start_time.elapsed().as_secs_f64();
-    counter!(ETL_TABLE_COPY_ROWS_TOTAL).increment(total_rows);
+    counter!(ETL_TABLE_COPY_ROWS_TOTAL).increment(progress.total_rows);
     histogram!(ETL_TABLE_COPY_DURATION_SECONDS).record(total_duration_secs);
 
-    Ok(TableCopyResult::Completed { total_rows, total_duration_secs })
+    Ok(TableCopyResult::Completed {
+        total_rows: progress.total_rows,
+        total_duration_secs,
+        barrier_required: progress.barrier_required,
+    })
 }
 
 /// Plans ctid work items for every physical table that backs `table_id`.
@@ -535,7 +566,7 @@ where
 {
     let child_replication_transaction =
         child_replication_client.begin_transaction(&snapshot_id).await?;
-    let mut total_rows = 0;
+    let mut progress = CopyProgress::default();
 
     loop {
         if is_shutdown_requested(&shutdown_rx) {
@@ -550,7 +581,7 @@ where
             // means all CTID work has been claimed.
             child_replication_transaction.commit().await?;
 
-            return Ok(CopyWorkerOutcome::Completed(CompletedCopyWorker { total_rows }));
+            return Ok(CopyWorkerOutcome::Completed(progress));
         };
 
         match copy_partition_rows(
@@ -567,10 +598,10 @@ where
         )
         .await?
         {
-            TableCopyResult::Completed { total_rows: partition_rows, .. } => {
-                total_rows += partition_rows;
+            ShutdownResult::Ok(partition_progress) => {
+                progress.merge(partition_progress);
             }
-            TableCopyResult::Shutdown => return Ok(CopyWorkerOutcome::Shutdown),
+            ShutdownResult::Shutdown(_) => return Ok(CopyWorkerOutcome::Shutdown),
         }
     }
 }
@@ -588,12 +619,12 @@ async fn copy_partition_rows<D>(
     destination: D,
     memory_monitor: MemoryMonitor,
     batch_budget: BatchBudgetController,
-) -> EtlResult<TableCopyResult>
+) -> EtlResult<ShutdownResult<CopyProgress, CopyProgress>>
 where
     D: Destination + Clone + Send + 'static,
 {
     if is_shutdown_requested(&shutdown_rx) {
-        return Ok(TableCopyResult::Shutdown);
+        return Ok(ShutdownResult::Shutdown(CopyProgress::default()));
     }
 
     let start_time = Instant::now();
@@ -630,7 +661,7 @@ where
     );
     pin!(table_copy_stream);
 
-    let total_rows = match copy_table_rows_from_stream(
+    let progress = match copy_table_rows_from_stream(
         table_copy_stream.as_mut(),
         shutdown_rx,
         connection_updates_rx,
@@ -639,26 +670,26 @@ where
     )
     .await?
     {
-        ShutdownResult::Ok(total_rows) => total_rows,
-        ShutdownResult::Shutdown(_) => {
-            return Ok(TableCopyResult::Shutdown);
+        ShutdownResult::Ok(progress) => progress,
+        ShutdownResult::Shutdown(progress) => {
+            return Ok(ShutdownResult::Shutdown(progress));
         }
     };
 
     let total_duration_secs = start_time.elapsed().as_secs_f64();
     counter!(ETL_TABLE_COPY_PARTITIONS_TOTAL).increment(1);
-    histogram!(ETL_TABLE_COPY_PARTITION_ROWS).record(total_rows as f64);
+    histogram!(ETL_TABLE_COPY_PARTITION_ROWS).record(progress.total_rows as f64);
     histogram!(ETL_TABLE_COPY_PARTITION_DURATION_SECONDS).record(total_duration_secs);
 
     info!(
         table_id = table_id.0,
         source_table_id = partition.source_table_id.0,
-        total_rows,
+        total_rows = progress.total_rows,
         total_duration_secs,
         "completed ctid partition copy"
     );
 
-    Ok(TableCopyResult::Completed { total_rows, total_duration_secs })
+    Ok(ShutdownResult::Ok(progress))
 }
 
 /// Copies rows from a batched table-copy stream into the destination with
@@ -669,19 +700,19 @@ async fn copy_table_rows_from_stream<D, S>(
     mut connection_updates_rx: watch::Receiver<PostgresConnectionUpdate>,
     replicated_table_schema: ReplicatedTableSchema,
     destination: D,
-) -> EtlResult<ShutdownResult<u64, u64>>
+) -> EtlResult<ShutdownResult<CopyProgress, CopyProgress>>
 where
     D: Destination + Clone + Send + 'static,
     S: Stream<Item = EtlResult<Vec<TableRow>>>,
 {
-    let mut total_rows = 0;
+    let mut progress = CopyProgress::default();
 
     loop {
         tokio::select! {
             biased;
 
             _ = shutdown_rx.changed() => {
-                return Ok(ShutdownResult::Shutdown(total_rows));
+                return Ok(ShutdownResult::Shutdown(progress));
             }
 
             changed = connection_updates_rx.changed() => {
@@ -713,7 +744,7 @@ where
 
             maybe_batch = table_copy_stream.next() => {
                 let Some(table_rows) = maybe_batch else {
-                    return Ok(ShutdownResult::Ok(total_rows));
+                    return Ok(ShutdownResult::Ok(progress));
                 };
 
                 let table_rows = table_rows?;
@@ -725,9 +756,9 @@ where
                 destination
                     .write_table_rows(&replicated_table_schema, table_rows, flush_result)
                     .await?;
-                pending_flush_result.await.into_result()?;
+                let write_status = pending_flush_result.await.into_result()?;
 
-                total_rows += batch_size;
+                progress.record_batch(batch_size, write_status);
 
                 let send_duration_seconds = before_sending.elapsed().as_secs_f64();
                 histogram!(

--- a/crates/etl/src/replication/table_sync/mod.rs
+++ b/crates/etl/src/replication/table_sync/mod.rs
@@ -18,7 +18,8 @@ use crate::failpoints::{
 use crate::{
     bail,
     destination::{
-        DestinationTableMetadata, DropTableForCopyResult, PipelineDestination, WriteTableRowsResult,
+        DestinationTableMetadata, DestinationWriteStatus, DropTableForCopyResult,
+        PipelineDestination, WriteTableRowsResult,
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -297,6 +298,7 @@ where
 
             let mut total_table_copy_rows = 0;
             let mut total_table_copy_duration_secs = 0.0;
+            let mut table_copy_barrier_required = false;
 
             // We check if the table should be copied, or we can skip it.
             if config.table_sync_copy.should_copy_table(table_id.into_inner()) {
@@ -318,9 +320,14 @@ where
                 .await?;
 
                 match result {
-                    TableCopyResult::Completed { total_rows, total_duration_secs } => {
+                    TableCopyResult::Completed {
+                        total_rows,
+                        total_duration_secs,
+                        barrier_required,
+                    } => {
                         total_table_copy_rows = total_rows as usize;
                         total_table_copy_duration_secs = total_duration_secs;
+                        table_copy_barrier_required = barrier_required;
                     }
                     TableCopyResult::Shutdown => {
                         info!(
@@ -340,14 +347,22 @@ where
             // started.
             replication_transaction.commit().await?;
 
-            // If no table rows were written, we call the method nonetheless with no rows,
-            // to kickstart table creation.
-            if total_table_copy_rows == 0 {
+            // If no table rows were written, call the method nonetheless to kickstart
+            // table creation. Additionally, if any copy write was only accepted (and not
+            // durably committed), the empty write is also the terminal table-wide
+            // durability barrier.
+            if total_table_copy_rows == 0 || table_copy_barrier_required {
                 let (flush_result, pending_flush_result) = WriteTableRowsResult::new(());
                 destination
                     .write_table_rows(&replicated_table_schema, vec![], flush_result)
                     .await?;
-                pending_flush_result.await.into_result()?;
+                match pending_flush_result.await.into_result()? {
+                    DestinationWriteStatus::Durable => {}
+                    DestinationWriteStatus::Accepted => bail!(
+                        ErrorKind::DestinationError,
+                        "Table copy durability barrier did not confirm durability"
+                    ),
+                }
             }
 
             info!(

--- a/crates/etl/src/test_utils/memory_destination.rs
+++ b/crates/etl/src/test_utils/memory_destination.rs
@@ -172,7 +172,7 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         let table_id = replicated_table_schema.id();
 
@@ -184,7 +184,7 @@ where
         info!(%table_id, row_count = table_rows.len(), "writing table rows");
         inner.table_rows.insert(table_id, table_rows);
 
-        async_result.send(Ok(()));
+        async_result.send(Ok(DestinationWriteStatus::Durable));
 
         Ok(())
     }

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -331,7 +331,7 @@ where
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         let fault = self.take_fault(FaultyOp::WriteTableRows).await?;
 

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -1,15 +1,21 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use etl::{
-    error::ErrorKind,
+    data::TableRow,
+    destination::{
+        Destination, DestinationWriteStatus, DropTableForCopyResult, PipelineDestination,
+        WriteEventsResult, WriteTableRowsResult,
+    },
+    error::{ErrorKind, EtlResult},
     event::{Event, EventType, InsertEvent},
     pipeline::PipelineId,
-    schema::{ColumnSchema, TableId},
+    schema::{ColumnSchema, ReplicatedTableSchema, TableId},
     store::{SchemaStore, TableState, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::{EventCondition, group_events_by_type_and_table_id},
         memory_destination::MemoryDestination,
+        notify::TimedNotify,
         notifying_store::NotifyingStore,
         pipeline::{
             PipelineBuilder, create_pipeline, create_pipeline_with_batch_config,
@@ -34,7 +40,10 @@ use etl_postgres::{
 use etl_telemetry::tracing::init_test_tracing;
 use pg_escape::{quote_identifier, quote_literal};
 use rand::random;
-use tokio::time::sleep;
+use tokio::{
+    sync::{Mutex, Notify},
+    time::sleep,
+};
 use tokio_postgres::types::{PgLsn, Type};
 
 /// Creates a test column schema with sensible defaults.
@@ -47,6 +56,141 @@ fn test_column(
 ) -> ColumnSchema {
     ColumnSchema::new(name.to_owned(), typ, -1, ordinal_position, nullable)
         .with_primary_key_ordinal_position(if primary_key { Some(1) } else { None })
+}
+
+/// State used by [`DeferredCopyDestination`] to control copy durability.
+#[derive(Default)]
+struct DeferredCopyDestinationState {
+    /// Number of nonempty copy writes received.
+    nonempty_writes: usize,
+    /// Rows retained after the first copy write is accepted.
+    accepted_rows: Vec<TableRow>,
+    /// Held terminal durability barrier result.
+    barrier_result: Option<WriteTableRowsResult>,
+}
+
+/// Destination test double that defers the first copy write's durability.
+#[derive(Clone)]
+struct DeferredCopyDestination<D> {
+    /// Immediate destination used for writes after the first copy batch.
+    inner: D,
+    /// Shared durability-control state.
+    state: Arc<Mutex<DeferredCopyDestinationState>>,
+    /// Notification emitted after the terminal barrier is held.
+    barrier_reached: Arc<Notify>,
+}
+
+impl<D> DeferredCopyDestination<D> {
+    /// Wraps an immediate destination with deferred copy durability behavior.
+    fn wrap(inner: D) -> Self {
+        Self {
+            inner,
+            state: Arc::new(Mutex::new(DeferredCopyDestinationState::default())),
+            barrier_reached: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Returns a notification for the next terminal durability barrier.
+    fn notify_on_barrier(&self) -> TimedNotify {
+        TimedNotify::new(Arc::clone(&self.barrier_reached))
+    }
+
+    /// Returns the number of nonempty copy writes received.
+    async fn nonempty_writes(&self) -> usize {
+        self.state.lock().await.nonempty_writes
+    }
+
+    /// Completes the held terminal durability barrier with `status`.
+    async fn complete_barrier(&self, status: DestinationWriteStatus) {
+        let barrier_result = self
+            .state
+            .lock()
+            .await
+            .barrier_result
+            .take()
+            .expect("terminal copy durability barrier should be held");
+        barrier_result.send(Ok(status));
+    }
+}
+
+impl<D> Destination for DeferredCopyDestination<D>
+where
+    D: PipelineDestination,
+{
+    fn name() -> &'static str {
+        "deferred_copy"
+    }
+
+    async fn startup(&self) -> EtlResult<()> {
+        self.inner.startup().await
+    }
+
+    async fn shutdown(&self) -> EtlResult<()> {
+        self.inner.shutdown().await
+    }
+
+    async fn drop_table_for_copy(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+        async_result: DropTableForCopyResult<()>,
+    ) -> EtlResult<()> {
+        self.inner.drop_table_for_copy(replicated_table_schema, async_result).await
+    }
+
+    async fn write_table_rows(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+        mut table_rows: Vec<TableRow>,
+        async_result: WriteTableRowsResult,
+    ) -> EtlResult<()> {
+        if table_rows.is_empty() {
+            // Hold the terminal empty write so the test can inspect table state
+            // before durability is confirmed.
+            let mut state = self.state.lock().await;
+            assert!(
+                state.barrier_result.is_none(),
+                "only one terminal copy durability barrier should be pending"
+            );
+            state.barrier_result = Some(async_result);
+            drop(state);
+
+            self.barrier_reached.notify_one();
+
+            return Ok(());
+        }
+
+        let table_rows = {
+            let mut state = self.state.lock().await;
+            state.nonempty_writes += 1;
+
+            if state.nonempty_writes == 1 {
+                // Take ownership of the first batch without making it durable.
+                state.accepted_rows = table_rows;
+                None
+            } else {
+                // Make the accepted rows durable with a later batch. ETL must
+                // still remember that the terminal barrier is required.
+                state.accepted_rows.append(&mut table_rows);
+                Some(std::mem::take(&mut state.accepted_rows))
+            }
+        };
+
+        let Some(table_rows) = table_rows else {
+            async_result.send(Ok(DestinationWriteStatus::Accepted));
+
+            return Ok(());
+        };
+
+        self.inner.write_table_rows(replicated_table_schema, table_rows, async_result).await
+    }
+
+    async fn write_events(
+        &self,
+        events: Vec<Event>,
+        async_result: WriteEventsResult,
+    ) -> EtlResult<()> {
+        self.inner.write_events(events, async_result).await
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -375,6 +519,61 @@ async fn table_copy_replicates_many_rows_with_parallel_connections() {
     let table_rows = destination.get_table_rows().await;
     let copied_rows = table_rows.get(&table_id).map_or(0, Vec::len);
     assert_eq!(copied_rows, total_rows as usize);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_copy_waits_for_durable_terminal_barrier_after_accepted_write() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+    let table_name = database_schema.users_schema().name.clone();
+
+    // Force at least two copy batches so the first can return Accepted and a
+    // later batch Durable. The terminal barrier must still be required.
+    insert_users_data(&mut database, &table_name, 0..=2).await;
+
+    let store = NotifyingStore::new();
+    let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let destination = DeferredCopyDestination::wrap(immediate_destination);
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = PipelineBuilder::new(
+        database.config.clone(),
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    )
+    .with_max_copy_connections_per_table(1)
+    .with_batch_config(BatchConfig { max_fill_ms: 1000, memory_budget_ratio: 0.2, max_bytes: 1 })
+    .build();
+
+    // Arm notifications before starting because they only observe future
+    // transitions.
+    let barrier_reached = destination.notify_on_barrier();
+    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    // The destination now holds the terminal barrier result.
+    barrier_reached.notified().await;
+
+    // A later Durable batch must not advance the table while the terminal
+    // barrier remains pending.
+    assert!(destination.nonempty_writes().await >= 2);
+    let table_states = store.get_table_states().await;
+    assert_eq!(
+        table_states.get(&table_id).map(TableState::as_type),
+        Some(TableStateType::DataSync)
+    );
+
+    // Confirming the terminal barrier unlocks normal table-state progression.
+    destination.complete_barrier(DestinationWriteStatus::Durable).await;
+    table_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/docs/src/content/docs/explanation/architecture.md
+++ b/docs/src/content/docs/explanation/architecture.md
@@ -84,7 +84,7 @@ pub trait Destination {
     fn shutdown(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
     fn startup(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
     fn drop_table_for_copy(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: DropTableForCopyResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
-    fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, rows: Vec<TableRow>, async_result: WriteTableRowsResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
+    fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, rows: Vec<TableRow>, async_result: WriteTableRowsResult) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult) -> impl Future<Output = EtlResult<()>> + Send;
 }
 ```
@@ -95,13 +95,14 @@ pub trait Destination {
 | `shutdown()` | After ETL stops submitting work | Clean up destination resources, drain writers, or stop background tasks |
 | `startup()` | After store caches are loaded, removed-publication tables are purged, and before workers start | Reconcile destination state after process restarts |
 | `drop_table_for_copy()` | Before restarting a table copy when previous destination state exists | Drop the existing destination object and destination-private replay state using the previously stored replicated schema |
-| `write_table_rows()` | During initial copy | Receive bulk rows for the current replicated schema |
+| `write_table_rows()` | During initial copy | Receive bulk rows or complete a deferred copy durability barrier for the current replicated schema |
 | `write_events()` | During catch-up and continuous replication | Receive streaming changes |
 
 Each write-like method receives an async result handle. The intent is different per method:
 
 - `write_events()`: after dispatch succeeds, ETL may keep processing other work while the destination finishes the batch. ETL still waits for that batch's async result before handing the destination the next streaming batch.
-- `drop_table_for_copy()` and `write_table_rows()`: ETL waits for the result immediately. After a successful drop, ETL clears its own copy-scoped schema, destination metadata, and table-sync progress before storing the fresh `0/0` copy schema.
+- `drop_table_for_copy()`: ETL waits for the result immediately. After a successful drop, ETL clears its own copy-scoped schema, destination metadata, and table-sync progress before storing the fresh `0/0` copy schema.
+- `write_table_rows()`: ETL waits for each result before requesting the next batch for that copy partition. `Durable` confirms that batch and any earlier accepted writes covered by the result. `Accepted` transfers ownership to the destination and lets copying continue without marking the table copy finished. If any batch is accepted this way, ETL sends a final empty batch after all copy workers finish; that table-wide barrier must cover every accepted write and return `Durable` before ETL stores `FinishedCopy`.
 
 ### Store
 

--- a/docs/src/content/docs/explanation/traits.md
+++ b/docs/src/content/docs/explanation/traits.md
@@ -17,7 +17,7 @@ pub trait Destination {
     fn shutdown(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
     fn startup(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
     fn drop_table_for_copy(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: DropTableForCopyResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
-    fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, table_rows: Vec<TableRow>, async_result: WriteTableRowsResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
+    fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, table_rows: Vec<TableRow>, async_result: WriteTableRowsResult) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult) -> impl Future<Output = EtlResult<()>> + Send;
 }
 ```
@@ -30,20 +30,21 @@ pub trait Destination {
 | `shutdown()` | Called when the pipeline shuts down. Default is a no-op. Override for cleanup or bookkeeping |
 | `startup()` | Called after store caches are loaded, removed-publication tables are purged, and before workers start. Default is a no-op. Override to reconcile destination state after restarts |
 | `drop_table_for_copy()` | Drops the existing destination object and destination-private replay state before restarting a table copy. Receives the previously stored replicated schema for locating the old object |
-| `write_table_rows()` | Writes rows during initial table copy. Receives the current replicated schema and may get an empty vector for tables with no data |
+| `write_table_rows()` | Writes rows during initial table copy. Receives the current replicated schema and may get an empty vector for an empty table or a deferred durability barrier |
 | `write_events()` | Processes streaming replication events (inserts, updates, deletes, truncates, relations, and transaction markers). Batches may span multiple tables |
 
 ### Implementation Notes
 
-- `drop_table_for_copy()` should be **idempotent**. ETL calls it before clearing copy-scoped store state, so implementations can still use the supplied schema and existing destination metadata to locate the old object.
+- `drop_table_for_copy()` should be **idempotent**. ETL calls it before clearing copy-scoped store state, so implementations can still use the supplied schema and existing destination metadata to locate the old object. Before returning success, it must also drain or invalidate writes accepted by an earlier copy attempt so stale work cannot mutate the recreated table.
 - `write_table_rows()` is called even for empty source tables so destinations can create or prepare initial destination state before streaming begins.
+- An immediate `write_table_rows()` implementation returns `DestinationWriteStatus::Durable` after the batch is durable. A deferred implementation may return `Accepted` after taking ownership of a nonempty batch. It must bound its accepted-but-not-durable backlog and delay `Accepted` when no capacity is available. If any batch returns `Accepted`, ETL sends an empty batch after all copy workers finish; the destination must return `Durable` from that call only after all rows accepted during the current copy attempt are durable.
 - `write_table_rows()` and `write_events()` must tolerate **duplicate delivery** because ETL may retry or replay after failure.
 - Handle **concurrent calls** safely, especially from parallel table sync workers.
 - Preserve **per-table event order**. During initial copy and catch-up, transaction markers are not a reliable all-tables transaction boundary.
 - Treat `Event::Relation` as an ordered schema transition, not a `write_events()` batch boundary. ETL batches streaming events by size and time, so one call can contain multiple schema changes, including multiple relation events for the same table.
 - Always complete the supplied async result handle. Dropping it reports a destination error to ETL.
 - `startup()` runs after ETL has loaded destination metadata and table schemas from the store and purged tables removed from the publication, so destinations can compare active persisted ETL state with their physical objects before replication work starts.
-- All three write-like methods use async results, but ETL waits differently. `drop_table_for_copy()` waits immediately before copy-scoped store cleanup. `write_table_rows()` also waits immediately, requesting the next batch only after the current one finishes for that copy partition. `write_events()` is the method where ETL can keep processing other work while the destination finishes the current batch; ETL still waits for that batch's async result before handing the destination the next streaming batch.
+- All three write-like methods use async results, but ETL waits differently. `drop_table_for_copy()` waits immediately before copy-scoped store cleanup. `write_table_rows()` also waits immediately, requesting the next batch only after the current one reports `Accepted` or `Durable` for that copy partition. `write_events()` is the method where ETL can keep processing other work while the destination finishes the current batch; ETL still waits for that batch's async result before handing the destination the next streaming batch.
 
 See [Event Types](/etl/explanation/events/) for details on the events received by `write_events()`.
 

--- a/docs/src/content/docs/guides/custom-implementations.md
+++ b/docs/src/content/docs/guides/custom-implementations.md
@@ -327,9 +327,9 @@ Create `src/http_destination.rs`. A destination implements the `Destination` tra
 
 There are also optional `startup()` and `shutdown()` methods with default no-op implementations. Override `startup()` if your destination needs to reconcile active durable ETL metadata with physical destination objects after a restart. Override `shutdown()` if your destination needs cleanup when the pipeline shuts down.
 
-ETL clears its own schema versions, destination metadata, and table-sync progress **only after `drop_table_for_copy()` succeeds**. That lets the destination use the supplied previously stored replicated schema and any existing destination metadata to find the object that must be removed. If the object is already gone, return success.
+ETL clears its own schema versions, destination metadata, and table-sync progress **only after `drop_table_for_copy()` succeeds**. That lets the destination use the supplied previously stored replicated schema and any existing destination metadata to find the object that must be removed. Before returning success, also drain or invalidate writes accepted by an earlier copy attempt so stale work cannot mutate the recreated object. If the object is already gone and no stale write can recreate or mutate it, return success.
 
-All write-like methods must complete their async result handle. Treat the method return value as the place for immediate dispatch or setup failures, and send the final write result through `async_result`. Immediate streaming destinations should send `DestinationWriteStatus::Durable` after a successful `write_events()` call. ETL is **at least once**, so make row and event writes idempotent. `write_events()` preserves per-table ordering, but batches can include multiple tables and transaction markers are not a complete all-tables boundary during initial copy and catch-up.
+All write-like methods must complete their async result handle. Treat the method return value as the place for immediate dispatch or setup failures, and send the final write result through `async_result`. Immediate destinations should send `DestinationWriteStatus::Durable` after successful `write_table_rows()` and `write_events()` calls. A copy destination that returns `DestinationWriteStatus::Accepted` must take ownership of the rows, bound its accepted-but-not-durable backlog, and delay `Accepted` until it has capacity. It must later treat an empty `write_table_rows()` call as a same-table durability barrier: return `Durable` only when every row accepted during that copy attempt is durable. ETL is **at least once**, so make row and event writes idempotent. `write_events()` preserves per-table ordering, but batches can include multiple tables and transaction markers are not a complete all-tables boundary during initial copy and catch-up.
 
 ```rust
 use reqwest::Client;
@@ -403,10 +403,10 @@ impl Destination for HttpDestination {
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
         rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         if rows.is_empty() {
-            async_result.send(Ok(()));
+            async_result.send(Ok(DestinationWriteStatus::Durable));
             return Ok(());
         }
         let table_name = replicated_table_schema.name().to_string();
@@ -419,7 +419,10 @@ impl Destination for HttpDestination {
             }).collect::<Vec<_>>()
         });
 
-        let result = self.post("rows", payload).await;
+        let result = self
+            .post("rows", payload)
+            .await
+            .map(|_| DestinationWriteStatus::Durable);
         async_result.send(result);
         Ok(())
     }

--- a/docs/src/content/docs/guides/first-pipeline.md
+++ b/docs/src/content/docs/guides/first-pipeline.md
@@ -110,10 +110,10 @@ impl Destination for LoggingDestination {
         &self,
         _replicated_table_schema: &ReplicatedTableSchema,
         rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
         println!("copied {} rows", rows.len());
-        async_result.send(Ok(()));
+        async_result.send(Ok(DestinationWriteStatus::Durable));
         Ok(())
     }
 

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -113,9 +113,9 @@ impl Destination for NoopDestination {
         &self,
         _replicated_table_schema: &ReplicatedTableSchema,
         _table_rows: Vec<TableRow>,
-        async_result: WriteTableRowsResult<()>,
+        async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
-        async_result.send(Ok(()));
+        async_result.send(Ok(DestinationWriteStatus::Durable));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Extends deferred durability handling from streaming writes to table copy.

- Allow copy writes to report `Accepted` or `Durable`.
- Continue copying after `Accepted` while retaining a sticky durability-barrier requirement.
- Require a final table-wide `Durable` barrier before storing `FinishedCopy`.
- Preserve existing behavior for immediate destinations and document the new contract.
- Add integration coverage for the deferred copy path.
