### PR TITLE
feat(etl): return a guard from task set drain

### DIFF
--- a/crates/etl/src/destination/mod.rs
+++ b/crates/etl/src/destination/mod.rs
@@ -26,4 +26,4 @@ pub use metadata::{
     AppliedDestinationTableMetadata, DestinationTableMetadata, DestinationTableSchemaStatus,
 };
 
-pub use crate::runtime::concurrency::TaskSet;
+pub use crate::runtime::concurrency::{TaskSet, TaskSetDrainGuard};

--- a/crates/etl/src/runtime/concurrency/mod.rs
+++ b/crates/etl/src/runtime/concurrency/mod.rs
@@ -11,4 +11,4 @@ pub(crate) use stream::{
     BackpressureStream, TryBatchBackpressureStream, apply_worker_apply_stream_id,
     table_sync_worker_apply_stream_id, table_sync_worker_copy_stream_id,
 };
-pub use task_set::TaskSet;
+pub use task_set::{TaskSet, TaskSetDrainGuard};

--- a/crates/etl/src/runtime/concurrency/task_set.rs
+++ b/crates/etl/src/runtime/concurrency/task_set.rs
@@ -1,6 +1,9 @@
 use std::{future::Future, sync::Arc};
 
-use tokio::{sync::Mutex, task::JoinSet};
+use tokio::{
+    sync::{Mutex, OwnedMutexGuard},
+    task::JoinSet,
+};
 use tracing::{error, warn};
 
 use crate::{
@@ -19,10 +22,9 @@ const TASK_REAP_THRESHOLD: usize = 32;
 /// This helper is for components that want to offload accepted work to
 /// background tasks while still keeping task handles owned and observable.
 ///
-/// It intentionally does not add its own concurrency control. ETL already
-/// limits concurrent work at higher levels, so this type only manages the
-/// lifecycle of spawned tasks: reap completed work during normal operation and
-/// shut down outstanding tasks safely.
+/// This type does not impose a work-concurrency policy, higher layers decide
+/// when work is submitted and how much may run concurrently. It coordinates
+/// task registration with reaping, draining, and shutdown.
 #[derive(Debug)]
 struct TaskSetInner {
     join_set: JoinSet<()>,
@@ -34,6 +36,18 @@ struct TaskSetInner {
 #[derive(Debug, Clone)]
 pub struct TaskSet {
     inner: Arc<Mutex<TaskSetInner>>,
+}
+
+/// Exclusive task-registration boundary retained after a [`TaskSet`] drains.
+///
+/// While this guard is alive, calls that access the same task registry wait for
+/// it to be dropped. Dropping the guard restores access without aborting any
+/// task.
+#[must_use = "dropping this guard allows new tasks to register"]
+#[derive(Debug)]
+pub struct TaskSetDrainGuard {
+    /// Retained lock for the task registry.
+    _guard: OwnedMutexGuard<TaskSetInner>,
 }
 
 impl TaskSet {
@@ -66,18 +80,32 @@ impl TaskSet {
         Ok(())
     }
 
-    /// Waits for all remaining tasks to finish without aborting them.
+    /// Drains the task set and retains exclusive access to its task registry.
     ///
-    /// This is useful for callers that want shutdown to complete
-    /// already-accepted work before cleaning up related resources.
-    pub async fn drain(&self) -> EtlResult<()> {
-        let mut inner = self.inner.lock().await;
+    /// Use this when resources used by registered tasks must be changed after
+    /// all previously registered work has finished and before later work can
+    /// start. The returned guard blocks [`TaskSet::spawn`] and other registry
+    /// operations until dropped.
+    ///
+    /// This method neither aborts tasks nor imposes a timeout. Cancelling it
+    /// releases the registry and leaves unfinished tasks tracked.
+    ///
+    /// The registry remains locked while registered tasks are awaited. Such
+    /// tasks must not directly or indirectly wait for an operation that
+    /// accesses this [`TaskSet`]. The caller must likewise not await any
+    /// operation that accesses this task registry while holding the returned
+    /// guard.
+    ///
+    /// If a tracked task panics, this method returns an error without a guard.
+    /// Tasks not yet joined remain tracked and continue running.
+    pub async fn drain(&self) -> EtlResult<TaskSetDrainGuard> {
+        let mut inner = Arc::clone(&self.inner).lock_owned().await;
 
         while let Some(result) = inner.join_set.join_next().await {
             self.handle_task_result(result)?;
         }
 
-        Ok(())
+        Ok(TaskSetDrainGuard { _guard: inner })
     }
 
     /// Aborts and reaps all remaining tasks during shutdown.

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -442,8 +442,9 @@ where
             errors.push(err);
         }
 
-        if let Err(err) = self.tasks.drain().await {
-            errors.push(err);
+        match self.tasks.drain().await {
+            Ok(guard) => drop(guard),
+            Err(err) => errors.push(err),
         }
 
         let result = if errors.is_empty() { Ok(()) } else { Err(errors.into()) };


### PR DESCRIPTION
## Summary

Change `TaskSet::drain()` to return a must-use `TaskSetDrainGuard`.

After all registered tasks finish, the guard retains exclusive access to the task registry. `spawn()` and other registry operations remain blocked until the guard is dropped.

❗ The `drain()` method doesn't seem to be used anywhere but tests, so blast radius is almost nil.

## Motivation

The previous `drain()` guaranteed only that the task set was empty when the method returned. It released the registry before the caller could reset resources used by those tasks:

1. `drain()` waits for existing tasks and returns (thus unlocking tasks registry).
2. A concurrent caller registers a new task.
3. The original caller resets or replaces some shared resources.
4. The new task accesses those resources during the reset.

Returning the guard lets callers make draining and resource reset one exclusive boundary. A concurrent task is either registered before the drain and awaited, or after the guard is dropped.

## Race this enables us to close

Snowflake tracks accepted-but-not-durable work for all streaming channels in shared destination state. During a table-copy retry, the destination must remove the retiring table's pending target and channel before dropping the remote
object.

Without retained exclusivity, an event task for another table can register after existing tasks have drained, snapshot the retiring table's pending target, and then resolve its channel while reset is removing that target and channel. The
returned guard lets the Snowflake follow-up make draining and reset one exclusive boundary.