### PR TITLE
feat(api): Add new restart endpoint

### DIFF
--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -25,7 +25,8 @@ use crate::{
 /// up those changes.
 ///
 /// If Kubernetes support is unavailable, or the pipeline has no active
-/// Kubernetes resources, the call is a no-op.
+/// Kubernetes resources, the call returns `false` without reconciling.
+/// Otherwise, it returns `true` after the Kubernetes resources are reconciled.
 pub(crate) async fn restart_pipeline_replicator_if_running(
     connection: &mut sqlx::PgConnection,
     tenant_id: &str,
@@ -34,16 +35,16 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     k8s_client: Option<&dyn K8sClient>,
     source_tls_config: &SourceTlsConfig,
     api_config: &ApiConfig,
-) -> Result<(), PipelineError> {
-    let Some(k8s_client) = k8s_client else {
-        return Ok(());
-    };
-
+) -> Result<bool, PipelineError> {
     let (pipeline, replicator, image, source, destination) =
         read_pipeline_components(connection, tenant_id, pipeline_id, encryption_key).await?;
 
+    let Some(k8s_client) = k8s_client else {
+        return Ok(false);
+    };
+
     if !should_reconcile_replicator_resources(k8s_client, tenant_id, replicator.id).await? {
-        return Ok(());
+        return Ok(false);
     }
 
     create_or_update_pipeline_resources_in_k8s(
@@ -59,7 +60,7 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     )
     .await?;
 
-    Ok(())
+    Ok(true)
 }
 
 /// Validates a source config against the trusted source profile, when enabled.

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -64,6 +64,9 @@ pub enum PipelineError {
     #[error("The pipeline with id {0} is active; stop it before deleting it")]
     ActivePipeline(i64),
 
+    #[error("The pipeline with id {0} is not running; start it before restarting it")]
+    InactivePipeline(i64),
+
     #[error("The source with id {0} was not found")]
     SourceNotFound(i64),
 
@@ -253,9 +256,9 @@ impl IntoResponse for PipelineError {
                 TableLookupError::TableNotFound(_) => StatusCode::BAD_GATEWAY,
             },
             PipelineError::Validation(error) => route_utils::validation_error_status_code(error),
-            PipelineError::ActivePipeline(_) | PipelineError::DuplicatePipeline => {
-                StatusCode::CONFLICT
-            }
+            PipelineError::ActivePipeline(_)
+            | PipelineError::InactivePipeline(_)
+            | PipelineError::DuplicatePipeline => StatusCode::CONFLICT,
             PipelineError::PipelineNotFound(_)
             | PipelineError::EtlStateNotInitialized
             | PipelineError::ImageIdNotDefault(_)
@@ -984,6 +987,55 @@ pub(crate) async fn start_pipeline(
     txn.commit().await?;
 
     Ok(StatusCode::OK)
+}
+
+#[utoipa::path(
+    post,
+    path = "/pipelines/{pipeline_id}/restart",
+    summary = "Restart a pipeline",
+    description = "Reconciles the pipeline's Kubernetes resources and restarts its replicator.",
+    params(
+        ("pipeline_id" = i64, Path, description = "Unique ID of the pipeline"),
+        ("tenant_id" = String, Header, description = "Tenant ID used to scope the request")
+    ),
+    responses(
+        (status = 202, description = "Pipeline restart initiated successfully"),
+        (status = 400, description = "Bad request", body = ErrorMessage),
+        (status = 404, description = "Pipeline, source, or destination not found", body = ErrorMessage),
+        (status = 409, description = "Pipeline is not running", body = ErrorMessage),
+        (status = 500, description = "Internal server error", body = ErrorMessage)
+    ),
+    tag = "Pipelines"
+)]
+pub(crate) async fn restart_pipeline(
+    headers: HeaderMap,
+    Extension(pool): Extension<PgPool>,
+    Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
+    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
+    Extension(api_config): Extension<Arc<ApiConfig>>,
+    pipeline_id: Path<i64>,
+) -> Result<impl IntoResponse, PipelineError> {
+    let tenant_id = extract_tenant_id(&headers)?;
+    let pipeline_id = pipeline_id.into_inner();
+
+    let mut connection = pool.acquire().await?;
+    let restarted = restart_pipeline_replicator_if_running(
+        &mut connection,
+        tenant_id,
+        pipeline_id,
+        &encryption_key,
+        k8s_client.as_deref(),
+        &source_tls_config,
+        &api_config,
+    )
+    .await?;
+
+    if !restarted {
+        return Err(PipelineError::InactivePipeline(pipeline_id));
+    }
+
+    Ok(StatusCode::ACCEPTED)
 }
 
 #[utoipa::path(

--- a/crates/etl-api/src/startup.rs
+++ b/crates/etl-api/src/startup.rs
@@ -53,8 +53,8 @@ use crate::{
             ReadPipelinesResponse, SimpleTableState, TableStatus, UpdatePipelineRequest,
             UpdatePipelineVersionRequest, ValidatePipelineRequest, ValidatePipelineResponse,
             create_pipeline, delete_pipeline, get_pipeline_replication_status, get_pipeline_status,
-            get_pipeline_version, read_all_pipelines, read_pipeline, rollback_tables,
-            start_pipeline, stop_all_pipelines, stop_pipeline, update_pipeline,
+            get_pipeline_version, read_all_pipelines, read_pipeline, restart_pipeline,
+            rollback_tables, start_pipeline, stop_all_pipelines, stop_pipeline, update_pipeline,
             update_pipeline_version, validate_pipeline,
         },
         sources::{
@@ -363,6 +363,7 @@ pub fn run(
         crate::routes::pipelines::get_pipeline_version,
         crate::routes::pipelines::get_pipeline_replication_status,
         crate::routes::pipelines::update_pipeline_version,
+        crate::routes::pipelines::restart_pipeline,
         crate::routes::tenants::create_tenant,
         crate::routes::tenants::create_or_update_tenant,
         crate::routes::tenants::read_tenant,
@@ -442,6 +443,7 @@ pub fn run(
             get(read_pipeline).post(update_pipeline).delete(delete_pipeline),
         )
         .route("/pipelines/{pipeline_id}/start", post(start_pipeline))
+        .route("/pipelines/{pipeline_id}/restart", post(restart_pipeline))
         .route("/pipelines/{pipeline_id}/stop", post(stop_pipeline))
         .route("/pipelines/{pipeline_id}/status", get(get_pipeline_status))
         .route(

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -1210,6 +1210,56 @@ async fn an_existing_pipeline_can_be_started() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn a_running_pipeline_can_be_restarted() {
+    init_test_tracing();
+    let k8s_state = MockK8sState::default();
+    let app = spawn_test_app_with_k8s_state(None, k8s_state.clone()).await;
+    create_default_image(&app).await;
+    let tenant_id = create_tenant(&app).await;
+    let source_id = create_source(&app, &tenant_id).await;
+    let destination_id = create_destination(&app, &tenant_id).await;
+    let pipeline_id = create_pipeline_with_config(
+        &app,
+        &tenant_id,
+        source_id,
+        destination_id,
+        new_pipeline_config(),
+    )
+    .await;
+    let create_calls_before = k8s_state.create_calls();
+
+    let response = app.restart_pipeline(&tenant_id, pipeline_id).await;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert!(k8s_state.create_calls() > create_calls_before);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stopped_pipeline_cannot_be_restarted() {
+    init_test_tracing();
+    let k8s_state = MockK8sState::default();
+    k8s_state.set_pod_status(PodStatus::Stopped).await;
+    let app = spawn_test_app_with_k8s_state(None, k8s_state.clone()).await;
+    create_default_image(&app).await;
+    let tenant_id = create_tenant(&app).await;
+    let source_id = create_source(&app, &tenant_id).await;
+    let destination_id = create_destination(&app, &tenant_id).await;
+    let pipeline_id = create_pipeline_with_config(
+        &app,
+        &tenant_id,
+        source_id,
+        destination_id,
+        new_pipeline_config(),
+    )
+    .await;
+
+    let response = app.restart_pipeline(&tenant_id, pipeline_id).await;
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    assert_eq!(k8s_state.create_calls(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn an_existing_pipeline_can_be_stopped() {
     init_test_tracing();
     // Arrange

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -339,6 +339,18 @@ impl TestApp {
             .expect("failed to execute request")
     }
 
+    pub(crate) async fn restart_pipeline(
+        &self,
+        tenant_id: &str,
+        pipeline_id: i64,
+    ) -> reqwest::Response {
+        self.post_authenticated(format!("{}/v1/pipelines/{pipeline_id}/restart", &self.address))
+            .header("tenant_id", tenant_id)
+            .send()
+            .await
+            .expect("failed to execute request")
+    }
+
     pub(crate) async fn stop_all_pipelines(&self, tenant_id: &str) -> reqwest::Response {
         self.post_authenticated(format!("{}/v1/pipelines/stop", &self.address))
             .header("tenant_id", tenant_id)


### PR DESCRIPTION
This PR adds a new restart endpoint for ETL which allows a more efficient restart without having to stop and start a pipeline.