### PR TITLE
feat(ducklake): map compatible NUMERIC(p, s) to DECIMAL(p, s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,7 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "reqwest",
+ "rust_decimal",
  "rustls",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ r2d2 = { version = "0.8", default-features = false }
 rand = { version = "0.9.2", default-features = false }
 regex = { version = "1.12.3", default-features = false, features = ["std", "unicode"] }
 reqwest = { version = "0.12.22", default-features = false }
+rust_decimal = { version = "1.42", default-features = false }
 rustls = { version = "0.23.31", default-features = false }
 secrecy = { version = "0.10.3", default-features = false }
 sentry = { version = "0.42.0" }

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -141,6 +141,7 @@ etl-telemetry = { workspace = true }
 futures = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 rand = { workspace = true, features = ["thread_rng"] }
+rust_decimal = { workspace = true }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/etl-destinations/src/ducklake/schema.rs
+++ b/crates/etl-destinations/src/ducklake/schema.rs
@@ -1,4 +1,7 @@
-use etl::schema::{ColumnSchema, DefaultExpression, Type, is_array_type, parse_default_expression};
+use etl::schema::{
+    ColumnSchema, DefaultExpression, NumericModifiers, Type, is_array_type,
+    parse_default_expression,
+};
 use tracing::warn;
 
 use crate::ducklake::{
@@ -55,6 +58,20 @@ fn postgres_column_type_to_ducklake_sql(typ: &Type) -> &'static str {
     } else {
         postgres_scalar_type_to_ducklake_sql(typ)
     }
+}
+
+/// Maximum precision (width) supported by DuckDB `DECIMAL(p, s)`.
+const DUCKDB_MAX_DECIMAL_PRECISION: i16 = 38;
+
+/// Returns whether Postgres [`NumericModifiers`] are within the range
+/// supported by DuckDB `DECIMAL(p, s)`.
+///
+/// DuckDB requires `1 <= p <= 38` and `0 <= s <= p`. Postgres allows a wider
+/// range (p up to 1000, negative scale, scale exceeding precision), so
+/// constrained `NUMERIC(p, s)` columns outside the DuckDB range must fall
+/// back to `varchar`.
+fn is_ducklake_compatible(nm: NumericModifiers) -> bool {
+    nm.p >= 1 && nm.p <= DUCKDB_MAX_DECIMAL_PRECISION && nm.s >= 0 && nm.s <= nm.p
 }
 
 /// Builds one DuckLake column definition.
@@ -416,6 +433,33 @@ mod tests {
             sql,
             r#"alter table "lake"."public"."table""name" rename column "old""column" to "new""column""#
         );
+    }
+
+    #[test]
+    fn is_ducklake_compatible_within_duckdb_range() {
+        assert!(is_ducklake_compatible(NumericModifiers { p: 1, s: 0 }));
+        assert!(is_ducklake_compatible(NumericModifiers { p: 10, s: 2 }));
+        assert!(is_ducklake_compatible(NumericModifiers { p: 38, s: 0 }));
+        assert!(is_ducklake_compatible(NumericModifiers { p: 38, s: 38 }));
+        assert!(is_ducklake_compatible(NumericModifiers { p: 18, s: 3 }));
+    }
+
+    #[test]
+    fn is_ducklake_compatible_precision_too_large() {
+        assert!(!is_ducklake_compatible(NumericModifiers { p: 39, s: 0 }));
+        assert!(!is_ducklake_compatible(NumericModifiers { p: 1000, s: 0 }));
+    }
+
+    #[test]
+    fn is_ducklake_compatible_negative_scale() {
+        assert!(!is_ducklake_compatible(NumericModifiers { p: 10, s: -3 }));
+        assert!(!is_ducklake_compatible(NumericModifiers { p: 2, s: -1000 }));
+    }
+
+    #[test]
+    fn is_ducklake_compatible_scale_exceeds_precision() {
+        assert!(!is_ducklake_compatible(NumericModifiers { p: 3, s: 5 }));
+        assert!(!is_ducklake_compatible(NumericModifiers { p: 38, s: 39 }));
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/schema.rs
+++ b/crates/etl-destinations/src/ducklake/schema.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
+
 use etl::schema::{
-    ColumnSchema, DefaultExpression, NumericModifiers, Type, is_array_type,
+    ColumnSchema, DefaultExpression, NumericModifiers, Type, is_array_type, numeric_modifiers,
     parse_default_expression,
 };
 use tracing::warn;
@@ -10,28 +12,34 @@ use crate::ducklake::{
 };
 
 /// Returns the DuckLake SQL type string for a given Postgres scalar type.
-fn postgres_scalar_type_to_ducklake_sql(typ: &Type) -> &'static str {
+fn postgres_scalar_type_to_ducklake_sql(typ: &Type, modifier: i32) -> Cow<'static, str> {
+    const FALLBACK_TYPE: &str = "varchar";
+
     match typ {
-        &Type::BOOL => "boolean",
-        &Type::INT2 => "smallint",
-        &Type::INT4 => "integer",
-        &Type::INT8 => "bigint",
-        &Type::FLOAT4 => "float",
-        &Type::FLOAT8 => "double",
-        &Type::DATE => "date",
-        &Type::TIME => "time",
-        &Type::TIMESTAMP => "timestamp",
-        &Type::TIMESTAMPTZ => "timestamptz",
-        &Type::UUID => "uuid",
-        &Type::JSON | &Type::JSONB => "json",
-        &Type::OID => "ubigint",
-        &Type::BYTEA => "blob",
-        _ => "varchar",
+        &Type::BOOL => "boolean".into(),
+        &Type::INT2 => "smallint".into(),
+        &Type::INT4 => "integer".into(),
+        &Type::INT8 => "bigint".into(),
+        &Type::FLOAT4 => "float".into(),
+        &Type::FLOAT8 => "double".into(),
+        &Type::NUMERIC => match numeric_modifiers(modifier).filter(is_ducklake_compatible) {
+            Some(NumericModifiers { p, s }) => format!("decimal({p}, {s})").into(),
+            _ => FALLBACK_TYPE.into(),
+        },
+        &Type::DATE => "date".into(),
+        &Type::TIME => "time".into(),
+        &Type::TIMESTAMP => "timestamp".into(),
+        &Type::TIMESTAMPTZ => "timestamptz".into(),
+        &Type::UUID => "uuid".into(),
+        &Type::JSON | &Type::JSONB => "json".into(),
+        &Type::OID => "ubigint".into(),
+        &Type::BYTEA => "blob".into(),
+        _ => FALLBACK_TYPE.into(),
     }
 }
 
 /// Returns the DuckDB SQL type string for a given Postgres array type.
-fn postgres_array_type_to_ducklake_sql(typ: &Type) -> &'static str {
+fn postgres_array_type_to_ducklake_sql(typ: &Type, _modifier: i32) -> &'static str {
     match typ {
         &Type::BOOL_ARRAY => "boolean[]",
         &Type::INT2_ARRAY => "smallint[]",
@@ -52,11 +60,11 @@ fn postgres_array_type_to_ducklake_sql(typ: &Type) -> &'static str {
 }
 
 /// Returns the DuckLake SQL type string for a Postgres column type.
-fn postgres_column_type_to_ducklake_sql(typ: &Type) -> &'static str {
+fn postgres_column_type_to_ducklake_sql(typ: &Type, modifier: i32) -> Cow<'static, str> {
     if is_array_type(typ) {
-        postgres_array_type_to_ducklake_sql(typ)
+        postgres_array_type_to_ducklake_sql(typ, modifier).into()
     } else {
-        postgres_scalar_type_to_ducklake_sql(typ)
+        postgres_scalar_type_to_ducklake_sql(typ, modifier)
     }
 }
 
@@ -70,7 +78,7 @@ const DUCKDB_MAX_DECIMAL_PRECISION: i16 = 38;
 /// range (p up to 1000, negative scale, scale exceeding precision), so
 /// constrained `NUMERIC(p, s)` columns outside the DuckDB range must fall
 /// back to `varchar`.
-fn is_ducklake_compatible(nm: NumericModifiers) -> bool {
+fn is_ducklake_compatible(nm: &NumericModifiers) -> bool {
     nm.p >= 1 && nm.p <= DUCKDB_MAX_DECIMAL_PRECISION && nm.s >= 0 && nm.s <= nm.p
 }
 
@@ -84,7 +92,8 @@ fn ducklake_column_definition(
     include_not_null: bool,
 ) -> String {
     let column_name = quote_identifier(&column_schema.name);
-    let duckdb_type = postgres_column_type_to_ducklake_sql(&column_schema.typ);
+    let duckdb_type =
+        postgres_column_type_to_ducklake_sql(&column_schema.typ, column_schema.modifier);
     let default_clause = if include_default {
         ducklake_default_clause(column_schema).unwrap_or_default()
     } else {
@@ -297,36 +306,74 @@ mod tests {
 
     #[test]
     fn scalar_type_mapping() {
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::BOOL), "boolean");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TEXT), "varchar");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INT2), "smallint");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INT4), "integer");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INT8), "bigint");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::FLOAT4), "float");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::FLOAT8), "double");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC), "varchar");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::DATE), "date");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIME), "time");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIMETZ), "varchar");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIMESTAMP), "timestamp");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIMESTAMPTZ), "timestamptz");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INTERVAL), "varchar");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::UUID), "uuid");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::JSON), "json");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::JSONB), "json");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::OID), "ubigint");
-        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::BYTEA), "blob");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::BOOL, -1), "boolean");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TEXT, -1), "varchar");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INT2, -1), "smallint");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INT4, -1), "integer");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INT8, -1), "bigint");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::FLOAT4, -1), "float");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::FLOAT8, -1), "double");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, -1), "varchar");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::DATE, -1), "date");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIME, -1), "time");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIMETZ, -1), "varchar");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIMESTAMP, -1), "timestamp");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::TIMESTAMPTZ, -1), "timestamptz");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::INTERVAL, -1), "varchar");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::UUID, -1), "uuid");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::JSON, -1), "json");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::JSONB, -1), "json");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::OID, -1), "ubigint");
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::BYTEA, -1), "blob");
+    }
+
+    #[test]
+    fn scalar_type_mapping_numeric_compatible() {
+        // NUMERIC(10, 2): typmod = ((10 << 16) | 2) + 4
+        let typmod = ((10i32 << 16) | 2) + 4;
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, typmod), "decimal(10, 2)");
+
+        // NUMERIC(38, 0): max DuckDB precision, zero scale.
+        #[allow(clippy::identity_op)]
+        let typmod = ((38i32 << 16) | 0) + 4;
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, typmod), "decimal(38, 0)");
+
+        // NUMERIC(38, 38): max DuckDB precision and scale.
+        #[allow(clippy::identity_op)]
+        let typmod = ((38i32 << 16) | 38) + 4;
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, typmod), "decimal(38, 38)");
+
+        // NUMERIC(1, 0): minimal.
+        #[allow(clippy::identity_op)]
+        let typmod = ((1i32 << 16) | 0) + 4;
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, typmod), "decimal(1, 0)");
+    }
+
+    #[test]
+    fn scalar_type_mapping_numeric_incompatible_falls_back_to_varchar() {
+        // NUMERIC(39, 0): precision exceeds DuckDB max.
+        #[allow(clippy::identity_op)]
+        let typmod = ((39i32 << 16) | 0) + 4;
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, typmod), "varchar");
+
+        // NUMERIC(10, -3): negative scale.
+        let typmod = ((10i32 << 16) | ((-3i16 as u16) as i32)) + 4;
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, typmod), "varchar");
+
+        // NUMERIC(3, 5): scale exceeds precision.
+        let typmod = ((3i32 << 16) | 5) + 4;
+        assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::NUMERIC, typmod), "varchar");
     }
 
     #[test]
     fn array_type_mapping() {
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::BOOL_ARRAY), "boolean[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::TEXT_ARRAY), "varchar[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::INT4_ARRAY), "integer[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::FLOAT8_ARRAY), "double[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::TIMETZ_ARRAY), "varchar[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::INTERVAL_ARRAY), "varchar[]");
-        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::UUID_ARRAY), "uuid[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::BOOL_ARRAY, -1), "boolean[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::TEXT_ARRAY, -1), "varchar[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::INT4_ARRAY, -1), "integer[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::FLOAT8_ARRAY, -1), "double[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::TIMETZ_ARRAY, -1), "varchar[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::INTERVAL_ARRAY, -1), "varchar[]");
+        assert_eq!(postgres_array_type_to_ducklake_sql(&Type::UUID_ARRAY, -1), "uuid[]");
     }
 
     #[test]
@@ -437,29 +484,29 @@ mod tests {
 
     #[test]
     fn is_ducklake_compatible_within_duckdb_range() {
-        assert!(is_ducklake_compatible(NumericModifiers { p: 1, s: 0 }));
-        assert!(is_ducklake_compatible(NumericModifiers { p: 10, s: 2 }));
-        assert!(is_ducklake_compatible(NumericModifiers { p: 38, s: 0 }));
-        assert!(is_ducklake_compatible(NumericModifiers { p: 38, s: 38 }));
-        assert!(is_ducklake_compatible(NumericModifiers { p: 18, s: 3 }));
+        assert!(is_ducklake_compatible(&NumericModifiers { p: 1, s: 0 }));
+        assert!(is_ducklake_compatible(&NumericModifiers { p: 10, s: 2 }));
+        assert!(is_ducklake_compatible(&NumericModifiers { p: 38, s: 0 }));
+        assert!(is_ducklake_compatible(&NumericModifiers { p: 38, s: 38 }));
+        assert!(is_ducklake_compatible(&NumericModifiers { p: 18, s: 3 }));
     }
 
     #[test]
     fn is_ducklake_compatible_precision_too_large() {
-        assert!(!is_ducklake_compatible(NumericModifiers { p: 39, s: 0 }));
-        assert!(!is_ducklake_compatible(NumericModifiers { p: 1000, s: 0 }));
+        assert!(!is_ducklake_compatible(&NumericModifiers { p: 39, s: 0 }));
+        assert!(!is_ducklake_compatible(&NumericModifiers { p: 1000, s: 0 }));
     }
 
     #[test]
     fn is_ducklake_compatible_negative_scale() {
-        assert!(!is_ducklake_compatible(NumericModifiers { p: 10, s: -3 }));
-        assert!(!is_ducklake_compatible(NumericModifiers { p: 2, s: -1000 }));
+        assert!(!is_ducklake_compatible(&NumericModifiers { p: 10, s: -3 }));
+        assert!(!is_ducklake_compatible(&NumericModifiers { p: 2, s: -1000 }));
     }
 
     #[test]
     fn is_ducklake_compatible_scale_exceeds_precision() {
-        assert!(!is_ducklake_compatible(NumericModifiers { p: 3, s: 5 }));
-        assert!(!is_ducklake_compatible(NumericModifiers { p: 38, s: 39 }));
+        assert!(!is_ducklake_compatible(&NumericModifiers { p: 3, s: 5 }));
+        assert!(!is_ducklake_compatible(&NumericModifiers { p: 38, s: 39 }));
     }
 
     #[test]

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -23,6 +23,7 @@ use etl_postgres::tokio::test_utils::TableModification;
 use etl_telemetry::tracing::init_test_tracing;
 use pg_escape::{quote_identifier, quote_literal};
 use rand::random;
+use rust_decimal::Decimal;
 use url::Url;
 
 use crate::support::ducklake::{
@@ -74,7 +75,7 @@ struct SimulatorDdlTypeRow {
     ddl_col_1_0: Option<i32>,
     ddl_col_2_0: Option<bool>,
     ddl_col_3_0_is_present: bool,
-    ddl_col_4_0: Option<String>,
+    ddl_col_4_0: Option<Decimal>,
 }
 
 /// Opens a DuckLake verification connection using blocking DuckDB APIs.
@@ -1589,7 +1590,7 @@ async fn schema_change_matches_simulator_generated_column_types() {
             ddl_col_1_0: Some(44),
             ddl_col_2_0: Some(true),
             ddl_col_3_0_is_present: true,
-            ddl_col_4_0: Some("12345.67".to_owned()),
+            ddl_col_4_0: Some(Decimal::new(1234567, 2)),
         }
     );
 }

--- a/crates/etl-postgres/src/schema.rs
+++ b/crates/etl-postgres/src/schema.rs
@@ -156,6 +156,54 @@ impl fmt::Display for TableName {
 /// attributes, such as length for varchar or precision for numeric types.
 type TypeModifier = i32;
 
+/// The size of the varlena header that Postgres adds to stored type modifiers.
+///
+/// Postgres encodes type-specific parameters into `atttypmod` with a
+/// `VARHDRSZ` offset so that `-1` (no modifier) never collides with a valid
+/// encoded value.
+///
+/// Postgres reference: `src/include/c.h`.
+const VARHDRSZ: i32 = 4;
+
+/// Decoded precision and scale from a Postgres `NUMERIC(p, s)` type modifier.
+///
+/// Postgres encodes the modifier as `((p << 16) | (s & 0xffff)) + VARHDRSZ`.
+/// Unconstrained `NUMERIC` columns use the sentinel modifier value `-1` and
+/// produce `None` from [`numeric_modifiers`].
+///
+/// `p` (precision) ranges from 1 to 1000 and `s` (scale) ranges from -1000 to
+/// 1000. Negative scales are permitted since Postgres 15.
+///
+/// Postgres reference: `src/backend/utils/adt/numeric.c`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct NumericModifiers {
+    /// The total number of significant digits (1..=1000).
+    pub p: i16,
+    /// The number of digits to the right of the decimal point (-1000..=1000).
+    pub s: i16,
+}
+
+/// Decodes a Postgres `atttypmod` value for a `NUMERIC` column into its
+/// precision and scale components.
+///
+/// Returns `None` when `modifier` is `-1`, which Postgres uses for
+/// unconstrained `NUMERIC` columns that have no explicit precision or scale.
+///
+/// Postgres reference: `src/backend/utils/adt/numeric.c`,
+/// `numerictypmodin` / `numerictypmodout`.
+pub fn numeric_modifiers(modifier: TypeModifier) -> Option<NumericModifiers> {
+    if modifier == -1 {
+        return None;
+    }
+
+    let tmp = modifier - VARHDRSZ;
+    let p = ((tmp >> 16) & 0xFFFF) as i16;
+    // Reinterpret the lower 16 bits as signed to recover negative scales.
+    let s = (tmp & 0xFFFF) as i16;
+
+    Some(NumericModifiers { p, s })
+}
+
 /// Represents the schema of a single column in a Postgres table.
 ///
 /// This type contains all metadata about a column including its name, data
@@ -467,5 +515,72 @@ mod tests {
         assert_eq!(schema.primary_key_ordinal_position, Some(1));
         assert!(!schema.nullable);
         assert_eq!(schema.default_expression.as_deref(), Some("'new'::text"));
+    }
+
+    #[test]
+    fn numeric_modifiers_unconstrained() {
+        assert_eq!(numeric_modifiers(-1), None);
+    }
+
+    #[test]
+    fn numeric_modifiers_precision_and_positive_scale() {
+        // NUMERIC(10, 2): typmod = ((10 << 16) | 2) + 4 = 655366
+        let m = numeric_modifiers(655366).unwrap();
+        assert_eq!(m.p, 10);
+        assert_eq!(m.s, 2);
+    }
+
+    #[test]
+    fn numeric_modifiers_zero_scale() {
+        // NUMERIC(38, 0): typmod = ((38 << 16) | 0) + 4 = 2490372
+        let m = numeric_modifiers(2490372).unwrap();
+        assert_eq!(m.p, 38);
+        assert_eq!(m.s, 0);
+    }
+
+    #[test]
+    fn numeric_modifiers_max_precision_and_scale() {
+        // NUMERIC(1000, 1000): typmod = ((1000 << 16) | 1000) + 4
+        let typmod = ((1000i32 << 16) | 1000) + VARHDRSZ;
+        let m = numeric_modifiers(typmod).unwrap();
+        assert_eq!(m.p, 1000);
+        assert_eq!(m.s, 1000);
+    }
+
+    #[test]
+    fn numeric_modifiers_negative_scale() {
+        // NUMERIC(2, -3): typmod = ((2 << 16) | (-3i16 as u16 as i32)) + 4
+        let typmod = ((2i32 << 16) | ((-3i16 as u16) as i32)) + VARHDRSZ;
+        let m = numeric_modifiers(typmod).unwrap();
+        assert_eq!(m.p, 2);
+        assert_eq!(m.s, -3);
+    }
+
+    #[test]
+    fn numeric_modifiers_min_negative_scale() {
+        // NUMERIC(1000, -1000)
+        let typmod = ((1000i32 << 16) | ((-1000i16 as u16) as i32)) + VARHDRSZ;
+        let m = numeric_modifiers(typmod).unwrap();
+        assert_eq!(m.p, 1000);
+        assert_eq!(m.s, -1000);
+    }
+
+    #[test]
+    fn numeric_modifiers_scale_exceeds_precision() {
+        // NUMERIC(3, 5): valid in Postgres, stores values like 0.00999
+        let typmod = ((3i32 << 16) | 5) + VARHDRSZ;
+        let m = numeric_modifiers(typmod).unwrap();
+        assert_eq!(m.p, 3);
+        assert_eq!(m.s, 5);
+    }
+
+    #[test]
+    fn numeric_modifiers_minimal() {
+        // NUMERIC(1, 0)
+        #[allow(clippy::identity_op)]
+        let typmod = ((1i32 << 16) | 0) + VARHDRSZ;
+        let m = numeric_modifiers(typmod).unwrap();
+        assert_eq!(m.p, 1);
+        assert_eq!(m.s, 0);
     }
 }

--- a/crates/etl/src/schema.rs
+++ b/crates/etl/src/schema.rs
@@ -12,7 +12,10 @@ use std::{
 
 pub use etl_postgres::{
     default_expression::{DefaultExpression, parse_default_expression},
-    schema::{ColumnSchema, SchemaError, SnapshotId, TableId, TableName, TableSchema},
+    schema::{
+        ColumnSchema, NumericModifiers, SchemaError, SnapshotId, TableId, TableName, TableSchema,
+        numeric_modifiers,
+    },
     type_utils::is_array_type,
 };
 pub use tokio_postgres::types::{PgLsn, Type};


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`NUMERIC` columns are mapped to `VARCHAR` in Ducklake.

## What is the new behavior?

For certain precision `p` and scale `s` parameters, the `NUMERIC(p, s)` can be safely mapped to `DECIMAL(p, s)`. This updates the `postgres_scalar_type_to_ducklake_sql` function in the DuckLake destination to add this mapping.

## Additional context

N/A
