### PR TITLE
test(etl): Add Postgres value roundtrip property tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,7 @@ dependencies = [
  "pg_escape",
  "pin-project-lite",
  "postgres-replication",
+ "proptest",
  "rand 0.9.4",
  "rustls",
  "serde",
@@ -4781,6 +4782,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5082,6 +5098,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_xoshiro"
@@ -7073,6 +7098,12 @@ checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ pg_escape = { version = "0.1.1", default-features = false }
 pin-project-lite = { version = "0.2.16", default-features = false }
 pkcs8 = { version = "0.11", default-features = false, features = ["pem", "encryption"] }
 postgres-replication = { git = "https://github.com/iambriccardo/rust-postgres", default-features = false, rev = "31acf55c7e5c2244e5bb3a36e7afa2a01bf52c38" }
+proptest = { version = "1.7.0", default-features = false, features = ["std"] }
 prost = { version = "0.14.1", default-features = false }
 r2d2 = { version = "0.8", default-features = false }
 rand = { version = "0.9.2", default-features = false }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -461,12 +461,14 @@ ClickHouse destination tests require a reachable ClickHouse HTTP endpoint:
 
 #### Value Roundtrip Property Test Variables
 
-The value roundtrip property tests in `crates/etl/tests/value_roundtrip.rs` run randomly generated cases against a real Postgres until a wall-clock budget elapses:
+The value roundtrip property tests in
+`crates/etl/tests/value_roundtrip.rs` run randomly generated cases
+against a real Postgres until a wall-clock budget elapses:
 
-| Variable | Description |
-|----------|-------------|
+| Variable                         | Description                                                                                   |
+|----------------------------------|-----------------------------------------------------------------------------------------------|
 | `ROUNDTRIP_PROPERTY_BUDGET_SECS` | Wall-clock budget per property in seconds (default `2`); raise it for deeper local or CI runs |
-| `ROUNDTRIP_PROPERTY_SEED` | Pin the chunk RNG seed to replay a failing chunk; the failure panic prints the seed to use |
+| `ROUNDTRIP_PROPERTY_SEED`        | Pin the chunk RNG seed to replay a failing chunk; the failure panic prints the seed to use    |
 
 #### Test Output and Logging
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -459,6 +459,15 @@ ClickHouse destination tests require a reachable ClickHouse HTTP endpoint:
 
 **Note:** ClickHouse tests are only run when the `clickhouse` and `test-utils` features are enabled. Each test creates a unique database in ClickHouse and drops it automatically when the test finishes. The Docker Compose setup started by `cargo x init` is sufficient for these tests.
 
+#### Value Roundtrip Property Test Variables
+
+The value roundtrip property tests in `crates/etl/tests/value_roundtrip.rs` run randomly generated cases against a real Postgres until a wall-clock budget elapses:
+
+| Variable | Description |
+|----------|-------------|
+| `ROUNDTRIP_PROPERTY_BUDGET_SECS` | Wall-clock budget per property in seconds (default `2`); raise it for deeper local or CI runs |
+| `ROUNDTRIP_PROPERTY_SEED` | Pin the chunk RNG seed to replay a failing chunk; the failure panic prints the seed to use |
+
 #### Test Output and Logging
 
 | Variable | Description |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -459,16 +459,17 @@ ClickHouse destination tests require a reachable ClickHouse HTTP endpoint:
 
 **Note:** ClickHouse tests are only run when the `clickhouse` and `test-utils` features are enabled. Each test creates a unique database in ClickHouse and drops it automatically when the test finishes. The Docker Compose setup started by `cargo x init` is sufficient for these tests.
 
-#### Value Roundtrip Property Test Variables
+#### Property Test Variables
 
-The value roundtrip property tests in
-`crates/etl/tests/value_roundtrip.rs` run randomly generated cases
-against a real Postgres until a wall-clock budget elapses:
+Property tests built on the shared runner in `etl::test_utils::property`
+(for example the value roundtrip tests in
+`crates/etl/tests/value_roundtrip.rs`) run randomly generated cases
+until a wall-clock budget elapses:
 
-| Variable                         | Description                                                                                   |
-|----------------------------------|-----------------------------------------------------------------------------------------------|
-| `ROUNDTRIP_PROPERTY_BUDGET_SECS` | Wall-clock budget per property in seconds (default `2`); raise it for deeper local or CI runs |
-| `ROUNDTRIP_PROPERTY_SEED`        | Pin the chunk RNG seed to replay a failing chunk; the failure panic prints the seed to use    |
+| Variable                    | Description                                                                                   |
+|-----------------------------|-----------------------------------------------------------------------------------------------|
+| `PROPERTY_TEST_BUDGET_SECS` | Wall-clock budget per property in seconds (default `2`); raise it for deeper local or CI runs |
+| `PROPERTY_TEST_SEED`        | Pin the chunk RNG seed to replay a failing chunk; the failure panic prints the seed to use    |
 
 #### Test Output and Logging
 

--- a/crates/etl-postgres/src/numeric.rs
+++ b/crates/etl-postgres/src/numeric.rs
@@ -482,9 +482,18 @@ fn format_numeric_value(
     scale: u16,
     digits: &[i16],
 ) -> std::fmt::Result {
-    // Handle zero case.
+    // Handle zero case. Postgres preserves the display scale of zero values,
+    // so `0.000` keeps its three fractional zeros.
     if digits.is_empty() {
-        return write!(f, "0");
+        write!(f, "0")?;
+        if scale > 0 {
+            write!(f, ".")?;
+            for _ in 0..scale {
+                write!(f, "0")?;
+            }
+        }
+
+        return Ok(());
     }
 
     // Output negative sign if needed.
@@ -742,9 +751,9 @@ mod tests {
 
     #[test]
     fn zero_canonicalization_basic() {
-        for s in ["0", "0.0", "000", "000.000"] {
+        for (s, expected) in [("0", "0"), ("0.0", "0.0"), ("000", "0"), ("000.000", "0.000")] {
             let num = PgNumeric::from_str(s).unwrap();
-            assert_eq!(num.to_string(), "0");
+            assert_eq!(num.to_string(), expected);
 
             if let PgNumeric::Value { sign, weight, scale: _, digits } = num {
                 assert_eq!(sign, Sign::Positive);
@@ -758,9 +767,9 @@ mod tests {
 
     #[test]
     fn zero_canonicalization_negative_zero() {
-        for s in ["-0", "-0.00"] {
+        for (s, expected) in [("-0", "0"), ("-0.00", "0.00")] {
             let num = PgNumeric::from_str(s).unwrap();
-            assert_eq!(num.to_string(), "0");
+            assert_eq!(num.to_string(), expected);
 
             if let PgNumeric::Value { sign, weight, scale: _, digits } = num {
                 // Normalize to positive zero.
@@ -770,6 +779,17 @@ mod tests {
             } else {
                 panic!("Expected Value variant");
             }
+        }
+    }
+
+    #[test]
+    fn zero_display_preserves_scale_from_exponent() {
+        // Regression for the value-roundtrip property: Postgres renders
+        // `0e-1` as `0.0`, so the display scale of zero must survive the
+        // parse/format roundtrip.
+        for (s, expected) in [("0e-1", "0.0"), ("0e-6", "0.000000"), ("0.00e-1", "0.000")] {
+            let num = PgNumeric::from_str(s).unwrap();
+            assert_eq!(num.to_string(), expected);
         }
     }
 

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -44,6 +44,7 @@ uuid = { workspace = true, features = ["v4"] }
 [dev-dependencies]
 etl-postgres = { workspace = true, features = ["tokio", "store", "test-utils"] }
 etl-telemetry = { workspace = true }
+proptest = { workspace = true }
 
 [[test]]
 name = "main"

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-test-utils = ["etl-postgres/test-utils"]
+test-utils = ["etl-postgres/test-utils", "dep:proptest"]
 failpoints = ["fail/failpoints"]
 egress = []
 fuzzing = []
@@ -29,6 +29,7 @@ metrics = { workspace = true }
 pg_escape = { workspace = true }
 pin-project-lite = { workspace = true }
 postgres-replication = { workspace = true }
+proptest = { workspace = true, optional = true }
 rand = { workspace = true, features = ["thread_rng"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
@@ -44,7 +45,6 @@ uuid = { workspace = true, features = ["v4"] }
 [dev-dependencies]
 etl-postgres = { workspace = true, features = ["tokio", "store", "test-utils"] }
 etl-telemetry = { workspace = true }
-proptest = { workspace = true }
 
 [[test]]
 name = "main"

--- a/crates/etl/src/postgres/codec/mod.rs
+++ b/crates/etl/src/postgres/codec/mod.rs
@@ -19,3 +19,5 @@ pub(crate) use event::{
 #[cfg(feature = "fuzzing")]
 pub(crate) use hex::parse_bytea_hex_string as parse_bytea_hex_string_for_fuzzing;
 pub(crate) use table_row::parse_table_row_from_postgres_copy_bytes;
+#[cfg(any(test, feature = "test-utils"))]
+pub(crate) use text::parse_cell_from_postgres_text;

--- a/crates/etl/src/test_utils/mod.rs
+++ b/crates/etl/src/test_utils/mod.rs
@@ -13,6 +13,10 @@ pub mod memory_destination;
 pub mod notify;
 pub mod notifying_store;
 pub mod pipeline;
+// Gated on the feature alone (not `cfg(test)`) because the runner needs the
+// optional `proptest` dependency that only the `test-utils` feature enables.
+#[cfg(feature = "test-utils")]
+pub mod property;
 pub mod replication_stream;
 pub mod schema;
 pub mod test_destination_wrapper;

--- a/crates/etl/src/test_utils/property.rs
+++ b/crates/etl/src/test_utils/property.rs
@@ -53,14 +53,11 @@ fn chunk_rng(seed: u64) -> TestRng {
 /// through a panic that also names the chunk seed, so the minimal failing
 /// input shows up in the test output and the chunk can be replayed with
 /// `PROPERTY_TEST_SEED`.
-pub fn run_property<S>(
+pub fn run_property<S: Strategy>(
     name: &str,
     strategy: &S,
     check: impl Fn(&S::Value) -> Result<(), TestCaseError>,
-) where
-    S: Strategy,
-    S::Value: std::fmt::Debug,
-{
+) {
     let deadline = Instant::now() + property_budget();
     let replay_seed = replay_seed();
     let mut total_cases = 0u64;

--- a/crates/etl/src/test_utils/property.rs
+++ b/crates/etl/src/test_utils/property.rs
@@ -1,0 +1,87 @@
+//! Budget-based property test runner.
+//!
+//! [`run_property`] runs freshly generated cases until a wall-clock budget
+//! elapses instead of a fixed case count. The budget comes from the
+//! `ROUNDTRIP_PROPERTY_BUDGET_SECS` environment variable (default 2), so a
+//! regular suite pays a few seconds per property while CI or local deep runs
+//! can raise it to minutes.
+//!
+//! On failure the panic names the failing chunk's RNG seed; set
+//! `ROUNDTRIP_PROPERTY_SEED` to that value to replay the chunk
+//! deterministically.
+
+use std::time::{Duration, Instant};
+
+use proptest::{
+    strategy::Strategy,
+    test_runner::{Config, RngAlgorithm, TestCaseError, TestRng, TestRunner},
+};
+
+/// Number of generated cases between deadline checks.
+const CASES_PER_CHUNK: u32 = 64;
+
+/// Returns the wall-clock budget for one property.
+fn property_budget() -> Duration {
+    let secs = std::env::var("ROUNDTRIP_PROPERTY_BUDGET_SECS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(2);
+
+    Duration::from_secs(secs)
+}
+
+/// Returns the pinned chunk seed from `ROUNDTRIP_PROPERTY_SEED`, if set.
+fn replay_seed() -> Option<u64> {
+    let value = std::env::var("ROUNDTRIP_PROPERTY_SEED").ok()?;
+    Some(value.parse().expect("ROUNDTRIP_PROPERTY_SEED must be a u64 seed"))
+}
+
+/// Builds the deterministic RNG for one chunk of cases from a `u64` seed.
+fn chunk_rng(seed: u64) -> TestRng {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&seed.to_le_bytes());
+    TestRng::from_seed(RngAlgorithm::ChaCha, &bytes)
+}
+
+/// Runs `check` on freshly generated values until the property budget elapses.
+///
+/// Each chunk runs a fixed number of cases (`CASES_PER_CHUNK`) from a fresh
+/// random seed. On failure the value is shrunk by proptest and reported
+/// through a panic that also names the chunk seed, so the minimal failing
+/// input shows up in the test output and the chunk can be replayed with
+/// `ROUNDTRIP_PROPERTY_SEED`.
+pub fn run_property<S>(
+    name: &str,
+    strategy: &S,
+    check: impl Fn(&S::Value) -> Result<(), TestCaseError>,
+) where
+    S: Strategy,
+    S::Value: std::fmt::Debug,
+{
+    let deadline = Instant::now() + property_budget();
+    let replay_seed = replay_seed();
+    let mut total_cases = 0u64;
+
+    loop {
+        let seed = replay_seed.unwrap_or_else(rand::random);
+        let config =
+            Config { cases: CASES_PER_CHUNK, failure_persistence: None, ..Default::default() };
+        let mut runner = TestRunner::new_with_rng(config, chunk_rng(seed));
+
+        match runner.run(strategy, |value| check(&value)) {
+            Ok(()) => total_cases += u64::from(CASES_PER_CHUNK),
+            Err(err) => panic!(
+                "property '{name}' failed after ~{total_cases} passing cases; rerun with \
+                 ROUNDTRIP_PROPERTY_SEED={seed} to replay the failing chunk:\n{err}"
+            ),
+        }
+
+        // A pinned replay seed regenerates the same cases, so it runs exactly
+        // one chunk.
+        if replay_seed.is_some() || Instant::now() >= deadline {
+            break;
+        }
+    }
+
+    println!("property '{name}': {total_cases} cases passed");
+}

--- a/crates/etl/src/test_utils/property.rs
+++ b/crates/etl/src/test_utils/property.rs
@@ -21,11 +21,14 @@ use proptest::{
 const CASES_PER_CHUNK: u32 = 64;
 
 /// Returns the wall-clock budget for one property.
+///
+/// Panics on a malformed value instead of falling back to the default, so a
+/// deep run with a typoed budget fails loudly rather than silently running
+/// the shallow default.
 fn property_budget() -> Duration {
-    let secs = std::env::var("PROPERTY_TEST_BUDGET_SECS")
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(2);
+    let secs = std::env::var("PROPERTY_TEST_BUDGET_SECS").map_or(2, |value| {
+        value.parse().expect("PROPERTY_TEST_BUDGET_SECS must be an integer number of seconds")
+    });
 
     Duration::from_secs(secs)
 }

--- a/crates/etl/src/test_utils/property.rs
+++ b/crates/etl/src/test_utils/property.rs
@@ -2,12 +2,12 @@
 //!
 //! [`run_property`] runs freshly generated cases until a wall-clock budget
 //! elapses instead of a fixed case count. The budget comes from the
-//! `ROUNDTRIP_PROPERTY_BUDGET_SECS` environment variable (default 2), so a
+//! `PROPERTY_TEST_BUDGET_SECS` environment variable (default 2), so a
 //! regular suite pays a few seconds per property while CI or local deep runs
 //! can raise it to minutes.
 //!
 //! On failure the panic names the failing chunk's RNG seed; set
-//! `ROUNDTRIP_PROPERTY_SEED` to that value to replay the chunk
+//! `PROPERTY_TEST_SEED` to that value to replay the chunk
 //! deterministically.
 
 use std::time::{Duration, Instant};
@@ -22,7 +22,7 @@ const CASES_PER_CHUNK: u32 = 64;
 
 /// Returns the wall-clock budget for one property.
 fn property_budget() -> Duration {
-    let secs = std::env::var("ROUNDTRIP_PROPERTY_BUDGET_SECS")
+    let secs = std::env::var("PROPERTY_TEST_BUDGET_SECS")
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(2);
@@ -30,10 +30,10 @@ fn property_budget() -> Duration {
     Duration::from_secs(secs)
 }
 
-/// Returns the pinned chunk seed from `ROUNDTRIP_PROPERTY_SEED`, if set.
+/// Returns the pinned chunk seed from `PROPERTY_TEST_SEED`, if set.
 fn replay_seed() -> Option<u64> {
-    let value = std::env::var("ROUNDTRIP_PROPERTY_SEED").ok()?;
-    Some(value.parse().expect("ROUNDTRIP_PROPERTY_SEED must be a u64 seed"))
+    let value = std::env::var("PROPERTY_TEST_SEED").ok()?;
+    Some(value.parse().expect("PROPERTY_TEST_SEED must be a u64 seed"))
 }
 
 /// Builds the deterministic RNG for one chunk of cases from a `u64` seed.
@@ -49,7 +49,7 @@ fn chunk_rng(seed: u64) -> TestRng {
 /// random seed. On failure the value is shrunk by proptest and reported
 /// through a panic that also names the chunk seed, so the minimal failing
 /// input shows up in the test output and the chunk can be replayed with
-/// `ROUNDTRIP_PROPERTY_SEED`.
+/// `PROPERTY_TEST_SEED`.
 pub fn run_property<S>(
     name: &str,
     strategy: &S,
@@ -72,7 +72,7 @@ pub fn run_property<S>(
             Ok(()) => total_cases += u64::from(CASES_PER_CHUNK),
             Err(err) => panic!(
                 "property '{name}' failed after ~{total_cases} passing cases; rerun with \
-                 ROUNDTRIP_PROPERTY_SEED={seed} to replay the failing chunk:\n{err}"
+                 PROPERTY_TEST_SEED={seed} to replay the failing chunk:\n{err}"
             ),
         }
 

--- a/crates/etl/src/test_utils/replication_stream.rs
+++ b/crates/etl/src/test_utils/replication_stream.rs
@@ -1,11 +1,15 @@
 //! Helpers for asserting replication stream conversions in integration tests.
 
 use postgres_replication::protocol::TupleData;
+use tokio_postgres::types::Type;
 
 use crate::{
-    data::TableRow,
+    data::{Cell, TableRow},
     error::EtlResult,
-    postgres::codec::{convert_tuple_to_row, parse_table_row_from_postgres_copy_bytes},
+    postgres::codec::{
+        convert_tuple_to_row, parse_cell_from_postgres_text,
+        parse_table_row_from_postgres_copy_bytes,
+    },
     schema::ColumnSchema,
 };
 
@@ -20,4 +24,10 @@ pub fn parse_tuple(
     column_schemas: &[ColumnSchema],
 ) -> EtlResult<TableRow> {
     convert_tuple_to_row(column_schemas.iter(), tuple_data)
+}
+
+/// Parses a single Postgres text-format value with the production conversion
+/// path.
+pub fn parse_text_cell(typ: &Type, value: &str) -> EtlResult<Cell> {
+    parse_cell_from_postgres_text(typ, value)
 }

--- a/crates/etl/tests/main.rs
+++ b/crates/etl/tests/main.rs
@@ -13,3 +13,4 @@ mod postgres_store;
 mod replication;
 mod replication_stream;
 mod support;
+mod value_roundtrip;

--- a/crates/etl/tests/value_roundtrip.rs
+++ b/crates/etl/tests/value_roundtrip.rs
@@ -8,8 +8,8 @@
 //!
 //! Every property runs new random cases until a wall-clock budget elapses,
 //! using the shared runner in `etl::test_utils::property`. See that module
-//! for the `ROUNDTRIP_PROPERTY_BUDGET_SECS` budget knob and the
-//! `ROUNDTRIP_PROPERTY_SEED` failure replay knob.
+//! for the `PROPERTY_TEST_BUDGET_SECS` budget knob and the
+//! `PROPERTY_TEST_SEED` failure replay knob.
 //!
 //! Known codec gaps stay outside the generated envelope and are documented on
 //! the strategies that would otherwise reach them: temporal `infinity`

--- a/crates/etl/tests/value_roundtrip.rs
+++ b/crates/etl/tests/value_roundtrip.rs
@@ -6,14 +6,19 @@
 //! Postgres stores. Postgres itself is the oracle, so these properties catch
 //! silent value corruption, not just parser panics.
 //!
-//! Every property runs new random cases until its wall-clock budget elapses.
-//! The budget comes from `ROUNDTRIP_PROPERTY_BUDGET_SECS` (default 3), so the
+//! Every property runs new random cases until a wall-clock budget elapses.
+//! The budget comes from `ROUNDTRIP_PROPERTY_BUDGET_SECS` (default 2), so the
 //! regular suite pays a few seconds per property while CI chaos jobs or local
 //! deep runs can raise it to minutes.
+//!
+//! Known codec gaps stay outside the generated envelope and are documented on
+//! the strategies that would otherwise reach them: temporal `infinity`
+//! values, `BC` dates, and years above 9999 are all legal in Postgres but are
+//! rejected by the codec today.
 
 use std::time::{Duration, Instant};
 
-use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use etl::{
     data::{ArrayCell, Cell},
     schema::ColumnSchema,
@@ -22,13 +27,15 @@ use etl::{
         replication_stream::{parse_copy_row, parse_text_cell},
     },
 };
+use etl_postgres::time::PgTimeTz;
 use etl_telemetry::tracing::init_test_tracing;
 use futures::StreamExt;
 use proptest::{option, prelude::*, test_runner::TestRunner as PropTestRunner};
 use tokio_postgres::{
     Client, Statement,
-    types::{ToSql, Type},
+    types::{Kind, ToSql, Type},
 };
+use uuid::Uuid;
 
 /// Number of generated cases between deadline checks.
 const CASES_PER_CHUNK: u32 = 64;
@@ -38,7 +45,7 @@ fn property_budget() -> Duration {
     let secs = std::env::var("ROUNDTRIP_PROPERTY_BUDGET_SECS")
         .ok()
         .and_then(|value| value.parse().ok())
-        .unwrap_or(3);
+        .unwrap_or(2);
 
     Duration::from_secs(secs)
 }
@@ -93,9 +100,27 @@ fn query_text(
     statement: &Statement,
     params: &[&(dyn ToSql + Sync)],
 ) -> Result<String, TestCaseError> {
+    query_texts(client, statement, params).map(|mut texts| texts.remove(0))
+}
+
+/// Fetches all text columns of the single row the statement returns.
+fn query_texts(
+    client: &Client,
+    statement: &Statement,
+    params: &[&(dyn ToSql + Sync)],
+) -> Result<Vec<String>, TestCaseError> {
     block_on(client.query_one(statement, params))
-        .map(|row| row.get(0))
+        .map(|row| (0..row.len()).map(|index| row.get(index)).collect())
         .map_err(|err| TestCaseError::fail(format!("postgres query failed: {err}")))
+}
+
+/// Parses one rendered text value and asserts it equals the expected cell.
+fn assert_parses_to(typ: &Type, rendered: &str, expected: &Cell) -> Result<(), TestCaseError> {
+    let cell = parse_text_cell(typ, rendered)
+        .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+
+    prop_assert_eq!(&cell, expected);
+    Ok(())
 }
 
 /// Strings that are valid Postgres `text` values (no NUL bytes).
@@ -118,11 +143,11 @@ async fn text_array_values_roundtrip_through_text_codec() {
 
     run_property("text[] text roundtrip", &pg_text_array(), |values| {
         let rendered = query_text(client, &render, &[values])?;
-        let cell = parse_text_cell(&Type::TEXT_ARRAY, &rendered)
-            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
-
-        prop_assert_eq!(&cell, &Cell::Array(ArrayCell::String(values.clone())));
-        Ok(())
+        assert_parses_to(
+            &Type::TEXT_ARRAY,
+            &rendered,
+            &Cell::Array(ArrayCell::String(values.clone())),
+        )
     });
 }
 
@@ -137,10 +162,113 @@ async fn int8_array_values_roundtrip_through_text_codec() {
     let strategy = proptest::collection::vec(option::of(any::<i64>()), 0..=8);
     run_property("int8[] text roundtrip", &strategy, |values| {
         let rendered = query_text(client, &render, &[values])?;
-        let cell = parse_text_cell(&Type::INT8_ARRAY, &rendered)
-            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+        assert_parses_to(&Type::INT8_ARRAY, &rendered, &Cell::Array(ArrayCell::I64(values.clone())))
+    });
+}
 
-        prop_assert_eq!(&cell, &Cell::Array(ArrayCell::I64(values.clone())));
+#[tokio::test(flavor = "multi_thread")]
+async fn scalar_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client
+        .prepare("select ($1::int2)::text, ($2::int4)::text, ($3::oid)::text, ($4::uuid)::text")
+        .await
+        .unwrap();
+
+    // `bool` is deliberately absent: the `bool::text` cast renders
+    // `true`/`false` through a dedicated cast function, while replication and
+    // COPY carry the `boolout` output function's `t`/`f`. The COPY property
+    // covers booleans on the representative path.
+    let strategy =
+        (any::<i16>(), any::<i32>(), any::<u32>(), any::<u128>().prop_map(Uuid::from_u128));
+    run_property("scalar text roundtrip", &strategy, |(i16v, i32v, oid, uuid)| {
+        let rendered = query_texts(client, &render, &[i16v, i32v, oid, uuid])?;
+        assert_parses_to(&Type::INT2, &rendered[0], &Cell::I16(*i16v))?;
+        assert_parses_to(&Type::INT4, &rendered[1], &Cell::I32(*i32v))?;
+        assert_parses_to(&Type::OID, &rendered[2], &Cell::U32(*oid))?;
+        assert_parses_to(&Type::UUID, &rendered[3], &Cell::Uuid(*uuid))
+    });
+}
+
+/// Compares floats bit-for-bit, treating every NaN payload as equal.
+///
+/// Postgres renders every NaN as `NaN`, so payload bits cannot survive the
+/// text roundtrip; sign and value bits of all other floats must.
+fn f64_matches(expected: f64, parsed: f64) -> bool {
+    if expected.is_nan() { parsed.is_nan() } else { expected.to_bits() == parsed.to_bits() }
+}
+
+/// [`f64_matches`] for `f32`.
+fn f32_matches(expected: f32, parsed: f32) -> bool {
+    if expected.is_nan() { parsed.is_nan() } else { expected.to_bits() == parsed.to_bits() }
+}
+
+/// All `f64` bit patterns: normals, subnormals, zeros, infinities, NaNs.
+fn any_f64() -> impl Strategy<Value = f64> {
+    any::<u64>().prop_map(f64::from_bits)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn float_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::float8)::text, ($2::float4)::text").await.unwrap();
+
+    let strategy = (any_f64(), any::<u32>().prop_map(f32::from_bits));
+    run_property("float text roundtrip", &strategy, |(f64v, f32v)| {
+        let rendered = query_texts(client, &render, &[f64v, f32v])?;
+
+        let Cell::F64(parsed64) = parse_text_cell(&Type::FLOAT8, &rendered[0]).map_err(|err| {
+            TestCaseError::fail(format!("codec rejected {:?}: {err}", rendered[0]))
+        })?
+        else {
+            return Err(TestCaseError::fail("expected f64 cell"));
+        };
+        prop_assert!(f64_matches(*f64v, parsed64), "float8 {f64v:?} parsed as {parsed64:?}");
+
+        let Cell::F32(parsed32) = parse_text_cell(&Type::FLOAT4, &rendered[1]).map_err(|err| {
+            TestCaseError::fail(format!("codec rejected {:?}: {err}", rendered[1]))
+        })?
+        else {
+            return Err(TestCaseError::fail("expected f32 cell"));
+        };
+        prop_assert!(f32_matches(*f32v, parsed32), "float4 {f32v:?} parsed as {parsed32:?}");
+        Ok(())
+    });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn float8_array_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::float8[])::text").await.unwrap();
+
+    let strategy = proptest::collection::vec(option::of(any_f64()), 0..=8);
+    run_property("float8[] text roundtrip", &strategy, |values| {
+        let rendered = query_text(client, &render, &[values])?;
+        let Cell::Array(ArrayCell::F64(parsed)) = parse_text_cell(&Type::FLOAT8_ARRAY, &rendered)
+            .map_err(|err| {
+            TestCaseError::fail(format!("codec rejected {rendered:?}: {err}"))
+        })?
+        else {
+            return Err(TestCaseError::fail("expected f64 array cell"));
+        };
+
+        prop_assert_eq!(parsed.len(), values.len());
+        for (expected, parsed) in values.iter().zip(&parsed) {
+            let matches = match (expected, parsed) {
+                (None, None) => true,
+                (Some(expected), Some(parsed)) => f64_matches(*expected, *parsed),
+                _ => false,
+            };
+            prop_assert!(matches, "float8[] {expected:?} parsed as {parsed:?}");
+        }
         Ok(())
     });
 }
@@ -208,7 +336,13 @@ async fn numeric_values_roundtrip_through_text_codec() {
     });
 }
 
-/// Dates over the full four-digit ISO year range.
+/// Dates over the four-digit ISO year range.
+///
+/// Postgres also legally emits `BC`-suffixed years and years above 9999
+/// (dates up to year 5874897, timestamps up to 294276), plus the special
+/// `infinity`/`-infinity` values, but the codec rejects all of them today.
+/// They stay outside the generated envelope until the codec handles them; see
+/// the findings recorded with this harness.
 fn pg_date() -> impl Strategy<Value = NaiveDate> {
     let min = NaiveDate::from_ymd_opt(1, 1, 1).unwrap().num_days_from_ce();
     let max = NaiveDate::from_ymd_opt(9999, 12, 31).unwrap().num_days_from_ce();
@@ -233,11 +367,36 @@ async fn date_values_roundtrip_through_text_codec() {
 
     run_property("date text roundtrip", &pg_date(), |date| {
         let rendered = query_text(client, &render, &[date])?;
-        let cell = parse_text_cell(&Type::DATE, &rendered)
-            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+        assert_parses_to(&Type::DATE, &rendered, &Cell::Date(*date))
+    });
+}
 
-        prop_assert_eq!(&cell, &Cell::Date(*date));
-        Ok(())
+#[tokio::test(flavor = "multi_thread")]
+async fn time_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::time)::text").await.unwrap();
+
+    run_property("time text roundtrip", &pg_time(), |time| {
+        let rendered = query_text(client, &render, &[time])?;
+        assert_parses_to(&Type::TIME, &rendered, &Cell::Time(*time))
+    });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timestamp_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::timestamp)::text").await.unwrap();
+
+    let strategy = (pg_date(), pg_time()).prop_map(|(date, time)| NaiveDateTime::new(date, time));
+    run_property("timestamp text roundtrip", &strategy, |timestamp| {
+        let rendered = query_text(client, &render, &[timestamp])?;
+        assert_parses_to(&Type::TIMESTAMP, &rendered, &Cell::Timestamp(*timestamp))
     });
 }
 
@@ -254,11 +413,210 @@ async fn timestamptz_values_roundtrip_through_text_codec() {
     });
     run_property("timestamptz text roundtrip", &strategy, |timestamp| {
         let rendered = query_text(client, &render, &[timestamp])?;
-        let cell = parse_text_cell(&Type::TIMESTAMPTZ, &rendered)
-            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+        assert_parses_to(&Type::TIMESTAMPTZ, &rendered, &Cell::TimestampTz(*timestamp))
+    });
+}
 
-        prop_assert_eq!(&cell, &Cell::TimestampTz(*timestamp));
-        Ok(())
+#[tokio::test(flavor = "multi_thread")]
+async fn timestamptz_array_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::timestamptz[])::text").await.unwrap();
+
+    // Rendered timestamptz array elements contain spaces, so they exercise
+    // the quoted-element path of the array parser.
+    let element = (pg_date(), pg_time()).prop_map(|(date, time)| {
+        DateTime::<Utc>::from_naive_utc_and_offset(NaiveDateTime::new(date, time), Utc)
+    });
+    let strategy = proptest::collection::vec(option::of(element), 0..=8);
+    run_property("timestamptz[] text roundtrip", &strategy, |values| {
+        let rendered = query_text(client, &render, &[values])?;
+        assert_parses_to(
+            &Type::TIMESTAMPTZ_ARRAY,
+            &rendered,
+            &Cell::Array(ArrayCell::TimestampTz(values.clone())),
+        )
+    });
+}
+
+/// Formats a Postgres `time with time zone` input literal.
+///
+/// Offsets cover the full Postgres range including a seconds component.
+fn timetz_literal(time: &NaiveTime, offset_seconds: i32) -> String {
+    let sign = if offset_seconds < 0 { '-' } else { '+' };
+    let abs = offset_seconds.unsigned_abs();
+
+    format!(
+        "{}{}{:02}:{:02}:{:02}",
+        time.format("%H:%M:%S%.6f"),
+        sign,
+        abs / 3600,
+        abs % 3600 / 60,
+        abs % 60
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timetz_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::text::timetz)::text").await.unwrap();
+
+    let strategy = (pg_time(), -57_599i32..=57_599);
+    run_property("timetz text roundtrip", &strategy, |(time, offset_seconds)| {
+        let literal = timetz_literal(time, *offset_seconds);
+        let rendered = query_text(client, &render, &[&literal])?;
+        let expected = PgTimeTz::new(*time, FixedOffset::east_opt(*offset_seconds).unwrap());
+        assert_parses_to(&Type::TIMETZ, &rendered, &Cell::TimeTz(expected))
+    });
+}
+
+/// JSON documents whose text form is stable through jsonb normalization:
+/// no floats (jsonb canonicalizes numeric text) and no NUL escapes (jsonb
+/// rejects them).
+fn jsonb_value() -> impl Strategy<Value = serde_json::Value> {
+    let leaf = prop_oneof![
+        Just(serde_json::Value::Null),
+        any::<bool>().prop_map(serde_json::Value::from),
+        any::<i64>().prop_map(serde_json::Value::from),
+        pg_text().prop_map(serde_json::Value::from),
+    ];
+
+    leaf.prop_recursive(3, 24, 6, |inner| {
+        prop_oneof![
+            proptest::collection::vec(inner.clone(), 0..=6).prop_map(serde_json::Value::from),
+            proptest::collection::btree_map(pg_text(), inner, 0..=6)
+                .prop_map(|map| serde_json::Value::Object(map.into_iter().collect())),
+        ]
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn jsonb_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::jsonb)::text").await.unwrap();
+
+    run_property("jsonb text roundtrip", &jsonb_value(), |value| {
+        let rendered = query_text(client, &render, &[value])?;
+        assert_parses_to(&Type::JSONB, &rendered, &Cell::Json(value.clone()))
+    });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bytea_array_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::bytea[])::text").await.unwrap();
+
+    // Rendered bytea array elements are quoted hex strings with doubled
+    // backslashes, so they exercise the escape path of the array parser
+    // feeding into the hex parser.
+    let strategy = proptest::collection::vec(
+        option::of(proptest::collection::vec(any::<u8>(), 0..=16)),
+        0..=8,
+    );
+    run_property("bytea[] text roundtrip", &strategy, |values| {
+        let rendered = query_text(client, &render, &[values])?;
+        assert_parses_to(
+            &Type::BYTEA_ARRAY,
+            &rendered,
+            &Cell::Array(ArrayCell::Bytes(values.clone())),
+        )
+    });
+}
+
+/// Enum labels valid for `create type ... as enum`: 1 to 63 bytes, no NUL.
+fn enum_label() -> impl Strategy<Value = String> {
+    any::<String>().prop_filter("enum labels are 1-63 bytes without NUL", |s| {
+        !s.is_empty() && s.len() <= 63 && !s.contains('\0')
+    })
+}
+
+/// Builds the enum and enum-array [`Type`]s the replication path would
+/// construct from the catalog for a custom enum.
+fn enum_types(labels: Vec<String>, oid: u32, array_oid: u32) -> (Type, Type) {
+    let element = Type::new("prop_enum".to_owned(), oid, Kind::Enum(labels), "test".to_owned());
+    let array = Type::new(
+        "_prop_enum".to_owned(),
+        array_oid,
+        Kind::Array(element.clone()),
+        "test".to_owned(),
+    );
+
+    (element, array)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn enum_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+
+    // Labels index into the set; the scalar pick and the array picks choose
+    // labels by index so they always name existing enum values.
+    let strategy = (
+        proptest::collection::btree_set(enum_label(), 1..=6),
+        any::<prop::sample::Index>(),
+        proptest::collection::vec(option::of(any::<prop::sample::Index>()), 0..=6),
+    );
+    run_property("enum text roundtrip", &strategy, |(labels, pick, array_picks)| {
+        let labels: Vec<String> = labels.iter().cloned().collect();
+        let scalar = labels[pick.index(labels.len())].clone();
+        let array: Vec<Option<String>> = array_picks
+            .iter()
+            .map(|pick| pick.as_ref().map(|pick| labels[pick.index(labels.len())].clone()))
+            .collect();
+
+        let quoted_labels =
+            labels.iter().map(|label| pg_escape::quote_literal(label)).collect::<Vec<_>>();
+        let (oid, array_oid, rendered_scalar, rendered_array) = block_on(async {
+            client.execute("drop type if exists test.prop_enum cascade", &[]).await?;
+            client
+                .execute(
+                    &format!("create type test.prop_enum as enum ({})", quoted_labels.join(", ")),
+                    &[],
+                )
+                .await?;
+
+            let row = client
+                .query_one(
+                    "select t.oid, t.typarray from pg_type t join pg_namespace n on n.oid = \
+                     t.typnamespace where t.typname = 'prop_enum' and n.nspname = 'test'",
+                    &[],
+                )
+                .await?;
+            let oid: u32 = row.get(0);
+            let array_oid: u32 = row.get(1);
+
+            let row = client
+                .query_one(
+                    "select ($1::text)::test.prop_enum::text, ($2::text[])::test.prop_enum[]::text",
+                    &[&scalar, &array],
+                )
+                .await?;
+
+            Ok::<_, tokio_postgres::Error>((
+                oid,
+                array_oid,
+                row.get::<_, String>(0),
+                row.get::<_, String>(1),
+            ))
+        })
+        .map_err(|err| TestCaseError::fail(format!("postgres enum setup failed: {err}")))?;
+
+        let (enum_type, enum_array_type) = enum_types(labels, oid, array_oid);
+        assert_parses_to(&enum_type, &rendered_scalar, &Cell::String(scalar))?;
+        assert_parses_to(&enum_array_type, &rendered_array, &Cell::Array(ArrayCell::String(array)))
     });
 }
 
@@ -281,23 +639,47 @@ async fn copy_rows_roundtrip_through_copy_codec() {
     let database = spawn_source_database().await;
     let client = database.client.as_ref().unwrap();
     client
-        .execute("create table test.copy_roundtrip (a text, b text[], c int8)", &[])
+        .execute(
+            "create table test.copy_roundtrip (a text, b text[], c int8, d float8, e timestamptz, \
+             f bytea, g bool)",
+            &[],
+        )
         .await
         .unwrap();
-    let insert =
-        client.prepare("insert into test.copy_roundtrip values ($1, $2, $3)").await.unwrap();
+    let insert = client
+        .prepare("insert into test.copy_roundtrip values ($1, $2, $3, $4, $5, $6, $7)")
+        .await
+        .unwrap();
 
     let column_schemas = vec![
         ColumnSchema::new("a".to_owned(), Type::TEXT, -1, 1, true),
         ColumnSchema::new("b".to_owned(), Type::TEXT_ARRAY, -1, 2, true),
         ColumnSchema::new("c".to_owned(), Type::INT8, -1, 3, true),
+        ColumnSchema::new("d".to_owned(), Type::FLOAT8, -1, 4, true),
+        ColumnSchema::new("e".to_owned(), Type::TIMESTAMPTZ, -1, 5, true),
+        ColumnSchema::new("f".to_owned(), Type::BYTEA, -1, 6, true),
+        ColumnSchema::new("g".to_owned(), Type::BOOL, -1, 7, true),
     ];
 
-    let strategy = (option::of(pg_text()), option::of(pg_text_array()), option::of(any::<i64>()));
-    run_property("copy row roundtrip", &strategy, |(text, array, int)| {
+    // NaN is excluded because expected-value comparison uses Cell equality;
+    // the float property covers NaN with bit-level comparison.
+    let float = any_f64().prop_filter("NaN breaks Cell equality", |f| !f.is_nan());
+    let timestamptz = (pg_date(), pg_time()).prop_map(|(date, time)| {
+        DateTime::<Utc>::from_naive_utc_and_offset(NaiveDateTime::new(date, time), Utc)
+    });
+    let strategy = (
+        option::of(pg_text()),
+        option::of(pg_text_array()),
+        option::of(any::<i64>()),
+        option::of(float),
+        option::of(timestamptz),
+        option::of(proptest::collection::vec(any::<u8>(), 0..=16)),
+        option::of(any::<bool>()),
+    );
+    run_property("copy row roundtrip", &strategy, |(text, array, int, float, tstz, bytes, b)| {
         let row_bytes = block_on(async {
             client.execute("delete from test.copy_roundtrip", &[]).await?;
-            client.execute(&insert, &[text, array, int]).await?;
+            client.execute(&insert, &[text, array, int, float, tstz, bytes, b]).await?;
             copy_single_row(client, "copy test.copy_roundtrip to stdout").await
         })
         .map_err(|err| TestCaseError::fail(format!("postgres copy failed: {err}")))?;
@@ -310,6 +692,10 @@ async fn copy_rows_roundtrip_through_copy_codec() {
             text.clone().map_or(Cell::Null, Cell::String),
             array.clone().map_or(Cell::Null, |values| Cell::Array(ArrayCell::String(values))),
             int.map_or(Cell::Null, Cell::I64),
+            float.map_or(Cell::Null, Cell::F64),
+            tstz.map_or(Cell::Null, Cell::TimestampTz),
+            bytes.clone().map_or(Cell::Null, Cell::Bytes),
+            b.map_or(Cell::Null, Cell::Bool),
         ];
         prop_assert_eq!(row.values(), expected.as_slice());
         Ok(())

--- a/crates/etl/tests/value_roundtrip.rs
+++ b/crates/etl/tests/value_roundtrip.rs
@@ -1,0 +1,317 @@
+//! Differential roundtrip properties for the Postgres text codec.
+//!
+//! Each property generates typed values, has a real Postgres render them in
+//! the text format that replication tuples and COPY carry, parses that text
+//! with the production codec, and asserts the parsed cell equals the value
+//! Postgres stores. Postgres itself is the oracle, so these properties catch
+//! silent value corruption, not just parser panics.
+//!
+//! Every property runs new random cases until its wall-clock budget elapses.
+//! The budget comes from `ROUNDTRIP_PROPERTY_BUDGET_SECS` (default 3), so the
+//! regular suite pays a few seconds per property while CI chaos jobs or local
+//! deep runs can raise it to minutes.
+
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use etl::{
+    data::{ArrayCell, Cell},
+    schema::ColumnSchema,
+    test_utils::{
+        database::spawn_source_database,
+        replication_stream::{parse_copy_row, parse_text_cell},
+    },
+};
+use etl_telemetry::tracing::init_test_tracing;
+use futures::StreamExt;
+use proptest::{option, prelude::*, test_runner::TestRunner as PropTestRunner};
+use tokio_postgres::{
+    Client, Statement,
+    types::{ToSql, Type},
+};
+
+/// Number of generated cases between deadline checks.
+const CASES_PER_CHUNK: u32 = 64;
+
+/// Returns the wall-clock budget for one property.
+fn property_budget() -> Duration {
+    let secs = std::env::var("ROUNDTRIP_PROPERTY_BUDGET_SECS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(3);
+
+    Duration::from_secs(secs)
+}
+
+/// Runs `check` on freshly generated values until the property budget elapses.
+///
+/// Each chunk uses a new random seed. On failure the value is shrunk by
+/// proptest and reported through a panic, so the minimal failing input shows
+/// up in the test output and can be turned into a regression test.
+fn run_property<S>(name: &str, strategy: &S, check: impl Fn(&S::Value) -> Result<(), TestCaseError>)
+where
+    S: Strategy,
+    S::Value: std::fmt::Debug,
+{
+    let deadline = Instant::now() + property_budget();
+    let mut total_cases = 0u64;
+
+    loop {
+        let mut runner = PropTestRunner::new(proptest::test_runner::Config {
+            cases: CASES_PER_CHUNK,
+            failure_persistence: None,
+            ..Default::default()
+        });
+
+        match runner.run(strategy, |value| check(&value)) {
+            Ok(()) => total_cases += u64::from(CASES_PER_CHUNK),
+            Err(err) => {
+                panic!("property '{name}' failed after ~{total_cases} passing cases:\n{err}")
+            }
+        }
+
+        if Instant::now() >= deadline {
+            break;
+        }
+    }
+
+    println!("property '{name}': {total_cases} cases passed");
+}
+
+/// Runs an async future to completion from inside a synchronous proptest
+/// closure.
+///
+/// Properties execute on a multi-threaded Tokio runtime worker, so blocking in
+/// place is safe and keeps the database connection driven.
+fn block_on<F: Future>(future: F) -> F::Output {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+}
+
+/// Fetches the single text column the statement returns.
+fn query_text(
+    client: &Client,
+    statement: &Statement,
+    params: &[&(dyn ToSql + Sync)],
+) -> Result<String, TestCaseError> {
+    block_on(client.query_one(statement, params))
+        .map(|row| row.get(0))
+        .map_err(|err| TestCaseError::fail(format!("postgres query failed: {err}")))
+}
+
+/// Strings that are valid Postgres `text` values (no NUL bytes).
+fn pg_text() -> impl Strategy<Value = String> {
+    any::<String>().prop_filter("postgres text cannot contain NUL", |s| !s.contains('\0'))
+}
+
+/// Nullable-element arrays of Postgres `text` values.
+fn pg_text_array() -> impl Strategy<Value = Vec<Option<String>>> {
+    proptest::collection::vec(option::of(pg_text()), 0..=8)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn text_array_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::text[])::text").await.unwrap();
+
+    run_property("text[] text roundtrip", &pg_text_array(), |values| {
+        let rendered = query_text(client, &render, &[values])?;
+        let cell = parse_text_cell(&Type::TEXT_ARRAY, &rendered)
+            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+
+        prop_assert_eq!(&cell, &Cell::Array(ArrayCell::String(values.clone())));
+        Ok(())
+    });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn int8_array_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::int8[])::text").await.unwrap();
+
+    let strategy = proptest::collection::vec(option::of(any::<i64>()), 0..=8);
+    run_property("int8[] text roundtrip", &strategy, |values| {
+        let rendered = query_text(client, &render, &[values])?;
+        let cell = parse_text_cell(&Type::INT8_ARRAY, &rendered)
+            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+
+        prop_assert_eq!(&cell, &Cell::Array(ArrayCell::I64(values.clone())));
+        Ok(())
+    });
+}
+
+/// Decimal literal strings covering integers, fractions, scientific notation,
+/// and the numeric specials.
+fn numeric_literal() -> impl Strategy<Value = String> {
+    let digits = |max: usize| proptest::collection::vec(0u8..=9, 1..=max);
+
+    let finite = (any::<bool>(), digits(45), option::of(digits(45)), option::of(-60i32..=60))
+        .prop_map(|(negative, int_digits, frac_digits, exponent)| {
+            let mut literal = String::new();
+            if negative {
+                literal.push('-');
+            }
+            for digit in int_digits {
+                literal.push((b'0' + digit) as char);
+            }
+            if let Some(frac_digits) = frac_digits {
+                literal.push('.');
+                for digit in frac_digits {
+                    literal.push((b'0' + digit) as char);
+                }
+            }
+            if let Some(exponent) = exponent {
+                literal.push('e');
+                literal.push_str(&exponent.to_string());
+            }
+
+            literal
+        });
+
+    prop_oneof![
+        45 => finite,
+        1 => Just("NaN".to_owned()),
+        1 => Just("Infinity".to_owned()),
+        1 => Just("-Infinity".to_owned()),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn numeric_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::text::numeric)::text").await.unwrap();
+
+    run_property("numeric text roundtrip", &numeric_literal(), |literal| {
+        let rendered = query_text(client, &render, &[literal])?;
+        let cell = parse_text_cell(&Type::NUMERIC, &rendered)
+            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+        let Cell::Numeric(numeric) = &cell else {
+            return Err(TestCaseError::fail(format!("expected numeric cell, got {cell:?}")));
+        };
+
+        // The parsed value must serialize back to exactly the canonical text
+        // Postgres produced, and re-parsing that text must be stable.
+        prop_assert_eq!(&numeric.to_string(), &rendered);
+        let reparsed = parse_text_cell(&Type::NUMERIC, &numeric.to_string()).map_err(|err| {
+            TestCaseError::fail(format!("codec rejected its own output {numeric}: {err}"))
+        })?;
+        prop_assert_eq!(&reparsed, &cell);
+        Ok(())
+    });
+}
+
+/// Dates over the full four-digit ISO year range.
+fn pg_date() -> impl Strategy<Value = NaiveDate> {
+    let min = NaiveDate::from_ymd_opt(1, 1, 1).unwrap().num_days_from_ce();
+    let max = NaiveDate::from_ymd_opt(9999, 12, 31).unwrap().num_days_from_ce();
+
+    (min..=max).prop_map(|days| NaiveDate::from_num_days_from_ce_opt(days).unwrap())
+}
+
+/// Microsecond-precision times of day, matching Postgres's time resolution.
+fn pg_time() -> impl Strategy<Value = NaiveTime> {
+    (0u32..86_400, 0u32..1_000_000).prop_map(|(seconds, micros)| {
+        NaiveTime::from_num_seconds_from_midnight_opt(seconds, micros * 1_000).unwrap()
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn date_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::date)::text").await.unwrap();
+
+    run_property("date text roundtrip", &pg_date(), |date| {
+        let rendered = query_text(client, &render, &[date])?;
+        let cell = parse_text_cell(&Type::DATE, &rendered)
+            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+
+        prop_assert_eq!(&cell, &Cell::Date(*date));
+        Ok(())
+    });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn timestamptz_values_roundtrip_through_text_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    let render = client.prepare("select ($1::timestamptz)::text").await.unwrap();
+
+    let strategy = (pg_date(), pg_time()).prop_map(|(date, time)| {
+        DateTime::<Utc>::from_naive_utc_and_offset(NaiveDateTime::new(date, time), Utc)
+    });
+    run_property("timestamptz text roundtrip", &strategy, |timestamp| {
+        let rendered = query_text(client, &render, &[timestamp])?;
+        let cell = parse_text_cell(&Type::TIMESTAMPTZ, &rendered)
+            .map_err(|err| TestCaseError::fail(format!("codec rejected {rendered:?}: {err}")))?;
+
+        prop_assert_eq!(&cell, &Cell::TimestampTz(*timestamp));
+        Ok(())
+    });
+}
+
+/// Reads the single COPY text row the table currently holds.
+async fn copy_single_row(client: &Client, query: &str) -> Result<Vec<u8>, tokio_postgres::Error> {
+    let stream = client.copy_out(query).await?;
+    let mut bytes = Vec::new();
+    futures::pin_mut!(stream);
+    while let Some(chunk) = stream.next().await {
+        bytes.extend_from_slice(&chunk?);
+    }
+
+    Ok(bytes)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn copy_rows_roundtrip_through_copy_codec() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let client = database.client.as_ref().unwrap();
+    client
+        .execute("create table test.copy_roundtrip (a text, b text[], c int8)", &[])
+        .await
+        .unwrap();
+    let insert =
+        client.prepare("insert into test.copy_roundtrip values ($1, $2, $3)").await.unwrap();
+
+    let column_schemas = vec![
+        ColumnSchema::new("a".to_owned(), Type::TEXT, -1, 1, true),
+        ColumnSchema::new("b".to_owned(), Type::TEXT_ARRAY, -1, 2, true),
+        ColumnSchema::new("c".to_owned(), Type::INT8, -1, 3, true),
+    ];
+
+    let strategy = (option::of(pg_text()), option::of(pg_text_array()), option::of(any::<i64>()));
+    run_property("copy row roundtrip", &strategy, |(text, array, int)| {
+        let row_bytes = block_on(async {
+            client.execute("delete from test.copy_roundtrip", &[]).await?;
+            client.execute(&insert, &[text, array, int]).await?;
+            copy_single_row(client, "copy test.copy_roundtrip to stdout").await
+        })
+        .map_err(|err| TestCaseError::fail(format!("postgres copy failed: {err}")))?;
+
+        let row = parse_copy_row(&row_bytes, &column_schemas).map_err(|err| {
+            TestCaseError::fail(format!("codec rejected copy row {row_bytes:?}: {err}"))
+        })?;
+
+        let expected = vec![
+            text.clone().map_or(Cell::Null, Cell::String),
+            array.clone().map_or(Cell::Null, |values| Cell::Array(ArrayCell::String(values))),
+            int.map_or(Cell::Null, Cell::I64),
+        ];
+        prop_assert_eq!(row.values(), expected.as_slice());
+        Ok(())
+    });
+}

--- a/crates/etl/tests/value_roundtrip.rs
+++ b/crates/etl/tests/value_roundtrip.rs
@@ -13,8 +13,8 @@
 //!
 //! Known codec gaps stay outside the generated envelope and are documented on
 //! the strategies that would otherwise reach them: temporal `infinity`
-//! values, `BC` dates, and years above 9999 are all legal in Postgres but are
-//! rejected by the codec today.
+//! values, `BC` dates, years above 9999, and the `24:00:00` time are all
+//! legal in Postgres but are rejected by the codec today.
 
 use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use etl::{
@@ -226,10 +226,25 @@ async fn float8_array_values_roundtrip_through_text_codec() {
 
 /// Decimal literal strings covering integers, fractions, scientific notation,
 /// and the numeric specials.
+///
+/// Exponents are tiered: most cases stay small so typical magnitudes
+/// dominate, while the two boundary tiers reach the extremes the codec and
+/// Postgres share, `1e131071` on the weight side and `1e-16383` on the
+/// scale side. With up to 45 integer and 45 fractional digits, exponents in
+/// `[-16_338, 131_027]` always stay inside Postgres's accepted range
+/// (verified empirically: one step past either bound overflows the numeric
+/// format), so Postgres stays a render oracle and never rejects a generated
+/// literal.
 fn numeric_literal() -> impl Strategy<Value = String> {
     let digits = |max: usize| proptest::collection::vec(0u8..=9, 1..=max);
 
-    let finite = (any::<bool>(), digits(45), option::of(digits(45)), option::of(-60i32..=60))
+    let exponent = prop_oneof![
+        8 => -60i32..=60,
+        1 => -16_338i32..=-16_200,
+        1 => 130_900i32..=131_027,
+    ];
+
+    let finite = (any::<bool>(), digits(45), option::of(digits(45)), option::of(exponent))
         .prop_map(|(negative, int_digits, frac_digits, exponent)| {
             let mut literal = String::new();
             if negative {
@@ -302,6 +317,12 @@ fn pg_date() -> impl Strategy<Value = NaiveDate> {
 }
 
 /// Microsecond-precision times of day, matching Postgres's time resolution.
+///
+/// Postgres also accepts and stores `24:00:00`, but `chrono::NaiveTime`
+/// cannot represent it and the codec rejects it (a pinned known gap; see
+/// `time_falls_back_for_non_iso_shapes` in the codec tests). It stays
+/// outside the envelope until the codec and destinations decide how to
+/// carry it.
 fn pg_time() -> impl Strategy<Value = NaiveTime> {
     (0u32..86_400, 0u32..1_000_000).prop_map(|(seconds, micros)| {
         NaiveTime::from_num_seconds_from_midnight_opt(seconds, micros * 1_000).unwrap()

--- a/crates/etl/tests/value_roundtrip.rs
+++ b/crates/etl/tests/value_roundtrip.rs
@@ -6,21 +6,15 @@
 //! Postgres stores. Postgres itself is the oracle, so these properties catch
 //! silent value corruption, not just parser panics.
 //!
-//! Every property runs new random cases until a wall-clock budget elapses.
-//! The budget comes from `ROUNDTRIP_PROPERTY_BUDGET_SECS` (default 2), so the
-//! regular suite pays a few seconds per property while CI chaos jobs or local
-//! deep runs can raise it to minutes.
-//!
-//! On failure the panic names the chunk's RNG seed; set
-//! `ROUNDTRIP_PROPERTY_SEED` to that value to replay the failing chunk
-//! deterministically.
+//! Every property runs new random cases until a wall-clock budget elapses,
+//! using the shared runner in `etl::test_utils::property`. See that module
+//! for the `ROUNDTRIP_PROPERTY_BUDGET_SECS` budget knob and the
+//! `ROUNDTRIP_PROPERTY_SEED` failure replay knob.
 //!
 //! Known codec gaps stay outside the generated envelope and are documented on
 //! the strategies that would otherwise reach them: temporal `infinity`
 //! values, `BC` dates, and years above 9999 are all legal in Postgres but are
 //! rejected by the codec today.
-
-use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use etl::{
@@ -28,90 +22,19 @@ use etl::{
     schema::ColumnSchema,
     test_utils::{
         database::spawn_source_database,
+        property::run_property,
         replication_stream::{parse_copy_row, parse_text_cell},
     },
 };
 use etl_postgres::time::PgTimeTz;
 use etl_telemetry::tracing::init_test_tracing;
 use futures::StreamExt;
-use proptest::{
-    option,
-    prelude::*,
-    test_runner::{RngAlgorithm, TestRng, TestRunner as PropTestRunner},
-};
+use proptest::{option, prelude::*};
 use tokio_postgres::{
     Client, Statement,
     types::{Kind, ToSql, Type},
 };
 use uuid::Uuid;
-
-/// Number of generated cases between deadline checks.
-const CASES_PER_CHUNK: u32 = 64;
-
-/// Returns the wall-clock budget for one property.
-fn property_budget() -> Duration {
-    let secs = std::env::var("ROUNDTRIP_PROPERTY_BUDGET_SECS")
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(2);
-
-    Duration::from_secs(secs)
-}
-
-/// Returns the pinned chunk seed from `ROUNDTRIP_PROPERTY_SEED`, if set.
-fn replay_seed() -> Option<u64> {
-    let value = std::env::var("ROUNDTRIP_PROPERTY_SEED").ok()?;
-    Some(value.parse().expect("ROUNDTRIP_PROPERTY_SEED must be a u64 seed"))
-}
-
-/// Builds the deterministic RNG for one chunk of cases from a `u64` seed.
-fn chunk_rng(seed: u64) -> TestRng {
-    let mut bytes = [0u8; 32];
-    bytes[..8].copy_from_slice(&seed.to_le_bytes());
-    TestRng::from_seed(RngAlgorithm::ChaCha, &bytes)
-}
-
-/// Runs `check` on freshly generated values until the property budget elapses.
-///
-/// Each chunk runs [`CASES_PER_CHUNK`] cases from a fresh random seed. On
-/// failure the value is shrunk by proptest and reported through a panic that
-/// also names the chunk seed, so the minimal failing input shows up in the
-/// test output and the chunk can be replayed with `ROUNDTRIP_PROPERTY_SEED`.
-fn run_property<S>(name: &str, strategy: &S, check: impl Fn(&S::Value) -> Result<(), TestCaseError>)
-where
-    S: Strategy,
-    S::Value: std::fmt::Debug,
-{
-    let deadline = Instant::now() + property_budget();
-    let replay_seed = replay_seed();
-    let mut total_cases = 0u64;
-
-    loop {
-        let seed = replay_seed.unwrap_or_else(rand::random);
-        let config = proptest::test_runner::Config {
-            cases: CASES_PER_CHUNK,
-            failure_persistence: None,
-            ..Default::default()
-        };
-        let mut runner = PropTestRunner::new_with_rng(config, chunk_rng(seed));
-
-        match runner.run(strategy, |value| check(&value)) {
-            Ok(()) => total_cases += u64::from(CASES_PER_CHUNK),
-            Err(err) => panic!(
-                "property '{name}' failed after ~{total_cases} passing cases; rerun with \
-                 ROUNDTRIP_PROPERTY_SEED={seed} to replay the failing chunk:\n{err}"
-            ),
-        }
-
-        // A pinned replay seed regenerates the same cases, so it runs exactly
-        // one chunk.
-        if replay_seed.is_some() || Instant::now() >= deadline {
-            break;
-        }
-    }
-
-    println!("property '{name}': {total_cases} cases passed");
-}
 
 /// Runs an async future to completion from inside a synchronous proptest
 /// closure.

--- a/crates/etl/tests/value_roundtrip.rs
+++ b/crates/etl/tests/value_roundtrip.rs
@@ -11,6 +11,10 @@
 //! regular suite pays a few seconds per property while CI chaos jobs or local
 //! deep runs can raise it to minutes.
 //!
+//! On failure the panic names the chunk's RNG seed; set
+//! `ROUNDTRIP_PROPERTY_SEED` to that value to replay the failing chunk
+//! deterministically.
+//!
 //! Known codec gaps stay outside the generated envelope and are documented on
 //! the strategies that would otherwise reach them: temporal `infinity`
 //! values, `BC` dates, and years above 9999 are all legal in Postgres but are
@@ -30,7 +34,11 @@ use etl::{
 use etl_postgres::time::PgTimeTz;
 use etl_telemetry::tracing::init_test_tracing;
 use futures::StreamExt;
-use proptest::{option, prelude::*, test_runner::TestRunner as PropTestRunner};
+use proptest::{
+    option,
+    prelude::*,
+    test_runner::{RngAlgorithm, TestRng, TestRunner as PropTestRunner},
+};
 use tokio_postgres::{
     Client, Statement,
     types::{Kind, ToSql, Type},
@@ -50,34 +58,54 @@ fn property_budget() -> Duration {
     Duration::from_secs(secs)
 }
 
+/// Returns the pinned chunk seed from `ROUNDTRIP_PROPERTY_SEED`, if set.
+fn replay_seed() -> Option<u64> {
+    let value = std::env::var("ROUNDTRIP_PROPERTY_SEED").ok()?;
+    Some(value.parse().expect("ROUNDTRIP_PROPERTY_SEED must be a u64 seed"))
+}
+
+/// Builds the deterministic RNG for one chunk of cases from a `u64` seed.
+fn chunk_rng(seed: u64) -> TestRng {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&seed.to_le_bytes());
+    TestRng::from_seed(RngAlgorithm::ChaCha, &bytes)
+}
+
 /// Runs `check` on freshly generated values until the property budget elapses.
 ///
-/// Each chunk uses a new random seed. On failure the value is shrunk by
-/// proptest and reported through a panic, so the minimal failing input shows
-/// up in the test output and can be turned into a regression test.
+/// Each chunk runs [`CASES_PER_CHUNK`] cases from a fresh random seed. On
+/// failure the value is shrunk by proptest and reported through a panic that
+/// also names the chunk seed, so the minimal failing input shows up in the
+/// test output and the chunk can be replayed with `ROUNDTRIP_PROPERTY_SEED`.
 fn run_property<S>(name: &str, strategy: &S, check: impl Fn(&S::Value) -> Result<(), TestCaseError>)
 where
     S: Strategy,
     S::Value: std::fmt::Debug,
 {
     let deadline = Instant::now() + property_budget();
+    let replay_seed = replay_seed();
     let mut total_cases = 0u64;
 
     loop {
-        let mut runner = PropTestRunner::new(proptest::test_runner::Config {
+        let seed = replay_seed.unwrap_or_else(rand::random);
+        let config = proptest::test_runner::Config {
             cases: CASES_PER_CHUNK,
             failure_persistence: None,
             ..Default::default()
-        });
+        };
+        let mut runner = PropTestRunner::new_with_rng(config, chunk_rng(seed));
 
         match runner.run(strategy, |value| check(&value)) {
             Ok(()) => total_cases += u64::from(CASES_PER_CHUNK),
-            Err(err) => {
-                panic!("property '{name}' failed after ~{total_cases} passing cases:\n{err}")
-            }
+            Err(err) => panic!(
+                "property '{name}' failed after ~{total_cases} passing cases; rerun with \
+                 ROUNDTRIP_PROPERTY_SEED={seed} to replay the failing chunk:\n{err}"
+            ),
         }
 
-        if Instant::now() >= deadline {
+        // A pinned replay seed regenerates the same cases, so it runs exactly
+        // one chunk.
+        if replay_seed.is_some() || Instant::now() >= deadline {
             break;
         }
     }


### PR DESCRIPTION
Property tests that use a real Postgres as the oracle: generate typed values, have Postgres render them in the text format that replication and COPY carry, parse that with the production codec, and assert the parsed `Cell` equals what Postgres stores. This catches silent value corruption, not just parser panics.

Covers numeric (incl. `NaN`/infinities), all temporal types, enums via catalog-derived types, jsonb, scalars, `text[]`/`int8[]`/`float8[]`/`bytea[]`/`timestamptz[]`, and full COPY rows.

Each property runs until a wall-clock budget elapses: `ROUNDTRIP_PROPERTY_BUDGET_SECS` (default 2, ~50s total suite cost; 30 gives an ~8 minute deep run of ~2.6M cases). Needs a test Postgres (`cargo xtask postgres create`), like the existing integration tests.

**(minor) bug found and fixed** (first commit): `PgNumeric`'s `Display` dropped the display scale of zero — Postgres renders `'0e-1'::numeric` as `0.0`, we printed `0` — even though the parser and binary wire format preserve it. Minimal failing input found by the numeric property.

**Codec gaps found, documented but not fixed here** — legal in Postgres, rejected by the codec**

- years above 9999 (`ConversionError`)
- BC dates (`ConversionError`)
- temporal `infinity`/`-infinity` (no `Cell` representation)