### PR TITLE
feat(bigquery): Improve column nullability handling

### DIFF
--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -307,6 +307,22 @@ fn is_transient_query_error(error: &BQError) -> RetryDecision {
     }
 }
 
+/// Returns whether BigQuery rejected `DROP DEFAULT` because no default exists.
+fn is_missing_column_default_error(error: &BQError) -> bool {
+    let BQError::ResponseError { error } = error else {
+        return false;
+    };
+
+    error.error.code == 400
+        && error.error.errors.iter().any(|nested_error| {
+            nested_error.get("reason").is_some_and(|reason| reason == "invalid")
+                && nested_error.get("message").is_some_and(|message| {
+                    message.starts_with("Cannot DROP DEFAULT value from column ")
+                        && message.ends_with(" which does not have a DEFAULT value.")
+                })
+        })
+}
+
 /// Logs a transient BigQuery query retry.
 fn log_query_retry(attempt: crate::retry::RetryAttempt<'_, BQError>) {
     warn!(
@@ -1003,14 +1019,14 @@ impl BigQueryClient {
         let column_name = quote_identifier(&column_schema.name, "BigQuery column name")?;
         let column_type = postgres_to_bigquery_type(&column_schema.typ);
 
-        info!("adding column {column_name} ({column_type}) to table {full_table_name} in BigQuery");
+        info!("adding column {column_name} ({column_type}) to table {full_table_name} in bigquery");
 
         if !column_schema.nullable && !is_array_type(&column_schema.typ) {
             warn!(
                 dataset_id = %dataset_id,
                 table_id = %table_id,
                 column_name = %column_schema.name,
-                "BigQuery does not support adding a top-level NOT NULL column; adding it as \
+                "bigquery does not support adding a top-level not null column; adding it as \
                  nullable"
             );
         }
@@ -1038,7 +1054,7 @@ impl BigQueryClient {
         let full_table_name = self.full_table_name(dataset_id, table_id)?;
         let column_name = quote_identifier(column_name, "BigQuery column name")?;
 
-        info!("dropping column {column_name} from table {full_table_name} in BigQuery");
+        info!("dropping column {column_name} from table {full_table_name} in bigquery");
 
         let query = format!("alter table {full_table_name} drop column {column_name}");
 
@@ -1062,7 +1078,7 @@ impl BigQueryClient {
         let old_name = quote_identifier(old_name, "BigQuery column name")?;
         let new_name = quote_identifier(new_name, "BigQuery column name")?;
 
-        info!("renaming column {old_name} to {new_name} in table {full_table_name} in BigQuery");
+        info!("renaming column {old_name} to {new_name} in table {full_table_name} in bigquery");
 
         let query = format!("alter table {full_table_name} rename column {old_name} to {new_name}");
 
@@ -1086,7 +1102,7 @@ impl BigQueryClient {
                 dataset_id = %dataset_id,
                 table_id = %table_id,
                 column_name = %column_name,
-                "skipping unsupported source column default for BigQuery"
+                "skipping unsupported source column default for bigquery"
             );
             return Ok(());
         };
@@ -1094,7 +1110,7 @@ impl BigQueryClient {
         let full_table_name = self.full_table_name(dataset_id, table_id)?;
         let column_name = quote_identifier(column_name, "BigQuery column name")?;
 
-        info!("setting default for column {column_name} in table {full_table_name} in BigQuery");
+        info!("setting default for column {column_name} in table {full_table_name} in bigquery");
 
         let query = format!(
             "alter table {full_table_name} alter column {column_name} set default \
@@ -1106,8 +1122,8 @@ impl BigQueryClient {
         Ok(())
     }
 
-    /// Drops a default expression from a BigQuery column.
-    pub async fn drop_column_default(
+    /// Clears a default expression from a BigQuery column when present.
+    pub async fn clear_column_default(
         &self,
         dataset_id: &BigQueryDatasetId,
         table_id: &BigQueryTableId,
@@ -1116,27 +1132,68 @@ impl BigQueryClient {
         let full_table_name = self.full_table_name(dataset_id, table_id)?;
         let column_name = quote_identifier(column_name, "BigQuery column name")?;
 
-        info!("dropping default for column {column_name} in table {full_table_name} in BigQuery");
+        info!("clearing default for column {column_name} in table {full_table_name} in bigquery");
 
         let query =
             format!("alter table {full_table_name} alter column {column_name} drop default");
 
-        let _ = self.query(QueryRequest::new(query)).await?;
+        match self.query_with_bigquery_error(QueryRequest::new(query)).await {
+            Ok(_) => {}
+            Err(error) if is_missing_column_default_error(&error) => {
+                debug!(
+                    table_id = %table_id,
+                    column_name = %column_name,
+                    "column has no default in bigquery; skipping drop default"
+                );
+            }
+            Err(error) => return Err(bq_error_to_etl_error(error)),
+        }
 
         Ok(())
     }
 
-    /// Relaxes a BigQuery column from `REQUIRED` to `NULLABLE`.
+    /// Relaxes a BigQuery column from `REQUIRED` to `NULLABLE` when needed.
     pub(super) async fn drop_column_not_null(
         &self,
         dataset_id: &BigQueryDatasetId,
         table_id: &BigQueryTableId,
         column_name: &str,
     ) -> EtlResult<()> {
+        let table = self
+            .client
+            .table()
+            .get(&self.project_id, dataset_id, table_id, None)
+            .await
+            .map_err(bq_error_to_etl_error)?;
+        let column_mode = table
+            .schema
+            .fields
+            .unwrap_or_default()
+            .into_iter()
+            .find(|field| field.name == column_name)
+            .ok_or_else(|| {
+                etl_error!(
+                    ErrorKind::DestinationError,
+                    "BigQuery column not found",
+                    format!("Column {column_name} was not found in table {table_id}")
+                )
+            })?
+            .mode;
+
+        if column_mode.as_deref() != Some("REQUIRED") {
+            debug!(
+                table_id = %table_id,
+                column_name,
+                column_mode = column_mode.as_deref().unwrap_or("NULLABLE"),
+                "column is already nullable in bigquery; skipping drop not null"
+            );
+            return Ok(());
+        }
+
         let full_table_name = self.full_table_name(dataset_id, table_id)?;
         let column_name = quote_identifier(column_name, "BigQuery column name")?;
 
-        info!("dropping not null for column {column_name} in table {full_table_name} in BigQuery");
+        info!("dropping not null for column {column_name} in table {full_table_name} in bigquery");
 
         let query =
             format!("alter table {full_table_name} alter column {column_name} drop not null");
@@ -1439,6 +1496,11 @@ impl BigQueryClient {
 
     /// Executes a BigQuery SQL query and returns the result set.
     pub async fn query(&self, request: QueryRequest) -> EtlResult<ResultSet> {
+        self.query_with_bigquery_error(request).await.map_err(bq_error_to_etl_error)
+    }
+
+    /// Executes a BigQuery SQL query while preserving the provider error.
+    async fn query_with_bigquery_error(&self, request: QueryRequest) -> Result<ResultSet, BQError> {
         let query_response = retry_with_backoff(
             QUERY_RETRY_POLICY,
             is_transient_query_error,
@@ -1450,7 +1512,7 @@ impl BigQueryClient {
             },
         )
         .await
-        .map_err(|failure| bq_error_to_etl_error(failure.last_error))?;
+        .map_err(|failure| failure.last_error)?;
 
         Ok(ResultSet::new_from_query_response(query_response))
     }
@@ -1525,6 +1587,35 @@ mod tests {
         };
 
         assert_eq!(is_transient_query_error(&error), RetryDecision::Retry);
+    }
+
+    #[test]
+    fn missing_column_default_error_matches_only_absent_default_response() {
+        let error = BQError::ResponseError {
+            error: ResponseError {
+                error: NestedResponseError {
+                    code: 400,
+                    errors: vec![
+                        [
+                            ("reason".to_owned(), "invalid".to_owned()),
+                            (
+                                "message".to_owned(),
+                                "Cannot DROP DEFAULT value from column status which does not have \
+                                 a DEFAULT value."
+                                    .to_owned(),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ],
+                    message: "Invalid schema change".to_owned(),
+                    status: "INVALID_ARGUMENT".to_owned(),
+                },
+            },
+        };
+
+        assert!(is_missing_column_default_error(&error));
+        assert!(!is_missing_column_default_error(&BQError::NoDataAvailable));
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/client.rs
+++ b/crates/etl-destinations/src/bigquery/client.rs
@@ -5,7 +5,7 @@ use etl::{
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
     pipeline::PipelineId,
-    schema::{ColumnSchema, ReplicatedTableSchema, Type},
+    schema::{ColumnSchema, ReplicatedTableSchema, Type, is_array_type},
 };
 use gcp_bigquery_client::{
     Client,
@@ -1005,9 +1005,19 @@ impl BigQueryClient {
 
         info!("adding column {column_name} ({column_type}) to table {full_table_name} in BigQuery");
 
-        // BigQuery requires new columns to be nullable (no NOT NULL constraint
-        // allowed). Defaults must be applied through a separate ALTER COLUMN
-        // statement because BigQuery rejects ADD COLUMN with a default value.
+        if !column_schema.nullable && !is_array_type(&column_schema.typ) {
+            warn!(
+                dataset_id = %dataset_id,
+                table_id = %table_id,
+                column_name = %column_schema.name,
+                "BigQuery does not support adding a top-level NOT NULL column; adding it as \
+                 nullable"
+            );
+        }
+
+        // BigQuery cannot add a top-level REQUIRED column or a column with a
+        // default to an existing table. Add it as nullable here and apply any
+        // supported default through a separate ALTER COLUMN statement.
         let query = format!("alter table {full_table_name} add column {column_name} {column_type}");
 
         let _ = self.query(QueryRequest::new(query)).await?;
@@ -1110,6 +1120,26 @@ impl BigQueryClient {
 
         let query =
             format!("alter table {full_table_name} alter column {column_name} drop default");
+
+        let _ = self.query(QueryRequest::new(query)).await?;
+
+        Ok(())
+    }
+
+    /// Relaxes a BigQuery column from `REQUIRED` to `NULLABLE`.
+    pub(super) async fn drop_column_not_null(
+        &self,
+        dataset_id: &BigQueryDatasetId,
+        table_id: &BigQueryTableId,
+        column_name: &str,
+    ) -> EtlResult<()> {
+        let full_table_name = self.full_table_name(dataset_id, table_id)?;
+        let column_name = quote_identifier(column_name, "BigQuery column name")?;
+
+        info!("dropping not null for column {column_name} in table {full_table_name} in BigQuery");
+
+        let query =
+            format!("alter table {full_table_name} alter column {column_name} drop not null");
 
         let _ = self.query(QueryRequest::new(query)).await?;
 

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -878,13 +878,22 @@ where
                 match modification {
                     ColumnModification::Rename { .. } => {}
                     ColumnModification::Nullability { old_nullable, new_nullable } => {
-                        warn!(
-                            table_id = %table_id,
-                            column_name = %change.new_column.name,
-                            old_nullable,
-                            new_nullable,
-                            "skipping source column nullability change for BigQuery"
-                        );
+                        if !*old_nullable && *new_nullable {
+                            self.client
+                                .drop_column_not_null(
+                                    &self.dataset_id,
+                                    &sequenced_bigquery_table_id.to_string(),
+                                    &change.new_column.name,
+                                )
+                                .await?;
+                        } else {
+                            warn!(
+                                table_id = %table_id,
+                                column_name = %change.new_column.name,
+                                "BigQuery does not support setting NOT NULL on an existing \
+                                 column; keeping the destination column nullable"
+                            );
+                        }
                     }
                     ColumnModification::Default { old_expression, new_expression } => {
                         let old_default_was_supported =

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -875,6 +875,10 @@ where
 
         for change in &diff.columns_to_change {
             for modification in &change.modifications {
+                // Schema changes normally keep BigQuery aligned with PostgreSQL, and failures
+                // are propagated. Nullability and default changes intentionally
+                // allow known unsupported source states, so later changes must
+                // tolerate that divergence.
                 match modification {
                     ColumnModification::Rename { .. } => {}
                     ColumnModification::Nullability { old_nullable, new_nullable } => {
@@ -890,17 +894,12 @@ where
                             warn!(
                                 table_id = %table_id,
                                 column_name = %change.new_column.name,
-                                "BigQuery does not support setting NOT NULL on an existing \
+                                "bigquery does not support setting not null on an existing \
                                  column; keeping the destination column nullable"
                             );
                         }
                     }
-                    ColumnModification::Default { old_expression, new_expression } => {
-                        let old_default_was_supported =
-                            old_expression.as_deref().is_some_and(|default_expression| {
-                                supports_column_default(default_expression, &change.old_column.typ)
-                            });
-
+                    ColumnModification::Default { new_expression, .. } => {
                         if let Some(new_default_expression) = new_expression.as_deref() {
                             if supports_column_default(
                                 new_default_expression,
@@ -919,33 +918,24 @@ where
                                 warn!(
                                     table_id = %table_id,
                                     column_name = %change.new_column.name,
-                                    "skipping unsupported source column default for BigQuery"
+                                    "skipping unsupported source column default for bigquery"
                                 );
-                                if old_default_was_supported {
-                                    self.client
-                                        .drop_column_default(
-                                            &self.dataset_id,
-                                            &sequenced_bigquery_table_id.to_string(),
-                                            &change.new_column.name,
-                                        )
-                                        .await?;
-                                }
+                                self.client
+                                    .clear_column_default(
+                                        &self.dataset_id,
+                                        &sequenced_bigquery_table_id.to_string(),
+                                        &change.new_column.name,
+                                    )
+                                    .await?;
                             }
-                        } else if old_default_was_supported {
+                        } else {
                             self.client
-                                .drop_column_default(
+                                .clear_column_default(
                                     &self.dataset_id,
                                     &sequenced_bigquery_table_id.to_string(),
                                     &change.new_column.name,
                                 )
                                 .await?;
-                        } else if old_expression.is_some() {
-                            warn!(
-                                table_id = %table_id,
-                                column_name = %change.new_column.name,
-                                "skipping source column default removal for BigQuery because no \
-                                 supported destination default was set"
-                            );
                         }
                     }
                 }

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -17,7 +17,7 @@ use etl::{
     },
 };
 use etl_destinations::bigquery::test_utils::{
-    parse_table_cell, setup_bigquery_database, skip_if_missing_bigquery_env_vars,
+    setup_bigquery_database, skip_if_missing_bigquery_env_vars,
 };
 use etl_postgres::tokio::test_utils::TableModification;
 use etl_telemetry::tracing::init_test_tracing;
@@ -26,8 +26,9 @@ use tokio::time::sleep;
 
 use crate::support::{
     bigquery::{
-        BigQueryDefaultsRow, BigQueryOrder, BigQuerySchemaChangeRow, BigQueryUser,
-        NonNullableColsScalar, NullableColsArray, NullableColsScalar, parse_bigquery_table_rows,
+        BigQueryDefaultsRow, BigQueryOrder, BigQuerySchemaChangeRow, BigQuerySchemaDivergenceRow,
+        BigQueryUser, NonNullableColsScalar, NullableColsArray, NullableColsScalar,
+        parse_bigquery_table_rows,
     },
     crypto::install_crypto_provider,
 };
@@ -2314,24 +2315,29 @@ async fn schema_change_tolerates_nullability_and_default_divergence() {
     pipeline.shutdown_and_wait().await.unwrap();
 
     let rows = bigquery_database.query_table(table_name).await.unwrap();
-    let mut values = rows
-        .into_iter()
-        .map(|row| {
-            let columns = row.columns.unwrap();
-            (
-                parse_table_cell::<String>(columns[1].clone()),
-                parse_table_cell::<String>(columns[2].clone()),
-                parse_table_cell::<String>(columns[3].clone()),
-            )
-        })
-        .collect::<Vec<_>>();
-    values.sort();
+    let mut rows = parse_bigquery_table_rows::<BigQuerySchemaDivergenceRow>(rows);
+    rows.sort();
     assert_eq!(
-        values,
+        rows,
         vec![
-            (None, None, Some("created".to_owned())),
-            (Some("after-default-drop".to_owned()), None, Some("explicit-after".to_owned()),),
-            (Some("before-drop".to_owned()), None, Some("explicit-before".to_owned()),),
+            BigQuerySchemaDivergenceRow {
+                id: 1,
+                name: Some("before-drop".to_owned()),
+                initially_required: None,
+                divergent_default: "explicit-before".to_owned(),
+            },
+            BigQuerySchemaDivergenceRow {
+                id: 2,
+                name: None,
+                initially_required: None,
+                divergent_default: "created".to_owned(),
+            },
+            BigQuerySchemaDivergenceRow {
+                id: 3,
+                name: Some("after-default-drop".to_owned()),
+                initially_required: None,
+                divergent_default: "explicit-after".to_owned(),
+            },
         ]
     );
 }

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -2068,7 +2068,11 @@ async fn schema_change_add_column_defaults() {
     let bigquery_database = setup_bigquery_database().await;
     let table_name = test_table_name("defaults_schema");
     let table_id = database
-        .create_table(table_name.clone(), true, &[("name", "text not null")])
+        .create_table(
+            table_name.clone(),
+            true,
+            &[("name", "text not null"), ("source_required", "text")],
+        )
         .await
         .expect("failed to create source table");
 
@@ -2079,7 +2083,7 @@ async fn schema_change_add_column_defaults() {
         .expect("failed to create publication");
     database
         .run_sql(&format!(
-            "insert into {} (name) values ('Alice')",
+            "insert into {} (name, source_required) values ('Alice', 'before')",
             table_name.as_quoted_identifier()
         ))
         .await
@@ -2111,6 +2115,15 @@ async fn schema_change_add_column_defaults() {
         .alter_table(
             table_name.clone(),
             &[
+                TableModification::AlterColumn { name: "name", alteration: "drop not null" },
+                TableModification::AlterColumn {
+                    name: "source_required",
+                    alteration: "set not null",
+                },
+                TableModification::AlterColumn {
+                    name: "source_required",
+                    alteration: "set default 'after'::text",
+                },
                 TableModification::AddColumn {
                     name: "status",
                     data_type: "text default 'new'::text",
@@ -2121,11 +2134,17 @@ async fn schema_change_add_column_defaults() {
         )
         .await
         .expect("failed to alter source table");
-    database
+
+    let rejected_insert = database
         .run_sql(&format!(
-            "insert into {} (name) values ('Bob')",
+            "insert into {} (name, source_required) values ('rejected', null)",
             table_name.as_quoted_identifier()
         ))
+        .await;
+    assert!(rejected_insert.is_err(), "Postgres should enforce the new NOT NULL constraint");
+
+    database
+        .run_sql(&format!("insert into {} (name) values (null)", table_name.as_quoted_identifier()))
         .await
         .expect("failed to insert defaulted source row");
 
@@ -2141,14 +2160,16 @@ async fn schema_change_add_column_defaults() {
         vec![
             BigQueryDefaultsRow {
                 id: 1,
-                name: "Alice".to_owned(),
+                name: Some("Alice".to_owned()),
+                source_required: "before".to_owned(),
                 status: None,
                 score: None,
                 active: None,
             },
             BigQueryDefaultsRow {
-                id: 2,
-                name: "Bob".to_owned(),
+                id: 3,
+                name: None,
+                source_required: "after".to_owned(),
                 status: Some("new".to_owned()),
                 score: Some(15),
                 active: Some(true),

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -2069,11 +2069,7 @@ async fn schema_change_add_column_defaults() {
     let bigquery_database = setup_bigquery_database().await;
     let table_name = test_table_name("defaults_schema");
     let table_id = database
-        .create_table(
-            table_name.clone(),
-            true,
-            &[("name", "text not null"), ("source_required", "text")],
-        )
+        .create_table(table_name.clone(), true, &[("name", "text not null")])
         .await
         .expect("failed to create source table");
 
@@ -2084,7 +2080,7 @@ async fn schema_change_add_column_defaults() {
         .expect("failed to create publication");
     database
         .run_sql(&format!(
-            "insert into {} (name, source_required) values ('Alice', 'before')",
+            "insert into {} (name) values ('Alice')",
             table_name.as_quoted_identifier()
         ))
         .await
@@ -2116,15 +2112,6 @@ async fn schema_change_add_column_defaults() {
         .alter_table(
             table_name.clone(),
             &[
-                TableModification::AlterColumn { name: "name", alteration: "drop not null" },
-                TableModification::AlterColumn {
-                    name: "source_required",
-                    alteration: "set not null",
-                },
-                TableModification::AlterColumn {
-                    name: "source_required",
-                    alteration: "set default 'after'::text",
-                },
                 TableModification::AddColumn {
                     name: "status",
                     data_type: "text default 'new'::text",
@@ -2136,16 +2123,11 @@ async fn schema_change_add_column_defaults() {
         .await
         .expect("failed to alter source table");
 
-    let rejected_insert = database
+    database
         .run_sql(&format!(
-            "insert into {} (name, source_required) values ('rejected', null)",
+            "insert into {} (name) values ('Bob')",
             table_name.as_quoted_identifier()
         ))
-        .await;
-    assert!(rejected_insert.is_err(), "Postgres should enforce the new NOT NULL constraint");
-
-    database
-        .run_sql(&format!("insert into {} (name) values (null)", table_name.as_quoted_identifier()))
         .await
         .expect("failed to insert defaulted source row");
 
@@ -2161,16 +2143,14 @@ async fn schema_change_add_column_defaults() {
         vec![
             BigQueryDefaultsRow {
                 id: 1,
-                name: Some("Alice".to_owned()),
-                source_required: "before".to_owned(),
+                name: "Alice".to_owned(),
                 status: None,
                 score: None,
                 active: None,
             },
             BigQueryDefaultsRow {
-                id: 3,
-                name: None,
-                source_required: "after".to_owned(),
+                id: 2,
+                name: "Bob".to_owned(),
                 status: Some("new".to_owned()),
                 score: Some(15),
                 active: Some(true),

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -17,7 +17,7 @@ use etl::{
     },
 };
 use etl_destinations::bigquery::test_utils::{
-    setup_bigquery_database, skip_if_missing_bigquery_env_vars,
+    parse_table_cell, setup_bigquery_database, skip_if_missing_bigquery_env_vars,
 };
 use etl_postgres::tokio::test_utils::TableModification;
 use etl_telemetry::tracing::init_test_tracing;
@@ -2179,6 +2179,164 @@ async fn schema_change_add_column_defaults() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn schema_change_tolerates_nullability_and_default_divergence() {
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = spawn_source_database().await;
+    let bigquery_database = setup_bigquery_database().await;
+    let table_name = test_table_name("nullability_schema");
+    let table_id = database
+        .create_table(
+            table_name.clone(),
+            true,
+            &[
+                ("name", "text"),
+                ("initially_required", "text not null"),
+                ("divergent_default", "text not null default md5(random()::text)"),
+            ],
+        )
+        .await
+        .expect("failed to create source table");
+
+    let publication_name = "test_pub_bq_nullability_schema".to_owned();
+    database
+        .create_publication(&publication_name, std::slice::from_ref(&table_name))
+        .await
+        .expect("failed to create publication");
+
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
+    let destination = TestDestinationWrapper::wrap(raw_destination);
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name,
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    table_ready.notified().await;
+
+    let set_not_null_notify = destination
+        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .await;
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[
+                TableModification::AlterColumn { name: "name", alteration: "set not null" },
+                TableModification::AlterColumn {
+                    name: "initially_required",
+                    alteration: "drop not null",
+                },
+                TableModification::AlterColumn {
+                    name: "divergent_default",
+                    alteration: "drop default",
+                },
+            ],
+        )
+        .await
+        .expect("failed to set source not null constraint");
+    database
+        .run_sql(&format!(
+            "insert into {} (name, initially_required, divergent_default) values ('before-drop', \
+             null, 'explicit-before')",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .expect("failed to insert non-null source row");
+
+    set_not_null_notify.notified().await;
+
+    let drop_not_null_notify = destination
+        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .await;
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[
+                TableModification::AlterColumn { name: "name", alteration: "drop not null" },
+                TableModification::AlterColumn {
+                    name: "divergent_default",
+                    alteration: "set default 'created'::text",
+                },
+            ],
+        )
+        .await
+        .expect("failed to drop source not null constraint");
+    database
+        .run_sql(&format!(
+            "insert into {} (name, initially_required) values (null, null)",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .expect("failed to insert null source row");
+
+    drop_not_null_notify.notified().await;
+
+    let drop_default_notify = destination
+        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .await;
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[TableModification::AlterColumn {
+                name: "divergent_default",
+                alteration: "drop default",
+            }],
+        )
+        .await
+        .expect("failed to drop supported source default");
+    database
+        .run_sql(&format!(
+            "insert into {} (name, initially_required, divergent_default) values \
+             ('after-default-drop', null, 'explicit-after')",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .expect("failed to insert source row after dropping default");
+
+    drop_default_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let rows = bigquery_database.query_table(table_name).await.unwrap();
+    let mut values = rows
+        .into_iter()
+        .map(|row| {
+            let columns = row.columns.unwrap();
+            (
+                parse_table_cell::<String>(columns[1].clone()),
+                parse_table_cell::<String>(columns[2].clone()),
+                parse_table_cell::<String>(columns[3].clone()),
+            )
+        })
+        .collect::<Vec<_>>();
+    values.sort();
+    assert_eq!(
+        values,
+        vec![
+            (None, None, Some("created".to_owned())),
+            (Some("after-default-drop".to_owned()), None, Some("explicit-after".to_owned()),),
+            (Some("before-drop".to_owned()), None, Some("explicit-before".to_owned()),),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn table_schema_change() {
     if skip_if_missing_bigquery_env_vars() {
         return;
@@ -2221,6 +2379,7 @@ async fn table_schema_change() {
         store.notify_on_table_state_type(table_id, TableStateType::SyncDone).await;
 
     pipeline.start().await.unwrap();
+
     table_sync_done.notified().await;
 
     let initial_state = store

--- a/crates/etl-destinations/tests/support/bigquery.rs
+++ b/crates/etl-destinations/tests/support/bigquery.rs
@@ -127,6 +127,27 @@ impl From<TableRow> for BigQueryDefaultsRow {
 }
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct BigQuerySchemaDivergenceRow {
+    pub(crate) id: i32,
+    pub(crate) name: Option<String>,
+    pub(crate) initially_required: Option<String>,
+    pub(crate) divergent_default: String,
+}
+
+impl From<TableRow> for BigQuerySchemaDivergenceRow {
+    fn from(value: TableRow) -> Self {
+        let columns = value.columns.unwrap();
+
+        BigQuerySchemaDivergenceRow {
+            id: parse_table_cell(columns[0].clone()).unwrap(),
+            name: parse_table_cell(columns[1].clone()),
+            initially_required: parse_table_cell(columns[2].clone()),
+            divergent_default: parse_table_cell(columns[3].clone()).unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) struct BigQuerySchemaChangeRow {
     pub(crate) id: i32,
     pub(crate) full_name: String,

--- a/crates/etl-destinations/tests/support/bigquery.rs
+++ b/crates/etl-destinations/tests/support/bigquery.rs
@@ -104,8 +104,7 @@ impl From<TableRow> for BigQueryOrder {
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) struct BigQueryDefaultsRow {
     pub(crate) id: i32,
-    pub(crate) name: Option<String>,
-    pub(crate) source_required: String,
+    pub(crate) name: String,
     pub(crate) status: Option<String>,
     pub(crate) score: Option<i32>,
     pub(crate) active: Option<bool>,
@@ -117,11 +116,10 @@ impl From<TableRow> for BigQueryDefaultsRow {
 
         BigQueryDefaultsRow {
             id: parse_table_cell(columns[0].clone()).unwrap(),
-            name: parse_table_cell(columns[1].clone()),
-            source_required: parse_table_cell(columns[2].clone()).unwrap(),
-            status: parse_table_cell(columns[3].clone()),
-            score: parse_table_cell(columns[4].clone()),
-            active: parse_table_cell(columns[5].clone()),
+            name: parse_table_cell(columns[1].clone()).unwrap(),
+            status: parse_table_cell(columns[2].clone()),
+            score: parse_table_cell(columns[3].clone()),
+            active: parse_table_cell(columns[4].clone()),
         }
     }
 }

--- a/crates/etl-destinations/tests/support/bigquery.rs
+++ b/crates/etl-destinations/tests/support/bigquery.rs
@@ -104,7 +104,8 @@ impl From<TableRow> for BigQueryOrder {
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) struct BigQueryDefaultsRow {
     pub(crate) id: i32,
-    pub(crate) name: String,
+    pub(crate) name: Option<String>,
+    pub(crate) source_required: String,
     pub(crate) status: Option<String>,
     pub(crate) score: Option<i32>,
     pub(crate) active: Option<bool>,
@@ -116,10 +117,11 @@ impl From<TableRow> for BigQueryDefaultsRow {
 
         BigQueryDefaultsRow {
             id: parse_table_cell(columns[0].clone()).unwrap(),
-            name: parse_table_cell(columns[1].clone()).unwrap(),
-            status: parse_table_cell(columns[2].clone()),
-            score: parse_table_cell(columns[3].clone()),
-            active: parse_table_cell(columns[4].clone()),
+            name: parse_table_cell(columns[1].clone()),
+            source_required: parse_table_cell(columns[2].clone()).unwrap(),
+            status: parse_table_cell(columns[3].clone()),
+            score: parse_table_cell(columns[4].clone()),
+            active: parse_table_cell(columns[5].clone()),
         }
     }
 }

--- a/docs/src/content/docs/explanation/schema-changes.md
+++ b/docs/src/content/docs/explanation/schema-changes.md
@@ -26,7 +26,7 @@ changes:
 | Rename a replicated column | Rename column |
 | Change a replicated column default | Column default modification |
 | Drop a replicated column default | Column default removal |
-| Drop `NOT NULL` from a replicated column | Detected in the schema snapshot, but not applied to built-in destinations |
+| Drop `NOT NULL` from a replicated column | BigQuery relaxes an existing `REQUIRED` column to `NULLABLE`; other built-in destinations currently leave nullability unchanged |
 | Set `NOT NULL` on a replicated column | Detected in the schema snapshot, but not applied to built-in destinations |
 | Several of the above in one statement | One schema snapshot, diffed into column additions, removals, and grouped column modifications |
 
@@ -73,7 +73,7 @@ ETL has one shared schema-change signal, but **DDL behavior is implemented per d
 
 | Destination | Current DDL behavior |
 |-------------|----------------------|
-| BigQuery | Supports add, drop, rename, and supported literal default metadata. BigQuery requires added columns to be nullable and does not backfill existing rows for `ADD COLUMN ... DEFAULT`. |
+| BigQuery | Supports add, drop, rename, `REQUIRED` to `NULLABLE` relaxation, and supported literal default metadata. BigQuery requires added columns to be nullable and does not backfill existing rows for `ADD COLUMN ... DEFAULT`. PostgreSQL remains responsible for enforcing later `SET NOT NULL` changes because BigQuery cannot tighten an existing column in place. |
 | ClickHouse | Supports add, drop, rename, and supported literal defaults. `ReplacingMergeTree` rejects primary-key drops or renames because the ordering expression cannot be rewritten safely. ClickHouse default expressions are metadata-only unless explicitly materialized; ETL does not issue `MATERIALIZE COLUMN`. |
 | DuckLake | Supports add, drop, rename, and supported literal defaults. DuckLake records supported add-time defaults as metadata without rewriting existing data files. |
 | Snowflake | Supports add, drop, rename, create-table literal defaults, and literal add-column defaults. Literal defaults are included in `ADD COLUMN` so Snowflake can expose add-time default values for existing rows; non-literal defaults and later default changes are skipped with a warning. |
@@ -294,10 +294,12 @@ These behaviors are **not full destination DDL semantics** yet:
   without ETL issuing a materialization rewrite. Snowflake only receives
   add-column defaults for source defaults that can be rendered as Snowflake
   literals.
-- Built-in destinations only enforce source column nullability when creating a
-  destination table. Streaming schema changes do not apply `SET NOT NULL` or
-  `DROP NOT NULL`; newly added columns remain nullable where the destination
-  requires that for historical rows.
+- BigQuery applies streaming `DROP NOT NULL` changes so future source NULL values
+  remain writable. BigQuery cannot change an existing `NULLABLE` column to
+  `REQUIRED`, so PostgreSQL enforces later `SET NOT NULL` changes while the
+  destination column remains nullable. Other built-in destinations currently
+  leave streaming nullability changes unchanged. Newly added columns remain
+  nullable where the destination requires that for historical rows.
 - The trigger payload includes `current_query` for debugging only. It can
   contain literals and multiple statements, so it must not be treated as
   replayable DDL.


### PR DESCRIPTION
## Summary

Improve BigQuery handling of PostgreSQL column nullability changes while preserving source semantics.

## Behavior

- Initial table creation continues to honor PostgreSQL nullability.
- `DROP NOT NULL` relaxes an existing BigQuery column from `REQUIRED` to `NULLABLE`.
- `SET NOT NULL` leaves the existing BigQuery column nullable and emits a warning because BigQuery cannot tighten it in place. PostgreSQL remains responsible for rejecting `NULL` values.
- Newly added top-level columns are always nullable because BigQuery cannot add a `REQUIRED` column to an existing table.
- A warning is emitted when a newly added PostgreSQL column is `NOT NULL`.
- Supported defaults are applied separately with `ALTER COLUMN SET DEFAULT`, since BigQuery rejects `ADD COLUMN ... DEFAULT` on existing tables.

Defaults and nullability remain independent: PostgreSQL evaluates defaults and enforces `NOT NULL` before rows reach the destination.