### PR TITLE
fix(xtask): stop printing generated database secrets

### DIFF
--- a/crates/xtask/src/commands/init.rs
+++ b/crates/xtask/src/commands/init.rs
@@ -59,18 +59,16 @@ impl InitArgs {
             wait_for_external_postgres(&database_url)?;
         }
 
-        println!("🔗 Database URL: {database_url}");
         if compose.is_some() {
             println!(
                 "🧪 Postgres test env: TESTS_DATABASE_HOST={} TESTS_DATABASE_PORT={} \
                  TESTS_DATABASE_REPLICA_HOST={} TESTS_DATABASE_REPLICA_PORT={} \
-                 TESTS_DATABASE_USERNAME={} TESTS_DATABASE_PASSWORD={}",
+                 TESTS_DATABASE_USERNAME={}",
                 config.db_host,
                 config.db_port,
                 config.db_host,
                 config.db_replica_port,
                 config.db_user,
-                config.db_password,
             );
         }
 
@@ -240,9 +238,8 @@ fn wait_for_docker_services(compose: &DockerCompose, config: &InitConfig) -> Res
     println!("✅ ClickHouse is up and running on port {}", config.clickhouse_http_port);
     println!("🔗 ClickHouse HTTP URL: http://localhost:{}", config.clickhouse_http_port);
     println!(
-        "🧪 ClickHouse test env: TESTS_CLICKHOUSE_URL=http://localhost:{} \
-         TESTS_CLICKHOUSE_USER={} TESTS_CLICKHOUSE_PASSWORD={}",
-        config.clickhouse_http_port, config.clickhouse_user, config.clickhouse_password,
+        "🧪 ClickHouse test env: TESTS_CLICKHOUSE_URL=http://localhost:{} TESTS_CLICKHOUSE_USER={}",
+        config.clickhouse_http_port, config.clickhouse_user,
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- remove database passwords and the credential-bearing Postgres URL from `cargo x init` output
- retain non-secret connection details