### PR TITLE
feat(core): Improve handling of shutdown

### DIFF
--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -13,6 +13,7 @@ use tracing::warn;
 use crate::{
     error::{ErrorKind, EtlResult},
     etl_error,
+    runtime::concurrency::{ShutdownResult, ShutdownRx},
 };
 
 /// Durability status reported by streaming and table-copy destination writes.
@@ -62,8 +63,8 @@ pub enum DestinationWriteStatus {
 /// Async completion handle used for
 /// [`crate::destination::Destination::write_table_rows`].
 ///
-/// ETL waits for this result before requesting the next row batch for the same
-/// copy partition. A destination may report
+/// Unless shutdown is requested, ETL waits for this result before requesting
+/// the next row batch for the same copy partition. A destination may report
 /// [`DestinationWriteStatus::Accepted`] to continue copying before the batch is
 /// durable. ETL then issues a terminal empty write as a table-wide durability
 /// barrier and requires [`DestinationWriteStatus::Durable`] before completing
@@ -73,8 +74,8 @@ pub type WriteTableRowsResult<T = DestinationWriteStatus> = AsyncResult<T>;
 /// Async completion handle used for
 /// [`crate::destination::Destination::drop_table_for_copy`].
 ///
-/// ETL waits for this result immediately before clearing stored table-copy
-/// metadata and starting a fresh copy.
+/// Unless shutdown is requested, ETL waits for this result immediately before
+/// clearing stored table-copy metadata and starting a fresh copy.
 pub type DropTableForCopyResult<T = ()> = AsyncResult<T>;
 
 /// Async completion handle used for
@@ -196,6 +197,22 @@ impl<T, M> Future for PendingAsyncResult<T, M> {
     }
 }
 
+impl<T, M> PendingAsyncResult<T, M> {
+    /// Waits for completion or returns when shutdown is requested.
+    pub(crate) async fn with_shutdown(
+        self,
+        shutdown_rx: &mut ShutdownRx,
+    ) -> ShutdownResult<CompletedAsyncResult<T, M>, ()> {
+        tokio::select! {
+            biased;
+
+            _ = shutdown_rx.changed() => ShutdownResult::Shutdown(()),
+
+            completed = self => ShutdownResult::Ok(completed),
+        }
+    }
+}
+
 /// Completed typed asynchronous result.
 #[derive(Debug)]
 pub(crate) struct CompletedAsyncResult<T, M> {
@@ -218,6 +235,7 @@ impl<T, M> CompletedAsyncResult<T, M> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::concurrency::create_shutdown_channel;
 
     #[tokio::test]
     async fn async_result_round_trips_success() {
@@ -260,5 +278,42 @@ mod tests {
 
         assert!(metadata.is_none());
         assert_eq!(result.unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn pending_async_result_completes_before_shutdown() {
+        let (_shutdown_tx, mut shutdown_rx) = create_shutdown_channel();
+        let (result_tx, pending_result) = WriteTableRowsResult::<u64>::new(());
+        result_tx.send(Ok(7));
+
+        let ShutdownResult::Ok(completed) = pending_result.with_shutdown(&mut shutdown_rx).await
+        else {
+            panic!("async result should complete before shutdown");
+        };
+
+        assert_eq!(completed.into_result().unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn pending_async_result_stops_waiting_on_shutdown() {
+        let (shutdown_tx, mut shutdown_rx) = create_shutdown_channel();
+        let (_result_tx, pending_result) = WriteTableRowsResult::<u64>::new(());
+        shutdown_tx.shutdown().unwrap();
+
+        let result = pending_result.with_shutdown(&mut shutdown_rx).await;
+
+        assert!(matches!(result, ShutdownResult::Shutdown(())));
+    }
+
+    #[tokio::test]
+    async fn pending_async_result_prioritizes_shutdown_over_completion() {
+        let (shutdown_tx, mut shutdown_rx) = create_shutdown_channel();
+        let (result_tx, pending_result) = WriteTableRowsResult::<u64>::new(());
+        result_tx.send(Ok(7));
+        shutdown_tx.shutdown().unwrap();
+
+        let result = pending_result.with_shutdown(&mut shutdown_rx).await;
+
+        assert!(matches!(result, ShutdownResult::Shutdown(())));
     }
 }

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -151,19 +151,6 @@ impl<T> AsyncResult<T> {
     }
 }
 
-impl<T> Drop for AsyncResult<T> {
-    fn drop(&mut self) {
-        let Some(tx) = self.tx.take() else {
-            return;
-        };
-
-        let _ = tx.send(Err(etl_error!(
-            ErrorKind::DestinationError,
-            "Async result dropped without sending"
-        )));
-    }
-}
-
 pin_project! {
     /// Receiver half of a typed asynchronous completion result.
     #[must_use = "pending async results do nothing unless polled"]

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -8,7 +8,7 @@ use std::{
 use pin_project_lite::pin_project;
 use tokio::sync::oneshot;
 use tokio_postgres::types::PgLsn;
-use tracing::warn;
+use tracing::debug;
 
 use crate::{
     error::{ErrorKind, EtlResult},
@@ -146,7 +146,7 @@ impl<T> AsyncResult<T> {
         };
 
         if tx.send(result).is_err() {
-            warn!("could not send async result because receiver was already closed");
+            debug!("async result receiver was already closed");
         }
     }
 }

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -249,7 +249,7 @@ mod tests {
 
         let err = pending_result.await.into_result().unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DestinationError);
-        assert_eq!(err.description(), Some("Async result dropped without sending"));
+        assert_eq!(err.description(), Some("Async result channel closed before sending"));
     }
 
     #[tokio::test]

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -90,10 +90,10 @@ pub trait Destination {
     /// The method return value is reserved for immediate dispatch/setup
     /// failures before the work has been accepted.
     ///
-    /// ETL waits for each table-copy batch to finish before reading the next
-    /// batch for the same copy partition. When multiple copy workers are
-    /// configured, this method can still run concurrently across different
-    /// partitions.
+    /// Unless shutdown is requested, ETL waits for each table-copy batch to
+    /// finish before reading the next batch for the same copy partition. When
+    /// multiple copy workers are configured, this method can still run
+    /// concurrently across different partitions.
     ///
     /// [`crate::destination::DestinationWriteStatus::Durable`] means the batch
     /// and all earlier accepted writes it covers are durable.

--- a/crates/etl/src/replication/table_sync/copy.rs
+++ b/crates/etl/src/replication/table_sync/copy.rs
@@ -756,7 +756,13 @@ where
                 destination
                     .write_table_rows(&replicated_table_schema, table_rows, flush_result)
                     .await?;
-                let write_status = pending_flush_result.await.into_result()?;
+                let ShutdownResult::Ok(completed_flush_result) = pending_flush_result
+                    .with_shutdown(&mut shutdown_rx)
+                    .await
+                else {
+                    return Ok(ShutdownResult::Shutdown(progress));
+                };
+                let write_status = completed_flush_result.into_result()?;
 
                 progress.record_batch(batch_size, write_status);
 

--- a/crates/etl/src/replication/table_sync/mod.rs
+++ b/crates/etl/src/replication/table_sync/mod.rs
@@ -30,7 +30,8 @@ use crate::{
         table_cache::SharedTableCache,
     },
     runtime::{
-        BatchBudgetController, MemoryMonitor, TableSyncWorkerState, concurrency::ShutdownRx,
+        BatchBudgetController, MemoryMonitor, TableSyncWorkerState,
+        concurrency::{ShutdownResult, ShutdownRx},
     },
     schema::{ReplicatedTableSchema, ReplicationMask, SchemaError, TableId},
     store::{PipelineStore, SchemaStore, StateStore},
@@ -103,7 +104,7 @@ pub(crate) async fn start_table_sync<S, D>(
     destination: D,
     shared_table_cache: &SharedTableCache,
     out_of_band_source_pool: OutOfBandSourcePool,
-    shutdown_rx: ShutdownRx,
+    mut shutdown_rx: ShutdownRx,
     memory_monitor: MemoryMonitor,
     batch_budget: BatchBudgetController,
 ) -> EtlResult<TableSyncResult>
@@ -210,7 +211,12 @@ where
                 destination
                     .drop_table_for_copy(&current_replication_table_schema, drop_result)
                     .await?;
-                pending_drop_result.await.into_result()?;
+                let ShutdownResult::Ok(completed_drop_result) =
+                    pending_drop_result.with_shutdown(&mut shutdown_rx).await
+                else {
+                    return Ok(TableSyncResult::Stopped);
+                };
+                completed_drop_result.into_result()?;
             }
 
             // We try to delete the slot if it already exists, since we might be starting a
@@ -356,7 +362,13 @@ where
                 destination
                     .write_table_rows(&replicated_table_schema, vec![], flush_result)
                     .await?;
-                match pending_flush_result.await.into_result()? {
+                let ShutdownResult::Ok(completed_flush_result) =
+                    pending_flush_result.with_shutdown(&mut shutdown_rx).await
+                else {
+                    return Ok(TableSyncResult::Stopped);
+                };
+
+                match completed_flush_result.into_result()? {
                     DestinationWriteStatus::Durable => {}
                     DestinationWriteStatus::Accepted => bail!(
                         ErrorKind::DestinationError,

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -193,22 +193,34 @@ where
     }
 }
 
-/// Destination test double that never completes a nonempty table-copy write.
+/// Behavior used by [`StalledCopyDestination`] for nonempty copy writes.
+#[derive(Clone, Copy)]
+enum StallMode {
+    /// Drops the result without completing it.
+    DropResult,
+    /// Retains the result without completing it.
+    HoldResult,
+}
+
+/// Destination test double that drops or indefinitely holds a copy result.
 #[derive(Clone)]
 struct StalledCopyDestination<D> {
     /// Destination used for operations other than nonempty table-copy writes.
     inner: D,
+    /// Behavior applied to the first nonempty table-copy write.
+    mode: StallMode,
     /// Held result that keeps the table-copy write pending.
     pending_result: Arc<Mutex<Option<WriteTableRowsResult>>>,
-    /// Notification emitted after a nonempty table-copy write is held.
+    /// Notification emitted after the result is dropped or held.
     write_reached: Arc<Notify>,
 }
 
 impl<D> StalledCopyDestination<D> {
-    /// Wraps a destination and stalls its first nonempty table-copy write.
-    fn wrap(inner: D) -> Self {
+    /// Wraps a destination with the selected stall behavior.
+    fn wrap(inner: D, mode: StallMode) -> Self {
         Self {
             inner,
+            mode,
             pending_result: Arc::new(Mutex::new(None)),
             write_reached: Arc::new(Notify::new()),
         }
@@ -257,10 +269,14 @@ where
                 .await;
         }
 
-        let mut pending_result = self.pending_result.lock().await;
-        assert!(pending_result.is_none(), "only one table-copy write should be pending");
-        *pending_result = Some(async_result);
-        drop(pending_result);
+        match self.mode {
+            StallMode::DropResult => drop(async_result),
+            StallMode::HoldResult => {
+                let mut pending_result = self.pending_result.lock().await;
+                assert!(pending_result.is_none(), "only one table-copy write should be pending");
+                *pending_result = Some(async_result);
+            }
+        }
 
         self.write_reached.notify_one();
 
@@ -314,6 +330,43 @@ async fn pipeline_shutdown_calls_destination_shutdown() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn table_copy_errors_when_async_result_is_dropped() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    let store = NotifyingStore::new();
+    let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let destination = StalledCopyDestination::wrap(immediate_destination, StallMode::DropResult);
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination,
+    );
+
+    let table_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+
+    pipeline.start().await.unwrap();
+
+    table_errored.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
+    let TableState::Errored { source_err, .. } = table_state else {
+        panic!("dropped async result should put the table in an errored state");
+    };
+    assert_eq!(source_err.kind(), ErrorKind::DestinationError);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn table_copy_shutdown_interrupts_pending_result_wait() {
     init_test_tracing();
 
@@ -324,7 +377,7 @@ async fn table_copy_shutdown_interrupts_pending_result_wait() {
 
     let store = NotifyingStore::new();
     let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
-    let destination = StalledCopyDestination::wrap(immediate_destination);
+    let destination = StalledCopyDestination::wrap(immediate_destination, StallMode::HoldResult);
 
     let pipeline_id: PipelineId = random();
     let mut pipeline = create_pipeline(
@@ -336,7 +389,9 @@ async fn table_copy_shutdown_interrupts_pending_result_wait() {
     );
 
     let write_reached = destination.notify_on_write();
+
     pipeline.start().await.unwrap();
+
     write_reached.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -10,7 +10,7 @@ use etl::{
     event::{Event, EventType, InsertEvent},
     pipeline::PipelineId,
     schema::{ColumnSchema, ReplicatedTableSchema, TableId},
-    store::{SchemaStore, TableState, TableStateType},
+    store::{SchemaStore, StateStore, TableState, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::{EventCondition, group_events_by_type_and_table_id},
@@ -193,6 +193,89 @@ where
     }
 }
 
+/// Destination test double that never completes a nonempty table-copy write.
+#[derive(Clone)]
+struct StalledCopyDestination<D> {
+    /// Destination used for operations other than nonempty table-copy writes.
+    inner: D,
+    /// Held result that keeps the table-copy write pending.
+    pending_result: Arc<Mutex<Option<WriteTableRowsResult>>>,
+    /// Notification emitted after a nonempty table-copy write is held.
+    write_reached: Arc<Notify>,
+}
+
+impl<D> StalledCopyDestination<D> {
+    /// Wraps a destination and stalls its first nonempty table-copy write.
+    fn wrap(inner: D) -> Self {
+        Self {
+            inner,
+            pending_result: Arc::new(Mutex::new(None)),
+            write_reached: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Returns a notification for the next stalled table-copy write.
+    fn notify_on_write(&self) -> TimedNotify {
+        TimedNotify::new(Arc::clone(&self.write_reached))
+    }
+}
+
+impl<D> Destination for StalledCopyDestination<D>
+where
+    D: PipelineDestination,
+{
+    fn name() -> &'static str {
+        "stalled_copy"
+    }
+
+    async fn startup(&self) -> EtlResult<()> {
+        self.inner.startup().await
+    }
+
+    async fn shutdown(&self) -> EtlResult<()> {
+        self.inner.shutdown().await
+    }
+
+    async fn drop_table_for_copy(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+        async_result: DropTableForCopyResult<()>,
+    ) -> EtlResult<()> {
+        self.inner.drop_table_for_copy(replicated_table_schema, async_result).await
+    }
+
+    async fn write_table_rows(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+        table_rows: Vec<TableRow>,
+        async_result: WriteTableRowsResult,
+    ) -> EtlResult<()> {
+        if table_rows.is_empty() {
+            return self
+                .inner
+                .write_table_rows(replicated_table_schema, table_rows, async_result)
+                .await;
+        }
+
+        let mut pending_result = self.pending_result.lock().await;
+        assert!(pending_result.is_none(), "only one table-copy write should be pending");
+        *pending_result = Some(async_result);
+        drop(pending_result);
+
+        self.write_reached.notify_one();
+
+        Ok(())
+    }
+
+    async fn write_events(
+        &self,
+        events: Vec<Event>,
+        async_result: WriteEventsResult,
+    ) -> EtlResult<()> {
+        self.inner.write_events(events, async_result).await
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn pipeline_shutdown_calls_destination_shutdown() {
     init_test_tracing();
@@ -228,6 +311,38 @@ async fn pipeline_shutdown_calls_destination_shutdown() {
 
     // Verify that shutdown was called on the destination.
     assert!(destination.shutdown_called().await);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_copy_shutdown_interrupts_pending_result_wait() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    let store = NotifyingStore::new();
+    let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let destination = StalledCopyDestination::wrap(immediate_destination);
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let write_reached = destination.notify_on_write();
+    pipeline.start().await.unwrap();
+    write_reached.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
+    assert!(matches!(table_state, TableState::DataSync));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -14,6 +14,7 @@ use etl::{
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::{EventCondition, group_events_by_type_and_table_id},
+        faults::FaultyOp,
         memory_destination::MemoryDestination,
         notify::TimedNotify,
         notifying_store::NotifyingStore,
@@ -193,7 +194,16 @@ where
     }
 }
 
-/// Behavior used by [`StalledCopyDestination`] for nonempty copy writes.
+/// Destination operation stalled by [`StalledCopyDestination`].
+#[derive(Clone, Copy)]
+enum StallTarget {
+    /// A destination drop before a fresh table copy.
+    DropTableForCopy,
+    /// A nonempty table-copy row write.
+    WriteTableRows,
+}
+
+/// Behavior used by [`StalledCopyDestination`] for the selected operation.
 #[derive(Clone, Copy)]
 enum StallMode {
     /// Drops the result without completing it.
@@ -205,30 +215,36 @@ enum StallMode {
 /// Destination test double that drops or indefinitely holds a copy result.
 #[derive(Clone)]
 struct StalledCopyDestination<D> {
-    /// Destination used for operations other than nonempty table-copy writes.
+    /// Destination used for operations other than the selected stall target.
     inner: D,
-    /// Behavior applied to the first nonempty table-copy write.
+    /// Destination operation to stall.
+    target: StallTarget,
+    /// Behavior applied to the selected operation.
     mode: StallMode,
-    /// Held result that keeps the table-copy write pending.
-    pending_result: Arc<Mutex<Option<WriteTableRowsResult>>>,
+    /// Held result that keeps a destination drop pending.
+    pending_drop_result: Arc<Mutex<Option<DropTableForCopyResult<()>>>>,
+    /// Held result that keeps a table-copy write pending.
+    pending_write_result: Arc<Mutex<Option<WriteTableRowsResult>>>,
     /// Notification emitted after the result is dropped or held.
-    write_reached: Arc<Notify>,
+    stall_reached: Arc<Notify>,
 }
 
 impl<D> StalledCopyDestination<D> {
     /// Wraps a destination with the selected stall behavior.
-    fn wrap(inner: D, mode: StallMode) -> Self {
+    fn wrap(inner: D, target: StallTarget, mode: StallMode) -> Self {
         Self {
             inner,
+            target,
             mode,
-            pending_result: Arc::new(Mutex::new(None)),
-            write_reached: Arc::new(Notify::new()),
+            pending_drop_result: Arc::new(Mutex::new(None)),
+            pending_write_result: Arc::new(Mutex::new(None)),
+            stall_reached: Arc::new(Notify::new()),
         }
     }
 
-    /// Returns a notification for the next stalled table-copy write.
-    fn notify_on_write(&self) -> TimedNotify {
-        TimedNotify::new(Arc::clone(&self.write_reached))
+    /// Returns a notification for the next stalled operation.
+    fn notify_on_stall(&self) -> TimedNotify {
+        TimedNotify::new(Arc::clone(&self.stall_reached))
     }
 }
 
@@ -253,7 +269,22 @@ where
         replicated_table_schema: &ReplicatedTableSchema,
         async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        self.inner.drop_table_for_copy(replicated_table_schema, async_result).await
+        if !matches!(self.target, StallTarget::DropTableForCopy) {
+            return self.inner.drop_table_for_copy(replicated_table_schema, async_result).await;
+        }
+
+        match self.mode {
+            StallMode::DropResult => drop(async_result),
+            StallMode::HoldResult => {
+                let mut pending_result = self.pending_drop_result.lock().await;
+                assert!(pending_result.is_none(), "only one destination drop should be pending");
+                *pending_result = Some(async_result);
+            }
+        }
+
+        self.stall_reached.notify_one();
+
+        Ok(())
     }
 
     async fn write_table_rows(
@@ -262,7 +293,7 @@ where
         table_rows: Vec<TableRow>,
         async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
-        if table_rows.is_empty() {
+        if !matches!(self.target, StallTarget::WriteTableRows) {
             return self
                 .inner
                 .write_table_rows(replicated_table_schema, table_rows, async_result)
@@ -272,13 +303,13 @@ where
         match self.mode {
             StallMode::DropResult => drop(async_result),
             StallMode::HoldResult => {
-                let mut pending_result = self.pending_result.lock().await;
+                let mut pending_result = self.pending_write_result.lock().await;
                 assert!(pending_result.is_none(), "only one table-copy write should be pending");
                 *pending_result = Some(async_result);
             }
         }
 
-        self.write_reached.notify_one();
+        self.stall_reached.notify_one();
 
         Ok(())
     }
@@ -340,7 +371,11 @@ async fn table_copy_errors_when_async_result_is_dropped() {
 
     let store = NotifyingStore::new();
     let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
-    let destination = StalledCopyDestination::wrap(immediate_destination, StallMode::DropResult);
+    let destination = StalledCopyDestination::wrap(
+        immediate_destination,
+        StallTarget::WriteTableRows,
+        StallMode::DropResult,
+    );
 
     let pipeline_id: PipelineId = random();
     let mut pipeline = create_pipeline(
@@ -377,7 +412,11 @@ async fn table_copy_shutdown_interrupts_pending_result_wait() {
 
     let store = NotifyingStore::new();
     let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
-    let destination = StalledCopyDestination::wrap(immediate_destination, StallMode::HoldResult);
+    let destination = StalledCopyDestination::wrap(
+        immediate_destination,
+        StallTarget::WriteTableRows,
+        StallMode::HoldResult,
+    );
 
     let pipeline_id: PipelineId = random();
     let mut pipeline = create_pipeline(
@@ -388,7 +427,7 @@ async fn table_copy_shutdown_interrupts_pending_result_wait() {
         destination.clone(),
     );
 
-    let write_reached = destination.notify_on_write();
+    let write_reached = destination.notify_on_stall();
 
     pipeline.start().await.unwrap();
 
@@ -398,6 +437,160 @@ async fn table_copy_shutdown_interrupts_pending_result_wait() {
 
     let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
     assert!(matches!(table_state, TableState::DataSync));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_table_for_copy_errors_when_async_result_is_dropped() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    let store = NotifyingStore::new();
+    let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let destination = StalledCopyDestination::wrap(
+        immediate_destination,
+        StallTarget::DropTableForCopy,
+        StallMode::DropResult,
+    );
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    table_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    store.reset_table_state(table_id).await.unwrap();
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination,
+    );
+
+    let table_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+
+    pipeline.start().await.unwrap();
+
+    table_errored.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
+    let TableState::Errored { source_err, .. } = table_state else {
+        panic!("dropped destination-drop result should put the table in an errored state");
+    };
+    assert_eq!(source_err.kind(), ErrorKind::DestinationError);
+    assert!(store.get_destination_table_metadata(table_id).await.unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_table_for_copy_shutdown_interrupts_pending_result_wait() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    let store = NotifyingStore::new();
+    let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let destination = StalledCopyDestination::wrap(
+        immediate_destination,
+        StallTarget::DropTableForCopy,
+        StallMode::HoldResult,
+    );
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    pipeline.start().await.unwrap();
+    table_ready.notified().await;
+
+    let drop_reached = destination.notify_on_stall();
+
+    store.reset_table_state(table_id).await.unwrap();
+
+    drop_reached.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
+    assert!(matches!(table_state, TableState::Init));
+    assert!(store.get_destination_table_metadata(table_id).await.unwrap().is_some());
+}
+
+/// Verifies that resetting a table during an active copy is overwritten by the
+/// active worker.
+///
+/// Real-time resets are not supported yet: the active worker currently owns a
+/// separate in-memory state and can overwrite the stored `Init` state when it
+/// advances. Supporting resets without restarting the pipeline requires
+/// coordinating the reset with that worker and changing this expectation so a
+/// fresh copy drops the existing destination table.
+#[tokio::test(flavor = "multi_thread")]
+async fn reset_during_active_copy_is_overwritten_by_active_worker() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    let store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let held_write = destination.hold_next(FaultyOp::WriteTableRows).await;
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    held_write.wait_reached().await;
+
+    // We reset the table state while the write table rows method is blocked.
+    store.reset_table_state(table_id).await.unwrap();
+
+    // We release the hold, which causes the system to continue its work and
+    // overrides the `Init` state which was set by the reset.
+    held_write.release_ok();
+
+    // The table becomes ready since naturally since the copy just continued.
+    table_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    assert!(!destination.was_table_dropped_for_copy(table_id).await);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Make table-copy shutdown responsive while waiting for asynchronous destination operations.

Previously, shutdown could hang indefinitely if a destination accepted a table-copy operation but never completed its `AsyncResult`. This affected row writes, terminal durability barriers, and destination-table cleanup before restarting a copy.

This change:

- Allows pending destination results to be interrupted by shutdown.
- Prioritizes shutdown when completion and shutdown become ready together.
- Leaves table state restartable without incorrectly recording unfinished work as durable.
- Reports a destination error when an `AsyncResult` sender is dropped without completion.
- Treats receiver closure after cancellation as debug-level information instead of an operational warning.
- Documents the updated shutdown behavior in the destination contract.