### PR TITLE
feat(configuration): add the ability to set default resources globally and per destination

### DIFF
--- a/crates/etl-api/README.md
+++ b/crates/etl-api/README.md
@@ -88,15 +88,21 @@ k8s:
   replicator_resources:
     cpu_request_millicores: 500
     memory_request_mib: 2000
+    destinations:
+      ducklake:
+        cpu_request_millicores: 1000
+        memory_request_mib: 4000
   vector_resources:
     cpu_request_millicores: 75
     memory_request_mib: 192
 ```
 
-These defaults are mandatory and request-only. The ETL API derives Kubernetes
-limits from the final request values with static multipliers in the Kubernetes
-materializer. Vector resources are configured only at the API level; pipeline
-configuration may override replicator resources only.
+The global replicator and Vector defaults are mandatory and request-only.
+Destination defaults are optional and may override either request field for
+`bigquery`, `clickhouse`, `ducklake`, `iceberg`, or `snowflake`. Missing
+destination fields fall back to the global replicator defaults. Vector
+resources are configured only at the API level; pipeline configuration may
+override replicator resources only.
 
 Pipeline configuration may override any replicator resource field:
 
@@ -108,11 +114,11 @@ replicator_resources:
   memory_limit_mib: 1843
 ```
 
-All pipeline resource fields are optional. If a request is omitted, the API
-configuration default is used. If a limit is omitted, the ETL API computes it
-from the final request and the static multiplier. Before Kubernetes resources
-are applied, final requests are clamped to at least `1m` CPU and `1Mi` memory,
-and final limits are clamped so they are never below their paired requests.
+All pipeline resource fields are optional. Request precedence is pipeline
+override, destination-kind default, then global default. If a limit is omitted,
+it matches the final request. Before Kubernetes resources are applied, final
+requests are clamped to at least `1m` CPU and `1Mi` memory, and final limits are
+clamped so they are never below their paired requests.
 
 ### Encryption Keys
 

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -1,9 +1,9 @@
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 use etl_config::{
     Config,
-    shared::{PgConnectionConfig, SentryConfig, TlsConfig},
+    shared::{DestinationKind, PgConnectionConfig, SentryConfig, TlsConfig},
 };
 use serde::{
     Deserialize, Deserializer,
@@ -56,8 +56,8 @@ pub struct K8sConfig {
     ///
     /// This key remains `replicator_resources` in API configuration files. It
     /// provides the mandatory baseline CPU and memory requests used for every
-    /// replicator pod unless a pipeline-level override supplies one of those
-    /// request values.
+    /// replicator pod unless a destination-kind default or pipeline-level
+    /// override supplies one of those request values.
     pub replicator_resources: DefaultReplicatorResourcesConfig,
     /// Default request sizing for the Vector sidecar.
     pub vector_resources: DefaultVectorResourcesConfig,
@@ -67,15 +67,40 @@ pub struct K8sConfig {
 ///
 /// These values are part of the ETL API service configuration, not the
 /// customer-facing pipeline configuration. They define the baseline Kubernetes
-/// requests for replicator containers. Resource limits are not configurable
-/// here; the ETL API sets them equal to requests unless a pipeline-level
-/// override provides explicit limits.
-#[derive(Debug, Clone, Deserialize)]
+/// requests for replicator containers. Destination-kind defaults may override
+/// these values. Resource limits are not configurable here; the ETL API sets
+/// them equal to requests unless a pipeline-level override provides explicit
+/// limits.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct DefaultReplicatorResourcesConfig {
     /// Replicator memory request, in Mi.
     pub memory_request_mib: i32,
     /// Replicator CPU request, in millicores.
     pub cpu_request_millicores: i32,
+    /// Partial default request overrides keyed by destination kind.
+    #[serde(default)]
+    pub destinations: BTreeMap<DestinationKind, DefaultReplicatorResourcesOverrideConfig>,
+}
+
+/// Partial default request sizing for one destination kind.
+///
+/// Omitted fields inherit their values from the global
+/// [`DefaultReplicatorResourcesConfig`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+pub struct DefaultReplicatorResourcesOverrideConfig {
+    /// Optional replicator memory request, in Mi.
+    pub memory_request_mib: Option<i32>,
+    /// Optional replicator CPU request, in millicores.
+    pub cpu_request_millicores: Option<i32>,
+}
+
+/// Fully resolved default request sizing for one replicator workload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ResolvedReplicatorResourcesConfig {
+    /// Replicator memory request, in Mi.
+    pub(crate) memory_request_mib: i32,
+    /// Replicator CPU request, in millicores.
+    pub(crate) cpu_request_millicores: i32,
 }
 
 /// Mandatory default request sizing for Vector sidecars.
@@ -101,11 +126,55 @@ impl ApiConfig {
     }
 }
 
+impl K8sConfig {
+    /// Resolves default replicator requests for a destination kind.
+    pub(crate) fn replicator_resources_for(
+        &self,
+        destination_kind: DestinationKind,
+    ) -> ResolvedReplicatorResourcesConfig {
+        let resources = self.replicator_resources.destinations.get(&destination_kind);
+
+        ResolvedReplicatorResourcesConfig {
+            memory_request_mib: resources
+                .and_then(|resources| resources.memory_request_mib)
+                .unwrap_or(self.replicator_resources.memory_request_mib),
+            cpu_request_millicores: resources
+                .and_then(|resources| resources.cpu_request_millicores)
+                .unwrap_or(self.replicator_resources.cpu_request_millicores),
+        }
+    }
+}
+
 impl DefaultReplicatorResourcesConfig {
     /// Validates that configured request values are positive.
     pub fn validate(&self) -> Result<(), String> {
         validate_positive_request("K8s replicator memory request", self.memory_request_mib)?;
         validate_positive_request("K8s replicator cpu request", self.cpu_request_millicores)?;
+        for (destination_kind, resources) in &self.destinations {
+            resources.validate(*destination_kind)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl DefaultReplicatorResourcesOverrideConfig {
+    /// Validates that configured request overrides are positive.
+    fn validate(&self, destination_kind: DestinationKind) -> Result<(), String> {
+        let destination_kind = destination_kind.as_str();
+
+        if let Some(memory_request_mib) = self.memory_request_mib {
+            validate_positive_request(
+                &format!("K8s {destination_kind} replicator memory request"),
+                memory_request_mib,
+            )?;
+        }
+        if let Some(cpu_request_millicores) = self.cpu_request_millicores {
+            validate_positive_request(
+                &format!("K8s {destination_kind} replicator cpu request"),
+                cpu_request_millicores,
+            )?;
+        }
 
         Ok(())
     }
@@ -279,5 +348,84 @@ impl<'de> Deserialize<'de> for ApiKey {
 
         const FIELDS: &[&str] = &["key"];
         deserializer.deserialize_struct("ApiKey", FIELDS, ApiKeyVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn destination_replicator_resources_override_selected_global_fields() {
+        let config: K8sConfig = serde_json::from_value(json!({
+            "replicator_resources": {
+                "memory_request_mib": 2000,
+                "cpu_request_millicores": 500,
+                "destinations": {
+                    "ducklake": {
+                        "memory_request_mib": 4000
+                    }
+                }
+            },
+            "vector_resources": {
+                "memory_request_mib": 192,
+                "cpu_request_millicores": 75
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            config.replicator_resources_for(DestinationKind::Ducklake),
+            ResolvedReplicatorResourcesConfig {
+                memory_request_mib: 4000,
+                cpu_request_millicores: 500,
+            }
+        );
+        assert_eq!(
+            config.replicator_resources_for(DestinationKind::BigQuery),
+            ResolvedReplicatorResourcesConfig {
+                memory_request_mib: 2000,
+                cpu_request_millicores: 500,
+            }
+        );
+    }
+
+    #[test]
+    fn destination_replicator_resources_are_optional() {
+        let config: K8sConfig = serde_json::from_value(json!({
+            "replicator_resources": {
+                "memory_request_mib": 2000,
+                "cpu_request_millicores": 500
+            },
+            "vector_resources": {
+                "memory_request_mib": 192,
+                "cpu_request_millicores": 75
+            }
+        }))
+        .unwrap();
+
+        assert!(config.replicator_resources.destinations.is_empty());
+        assert_eq!(
+            config.replicator_resources_for(DestinationKind::Ducklake),
+            ResolvedReplicatorResourcesConfig {
+                memory_request_mib: 2000,
+                cpu_request_millicores: 500,
+            }
+        );
+    }
+
+    #[test]
+    fn destination_replicator_resource_overrides_must_be_positive() {
+        let resources = DefaultReplicatorResourcesOverrideConfig {
+            memory_request_mib: Some(0),
+            cpu_request_millicores: None,
+        };
+
+        assert_eq!(
+            resources.validate(DestinationKind::Ducklake),
+            Err("K8s ducklake replicator memory request must be greater than 0".to_owned())
+        );
     }
 }

--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use etl_config::shared::DestinationKind;
 use etl_maintenance::DuckLakeMaintenancePolicy;
 use thiserror::Error;
 
@@ -99,6 +100,20 @@ pub enum DestinationType {
         /// secret entry.
         passphrase_secret_required: bool,
     },
+}
+
+impl DestinationType {
+    /// Returns the product destination kind represented by this Kubernetes
+    /// type.
+    pub const fn kind(self) -> DestinationKind {
+        match self {
+            DestinationType::BigQuery => DestinationKind::BigQuery,
+            DestinationType::Iceberg => DestinationKind::Iceberg,
+            DestinationType::ClickHouse { .. } => DestinationKind::ClickHouse,
+            DestinationType::Ducklake => DestinationKind::Ducklake,
+            DestinationType::Snowflake { .. } => DestinationKind::Snowflake,
+        }
+    }
 }
 
 impl From<&StoredDestinationConfig> for DestinationType {

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -5,6 +5,8 @@ use base64::{Engine, prelude::BASE64_STANDARD};
 use chrono::Utc;
 use etl_config::Environment;
 #[cfg(test)]
+use etl_config::shared::DestinationKind;
+#[cfg(test)]
 use etl_maintenance::DuckLakeMaintenancePolicy;
 use k8s_openapi::{
     api::{
@@ -22,8 +24,10 @@ use serde_json::json;
 use thiserror::Error;
 use tracing::debug;
 
+#[cfg(test)]
+use crate::config::DefaultReplicatorResourcesConfig;
 use crate::{
-    config::{DefaultReplicatorResourcesConfig, DefaultVectorResourcesConfig, K8sConfig},
+    config::{DefaultVectorResourcesConfig, K8sConfig, ResolvedReplicatorResourcesConfig},
     configs::{
         log::LogLevel,
         pipeline::{DuckLakeMaintenanceConfig, ReplicatorResourcesConfig},
@@ -142,8 +146,10 @@ impl ReplicatorStatefulSetResourcesConfig {
     #[cfg(test)]
     fn for_environment(environment: &Environment) -> Result<Self, K8sError> {
         let k8s_config = test_k8s_config(environment);
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::BigQuery);
         Self::from_default_resources(
-            &k8s_config.replicator_resources,
+            &default_replicator_resources,
             &k8s_config.vector_resources,
             None,
         )
@@ -160,7 +166,7 @@ impl ReplicatorStatefulSetResourcesConfig {
     /// the pod qualify for Kubernetes Guaranteed QoS unless the pipeline opts
     /// into different replicator limits.
     fn from_default_resources(
-        default_replicator_resources: &DefaultReplicatorResourcesConfig,
+        default_replicator_resources: &ResolvedReplicatorResourcesConfig,
         default_vector_resources: &DefaultVectorResourcesConfig,
         pipeline_replicator_resources: Option<&ReplicatorResourcesConfig>,
     ) -> Result<Self, K8sError> {
@@ -246,6 +252,7 @@ fn test_k8s_config(environment: &Environment) -> K8sConfig {
         replicator_resources: DefaultReplicatorResourcesConfig {
             memory_request_mib,
             cpu_request_millicores,
+            destinations: Default::default(),
         },
         vector_resources: DefaultVectorResourcesConfig {
             memory_request_mib: 192,
@@ -725,8 +732,10 @@ impl K8sClient for HttpK8sClient {
 
         let prefix = request.prefix.as_str();
         let replicator_image = request.replicator_image.as_str();
+        let default_replicator_resources =
+            self.k8s_config.replicator_resources_for(request.destination_type.kind());
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
-            &self.k8s_config.replicator_resources,
+            &default_replicator_resources,
             &self.k8s_config.vector_resources,
             request.replicator_resources.as_ref(),
         )?;
@@ -1776,7 +1785,10 @@ mod tests {
     use insta::{assert_json_snapshot, assert_snapshot};
 
     use super::*;
-    use crate::configs::pipeline::ReplicatorResourcesConfig;
+    use crate::{
+        config::DefaultReplicatorResourcesOverrideConfig,
+        configs::pipeline::ReplicatorResourcesConfig,
+    };
 
     const TENANT_ID: &str = "abcdefghijklmnopqrst";
     const PIPELINE_ID: i64 = 24;
@@ -1927,9 +1939,11 @@ mod tests {
             ..ReplicatorResourcesConfig::default()
         };
         let k8s_config = test_k8s_config(&Environment::Prod);
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::BigQuery);
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
-            &k8s_config.replicator_resources,
+            &default_replicator_resources,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
@@ -1950,9 +1964,11 @@ mod tests {
             memory_limit_mib: Some(2048),
         };
         let k8s_config = test_k8s_config(&Environment::Prod);
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::BigQuery);
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
-            &k8s_config.replicator_resources,
+            &default_replicator_resources,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
@@ -1976,15 +1992,18 @@ mod tests {
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: -10,
                 memory_request_mib: 0,
+                destinations: Default::default(),
             },
             vector_resources: DefaultVectorResourcesConfig {
                 cpu_request_millicores: 0,
                 memory_request_mib: -20,
             },
         };
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::BigQuery);
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
-            &k8s_config.replicator_resources,
+            &default_replicator_resources,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
@@ -2009,9 +2028,11 @@ mod tests {
             memory_limit_mib: Some(100),
         };
         let k8s_config = test_k8s_config(&Environment::Prod);
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::BigQuery);
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
-            &k8s_config.replicator_resources,
+            &default_replicator_resources,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
@@ -2029,15 +2050,18 @@ mod tests {
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: 500,
                 memory_request_mib: 500,
+                destinations: Default::default(),
             },
             vector_resources: DefaultVectorResourcesConfig {
                 cpu_request_millicores: 80,
                 memory_request_mib: 192,
             },
         };
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::BigQuery);
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
-            &k8s_config.replicator_resources,
+            &default_replicator_resources,
             &k8s_config.vector_resources,
             None,
         )
@@ -2212,32 +2236,41 @@ mod tests {
     }
 
     #[test]
-    fn test_replicator_stateful_set_resources_prefers_pipeline_over_api_config() {
+    fn test_replicator_resources_prefer_pipeline_then_destination_then_global_defaults() {
         let overrides = ReplicatorResourcesConfig {
             cpu_request_millicores: Some(900),
-            memory_request_mib: Some(1800),
             ..ReplicatorResourcesConfig::default()
         };
+        let destinations = BTreeMap::from([(
+            DestinationKind::Ducklake,
+            DefaultReplicatorResourcesOverrideConfig {
+                cpu_request_millicores: Some(600),
+                memory_request_mib: Some(800),
+            },
+        )]);
         let k8s_config = K8sConfig {
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: 300,
                 memory_request_mib: 400,
+                destinations,
             },
             vector_resources: DefaultVectorResourcesConfig {
                 cpu_request_millicores: 80,
                 memory_request_mib: 192,
             },
         };
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::Ducklake);
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
-            &k8s_config.replicator_resources,
+            &default_replicator_resources,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
         .unwrap();
 
         assert_eq!(stateful_set_resources.replicator_cpu_request, "900m");
-        assert_eq!(stateful_set_resources.replicator_memory_request, "1800Mi");
+        assert_eq!(stateful_set_resources.replicator_memory_request, "800Mi");
     }
 
     #[test]

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -587,6 +587,7 @@ async fn spawn_test_app_with_services(
             replicator_resources: DefaultReplicatorResourcesConfig {
                 memory_request_mib: 250,
                 cpu_request_millicores: 125,
+                destinations: Default::default(),
             },
             vector_resources: DefaultVectorResourcesConfig {
                 memory_request_mib: 192,

--- a/crates/etl-config/src/shared/destination.rs
+++ b/crates/etl-config/src/shared/destination.rs
@@ -63,7 +63,8 @@ pub enum DuckLakeMaintenanceMode {
 }
 
 /// Supported product destination kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DestinationKind {
     /// Google BigQuery destination.
     BigQuery,


### PR DESCRIPTION
Example of configuration:

Before:
```yaml
replicator_resources:
    cpu_request_millicores: 500
    memory_request_mib: 2000
```

After:
```yaml
replicator_resources:
    cpu_request_millicores: 500
    memory_request_mib: 2000
    destinations:
      ducklake:
        cpu_request_millicores: 1000
        memory_request_mib: 4000
```