### PR TITLE
feat(etl): add the ability to dynamically add/remove tables from publication

### DIFF
--- a/crates/etl-config/src/shared/pipeline.rs
+++ b/crates/etl-config/src/shared/pipeline.rs
@@ -292,7 +292,8 @@ pub struct PipelineConfig {
     /// Number of milliseconds between one memory usage refresh and another.
     #[serde(default = "default_memory_refresh_interval_ms")]
     pub memory_refresh_interval_ms: u64,
-    /// Number of milliseconds between one replication lag refresh and another.
+    /// Number of milliseconds between source replication lag and publication
+    /// membership refreshes.
     #[serde(default = "default_replication_lag_refresh_interval_ms")]
     pub replication_lag_refresh_interval_ms: u64,
     /// Optional memory-based backpressure configuration.
@@ -477,7 +478,8 @@ pub struct PipelineConfigWithoutSecrets {
     /// Number of milliseconds between one memory usage refresh and another.
     #[serde(default = "default_memory_refresh_interval_ms")]
     pub memory_refresh_interval_ms: u64,
-    /// Number of milliseconds between one replication lag refresh and another.
+    /// Number of milliseconds between source replication lag and publication
+    /// membership refreshes.
     #[serde(default = "default_replication_lag_refresh_interval_ms")]
     pub replication_lag_refresh_interval_ms: u64,
     /// Optional memory-based backpressure configuration.

--- a/crates/etl/src/pipeline.rs
+++ b/crates/etl/src/pipeline.rs
@@ -4,9 +4,8 @@
 //! replication with destination systems. Manages worker lifecycles, shutdown
 //! coordination, and error handling.
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
-use etl_postgres::slots::EtlReplicationSlot;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
 
@@ -24,7 +23,6 @@ use crate::{
         ApplyWorker, ApplyWorkerHandle, MemoryMonitor, TableSyncWorkerPool,
         concurrency::create_shutdown_channel,
     },
-    schema::TableId,
     store::PipelineStore,
 };
 
@@ -332,18 +330,16 @@ where
         self.wait().await
     }
 
-    /// Initializes table states for tables in the publication and
-    /// purges state for tables removed from it.
+    /// Initializes table states for tables currently in the publication.
     ///
     /// Ensures each table currently in the Postgres publication has a
     /// corresponding table state; tables without existing states are
     /// initialized to [`TableState::Init`].
     ///
-    /// Also detects tables for which we have stored state but are no longer
-    /// part of the publication, deletes their stored state (replication state,
-    /// destination table metadata, table schemas, and durable table-sync
-    /// progress), and performs best-effort cleanup of their table sync
-    /// replication slots without touching the actual destination tables.
+    /// Stored state for absent tables is intentionally preserved here. The main
+    /// apply worker reconciles removals only after its logical replication
+    /// stream crosses the catalog snapshot's WAL barrier; deleting eagerly at
+    /// startup could skip retained pre-removal WAL that has not been replayed.
     async fn initialize_table_states(
         &self,
         replication_client: &PgReplicationClient,
@@ -377,36 +373,6 @@ where
         for table_id in &publication_table_ids {
             if !table_states.contains_key(table_id) {
                 self.store.update_table_state(*table_id, TableState::Init).await?;
-            }
-        }
-
-        // Detect and purge tables that have been removed from the publication.
-        //
-        // The purging doesn't delete any data in the destination, it just removes
-        // internal state for that table.
-        let publication_set: HashSet<TableId> = publication_table_ids.iter().copied().collect();
-        for &table_id in table_states.keys() {
-            if !publication_set.contains(&table_id) {
-                info!(
-                    table_id = table_id.0,
-                    "table removed from publication, purging stored state and slot"
-                );
-
-                // We delete all table state before removing the slot, so that we don't
-                // incur in the case where we have a slot tied to an invalid state.
-                self.store.delete_table_state(table_id).await?;
-
-                // We try to delete the replication slot.
-                let slot_name: String =
-                    EtlReplicationSlot::for_table_sync_worker(self.config.id, table_id)
-                        .try_into()?;
-                replication_client.delete_slot_if_exists(&slot_name).await?;
-
-                info!(
-                    table_id = table_id.0,
-                    slot_name,
-                    "purged stored state and table sync slot for table removed from publication"
-                );
             }
         }
 

--- a/crates/etl/src/postgres/mod.rs
+++ b/crates/etl/src/postgres/mod.rs
@@ -11,5 +11,5 @@ pub(crate) mod client;
 pub(crate) mod codec;
 pub mod migrations;
 
-pub(crate) use source_pool::OutOfBandSourcePool;
+pub(crate) use source_pool::{OutOfBandSourcePool, PublicationTableSnapshot};
 pub(crate) use stream::{EventsStream, StatusUpdateResult, StatusUpdateType, TableCopyStream};

--- a/crates/etl/src/postgres/source_pool.rs
+++ b/crates/etl/src/postgres/source_pool.rs
@@ -2,13 +2,18 @@
 
 use std::{str::FromStr, sync::LazyLock, time::Duration};
 
-use sqlx::{PgPool, postgres::PgPoolOptions};
+use sqlx::{
+    PgPool,
+    postgres::{PgPoolOptions, types::Oid as SqlxTableId},
+};
 use tokio_postgres::types::PgLsn;
 
 use crate::{
+    bail,
     config::{IntoConnectOptions, PgConnectionConfig, PgConnectionOptions},
     error::{ErrorKind, EtlResult},
     etl_error,
+    schema::TableId,
 };
 
 /// Maximum number of connections in the out-of-band pool.
@@ -20,10 +25,20 @@ const IDLE_TIMEOUT_REFRESH_PADDING: Duration = Duration::from_secs(30);
 /// Application name for ETL out-of-band source database connections.
 const APP_NAME_REPLICATOR_OUT_OF_BAND: &str = "supabase_etl_replicator_out_of_band";
 
+/// Publication membership observed at a source WAL position.
+#[derive(Debug, Clone)]
+pub(crate) struct PublicationTableSnapshot {
+    /// Table identifiers visible in the publication catalog snapshot.
+    pub(crate) table_ids: Vec<TableId>,
+    /// Source WAL position that follows the catalog snapshot's visible commits.
+    pub(crate) barrier_lsn: PgLsn,
+}
+
 /// Connection options for out-of-band source database queries.
 ///
-/// Uses the common bounded-query Postgres defaults because lag sampling queries
-/// should be quick and should not block source database work.
+/// Uses the common bounded-query Postgres defaults because lag sampling and
+/// publication membership queries should be quick and should not block source
+/// database work.
 static OUT_OF_BAND_OPTIONS: LazyLock<PgConnectionOptions> =
     LazyLock::new(|| PgConnectionOptions::builder(APP_NAME_REPLICATOR_OUT_OF_BAND).build());
 
@@ -77,5 +92,86 @@ impl OutOfBandSourcePool {
                 current_wal_lsn
             )
         })
+    }
+
+    /// Queries publication membership and a source WAL barrier in one
+    /// statement.
+    ///
+    /// Primaries use the current WAL insert position. Standbys use the replay
+    /// position because logical decoding there cannot advance beyond replayed
+    /// WAL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorKind::ConfigError`] if the publication contains no
+    /// tables.
+    pub(crate) async fn get_publication_table_snapshot(
+        &self,
+        publication_name: &str,
+    ) -> EtlResult<PublicationTableSnapshot> {
+        let rows: Vec<(Option<SqlxTableId>, String)> = sqlx::query_as(
+            r#"
+            with publication_tables as materialized (
+                select distinct gpt.relid::oid as table_id
+                from pg_get_publication_tables($1) gpt
+            )
+            select
+                publication_tables.table_id,
+                case
+                    when pg_is_in_recovery() then pg_last_wal_replay_lsn()
+                    else pg_current_wal_lsn()
+                end::text as barrier_lsn
+            from (select 1) singleton
+            left join publication_tables on true
+            order by publication_tables.table_id
+            "#,
+        )
+        .bind(publication_name)
+        .fetch_all(self.pool())
+        .await
+        .map_err(|error| {
+            etl_error!(
+                ErrorKind::SourceQueryFailed,
+                "Publication table snapshot query failed",
+                source: error
+            )
+        })?;
+
+        let barrier_lsn = rows
+            .first()
+            .ok_or_else(|| {
+                etl_error!(
+                    ErrorKind::InvalidState,
+                    "Publication table snapshot query returned no rows"
+                )
+            })?
+            .1
+            .parse::<PgLsn>()
+            .map_err(|_| {
+                etl_error!(
+                    ErrorKind::InvalidState,
+                    "Invalid publication barrier LSN returned by Postgres",
+                    rows.first().map(|row| row.1.clone()).unwrap_or_default()
+                )
+            })?;
+        let table_ids = rows
+            .into_iter()
+            .filter_map(|(table_id, _)| table_id.map(|table_id| TableId::new(table_id.0)))
+            .collect::<Vec<_>>();
+
+        if table_ids.is_empty() {
+            bail!(
+                ErrorKind::ConfigError,
+                "Publication has no tables",
+                format!(
+                    "Publication '{}' does not contain any tables. Ensure the publication is \
+                     configured with tables using FOR TABLE, FOR ALL TABLES, or FOR TABLES IN \
+                     SCHEMA.",
+                    publication_name
+                )
+            );
+        }
+
+        Ok(PublicationTableSnapshot { table_ids, barrier_lsn })
     }
 }

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use etl_config::shared::PipelineConfig;
+use etl_postgres::slots::EtlReplicationSlot;
 use futures::StreamExt;
 use metrics::{counter, gauge, histogram};
 use postgres_replication::{
@@ -28,11 +29,12 @@ use postgres_replication::{
 };
 use tokio::{
     pin,
-    sync::{Mutex, Semaphore, watch},
+    sync::{Mutex, Semaphore, mpsc, watch},
     task::JoinHandle,
     time::MissedTickBehavior,
 };
 use tokio_postgres::types::PgLsn;
+use tokio_stream::wrappers::IntervalStream;
 use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "failpoints")]
@@ -62,7 +64,8 @@ use crate::{
     },
     pipeline::PipelineId,
     postgres::{
-        EventsStream, OutOfBandSourcePool, StatusUpdateResult, StatusUpdateType,
+        EventsStream, OutOfBandSourcePool, PublicationTableSnapshot, StatusUpdateResult,
+        StatusUpdateType,
         client::{PgReplicationClient, PostgresConnectionUpdate},
         codec::{
             DDL_MESSAGE_PREFIX, SchemaChangeMessage, delete_message_payload_bytes,
@@ -408,6 +411,83 @@ impl SchemaCleanupRun {
     }
 }
 
+/// Publication monitor owned by the main apply worker.
+///
+/// Table-sync apply loops perform individual COPY phases and do not need their
+/// own monitor. The main apply worker remains active while those workers run,
+/// so it continues detecting publication changes during COPY.
+#[derive(Debug)]
+struct PublicationMonitor {
+    /// Background publication membership polling task.
+    task: JoinHandle<()>,
+    /// Publication snapshots produced by the polling task.
+    snapshot_rx: mpsc::Receiver<PublicationTableSnapshot>,
+}
+
+impl PublicationMonitor {
+    /// Starts a publication membership monitor.
+    fn spawn(
+        out_of_band_source_pool: OutOfBandSourcePool,
+        publication_name: String,
+        refresh_interval: Duration,
+    ) -> Self {
+        let (publication_snapshot_tx, snapshot_rx) = mpsc::channel(1);
+        let task = tokio::spawn(async move {
+            Self::run(
+                out_of_band_source_pool,
+                publication_name,
+                refresh_interval,
+                publication_snapshot_tx,
+            )
+            .await;
+        });
+
+        Self { task, snapshot_rx }
+    }
+
+    /// Polls publication membership without blocking the replication stream.
+    async fn run(
+        out_of_band_source_pool: OutOfBandSourcePool,
+        publication_name: String,
+        refresh_interval: Duration,
+        publication_snapshot_tx: mpsc::Sender<PublicationTableSnapshot>,
+    ) {
+        let mut interval = tokio::time::interval(refresh_interval);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut interval_stream = IntervalStream::new(interval);
+
+        while interval_stream.next().await.is_some() {
+            match out_of_band_source_pool.get_publication_table_snapshot(&publication_name).await {
+                Ok(snapshot) => match publication_snapshot_tx.try_send(snapshot) {
+                    Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                    Err(mpsc::error::TrySendError::Closed(_)) => return,
+                },
+                Err(error) => {
+                    warn!(
+                        publication_name,
+                        error = %error,
+                        "publication monitor failed to poll source database"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Aborts and joins the polling task.
+    async fn teardown(mut self) {
+        self.task.abort();
+
+        if let Err(error) = (&mut self.task).await
+            && !error.is_cancelled()
+        {
+            warn!(
+                error = %error,
+                "publication monitor task failed before completing"
+            );
+        }
+    }
+}
+
 /// Background tasks owned by an apply loop invocation.
 #[derive(Debug)]
 struct ApplyLoopTasks {
@@ -415,6 +495,8 @@ struct ApplyLoopTasks {
     schema_cleanup_task: Option<JoinHandle<()>>,
     /// Background replication lag sampler task owned by this apply loop.
     replication_lag_sampler_task: JoinHandle<()>,
+    /// Publication monitor present only on the main apply worker.
+    publication_monitor: Option<PublicationMonitor>,
 }
 
 impl ApplyLoopTasks {
@@ -424,15 +506,24 @@ impl ApplyLoopTasks {
         replication_lag_metrics: ReplicationLagMetrics,
         worker_type: WorkerType,
         replication_lag_refresh_interval: Duration,
+        publication_name: String,
     ) -> Self {
         let replication_lag_sampler_task = Self::spawn_replication_lag_sampler(
-            out_of_band_source_pool,
+            out_of_band_source_pool.clone(),
             replication_lag_metrics,
             worker_type,
             replication_lag_refresh_interval,
         );
 
-        Self { schema_cleanup_task: None, replication_lag_sampler_task }
+        let publication_monitor = (worker_type == WorkerType::Apply).then(|| {
+            PublicationMonitor::spawn(
+                out_of_band_source_pool,
+                publication_name,
+                replication_lag_refresh_interval,
+            )
+        });
+
+        Self { schema_cleanup_task: None, replication_lag_sampler_task, publication_monitor }
     }
 
     /// Returns `true` if a schema cleanup task is still running.
@@ -562,6 +653,9 @@ impl ApplyLoopTasks {
         schema_cleanup_deadline: &Arc<Mutex<Option<Instant>>>,
     ) {
         self.handle_replication_lag_sampler_task_result().await;
+        if let Some(publication_monitor) = self.publication_monitor.take() {
+            publication_monitor.teardown().await;
+        }
         self.handle_schema_cleanup_task_result(worker_type, schema_cleanup_deadline).await;
     }
 
@@ -654,6 +748,10 @@ struct ApplyLoopState {
     flush_deadline: Option<Instant>,
     /// The deadline for the next proactive keep alive status update.
     keep_alive_deadline: Instant,
+    /// Highest decoder-safe position reported by a primary keep alive.
+    last_keep_alive_lsn: PgLsn,
+    /// Latest publication membership awaiting its decoder-safe WAL barrier.
+    pending_publication_snapshot: Option<PublicationTableSnapshot>,
     /// Destination write result waiting to be applied to replication progress.
     pending_flush_result: Option<PendingWriteEventsResult>,
     /// The strongest exit that this apply loop invocation should eventually
@@ -708,6 +806,8 @@ impl ApplyLoopState {
             draining_for_shutdown: false,
             flush_deadline: None,
             keep_alive_deadline: Instant::now() + keep_alive_deadline_duration,
+            last_keep_alive_lsn: replication_progress.last_received_lsn(),
+            pending_publication_snapshot: None,
             pending_flush_result: None,
             exit_intent: None,
             processing_paused: false,
@@ -802,6 +902,25 @@ impl ApplyLoopState {
     fn update_last_received_lsn(&mut self, lsn: PgLsn) {
         self.replication_progress.update_last_received_lsn(lsn);
         self.update_replication_lag_metrics_from_progress();
+    }
+
+    /// Records a decoder-safe logical sender position from a primary keep
+    /// alive.
+    fn update_last_keep_alive_lsn(&mut self, lsn: PgLsn) {
+        self.last_keep_alive_lsn = self.last_keep_alive_lsn.max(lsn);
+    }
+
+    /// Replaces the pending publication snapshot with the latest observation.
+    fn set_pending_publication_snapshot(&mut self, snapshot: PublicationTableSnapshot) {
+        self.pending_publication_snapshot = Some(snapshot);
+    }
+
+    /// Returns whether the pending publication snapshot crossed its WAL
+    /// barrier.
+    fn publication_reconciliation_is_ready(&self) -> bool {
+        self.pending_publication_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.barrier_lsn <= self.last_keep_alive_lsn)
     }
 
     /// Updates the last durable flush LSN and snapshots replication lag
@@ -1095,6 +1214,7 @@ where
             replication_lag_metrics.clone(),
             worker_type,
             replication_lag_refresh_interval,
+            config.publication_name.clone(),
         );
 
         let state = ApplyLoopState::new(
@@ -1196,8 +1316,9 @@ where
     /// 2. PostgreSQL connection lifecycle updates.
     /// 3. Pending destination flush results.
     /// 4. Batch flush deadline expiry.
-    /// 5. Incoming replication messages.
-    /// 6. Periodic heartbeats once the computed keep alive deadline expires.
+    /// 5. Publication membership snapshots.
+    /// 6. Incoming replication messages.
+    /// 7. Periodic heartbeats once the computed keep alive deadline expires.
     ///
     /// PostgreSQL normally sends keep alives at roughly half of
     /// `wal_sender_timeout`. We wait a little longer than that before
@@ -1220,6 +1341,10 @@ where
         replication_client: &PgReplicationClient,
         connection_updates_rx: &mut watch::Receiver<PostgresConnectionUpdate>,
     ) -> EtlResult<Option<ApplyLoopResult>> {
+        // Reconcile publication membership before spawning table sync workers so a
+        // removed table is not restarted after its WAL barrier is safe.
+        self.maybe_reconcile_publication_when_idle().await?;
+
         // We try to process syncing tables if we are idle, so that we advance state
         // faster.
         self.maybe_process_syncing_tables_when_idle().await?;
@@ -1259,7 +1384,12 @@ where
                 self.flush_batch("flush deadline reached").await?;
             }
 
-            // PRIORITY 5: Process incoming replication messages from PostgreSQL.
+            // PRIORITY 5: Record publication membership snapshots from the source monitor.
+            maybe_snapshot = Self::wait_for_publication_snapshot(self.tasks.publication_monitor.as_mut()) => {
+                self.handle_publication_snapshot(events_stream.as_mut(), maybe_snapshot).await?;
+            }
+
+            // PRIORITY 6: Process incoming replication messages from PostgreSQL.
             // New WAL messages are only accepted while the loop is still actively ingesting.
             maybe_message = events_stream.next(), if self.state.can_process_messages() => {
                 self.handle_stream_message(
@@ -1270,7 +1400,7 @@ where
                 .await?;
             }
 
-            // PRIORITY 6: Emit a periodic status update once the computed keep alive deadline
+            // PRIORITY 7: Emit a periodic status update once the computed keep alive deadline
             // expires. This intentionally resends the same effective flush LSN so PostgreSQL keeps
             // the standby connection open during long stalls, including cases where the loop is
             // paused behind an in-flight flush and therefore not making visible progress yet. This
@@ -1288,6 +1418,8 @@ where
                     .reset_keep_alive_deadline(self.keep_alive_deadline_duration);
             }
         }
+
+        self.maybe_reconcile_publication_when_idle().await?;
 
         // We try to process syncing tables if we are idle, so that we advance state
         // faster.
@@ -1437,6 +1569,16 @@ where
         tokio::time::sleep_until(deadline.into()).await;
     }
 
+    /// Waits for a publication snapshot when this is the main apply worker.
+    async fn wait_for_publication_snapshot(
+        publication_monitor: Option<&mut PublicationMonitor>,
+    ) -> Option<PublicationTableSnapshot> {
+        match publication_monitor {
+            Some(publication_monitor) => publication_monitor.snapshot_rx.recv().await,
+            None => std::future::pending().await,
+        }
+    }
+
     /// Computes the keep alive deadline from PostgreSQL's `wal_sender_timeout`.
     ///
     /// PostgreSQL normally sends a keep alive after roughly half of this
@@ -1543,6 +1685,45 @@ where
         // table schema snapshots.
         if let StatusUpdateResult::Sent = status_update_result {
             self.maybe_spawn_schema_cleanup().await?;
+        }
+
+        Ok(())
+    }
+
+    /// Records a publication snapshot and requests a decoder progress reply
+    /// when its source WAL barrier has not been observed yet.
+    async fn handle_publication_snapshot(
+        &mut self,
+        mut events_stream: Pin<&mut BackpressureStream<EventsStream>>,
+        publication_snapshot: Option<PublicationTableSnapshot>,
+    ) -> EtlResult<()> {
+        let Some(publication_snapshot) = publication_snapshot else {
+            if let Some(publication_monitor) = self.tasks.publication_monitor.take() {
+                publication_monitor.teardown().await;
+            }
+            warn!("publication monitor stopped before the apply loop completed");
+            return Ok(());
+        };
+
+        // Keep one fixed barrier until it is reconciled. Replacing it with every
+        // newer source WAL position could make publication changes starve while
+        // a busy source continuously advances faster than this consumer.
+        if self.state.pending_publication_snapshot.is_some() {
+            return Ok(());
+        }
+
+        let barrier_lsn = publication_snapshot.barrier_lsn;
+        let needs_barrier_reply = barrier_lsn > self.state.last_keep_alive_lsn;
+        self.state.set_pending_publication_snapshot(publication_snapshot);
+
+        if needs_barrier_reply {
+            self.send_status_update(
+                events_stream.as_mut(),
+                true,
+                StatusUpdateType::PeriodicKeepAlive,
+            )
+            .await?;
+            self.state.reset_keep_alive_deadline(self.keep_alive_deadline_duration);
         }
 
         Ok(())
@@ -1948,6 +2129,10 @@ where
             ReplicationMessage::PrimaryKeepAlive(message) => {
                 let end_lsn = PgLsn::from(message.wal_end());
                 self.state.update_last_received_lsn(end_lsn);
+                // Unlike the `wal_end` field carried by `XLogData`, the logical
+                // sender's keep alive position is bounded by WAL it has decoded
+                // and sent. Keep this separate as the publication barrier.
+                self.state.update_last_keep_alive_lsn(end_lsn);
 
                 debug!(
                     wal_end = %end_lsn,
@@ -2624,6 +2809,101 @@ where
         }
 
         self.schema_store.upsert_replication_progress(worker_type, flush_lsn).await
+    }
+
+    /// Reconciles publication membership after the logical sender crosses the
+    /// source catalog snapshot's WAL barrier.
+    async fn maybe_reconcile_publication_when_idle(&mut self) -> EtlResult<()> {
+        if self.state.exit_intent.is_some()
+            || !self.state.is_idle()
+            || !self.state.publication_reconciliation_is_ready()
+        {
+            return Ok(());
+        }
+
+        let Some(publication_snapshot) = self.state.pending_publication_snapshot.clone() else {
+            return Ok(());
+        };
+        let WorkerContext::Apply(ctx) = &mut self.worker_context else {
+            return Ok(());
+        };
+
+        let has_deferred_removals =
+            Self::reconcile_publication_snapshot(ctx, publication_snapshot).await?;
+        if !has_deferred_removals {
+            self.state.pending_publication_snapshot = None;
+        }
+
+        Ok(())
+    }
+
+    /// Applies one decoder-safe publication snapshot to runtime table state.
+    ///
+    /// Returns `true` when a removed table still has an active table sync
+    /// worker and must be retried after that worker completes.
+    async fn reconcile_publication_snapshot(
+        ctx: &mut ApplyWorkerContext<S, D>,
+        publication_snapshot: PublicationTableSnapshot,
+    ) -> EtlResult<bool> {
+        let publication_table_ids: HashSet<TableId> =
+            publication_snapshot.table_ids.into_iter().collect();
+        let table_states = ctx.store.get_table_states().await?;
+        let added_tables = publication_table_ids
+            .iter()
+            .filter(|table_id| !table_states.contains_key(table_id))
+            .map(|table_id| (*table_id, TableState::Init))
+            .collect::<Vec<_>>();
+
+        if !added_tables.is_empty() {
+            info!(
+                publication_name = %ctx.config.publication_name,
+                table_count = added_tables.len(),
+                "initializing tables added to publication"
+            );
+            ctx.store.update_table_states(added_tables).await?;
+        }
+
+        let removed_tables = table_states
+            .keys()
+            .filter(|table_id| !publication_table_ids.contains(table_id))
+            .copied()
+            .collect::<Vec<_>>();
+        let mut tables_to_deactivate = Vec::new();
+        let mut has_deferred_removals = false;
+        for table_id in removed_tables {
+            if ctx.pool.get_active_worker_state(table_id).await.is_some() {
+                has_deferred_removals = true;
+                debug!(
+                    table_id = table_id.0,
+                    "deferring publication removal while table sync worker is active"
+                );
+                continue;
+            }
+
+            tables_to_deactivate.push(table_id);
+        }
+
+        if tables_to_deactivate.is_empty() {
+            return Ok(has_deferred_removals);
+        }
+
+        let slot_client = PgReplicationClient::connect(ctx.config.pg_connection.clone()).await?;
+        for table_id in tables_to_deactivate {
+            let slot_name: String =
+                EtlReplicationSlot::for_table_sync_worker(ctx.pipeline_id, table_id).try_into()?;
+            slot_client.delete_slot_if_exists(&slot_name).await?;
+
+            // Do not use the full deletion lifecycle here. It removes destination
+            // metadata while deliberately leaving the physical destination table,
+            // which would orphan that object and prevent a later re-add from
+            // replacing it with a fresh copy.
+            ctx.store.deactivate_table_state(table_id).await?;
+            ctx.shared_table_cache.remove_table(table_id).await;
+
+            info!(table_id = table_id.0, slot_name, "deactivated table removed from publication");
+        }
+
+        Ok(has_deferred_removals)
     }
 
     /// Processes syncing tables when the apply loop is idle.

--- a/crates/etl/src/store/both/memory.rs
+++ b/crates/etl/src/store/both/memory.rs
@@ -294,6 +294,16 @@ impl TableStateLifecycleStore for MemoryStore {
 
                 Ok(reset_count)
             }
+            TableStateOperation::Deactivate { table_id } => {
+                let mut inner = self.inner.lock().await;
+                let affected_table_count = usize::from(inner.table_states.contains_key(&table_id));
+
+                Arc::make_mut(&mut inner.table_states).remove(&table_id);
+                inner.table_state_history.remove(&table_id);
+                inner.replication_progress.remove(&WorkerType::TableSync { table_id });
+
+                Ok(affected_table_count)
+            }
             TableStateOperation::Delete { table_id } => {
                 let mut inner = self.inner.lock().await;
                 let affected_table_count = usize::from(inner.table_states.contains_key(&table_id));

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -739,6 +739,35 @@ impl TableStateLifecycleStore for PostgresStore {
 
                 Ok(reset_count)
             }
+            TableStateOperation::Deactivate { table_id } => {
+                let mut inner = self.inner.lock().await;
+                let affected_table_count = usize::from(inner.table_states.contains_key(&table_id));
+                let mut tx = self.pool.begin().await?;
+
+                pg_table_state::delete_table_state(&mut *tx, self.pipeline_id as i64, table_id)
+                    .await?;
+
+                progress::delete_replication_progress_for_table(
+                    &mut *tx,
+                    self.pipeline_id as i64,
+                    table_id,
+                )
+                .await
+                .map_err(|error| {
+                    etl_error!(
+                        ErrorKind::SourceQueryFailed,
+                        "Replication progress deletion failed",
+                        source: error
+                    )
+                })?;
+
+                tx.commit().await?;
+
+                inner.remove_table_state(table_id);
+                emit_table_metrics(&inner.state_counts);
+
+                Ok(affected_table_count)
+            }
             TableStateOperation::Delete { table_id } => {
                 let mut inner = self.inner.lock().await;
                 let affected_table_count = usize::from(inner.table_states.contains_key(&table_id));

--- a/crates/etl/src/store/lifecycle.rs
+++ b/crates/etl/src/store/lifecycle.rs
@@ -16,8 +16,10 @@ use crate::{error::EtlResult, schema::TableId};
 ///   fresh copy after its destination table has been dropped.
 /// - [`TableStateOperation::ResetForResync`] resets the whole pipeline for a
 ///   fresh synchronization pass.
+/// - [`TableStateOperation::Deactivate`] stops replicating a table while
+///   retaining enough destination identity to replace it if it is re-added.
 /// - [`TableStateOperation::Delete`] removes all ETL-owned state for a table
-///   that is no longer part of the publication.
+///   during permanent cleanup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TableStateOperation {
     /// Prepare a table state entry for a fresh table copy.
@@ -41,12 +43,24 @@ pub enum TableStateOperation {
     /// restarted table sync can drop any existing destination object before
     /// clearing its own copy state.
     ResetForResync,
-    /// Delete all ETL-owned state for a table removed from the publication.
+    /// Deactivate a table removed from the publication.
+    ///
+    /// Deletes table state history and durable table-sync progress while
+    /// preserving stored schemas and destination metadata. The destination
+    /// object itself is deliberately left untouched, and retaining its metadata
+    /// prevents it from becoming unreachable: if the same source table is later
+    /// re-added, the fresh copy can locate and replace the existing destination
+    /// object instead of appending duplicate data to it.
+    Deactivate {
+        /// The removed table whose active replication state should be deleted.
+        table_id: TableId,
+    },
+    /// Delete all ETL-owned state for a table during permanent cleanup.
     ///
     /// Deletes table state history, stored table schemas, destination table
     /// metadata, and durable table-sync progress for `table_id`. Does not drop
-    /// or otherwise modify the destination object, since publication removal is
-    /// an ETL state deletion rather than a destination data deletion.
+    /// or otherwise modify the destination object. Callers performing permanent
+    /// cleanup must coordinate destination deletion separately when required.
     Delete {
         /// The removed table whose ETL state should be deleted.
         table_id: TableId,
@@ -56,7 +70,7 @@ pub enum TableStateOperation {
 /// Lifecycle operations across state and schema stores.
 ///
 /// Provides primitives for table-copy preparation, reset-to-resync recovery,
-/// and publication removal. Implementations must keep persistent state and
+/// and publication deactivation. Implementations must keep persistent state and
 /// in-memory caches consistent for each operation.
 pub trait TableStateLifecycleStore: Sync {
     /// Applies a table state lifecycle `operation`.
@@ -67,8 +81,8 @@ pub trait TableStateLifecycleStore: Sync {
     /// table state entries affected by the operation:
     /// - `0` for copy preparation because table state is preserved.
     /// - The number of reset table states for pipeline resync.
-    /// - `1` when a table removal deletes an existing table state, otherwise
-    ///   `0`.
+    /// - `1` when deactivation or deletion removes an existing table state,
+    ///   otherwise `0`.
     fn apply_table_state_operation(
         &self,
         operation: TableStateOperation,
@@ -107,14 +121,29 @@ pub trait TableStateLifecycleStore: Sync {
         async move { self.apply_table_state_operation(TableStateOperation::ResetForResync).await }
     }
 
+    /// Deactivates replication state for `table_id` while preserving
+    /// destination identity and schema information for a possible future
+    /// re-add.
+    fn deactivate_table_state(
+        &self,
+        table_id: TableId,
+    ) -> impl Future<Output = EtlResult<()>> + Send {
+        async move {
+            self.apply_table_state_operation(TableStateOperation::Deactivate { table_id }).await?;
+
+            Ok(())
+        }
+    }
+
     /// Deletes all stored ETL state for `table_id`.
     ///
     /// Removes table state (including history), table schemas, destination
     /// table metadata, and durable table-sync progress. This must NOT drop or
     /// modify the actual destination table.
     ///
-    /// Intended for use when a table is removed from the publication. This is a
-    /// convenience wrapper around [`TableStateOperation::Delete`].
+    /// Intended for permanent ETL-owned cleanup, not temporary publication
+    /// removal. This is a convenience wrapper around
+    /// [`TableStateOperation::Delete`].
     fn delete_table_state(&self, table_id: TableId) -> impl Future<Output = EtlResult<()>> + Send {
         async move {
             self.apply_table_state_operation(TableStateOperation::Delete { table_id }).await?;

--- a/crates/etl/src/test_utils/notifying_store.rs
+++ b/crates/etl/src/test_utils/notifying_store.rs
@@ -34,6 +34,7 @@ pub enum StateStoreMethod {
 
 type TableStateTypeCondition = (TableId, TableStateType, Arc<Notify>);
 type TableStateCondition = (TableId, Arc<Notify>, Box<dyn Fn(&TableState) -> bool + Send + Sync>);
+type TableStateRemovedCondition = (TableId, Arc<Notify>);
 type TableSchemaCountCondition = (TableId, usize, Arc<Notify>);
 type TableSchemaPruneCondition = Arc<Notify>;
 
@@ -45,6 +46,7 @@ struct Inner {
     replication_progress: HashMap<WorkerType, PgLsn>,
     table_state_type_conditions: Vec<TableStateTypeCondition>,
     table_state_conditions: Vec<TableStateCondition>,
+    table_state_removed_conditions: Vec<TableStateRemovedCondition>,
     table_schema_count_conditions: Vec<TableSchemaCountCondition>,
     table_schema_prune_conditions: Vec<TableSchemaPruneCondition>,
     method_call_notifiers: HashMap<StateStoreMethod, Vec<Arc<Notify>>>,
@@ -75,6 +77,14 @@ impl Inner {
             } else {
                 true
             }
+        });
+
+        self.table_state_removed_conditions.retain(|(tid, notify)| {
+            let should_retain = table_states.contains_key(tid);
+            if !should_retain {
+                notify.notify_one();
+            }
+            should_retain
         });
 
         self.table_schema_count_conditions.retain(|(tid, expected_count, notify)| {
@@ -117,6 +127,7 @@ impl NotifyingStore {
             replication_progress: HashMap::new(),
             table_state_type_conditions: Vec::new(),
             table_state_conditions: Vec::new(),
+            table_state_removed_conditions: Vec::new(),
             table_schema_count_conditions: Vec::new(),
             table_schema_prune_conditions: Vec::new(),
             method_call_notifiers: HashMap::new(),
@@ -196,6 +207,16 @@ impl NotifyingStore {
         let notify = Arc::new(Notify::new());
         let mut inner = self.inner.write().await;
         inner.table_state_conditions.push((table_id, Arc::clone(&notify), Box::new(condition)));
+
+        TimedNotify::new(notify)
+    }
+
+    /// Registers a notification that fires when a future lifecycle operation
+    /// removes the table's current state.
+    pub async fn notify_on_table_state_removed(&self, table_id: TableId) -> TimedNotify {
+        let notify = Arc::new(Notify::new());
+        let mut inner = self.inner.write().await;
+        inner.table_state_removed_conditions.push((table_id, Arc::clone(&notify)));
 
         TimedNotify::new(notify)
     }
@@ -479,6 +500,17 @@ impl TableStateLifecycleStore for NotifyingStore {
                 inner.check_conditions();
 
                 Ok(reset_count)
+            }
+            TableStateOperation::Deactivate { table_id } => {
+                let mut inner = self.inner.write().await;
+                let affected_table_count = usize::from(inner.table_states.contains_key(&table_id));
+
+                Arc::make_mut(&mut inner.table_states).remove(&table_id);
+                inner.table_state_history.remove(&table_id);
+                inner.replication_progress.remove(&WorkerType::TableSync { table_id });
+                inner.check_conditions();
+
+                Ok(affected_table_count)
             }
             TableStateOperation::Delete { table_id } => {
                 let mut inner = self.inner.write().await;

--- a/crates/etl/src/test_utils/pipeline.rs
+++ b/crates/etl/src/test_utils/pipeline.rs
@@ -77,6 +77,8 @@ pub struct PipelineBuilder<S, D> {
     max_copy_connections_per_table: u16,
     /// The time between memory refreshes of the memory monitor. Default: 0.2.
     memory_refresh_interval_ms: u64,
+    /// The time between source replication lag and publication refreshes.
+    replication_lag_refresh_interval_ms: u64,
     /// Memory-based backpressure configuration. Default: enabled with defaults.
     memory_backpressure: MemoryBackpressureConfig,
 }
@@ -130,6 +132,8 @@ where
             invalidated_slot_behavior: InvalidatedSlotBehavior::Error,
             max_copy_connections_per_table: PipelineConfig::DEFAULT_MAX_COPY_CONNECTIONS_PER_TABLE,
             memory_refresh_interval_ms: 100,
+            replication_lag_refresh_interval_ms:
+                PipelineConfig::DEFAULT_REPLICATION_LAG_REFRESH_INTERVAL_MS,
             memory_backpressure: MemoryBackpressureConfig {
                 activate_threshold: 0.95,
                 resume_threshold: 0.85,
@@ -176,6 +180,13 @@ where
         self
     }
 
+    /// Sets the interval used to refresh source replication lag and publication
+    /// membership.
+    pub fn with_replication_lag_refresh_interval_ms(mut self, interval_ms: u64) -> Self {
+        self.replication_lag_refresh_interval_ms = interval_ms;
+        self
+    }
+
     /// Builds and returns the configured pipeline.
     ///
     /// This method consumes the builder and creates a `Pipeline` instance with
@@ -195,8 +206,7 @@ where
             invalidated_slot_behavior: self.invalidated_slot_behavior,
             max_copy_connections_per_table: self.max_copy_connections_per_table,
             memory_refresh_interval_ms: self.memory_refresh_interval_ms,
-            replication_lag_refresh_interval_ms:
-                PipelineConfig::DEFAULT_REPLICATION_LAG_REFRESH_INTERVAL_MS,
+            replication_lag_refresh_interval_ms: self.replication_lag_refresh_interval_ms,
             memory_backpressure: Some(self.memory_backpressure),
             run_source_migrations: true,
         };

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -9,7 +9,7 @@ use etl::{
     error::{ErrorKind, EtlResult},
     event::{Event, EventType, InsertEvent},
     pipeline::PipelineId,
-    schema::{ColumnSchema, ReplicatedTableSchema, TableId},
+    schema::{ColumnSchema, ReplicatedTableSchema, SnapshotId, TableId},
     store::{SchemaStore, StateStore, TableState, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
@@ -1201,10 +1201,12 @@ async fn publication_changes_are_correctly_handled() {
     // Wait for the table_3 to be done.
     let table_3_ready_notify =
         store.notify_on_table_state_type(table_3_id, TableStateType::Ready).await;
+    let table_2_removed_notify = store.notify_on_table_state_removed(table_2_id).await;
 
     pipeline.start().await.unwrap();
 
     table_3_ready_notify.notified().await;
+    table_2_removed_notify.notified().await;
 
     // Insert one row in table_1 and table_3 and wait for the new events.
     let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
@@ -1235,6 +1237,256 @@ async fn publication_changes_are_correctly_handled() {
     assert_eq!(table_1_inserts.len(), 1);
     let table_3_inserts = grouped.get(&(EventType::Insert, table_3_id)).cloned().unwrap();
     assert_eq!(table_3_inserts.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_changes_are_applied_at_runtime() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let table_1 = test_table_name("runtime_publication_table_1");
+    let table_1_id =
+        database.create_table(table_1.clone(), true, &[("value", "int4 not null")]).await.unwrap();
+    database.insert_values(table_1.clone(), &["value"], &[&1]).await.unwrap();
+    let sentinel_table = test_table_name("runtime_publication_sentinel");
+    let sentinel_table_id = database
+        .create_table(sentinel_table.clone(), true, &[("value", "int4 not null")])
+        .await
+        .unwrap();
+
+    let publication_name = "test_runtime_publication_changes";
+    database
+        .create_publication(publication_name, &[table_1.clone(), sentinel_table])
+        .await
+        .unwrap();
+
+    let store = NotifyingStore::new();
+    let memory_destination = MemoryDestination::new(store.clone());
+    let destination = TestDestinationWrapper::wrap(memory_destination);
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = PipelineBuilder::new(
+        database.config.clone(),
+        pipeline_id,
+        publication_name.to_owned(),
+        store.clone(),
+        destination.clone(),
+    )
+    .with_replication_lag_refresh_interval_ms(100)
+    .build();
+
+    let table_1_ready = store.notify_on_table_state_type(table_1_id, TableStateType::Ready).await;
+    let sentinel_table_ready =
+        store.notify_on_table_state_type(sentinel_table_id, TableStateType::Ready).await;
+    pipeline.start().await.unwrap();
+    table_1_ready.notified().await;
+    sentinel_table_ready.notified().await;
+
+    let table_2 = test_table_name("runtime_publication_table_2");
+    let table_2_id =
+        database.create_table(table_2.clone(), true, &[("value", "int4 not null")]).await.unwrap();
+    database.insert_values(table_2.clone(), &["value"], &[&2]).await.unwrap();
+
+    let table_2_ready = store.notify_on_table_state_type(table_2_id, TableStateType::Ready).await;
+    database
+        .client
+        .as_ref()
+        .unwrap()
+        .execute(
+            &format!(
+                "alter publication {} add table {}",
+                quote_identifier(publication_name),
+                table_2.as_quoted_identifier()
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+    table_2_ready.notified().await;
+
+    let copied_rows = destination.get_table_rows().await;
+    assert_eq!(copied_rows.get(&table_2_id).unwrap().len(), 1);
+
+    let table_1_removed = store.notify_on_table_state_removed(table_1_id).await;
+    let table_2_removed = store.notify_on_table_state_removed(table_2_id).await;
+    database
+        .client
+        .as_ref()
+        .unwrap()
+        .execute(
+            &format!(
+                "alter publication {} drop table {}, {}",
+                quote_identifier(publication_name),
+                table_1.as_quoted_identifier(),
+                table_2.as_quoted_identifier()
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+    table_1_removed.notified().await;
+    table_2_removed.notified().await;
+
+    assert!(store.get_table_state(table_1_id).await.unwrap().is_none());
+    assert!(store.get_table_state(table_2_id).await.unwrap().is_none());
+    assert!(store.get_table_state(sentinel_table_id).await.unwrap().is_some());
+    assert!(store.get_applied_destination_table_metadata(table_1_id).await.unwrap().is_some());
+    assert!(store.get_table_schema(&table_1_id, SnapshotId::max()).await.unwrap().is_some());
+
+    database.insert_values(table_1.clone(), &["value"], &[&3]).await.unwrap();
+
+    let table_1_ready = store.notify_on_table_state_type(table_1_id, TableStateType::Ready).await;
+    database
+        .client
+        .as_ref()
+        .unwrap()
+        .execute(
+            &format!(
+                "alter publication {} add table {}",
+                quote_identifier(publication_name),
+                table_1.as_quoted_identifier()
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+    table_1_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let copied_rows = destination.get_table_rows().await;
+    assert_eq!(copied_rows.get(&table_1_id).unwrap().len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_publication_is_not_applied_at_runtime() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let table = test_table_name("runtime_empty_publication");
+    let table_id =
+        database.create_table(table.clone(), true, &[("value", "int4 not null")]).await.unwrap();
+
+    let publication_name = "test_runtime_empty_publication";
+    database.create_publication(publication_name, std::slice::from_ref(&table)).await.unwrap();
+
+    let store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let mut pipeline = PipelineBuilder::new(
+        database.config.clone(),
+        random(),
+        publication_name.to_owned(),
+        store.clone(),
+        destination,
+    )
+    .with_replication_lag_refresh_interval_ms(100)
+    .build();
+
+    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    pipeline.start().await.unwrap();
+    table_ready.notified().await;
+
+    database
+        .client
+        .as_ref()
+        .unwrap()
+        .execute(
+            &format!(
+                "alter publication {} drop table {}",
+                quote_identifier(publication_name),
+                table.as_quoted_identifier()
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    sleep(Duration::from_secs(1)).await;
+    assert_eq!(
+        store.get_table_state(table_id).await.unwrap().as_ref().map(TableState::as_type),
+        Some(TableStateType::Ready)
+    );
+
+    pipeline.shutdown_and_wait().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publication_removal_waits_for_active_table_sync_worker() {
+    init_test_tracing();
+
+    let mut database = spawn_source_database().await;
+    let table = test_table_name("runtime_publication_active_sync");
+    let table_id =
+        database.create_table(table.clone(), true, &[("value", "int4 not null")]).await.unwrap();
+    database.insert_values(table.clone(), &["value"], &[&1]).await.unwrap();
+    let sentinel_table = test_table_name("runtime_publication_active_sync_sentinel");
+    let sentinel_table_id = database
+        .create_table(sentinel_table.clone(), true, &[("value", "int4 not null")])
+        .await
+        .unwrap();
+
+    let publication_name = "test_runtime_publication_active_sync";
+    database.create_publication(publication_name, std::slice::from_ref(&table)).await.unwrap();
+
+    let store = NotifyingStore::new();
+    let immediate_destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let destination = DeferredCopyDestination::wrap(immediate_destination);
+    let mut pipeline = PipelineBuilder::new(
+        database.config.clone(),
+        random(),
+        publication_name.to_owned(),
+        store.clone(),
+        destination.clone(),
+    )
+    .with_replication_lag_refresh_interval_ms(100)
+    .build();
+
+    let barrier_reached = destination.notify_on_barrier();
+    pipeline.start().await.unwrap();
+    barrier_reached.notified().await;
+
+    let table_removed = store.notify_on_table_state_removed(table_id).await;
+    let sentinel_table_ready =
+        store.notify_on_table_state_type(sentinel_table_id, TableStateType::Ready).await;
+    let transaction = database.client.as_mut().unwrap().transaction().await.unwrap();
+    transaction
+        .execute(
+            &format!(
+                "alter publication {} add table {}",
+                quote_identifier(publication_name),
+                sentinel_table.as_quoted_identifier()
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+    transaction
+        .execute(
+            &format!(
+                "alter publication {} drop table {}",
+                quote_identifier(publication_name),
+                table.as_quoted_identifier()
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+    transaction.commit().await.unwrap();
+
+    sleep(Duration::from_secs(1)).await;
+    let table_states = store.get_table_states().await;
+    assert_eq!(
+        table_states.get(&table_id).map(TableState::as_type),
+        Some(TableStateType::DataSync)
+    );
+
+    let sentinel_barrier_reached = destination.notify_on_barrier();
+    destination.complete_barrier(DestinationWriteStatus::Durable).await;
+    table_removed.notified().await;
+    sentinel_barrier_reached.notified().await;
+    destination.complete_barrier(DestinationWriteStatus::Durable).await;
+    sentinel_table_ready.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -946,6 +946,69 @@ async fn delete_table_state_deletes_state_schema_metadata_and_progress_for_table
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn deactivate_table_state_preserves_schema_and_destination_metadata() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let pipeline_id = 1;
+    let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    let table_schema = create_sample_table_schema();
+    let table_id = table_schema.id;
+    let metadata = DestinationTableMetadata::new_applied(
+        "dest_table".to_owned(),
+        SnapshotId::initial(),
+        ReplicationMask::from_bytes(vec![1, 1, 1]),
+    );
+
+    store.update_table_state(table_id, TableState::Init).await.unwrap();
+    store.update_table_state(table_id, TableState::Ready).await.unwrap();
+    store.store_table_schema(table_schema).await.unwrap();
+    store.store_destination_table_metadata(table_id, metadata).await.unwrap();
+    store
+        .upsert_replication_progress(WorkerType::TableSync { table_id }, PgLsn::from(200u64))
+        .await
+        .unwrap();
+
+    store.deactivate_table_state(table_id).await.unwrap();
+
+    assert!(store.get_table_state(table_id).await.unwrap().is_none());
+    assert!(store.get_table_schema(&table_id, SnapshotId::max()).await.unwrap().is_some());
+    assert!(store.get_applied_destination_table_metadata(table_id).await.unwrap().is_some());
+    assert!(
+        store.get_replication_progress(WorkerType::TableSync { table_id }).await.unwrap().is_none()
+    );
+
+    let pool = connect_to_source_database(&database.config, 0, 1, None)
+        .await
+        .expect("Failed to connect to source database with sqlx");
+    let state_history_count: i64 = sqlx::query_scalar(
+        "select count(*) from etl.replication_state where pipeline_id = $1 and table_id = $2",
+    )
+    .bind(pipeline_id as i64)
+    .bind(SqlxTableId(table_id.into_inner()))
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(state_history_count, 0);
+
+    let new_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    new_store.load_table_states().await.unwrap();
+    new_store.load_table_schemas().await.unwrap();
+    new_store.load_destination_tables_metadata().await.unwrap();
+
+    assert!(new_store.get_table_state(table_id).await.unwrap().is_none());
+    assert!(new_store.get_table_schema(&table_id, SnapshotId::max()).await.unwrap().is_some());
+    assert!(new_store.get_applied_destination_table_metadata(table_id).await.unwrap().is_some());
+    assert!(
+        new_store
+            .get_replication_progress(WorkerType::TableSync { table_id })
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn prepare_table_state_for_copy_preserves_state_and_deletes_copy_data() {
     init_test_tracing();
 

--- a/crates/etl/tests/replication.rs
+++ b/crates/etl/tests/replication.rs
@@ -1537,14 +1537,9 @@ async fn get_publication_table_ids_errors_when_empty() {
 
     let client = PgReplicationClient::connect(database.config.clone()).await.unwrap();
 
-    // Attempting to get table IDs from an empty publication should error.
-    let result = client.get_publication_table_ids(publication_name).await;
-
-    // Should return a ConfigError since the publication has no tables.
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::ConfigError);
-    assert!(err.to_string().contains("does not contain any tables"));
+    let error = client.get_publication_table_ids(publication_name).await.unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::ConfigError);
+    assert!(error.to_string().contains("Publication has no tables"));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
+ Detect publication table additions and removals at runtime without restarting the replicator.
+ Wait for the replication stream to cross a WAL barrier, preventing retained pre-removal events from being skipped. Defer removal while a table copy is active.
+ Preserve destination metadata so a re-added table can locate and replace its existing destination object; reject empty publications to avoid an unsupported no-table state.
+ Add integration and store lifecycle coverage.