### PR TITLE
chaos(etl): Cover shutdown drain and apply disconnect with held write responses

### DIFF
--- a/crates/etl/src/test_utils/database.rs
+++ b/crates/etl/src/test_utils/database.rs
@@ -20,13 +20,15 @@
 //! See `scripts/docker/docker-compose.yaml` for the test database
 //! configuration.
 
+use std::time::Duration;
+
 use etl_config::shared::{PgConnectionConfig, TcpKeepaliveConfig};
 use etl_postgres::{test_utils::local_tls_config_from_env, tokio::test_utils::PgDatabase};
 use pg_escape::quote_identifier;
-use tokio_postgres::Client;
+use tokio_postgres::{Client, types::PgLsn};
 use uuid::Uuid;
 
-use crate::{postgres::migrations, schema::TableName};
+use crate::{postgres::migrations, schema::TableName, test_utils::notify::DEFAULT_NOTIFY_TIMEOUT};
 
 /// The schema name used for organizing test tables.
 ///
@@ -138,4 +140,41 @@ pub async fn spawn_source_database() -> PgDatabase<Client> {
     migrations::run_source_migrations(&config).await.expect("Failed to run source migrations");
 
     database
+}
+
+/// Returns the replication slot's confirmed flush LSN and active walsender PID.
+pub async fn replication_slot_state(client: &Client, slot_name: &str) -> (PgLsn, Option<i32>) {
+    let row = client
+        .query_one(
+            "select confirmed_flush_lsn, active_pid from pg_replication_slots where slot_name = $1",
+            &[&slot_name],
+        )
+        .await
+        .unwrap();
+
+    (row.get(0), row.get(1))
+}
+
+/// Waits until the replication slot is served by a walsender other than
+/// `old_pid`.
+///
+/// # Panics
+///
+/// Panics after [`DEFAULT_NOTIFY_TIMEOUT`] if no new walsender becomes active,
+/// mirroring [`crate::test_utils::notify::TimedNotify`].
+pub async fn wait_for_new_walsender(client: &Client, slot_name: &str, old_pid: i32) {
+    tokio::time::timeout(DEFAULT_NOTIFY_TIMEOUT, async {
+        loop {
+            let (_, active_pid) = replication_slot_state(client, slot_name).await;
+            if let Some(pid) = active_pid
+                && pid != old_pid
+            {
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for a new walsender to serve the replication slot");
 }

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -12,7 +12,9 @@ use etl::{
     schema::{ColumnSchema, ReplicatedTableSchema, TableId},
     store::{SchemaStore, StateStore, TableState, TableStateType},
     test_utils::{
-        database::{spawn_source_database, test_table_name},
+        database::{
+            replication_slot_state, spawn_source_database, test_table_name, wait_for_new_walsender,
+        },
         event::{EventCondition, group_events_by_type_and_table_id},
         faults::FaultyOp,
         memory_destination::MemoryDestination,
@@ -45,7 +47,7 @@ use tokio::{
     sync::{Mutex, Notify},
     time::sleep,
 };
-use tokio_postgres::types::{PgLsn, Type};
+use tokio_postgres::types::Type;
 
 /// Creates a test column schema with sensible defaults.
 fn test_column(
@@ -1287,16 +1289,8 @@ async fn streaming_reconnect_does_not_replay_already_flushed_events() {
     let client = database.client.as_ref().unwrap();
     let terminated_pid = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
-            let row = client
-                .query_one(
-                    "select confirmed_flush_lsn, active_pid from pg_replication_slots where \
-                     slot_name = $1",
-                    &[&apply_slot_name],
-                )
-                .await
-                .unwrap();
-            let confirmed_flush_lsn: PgLsn = row.get(0);
-            let active_pid: Option<i32> = row.get(1);
+            let (confirmed_flush_lsn, active_pid) =
+                replication_slot_state(client, &apply_slot_name).await;
 
             if confirmed_flush_lsn >= first_insert.commit_lsn
                 && let Some(active_pid) = active_pid
@@ -1312,28 +1306,7 @@ async fn streaming_reconnect_does_not_replay_already_flushed_events() {
 
     client.query_one("select pg_terminate_backend($1)", &[&terminated_pid]).await.unwrap();
 
-    tokio::time::timeout(Duration::from_secs(10), async {
-        loop {
-            let row = client
-                .query_one(
-                    "select active_pid from pg_replication_slots where slot_name = $1",
-                    &[&apply_slot_name],
-                )
-                .await
-                .unwrap();
-            let active_pid: Option<i32> = row.get(0);
-
-            if let Some(active_pid) = active_pid
-                && active_pid != terminated_pid
-            {
-                break;
-            }
-
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    .expect("timed out waiting for apply worker to reconnect after source connection loss");
+    wait_for_new_walsender(client, &apply_slot_name, terminated_pid).await;
 
     let second_insert_notify =
         destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -7,7 +7,7 @@ use etl::{
     schema::TableId,
     store::{StateStore, TableRetryPolicy, TableState, TableStateType},
     test_utils::{
-        database::spawn_source_database,
+        database::{replication_slot_state, spawn_source_database, wait_for_new_walsender},
         event::group_events_by_type_and_table_id,
         faults::{FaultAction, FaultyOp},
         memory_destination::MemoryDestination,
@@ -20,7 +20,7 @@ use etl::{
 use etl_postgres::slots::EtlReplicationSlot;
 use etl_telemetry::tracing::init_test_tracing;
 use rand::random;
-use tokio_postgres::{Client, types::PgLsn};
+use tokio_postgres::types::PgLsn;
 
 /// Counts recorded insert events for the table.
 fn count_table_inserts(events: &[Event], table_id: TableId) -> usize {
@@ -38,37 +38,6 @@ fn table_insert_commit_lsns(events: &[Event], table_id: TableId) -> Vec<PgLsn> {
             _ => None,
         })
         .collect()
-}
-
-/// Returns the apply slot's confirmed flush LSN and active walsender PID.
-async fn apply_slot_state(client: &Client, slot_name: &str) -> (PgLsn, Option<i32>) {
-    let row = client
-        .query_one(
-            "select confirmed_flush_lsn, active_pid from pg_replication_slots where slot_name = $1",
-            &[&slot_name],
-        )
-        .await
-        .unwrap();
-
-    (row.get(0), row.get(1))
-}
-
-/// Waits until the apply slot is served by a walsender other than `old_pid`.
-async fn wait_for_new_walsender(client: &Client, slot_name: &str, old_pid: i32) {
-    tokio::time::timeout(Duration::from_secs(30), async {
-        loop {
-            let (_, active_pid) = apply_slot_state(client, slot_name).await;
-            if let Some(pid) = active_pid
-                && pid != old_pid
-            {
-                return;
-            }
-
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-    })
-    .await
-    .expect("timed out waiting for the apply worker to reconnect");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -348,7 +317,7 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
 
     // WHEN: the apply connection dies while the write response is withheld
     let client = database.client.as_ref().unwrap();
-    let (flush_lsn_at_kill, active_pid) = apply_slot_state(client, &apply_slot_name).await;
+    let (flush_lsn_at_kill, active_pid) = replication_slot_state(client, &apply_slot_name).await;
     let old_pid = active_pid.expect("apply walsender should be active");
 
     client.query_one("select pg_terminate_backend($1)", &[&old_pid]).await.unwrap();
@@ -432,7 +401,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
 
     // WHEN: the apply connection dies and the response releases before reconnect
     let client = database.client.as_ref().unwrap();
-    let (_, active_pid) = apply_slot_state(client, &apply_slot_name).await;
+    let (_, active_pid) = replication_slot_state(client, &apply_slot_name).await;
     let old_pid = active_pid.expect("apply walsender should be active");
 
     let first_insert_recorded = destination

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -1,9 +1,13 @@
+use std::time::Duration;
+
 use etl::{
     error::ErrorKind,
+    event::EventType,
     pipeline::PipelineId,
     store::{StateStore, TableRetryPolicy, TableState, TableStateType},
     test_utils::{
         database::spawn_source_database,
+        event::group_events_by_type_and_table_id,
         faults::{FaultAction, FaultyOp},
         memory_destination::MemoryDestination,
         notifying_store::NotifyingStore,
@@ -197,4 +201,59 @@ async fn drop_table_for_copy_failure_after_write_keeps_table_restartable_until_r
     assert_eq!(table_rows.get(&table_id).unwrap().len(), initial_rows);
 
     pipeline.shutdown_and_wait().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn shutdown_drains_pending_write_events_before_destination_shutdown() {
+    init_test_tracing();
+
+    // GIVEN: a streaming pipeline whose next write_events response is held
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+
+    let store = NotifyingStore::new();
+    let memory_destination = MemoryDestination::new(store.clone());
+    let destination = TestDestinationWrapper::wrap(memory_destination.clone());
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    let hold = destination.hold_next(FaultyOp::WriteEvents).await;
+
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    hold.wait_reached().await;
+
+    // WHEN: the pipeline shuts down while the write response is withheld
+    let mut shutdown_task = tokio::spawn(pipeline.shutdown_and_wait());
+
+    // THEN: shutdown waits on the pending response instead of proceeding
+    let still_draining =
+        tokio::time::timeout(Duration::from_secs(2), &mut shutdown_task).await.is_err();
+    assert!(still_draining);
+    assert!(!destination.shutdown_called().await);
+
+    // WHEN: the held response is released
+    hold.release_ok();
+
+    // THEN: shutdown completes and the write was acknowledged before it
+    shutdown_task.await.unwrap().unwrap();
+    assert!(destination.shutdown_called().await);
+
+    let events = destination.get_events().await;
+    let grouped_events = group_events_by_type_and_table_id(&events);
+    assert_eq!(grouped_events.get(&(EventType::Insert, table_id)).map_or(0, Vec::len), 1);
 }

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -2,8 +2,9 @@ use std::time::Duration;
 
 use etl::{
     error::ErrorKind,
-    event::EventType,
+    event::{Event, EventType},
     pipeline::PipelineId,
+    schema::TableId,
     store::{StateStore, TableRetryPolicy, TableState, TableStateType},
     test_utils::{
         database::spawn_source_database,
@@ -16,8 +17,59 @@ use etl::{
         test_schema::{TableSelection, insert_users_data, setup_test_database_schema},
     },
 };
+use etl_postgres::slots::EtlReplicationSlot;
 use etl_telemetry::tracing::init_test_tracing;
 use rand::random;
+use tokio_postgres::{Client, types::PgLsn};
+
+/// Counts recorded insert events for the table.
+fn count_table_inserts(events: &[Event], table_id: TableId) -> usize {
+    table_insert_commit_lsns(events, table_id).len()
+}
+
+/// Returns the commit LSNs of recorded insert events for the table, in order.
+fn table_insert_commit_lsns(events: &[Event], table_id: TableId) -> Vec<PgLsn> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            Event::Insert(insert) if insert.replicated_table_schema.id() == table_id => {
+                Some(insert.commit_lsn)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Returns the apply slot's confirmed flush LSN and active walsender PID.
+async fn apply_slot_state(client: &Client, slot_name: &str) -> (PgLsn, Option<i32>) {
+    let row = client
+        .query_one(
+            "select confirmed_flush_lsn, active_pid from pg_replication_slots where slot_name = $1",
+            &[&slot_name],
+        )
+        .await
+        .unwrap();
+
+    (row.get(0), row.get(1))
+}
+
+/// Waits until the apply slot is served by a walsender other than `old_pid`.
+async fn wait_for_new_walsender(client: &Client, slot_name: &str, old_pid: i32) {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let (_, active_pid) = apply_slot_state(client, slot_name).await;
+            if let Some(pid) = active_pid
+                && pid != old_pid
+            {
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for the apply worker to reconnect");
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
@@ -256,4 +308,166 @@ async fn shutdown_drains_pending_write_events_before_destination_shutdown() {
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
     assert_eq!(grouped_events.get(&(EventType::Insert, table_id)).map_or(0, Vec::len), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_loss() {
+    init_test_tracing();
+
+    // GIVEN: a streaming pipeline whose next write_events response is held
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+
+    let store = NotifyingStore::new();
+    let memory_destination = MemoryDestination::new(store.clone());
+    let destination = TestDestinationWrapper::wrap(memory_destination.clone());
+
+    let pipeline_id: PipelineId = random();
+    let apply_slot_name: String =
+        EtlReplicationSlot::for_apply_worker(pipeline_id).try_into().unwrap();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    let hold = destination.hold_next(FaultyOp::WriteEvents).await;
+
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    hold.wait_reached().await;
+
+    // WHEN: the apply connection dies while the write response is withheld
+    let client = database.client.as_ref().unwrap();
+    let (flush_lsn_at_kill, active_pid) = apply_slot_state(client, &apply_slot_name).await;
+    let old_pid = active_pid.expect("apply walsender should be active");
+
+    client.query_one("select pg_terminate_backend($1)", &[&old_pid]).await.unwrap();
+
+    wait_for_new_walsender(client, &apply_slot_name, old_pid).await;
+
+    // WHEN: the held response is released only after the reconnect
+    let replay_recorded = destination
+        .notify_on_events(move |events| count_table_inserts(events, table_id) == 2)
+        .await;
+
+    hold.release_ok();
+
+    // THEN: the insert replays because the acknowledgement never reached the
+    // old apply loop
+    replay_recorded.notified().await;
+
+    let commit_lsns = table_insert_commit_lsns(&destination.get_events().await, table_id);
+    assert_eq!(commit_lsns.len(), 2);
+    assert_eq!(commit_lsns[0], commit_lsns[1]);
+    let first_commit_lsn = commit_lsns[0];
+
+    // THEN: durable progress never advanced past the unacknowledged write
+    assert!(flush_lsn_at_kill < first_commit_lsn);
+
+    // THEN: streaming continues without loss after the replay
+    let second_insert = destination
+        .notify_on_events(move |events| {
+            table_insert_commit_lsns(events, table_id)
+                .last()
+                .is_some_and(|last| *last > first_commit_lsn)
+        })
+        .await;
+
+    insert_users_data(&mut database, &database_schema.users_schema().name, 2..=2).await;
+
+    second_insert.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let final_lsns = table_insert_commit_lsns(&destination.get_events().await, table_id);
+    assert_eq!(final_lsns.iter().filter(|lsn| **lsn == first_commit_lsn).count(), 2);
+    assert_eq!(final_lsns.iter().filter(|lsn| **lsn > first_commit_lsn).count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_loss() {
+    init_test_tracing();
+
+    // GIVEN: a streaming pipeline whose next write_events response is held
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let table_id = database_schema.users_schema().id;
+
+    let store = NotifyingStore::new();
+    let memory_destination = MemoryDestination::new(store.clone());
+    let destination = TestDestinationWrapper::wrap(memory_destination.clone());
+
+    let pipeline_id: PipelineId = random();
+    let apply_slot_name: String =
+        EtlReplicationSlot::for_apply_worker(pipeline_id).try_into().unwrap();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline.start().await.unwrap();
+
+    users_ready.notified().await;
+
+    let hold = destination.hold_next(FaultyOp::WriteEvents).await;
+
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
+
+    hold.wait_reached().await;
+
+    // WHEN: the apply connection dies and the response releases before reconnect
+    let client = database.client.as_ref().unwrap();
+    let (_, active_pid) = apply_slot_state(client, &apply_slot_name).await;
+    let old_pid = active_pid.expect("apply walsender should be active");
+
+    let first_insert_recorded = destination
+        .notify_on_events(move |events| count_table_inserts(events, table_id) >= 1)
+        .await;
+
+    client.query_one("select pg_terminate_backend($1)", &[&old_pid]).await.unwrap();
+
+    hold.release_ok();
+
+    first_insert_recorded.notified().await;
+    let first_commit_lsn = table_insert_commit_lsns(&destination.get_events().await, table_id)[0];
+
+    wait_for_new_walsender(client, &apply_slot_name, old_pid).await;
+
+    // THEN: streaming continues without loss, replaying the insert at most once
+    let second_insert = destination
+        .notify_on_events(move |events| {
+            table_insert_commit_lsns(events, table_id)
+                .last()
+                .is_some_and(|last| *last > first_commit_lsn)
+        })
+        .await;
+
+    insert_users_data(&mut database, &database_schema.users_schema().name, 2..=2).await;
+
+    second_insert.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let final_lsns = table_insert_commit_lsns(&destination.get_events().await, table_id);
+    let first_count = final_lsns.iter().filter(|lsn| **lsn == first_commit_lsn).count();
+    assert!(
+        (1..=2).contains(&first_count),
+        "insert must survive with at most one replay, got {first_count} copies"
+    );
+    assert_eq!(final_lsns.iter().filter(|lsn| **lsn > first_commit_lsn).count(), 1);
 }

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -257,9 +257,9 @@ async fn shutdown_drains_pending_write_events_before_destination_shutdown() {
     let mut shutdown_task = tokio::spawn(pipeline.shutdown_and_wait());
 
     // THEN: shutdown waits on the pending response instead of proceeding
-    let still_draining =
-        tokio::time::timeout(Duration::from_secs(2), &mut shutdown_task).await.is_err();
-    assert!(still_draining);
+    if let Ok(result) = tokio::time::timeout(Duration::from_secs(2), &mut shutdown_task).await {
+        panic!("shutdown completed while the write response was withheld: {result:?}");
+    }
     assert!(!destination.shutdown_called().await);
 
     // WHEN: the held response is released

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -8,7 +8,7 @@ use etl::{
     store::{StateStore, TableRetryPolicy, TableState, TableStateType},
     test_utils::{
         database::{replication_slot_state, spawn_source_database, wait_for_new_walsender},
-        event::group_events_by_type_and_table_id,
+        event::{EventCondition, group_events_by_type_and_table_id},
         faults::{FaultAction, FaultyOp},
         memory_destination::MemoryDestination,
         notifying_store::NotifyingStore,
@@ -21,11 +21,6 @@ use etl_postgres::slots::EtlReplicationSlot;
 use etl_telemetry::tracing::init_test_tracing;
 use rand::random;
 use tokio_postgres::types::PgLsn;
-
-/// Counts recorded insert events for the table.
-fn count_table_inserts(events: &[Event], table_id: TableId) -> usize {
-    table_insert_commit_lsns(events, table_id).len()
-}
 
 /// Returns the commit LSNs of recorded insert events for the table, in order.
 fn table_insert_commit_lsns(events: &[Event], table_id: TableId) -> Vec<PgLsn> {
@@ -326,7 +321,7 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
 
     // WHEN: the held response is released only after the reconnect
     let replay_recorded = destination
-        .notify_on_events(move |events| count_table_inserts(events, table_id) == 2)
+        .wait_for_all_events(vec![EventCondition::Table(EventType::Insert, table_id, 2)])
         .await;
 
     hold.release_ok();
@@ -405,7 +400,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
     let old_pid = active_pid.expect("apply walsender should be active");
 
     let first_insert_recorded = destination
-        .notify_on_events(move |events| count_table_inserts(events, table_id) >= 1)
+        .wait_for_all_events(vec![EventCondition::Table(EventType::Insert, table_id, 1)])
         .await;
 
     client.query_one("select pg_terminate_backend($1)", &[&old_pid]).await.unwrap();

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -408,7 +408,9 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
     hold.release_ok();
 
     first_insert_recorded.notified().await;
-    let first_commit_lsn = table_insert_commit_lsns(&destination.get_events().await, table_id)[0];
+    let first_commit_lsn = *table_insert_commit_lsns(&destination.get_events().await, table_id)
+        .first()
+        .expect("released insert should be recorded");
 
     wait_for_new_walsender(client, &apply_slot_name, old_pid).await;
 


### PR DESCRIPTION
Adds `HoldResponse` consumer scenarios. Each test freezes the pipeline inside the window where a destination write has been applied but not yet acknowledged, then disrupts it.

#### `shutdown_drains_pending_write_events_before_destination_shutdown`

Holds a streaming write response and shuts the pipeline down. Shutdown must wait for the pending response instead of abandoning it or reaching `Destination::shutdown` early.

#### `apply_disconnect_with_write_held_until_after_reconnect_replays_without_loss`

Kills the apply `walsender` while the response is held and releases it only after the reconnect, modeling a destination that answers slower than the source outage. Asserts by commit LSN that the write replays exactly once, that `confirmed_flush_lsn` sampled at kill time never passed the unacknowledged write, and that streaming continues without loss afterwards.

#### `apply_disconnect_with_write_released_before_reconnect_recovers_without_loss`

Same kill, but the acknowledgement races the disconnect handling. The apply loop prioritizes connection updates over flush results, so the ack is usually discarded and the write replayed; the race is real, so the test asserts the bounded envelope instead of a fixed count: the insert survives with at most one replay, later writes appear exactly once.