### PR TITLE
fix: require durability for terminal table sync batches

### DIFF
--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -16,7 +16,7 @@ use etl::{
     data::{SizeHint, TableRow},
     destination::{
         Destination, DestinationWriteStatus, DropTableForCopyResult, PipelineDestination,
-        WriteEventsResult, WriteTableRowsResult,
+        WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
     error::EtlResult,
     event::Event,
@@ -408,10 +408,11 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         let counts = classify_events(&events);
-        self.inner.write_events(events, async_result).await?;
+        self.inner.write_events(events, durability, async_result).await?;
 
         Self::count_events(&self.stats, &counts);
         let target = self.stats.cdc_target.load(Ordering::Acquire);
@@ -454,6 +455,7 @@ impl Destination for NullDestination {
     async fn write_events(
         &self,
         _events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         async_result.send(Ok(DestinationWriteStatus::Durable));
@@ -720,18 +722,25 @@ impl Destination for BenchDestination {
     async fn write_events(
         &self,
         events: Vec<Event>,
+        durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         match self {
-            Self::Null(destination) => destination.write_events(events, async_result).await,
+            Self::Null(destination) => {
+                destination.write_events(events, durability, async_result).await
+            }
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => {
-                Box::pin(destination.write_events(events, async_result)).await
+                Box::pin(destination.write_events(events, durability, async_result)).await
             }
             #[cfg(feature = "clickhouse")]
-            Self::ClickHouse(destination) => destination.write_events(events, async_result).await,
+            Self::ClickHouse(destination) => {
+                destination.write_events(events, durability, async_result).await
+            }
             #[cfg(feature = "snowflake")]
-            Self::Snowflake(destination) => destination.write_events(events, async_result).await,
+            Self::Snowflake(destination) => {
+                destination.write_events(events, durability, async_result).await
+            }
         }
     }
 }

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -10,8 +10,8 @@ use etl::{
     data::{Cell, OldTableRow, TableRow, UpdatedTableRow},
     destination::{
         Destination, DestinationTableMetadata, DestinationTableSchemaStatus,
-        DestinationWriteStatus, DropTableForCopyResult, TaskSet, WriteEventsResult,
-        WriteTableRowsResult,
+        DestinationWriteStatus, DropTableForCopyResult, TaskSet, WriteEventsDurability,
+        WriteEventsResult, WriteTableRowsResult,
     },
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
@@ -1391,6 +1391,7 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -4,7 +4,8 @@ use etl::{
     data::{Cell, OldTableRow, TableRow, UpdatedTableRow},
     destination::{
         Destination, DestinationTableMetadata, DestinationTableSchemaStatus,
-        DestinationWriteStatus, DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult,
+        DestinationWriteStatus, DropTableForCopyResult, WriteEventsDurability, WriteEventsResult,
+        WriteTableRowsResult,
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -1476,6 +1477,7 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         let result = self.write_events_inner(events).await;

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -10,8 +10,8 @@ use etl::{
     data::{OldTableRow, PartialTableRow, TableRow, UpdatedTableRow},
     destination::{
         Destination, DestinationTableMetadata, DestinationTableSchemaStatus,
-        DestinationWriteStatus, DropTableForCopyResult, TaskSet, WriteEventsResult,
-        WriteTableRowsResult,
+        DestinationWriteStatus, DropTableForCopyResult, TaskSet, WriteEventsDurability,
+        WriteEventsResult, WriteTableRowsResult,
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -339,6 +339,7 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;

--- a/crates/etl-destinations/src/iceberg/core.rs
+++ b/crates/etl-destinations/src/iceberg/core.rs
@@ -8,7 +8,7 @@ use etl::{
     data::{Cell, OldTableRow, TableRow, UpdatedTableRow},
     destination::{
         Destination, DestinationTableMetadata, DestinationWriteStatus, DropTableForCopyResult,
-        TaskSet, WriteEventsResult, WriteTableRowsResult,
+        TaskSet, WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
     error::{ErrorKind, EtlResult},
     etl_error,
@@ -628,6 +628,7 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -5,7 +5,8 @@ use etl::{
     data::{OldTableRow, TableRow, UpdatedTableRow},
     destination::{
         DestinationTableMetadata, DestinationTableSchemaStatus, DestinationWriteStatus,
-        DropTableForCopyResult, TaskSet, WriteEventsResult, WriteTableRowsResult,
+        DropTableForCopyResult, TaskSet, WriteEventsDurability, WriteEventsResult,
+        WriteTableRowsResult,
     },
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
@@ -519,6 +520,7 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;
@@ -526,7 +528,23 @@ where
         let destination = self.clone();
         self.tasks
             .spawn(async move {
-                let result = destination.process_events(events).await;
+                let result = async {
+                    let status = destination.process_events(events).await?;
+                    if durability == WriteEventsDurability::RequireDurable
+                        && status == DestinationWriteStatus::Accepted
+                    {
+                        destination
+                            .client
+                            .wait_for_pending_durability()
+                            .await
+                            .map_err(EtlError::from)?;
+
+                        Ok(DestinationWriteStatus::Durable)
+                    } else {
+                        Ok(status)
+                    }
+                }
+                .await;
                 async_result.send(result);
             })
             .await;

--- a/crates/etl-examples/Cargo.toml
+++ b/crates/etl-examples/Cargo.toml
@@ -42,9 +42,9 @@ snowflake = ["etl-destinations/snowflake"]
 [dependencies]
 
 clap = { workspace = true, default-features = true, features = [
-  "std",
-  "derive",
-  "env",
+    "std",
+    "derive",
+    "env",
 ] }
 etl = { workspace = true }
 etl-config = { workspace = true }
@@ -54,7 +54,7 @@ rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 tokio = { workspace = true, features = ["macros", "signal", "time"] }
 tracing = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true, default-features = true, features = [
-  "env-filter",
+    "env-filter",
 ] }
 url = { workspace = true }
 

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -78,16 +78,32 @@ pub type WriteTableRowsResult<T = DestinationWriteStatus> = AsyncResult<T>;
 /// clearing stored table-copy metadata and starting a fresh copy.
 pub type DropTableForCopyResult<T = ()> = AsyncResult<T>;
 
+/// Durability requirement for a streaming destination write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteEventsDurability {
+    /// The destination may report either
+    /// [`DestinationWriteStatus::Accepted`] or
+    /// [`DestinationWriteStatus::Durable`].
+    MayDefer,
+    /// The destination must report [`DestinationWriteStatus::Durable`] for the
+    /// write and all earlier accepted writes in the same ordered apply-loop
+    /// stream.
+    RequireDurable,
+}
+
 /// Async completion handle used for
 /// [`crate::destination::Destination::write_events`].
 ///
 /// This is the path where asynchronous completion changes ETL behavior the
 /// most: once dispatch succeeds, the apply loop may continue other work while
-/// the destination finishes the batch.
+/// the destination finishes the batch. [`WriteEventsDurability`] determines
+/// which successful completion statuses are valid for each call.
 pub type WriteEventsResult<T = DestinationWriteStatus> = AsyncResult<T>;
+
 /// Pending async completion used for `Destination::write_events`.
 pub(crate) type PendingWriteEventsResult<T = DestinationWriteStatus> =
     PendingAsyncResult<T, ApplyLoopAsyncResultMetadata>;
+
 /// Completed async completion used for `Destination::write_events`.
 pub(crate) type CompletedWriteEventsResult<T = DestinationWriteStatus> =
     CompletedAsyncResult<T, ApplyLoopAsyncResultMetadata>;
@@ -112,6 +128,8 @@ pub(crate) struct ApplyLoopAsyncResultMetadata {
     /// [`DestinationWriteStatus::Accepted`] results and advances only when a
     /// later cumulative durable result covers the carried LSN.
     pub commit_end_lsn: Option<PgLsn>,
+    /// Durability requirement supplied with the dispatched write.
+    pub durability: WriteEventsDurability,
     /// Dispatch-time metrics for the batch.
     pub metrics: DispatchMetrics,
 }
@@ -228,6 +246,7 @@ mod tests {
     async fn async_result_round_trips_success() {
         let metadata = ApplyLoopAsyncResultMetadata {
             commit_end_lsn: Some(PgLsn::from(42)),
+            durability: WriteEventsDurability::MayDefer,
             metrics: DispatchMetrics { items_count: 1, dispatched_at: Instant::now() },
         };
         let (result_tx, pending_result) = WriteEventsResult::new(metadata);
@@ -239,6 +258,7 @@ mod tests {
 
         let metadata = metadata.expect("metadata should be present");
         assert_eq!(metadata.commit_end_lsn, Some(PgLsn::from(42)));
+        assert_eq!(metadata.durability, WriteEventsDurability::MayDefer);
         assert_eq!(result.unwrap(), 7);
     }
 

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -2,7 +2,9 @@ use std::future::Future;
 
 use crate::{
     data::TableRow,
-    destination::{DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult},
+    destination::{
+        DropTableForCopyResult, WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
+    },
     error::EtlResult,
     event::Event,
     schema::ReplicatedTableSchema,
@@ -155,6 +157,11 @@ pub trait Destination {
     /// destination accepted ownership of the write, but ETL must not advance
     /// durable progress for it yet.
     ///
+    /// [`WriteEventsDurability::MayDefer`] permits either status, while
+    /// [`WriteEventsDurability::RequireDurable`] requires `Durable` and its
+    /// cumulative guarantee for all earlier accepted writes in the same
+    /// apply-loop stream.
+    ///
     /// ETL keeps at most one streaming write result pending while it continues
     /// building the next batch. If a result completes as
     /// [`crate::destination::DestinationWriteStatus::Accepted`], ETL carries
@@ -189,6 +196,7 @@ pub trait Destination {
     fn write_events(
         &self,
         events: Vec<Event>,
+        durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> impl Future<Output = EtlResult<()>> + Send;
 }

--- a/crates/etl/src/destination/mod.rs
+++ b/crates/etl/src/destination/mod.rs
@@ -18,7 +18,8 @@ pub(crate) use async_result::{
     PendingWriteEventsResult,
 };
 pub use async_result::{
-    DestinationWriteStatus, DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult,
+    DestinationWriteStatus, DropTableForCopyResult, WriteEventsDurability, WriteEventsResult,
+    WriteTableRowsResult,
 };
 pub use base::Destination;
 pub use capabilities::PipelineDestination;

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -72,8 +72,8 @@
 //!     },
 //!     data::TableRow,
 //!     destination::{
-//!         Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsResult,
-//!         WriteTableRowsResult,
+//!         Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsDurability,
+//!         WriteEventsResult, WriteTableRowsResult,
 //!     },
 //!     error::EtlResult,
 //!     event::Event,
@@ -109,6 +109,7 @@
 //!     async fn write_events(
 //!         &self,
 //!         _events: Vec<Event>,
+//!         _durability: WriteEventsDurability,
 //!         async_result: WriteEventsResult,
 //!     ) -> EtlResult<()> {
 //!         async_result.send(Ok(DestinationWriteStatus::Durable));

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -1729,13 +1729,13 @@ where
         // If there was an error in the flushing, we return it immediately.
         let status = result?;
 
-        if let Some(metadata) = metadata {
+        if let Some(metadata) = metadata.as_ref() {
             if metadata.durability == WriteEventsDurability::RequireDurable
                 && status == DestinationWriteStatus::Accepted
             {
                 bail!(
                     ErrorKind::DestinationError,
-                    "Destination returned Accepted for a write that required durability"
+                    "Destination was expected to durably persist last batch but it didn't do it"
                 );
             }
 
@@ -1775,6 +1775,16 @@ where
         // If processing was paused, there must be a queued batch that still needs to be
         // flushed now that the previous in-flight result has resolved.
         if processing_paused {
+            if let Some(metadata) = metadata.as_ref() {
+                // A required-durability write is terminal, so `Complete` must have
+                // stopped intake before a successor batch could be queued behind it.
+                debug_assert_ne!(
+                    metadata.durability,
+                    WriteEventsDurability::RequireDurable,
+                    "required-durability write must not have a queued successor batch"
+                );
+            }
+
             self.flush_batch("pending flush result received").await?;
         }
 
@@ -1891,6 +1901,9 @@ where
 
         let (events_batch, events_batch_bytes) = self.state.take_events_batch();
         let events_batch_size = events_batch.len();
+        // `Complete` is terminal, so no later write is guaranteed to settle an
+        // `Accepted` result. Its final batch must confirm cumulative durability
+        // before the apply loop can complete.
         let durability = match self.state.exit_intent {
             Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
             Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -44,7 +44,8 @@ use crate::{
     data::SizeHint,
     destination::{
         ApplyLoopAsyncResultMetadata, CompletedWriteEventsResult, DestinationWriteStatus,
-        DispatchMetrics, PendingWriteEventsResult, PipelineDestination, WriteEventsResult,
+        DispatchMetrics, PendingWriteEventsResult, PipelineDestination, WriteEventsDurability,
+        WriteEventsResult,
     },
     error::{ErrorKind, EtlError, EtlResult},
     etl_error,
@@ -1729,6 +1730,15 @@ where
         let status = result?;
 
         if let Some(metadata) = metadata {
+            if metadata.durability == WriteEventsDurability::RequireDurable
+                && status == DestinationWriteStatus::Accepted
+            {
+                bail!(
+                    ErrorKind::DestinationError,
+                    "Destination returned Accepted for a write that required durability"
+                );
+            }
+
             counter!(
                 ETL_EVENTS_PROCESSED_TOTAL,
                 WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
@@ -1881,6 +1891,10 @@ where
 
         let (events_batch, events_batch_bytes) = self.state.take_events_batch();
         let events_batch_size = events_batch.len();
+        let durability = match self.state.exit_intent {
+            Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
+            Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,
+        };
         debug!(
             worker_type = %self.worker_context.worker_type(),
             batch_size = events_batch_size,
@@ -1893,6 +1907,7 @@ where
         // and recorded once the destination acknowledges the batch.
         let metadata = ApplyLoopAsyncResultMetadata {
             commit_end_lsn: self.state.last_commit_end_lsn.take(),
+            durability,
             metrics: DispatchMetrics {
                 items_count: events_batch_size,
                 dispatched_at: Instant::now(),
@@ -1903,7 +1918,7 @@ where
         // the pending receiver is stored on the loop state until the
         // destination signals completion.
         let (flush_result, pending_flush_result) = WriteEventsResult::new(metadata);
-        self.destination.write_events(events_batch, flush_result).await?;
+        self.destination.write_events(events_batch, durability, flush_result).await?;
         self.state.pending_flush_result = Some(pending_flush_result);
 
         // We reset the deadline for the batch, since we are now flushing a new batch.

--- a/crates/etl/src/runtime/table_sync/worker.rs
+++ b/crates/etl/src/runtime/table_sync/worker.rs
@@ -812,9 +812,7 @@ where
                     bail!(
                         ErrorKind::InvalidState,
                         "Table sync apply loop completed before reaching SyncDone",
-                        format!(
-                            "Expected SyncDone before resource cleanup, found {table_state}"
-                        )
+                        format!("Expected SyncDone before resource cleanup, found {table_state}")
                     );
                 }
 

--- a/crates/etl/src/runtime/table_sync/worker.rs
+++ b/crates/etl/src/runtime/table_sync/worker.rs
@@ -776,7 +776,7 @@ where
 
         let worker_context = WorkerContext::TableSync(TableSyncWorkerContext {
             table_id: self.table_id,
-            table_sync_worker_state: state,
+            table_sync_worker_state: state.clone(),
             state_store: self.store.clone(),
         });
 
@@ -799,6 +799,25 @@ where
 
         match apply_loop_result {
             ApplyLoopResult::Completed => {
+                // The terminal commit requests `Complete` before its destination write has
+                // finished. That intent must not become `ApplyLoopResult::Completed` until
+                // the write reports `Durable` and `SyncDone` has been stored. Check the state
+                // again at the cleanup boundary so a future ordering regression cannot delete
+                // the progress row and replication slot prematurely.
+                //
+                // The apply worker may already have persisted `Ready`, but while this worker
+                // is active it leaves this shared in-memory state at `SyncDone`.
+                let table_state = state.lock().await.table_state().as_type();
+                if table_state != TableStateType::SyncDone {
+                    bail!(
+                        ErrorKind::InvalidState,
+                        "Table sync apply loop completed before reaching SyncDone",
+                        format!(
+                            "Expected SyncDone before resource cleanup, found {table_state}"
+                        )
+                    );
+                }
+
                 info!(
                     table_id = self.table_id.0,
                     "table sync apply loop completed successfully, deleting slot"

--- a/crates/etl/src/test_utils/memory_destination.rs
+++ b/crates/etl/src/test_utils/memory_destination.rs
@@ -7,7 +7,8 @@ use crate::{
     data::TableRow,
     destination::{
         Destination, DestinationTableMetadata, DestinationTableSchemaStatus,
-        DestinationWriteStatus, DropTableForCopyResult, WriteEventsResult, WriteTableRowsResult,
+        DestinationWriteStatus, DropTableForCopyResult, WriteEventsDurability, WriteEventsResult,
+        WriteTableRowsResult,
     },
     error::EtlResult,
     event::Event,
@@ -192,6 +193,7 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         let mut table_schemas = HashMap::new();

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -14,7 +14,7 @@ use crate::{
     data::TableRow,
     destination::{
         ApplyLoopAsyncResultMetadata, Destination, DispatchMetrics, DropTableForCopyResult,
-        PipelineDestination, WriteEventsResult, WriteTableRowsResult,
+        PipelineDestination, WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
     error::EtlResult,
     event::{Event, EventType},
@@ -368,6 +368,7 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;
@@ -382,12 +383,13 @@ where
         let (wrapped_flush_result, pending_flush_result) =
             WriteEventsResult::new(ApplyLoopAsyncResultMetadata {
                 commit_end_lsn: None,
+                durability,
                 metrics: DispatchMetrics {
                     items_count: events.len(),
                     dispatched_at: Instant::now(),
                 },
             });
-        destination.write_events(events.clone(), wrapped_flush_result).await?;
+        destination.write_events(events.clone(), durability, wrapped_flush_result).await?;
 
         // We spawn a task to handle the result, this way the wrapper behaves like a
         // transparent layer that doesn't block on the result of the inner

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -4,7 +4,7 @@ use etl::{
     data::TableRow,
     destination::{
         Destination, DestinationWriteStatus, DropTableForCopyResult, PipelineDestination,
-        WriteEventsResult, WriteTableRowsResult,
+        WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
     error::{ErrorKind, EtlResult},
     event::{Event, EventType, InsertEvent},
@@ -188,9 +188,10 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
-        self.inner.write_events(events, async_result).await
+        self.inner.write_events(events, durability, async_result).await
     }
 }
 
@@ -317,9 +318,10 @@ where
     async fn write_events(
         &self,
         events: Vec<Event>,
+        durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
-        self.inner.write_events(events, async_result).await
+        self.inner.write_events(events, durability, async_result).await
     }
 }
 

--- a/docs/src/content/docs/explanation/architecture.md
+++ b/docs/src/content/docs/explanation/architecture.md
@@ -85,7 +85,7 @@ pub trait Destination {
     fn startup(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
     fn drop_table_for_copy(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: DropTableForCopyResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, rows: Vec<TableRow>, async_result: WriteTableRowsResult) -> impl Future<Output = EtlResult<()>> + Send;
-    fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult) -> impl Future<Output = EtlResult<()>> + Send;
+    fn write_events(&self, events: Vec<Event>, durability: WriteEventsDurability, async_result: WriteEventsResult) -> impl Future<Output = EtlResult<()>> + Send;
 }
 ```
 
@@ -100,7 +100,7 @@ pub trait Destination {
 
 Each write-like method receives an async result handle. The intent is different per method:
 
-- `write_events()`: after dispatch succeeds, ETL may keep processing other work while the destination finishes the batch. ETL still waits for that batch's async result before handing the destination the next streaming batch.
+- `write_events()`: after dispatch succeeds, ETL may keep processing other work while the destination finishes the batch. ETL still waits for that batch's async result before handing the destination the next streaming batch. `MayDefer` permits `Accepted` or `Durable`; `RequireDurable` requires cumulative durable completion.
 - `drop_table_for_copy()`: ETL waits for the result immediately. After a successful drop, ETL clears its own copy-scoped schema, destination metadata, and table-sync progress before storing the fresh `0/0` copy schema.
 - `write_table_rows()`: ETL waits for each result before requesting the next batch for that copy partition. `Durable` confirms that batch and any earlier accepted writes covered by the result. `Accepted` transfers ownership to the destination and lets copying continue without marking the table copy finished. If any batch is accepted this way, ETL sends a final empty batch after all copy workers finish; that table-wide barrier must cover every accepted write and return `Durable` before ETL stores `FinishedCopy`.
 

--- a/docs/src/content/docs/explanation/events.md
+++ b/docs/src/content/docs/explanation/events.md
@@ -289,7 +289,12 @@ Handle this by either:
 - Ignoring Begin/Commit if transaction markers are not required
 
 ```rust
-async fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult) -> EtlResult<()> {
+async fn write_events(
+    &self,
+    events: Vec<Event>,
+    _durability: WriteEventsDurability,
+    async_result: WriteEventsResult,
+) -> EtlResult<()> {
     let result = async {
         for event in events {
             match event {

--- a/docs/src/content/docs/explanation/traits.md
+++ b/docs/src/content/docs/explanation/traits.md
@@ -18,7 +18,7 @@ pub trait Destination {
     fn startup(&self) -> impl Future<Output = EtlResult<()>> + Send { async { Ok(()) } }
     fn drop_table_for_copy(&self, replicated_table_schema: &ReplicatedTableSchema, async_result: DropTableForCopyResult<()>) -> impl Future<Output = EtlResult<()>> + Send;
     fn write_table_rows(&self, replicated_table_schema: &ReplicatedTableSchema, table_rows: Vec<TableRow>, async_result: WriteTableRowsResult) -> impl Future<Output = EtlResult<()>> + Send;
-    fn write_events(&self, events: Vec<Event>, async_result: WriteEventsResult) -> impl Future<Output = EtlResult<()>> + Send;
+    fn write_events(&self, events: Vec<Event>, durability: WriteEventsDurability, async_result: WriteEventsResult) -> impl Future<Output = EtlResult<()>> + Send;
 }
 ```
 
@@ -38,6 +38,7 @@ pub trait Destination {
 - `drop_table_for_copy()` should be **idempotent**. ETL calls it before clearing copy-scoped store state, so implementations can still use the supplied schema and existing destination metadata to locate the old object. Before returning success, it must also drain or invalidate writes accepted by an earlier copy attempt so stale work cannot mutate the recreated table.
 - `write_table_rows()` is called even for empty source tables so destinations can create or prepare initial destination state before streaming begins.
 - An immediate `write_table_rows()` implementation returns `DestinationWriteStatus::Durable` after the batch is durable. A deferred implementation may return `Accepted` after taking ownership of a nonempty batch. It must bound its accepted-but-not-durable backlog and delay `Accepted` when no capacity is available. If any batch returns `Accepted`, ETL sends an empty batch after all copy workers finish; the destination must return `Durable` from that call only after all rows accepted during the current copy attempt are durable.
+- `WriteEventsDurability::MayDefer` permits `write_events()` to return `Accepted` or `Durable`. `WriteEventsDurability::RequireDurable` cannot return `Accepted`: it must return `Durable` only after the current write and all earlier accepted writes in the same ordered apply-loop stream are durable.
 - `write_table_rows()` and `write_events()` must tolerate **duplicate delivery** because ETL may retry or replay after failure.
 - Handle **concurrent calls** safely, especially from parallel table sync workers.
 - Preserve **per-table event order**. During initial copy and catch-up, transaction markers are not a reliable all-tables transaction boundary.

--- a/docs/src/content/docs/guides/custom-implementations.md
+++ b/docs/src/content/docs/guides/custom-implementations.md
@@ -329,7 +329,7 @@ There are also optional `startup()` and `shutdown()` methods with default no-op 
 
 ETL clears its own schema versions, destination metadata, and table-sync progress **only after `drop_table_for_copy()` succeeds**. That lets the destination use the supplied previously stored replicated schema and any existing destination metadata to find the object that must be removed. Before returning success, also drain or invalidate writes accepted by an earlier copy attempt so stale work cannot mutate the recreated object. If the object is already gone and no stale write can recreate or mutate it, return success.
 
-All write-like methods must complete their async result handle. Treat the method return value as the place for immediate dispatch or setup failures, and send the final write result through `async_result`. Immediate destinations should send `DestinationWriteStatus::Durable` after successful `write_table_rows()` and `write_events()` calls. A copy destination that returns `DestinationWriteStatus::Accepted` must take ownership of the rows, bound its accepted-but-not-durable backlog, and delay `Accepted` until it has capacity. It must later treat an empty `write_table_rows()` call as a same-table durability barrier: return `Durable` only when every row accepted during that copy attempt is durable. ETL is **at least once**, so make row and event writes idempotent. `write_events()` preserves per-table ordering, but batches can include multiple tables and transaction markers are not a complete all-tables boundary during initial copy and catch-up.
+All write-like methods must complete their async result handle. Treat the method return value as the place for immediate dispatch or setup failures, and send the final write result through `async_result`. Immediate destinations should send `DestinationWriteStatus::Durable` after successful `write_table_rows()` and `write_events()` calls. A copy destination that returns `DestinationWriteStatus::Accepted` must take ownership of the rows, bound its accepted-but-not-durable backlog, and delay `Accepted` until it has capacity. It must later treat an empty `write_table_rows()` call as a same-table durability barrier: return `Durable` only when every row accepted during that copy attempt is durable. For streaming writes, `WriteEventsDurability::MayDefer` permits either `Accepted` or `Durable`, but `WriteEventsDurability::RequireDurable` cannot return `Accepted`: it must cover the current write and all earlier accepted writes in that ordered apply-loop stream. ETL is **at least once**, so make row and event writes idempotent. `write_events()` preserves per-table ordering, but batches can include multiple tables and transaction markers are not a complete all-tables boundary during initial copy and catch-up.
 
 ```rust
 use reqwest::Client;
@@ -338,8 +338,8 @@ use std::time::Duration;
 use tracing::{info, warn};
 
 use etl::destination::{
-    Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsResult,
-    WriteTableRowsResult,
+    Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsDurability,
+    WriteEventsResult, WriteTableRowsResult,
 };
 use etl::error::{ErrorKind, EtlResult};
 use etl::{data::TableRow, event::Event, schema::ReplicatedTableSchema};
@@ -430,6 +430,7 @@ impl Destination for HttpDestination {
     async fn write_events(
         &self,
         events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         if events.is_empty() {

--- a/docs/src/content/docs/guides/first-pipeline.md
+++ b/docs/src/content/docs/guides/first-pipeline.md
@@ -77,8 +77,8 @@ use etl::{
     },
     data::TableRow,
     destination::{
-        Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsResult,
-        WriteTableRowsResult,
+        Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsDurability,
+        WriteEventsResult, WriteTableRowsResult,
     },
     error::EtlResult,
     event::Event,
@@ -120,6 +120,7 @@ impl Destination for LoggingDestination {
     async fn write_events(
         &self,
         events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         println!("received {} streaming events", events.len());

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -82,8 +82,8 @@ use etl::{
     },
     data::TableRow,
     destination::{
-        Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsResult,
-        WriteTableRowsResult,
+        Destination, DestinationWriteStatus, DropTableForCopyResult, WriteEventsDurability,
+        WriteEventsResult, WriteTableRowsResult,
     },
     error::EtlResult,
     event::Event,
@@ -122,6 +122,7 @@ impl Destination for NoopDestination {
     async fn write_events(
         &self,
         _events: Vec<Event>,
+        _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
         async_result.send(Ok(DestinationWriteStatus::Durable));


### PR DESCRIPTION
## Summary

- Add an explicit `WriteEventsDurability` requirement to `write_events`.
- Dispatch terminal table-sync batches with `RequireDurable`.
- Make Snowflake wait for pending streaming commits before returning `Durable`.
- Reject `Accepted` for required writes and verify `SyncDone` before cleanup.
- Document Snowflake’s current client-wide barrier and follow-up scoping options.

## Context

A table-sync worker could receive `Accepted` for its terminal CDC batch and complete before that batch became durable. With no later batch, ETL had no result through which to observe durability.

This change makes terminal event-batch durability an explicit destination contract. 