### PR TITLE
ref(tests): Align waiting conditions

### DIFF
--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1295,6 +1295,11 @@ where
                 .await?;
         }
 
+        // Invalidate Storage Write API connections after dropping the physical
+        // tables. A subsequent copy can recreate a table with the same ID, and a
+        // cached connection may still refer to the previous table incarnation.
+        self.client.invalidate_all_connections().await;
+
         // Once destination cleanup is done, remove any stale local cache entries.
         let mut inner = self.inner.lock().await;
         inner.clear_table_cache(&base_bigquery_table_id);

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -10,6 +10,7 @@ use etl::{
     store::{StateStore, TableState, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::{create_pipeline, create_pipeline_with_batch_config},
         test_destination_wrapper::TestDestinationWrapper,
@@ -155,8 +156,13 @@ async fn table_copy_and_streaming_with_restart() {
 
     pipeline.start().await.unwrap();
 
-    // We expect 2 insert events for each table (4 total).
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    // We expect 2 insert events for each table.
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     // Insert additional data.
     insert_mock_data(
@@ -329,7 +335,13 @@ async fn table_insert_update_delete() {
     users_state_notify.notified().await;
 
     // Wait for the first insert.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Insert,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
 
     // Insert a row.
     database
@@ -350,7 +362,13 @@ async fn table_insert_update_delete() {
     assert_eq!(parsed_users_rows, vec![BigQueryUser::new(1, "user_1", 1),]);
 
     // Wait for the update.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Update,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
 
     // Update the row.
     database
@@ -371,7 +389,13 @@ async fn table_insert_update_delete() {
     assert_eq!(parsed_users_rows, vec![BigQueryUser::new(1, "user_10", 10),]);
 
     // Wait for the update.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Delete,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
 
     // Update the row.
     database
@@ -427,7 +451,10 @@ async fn table_subsequent_updates() {
 
     // Wait for the first insert.
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Insert, 1), (EventType::Update, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 1),
+            EventCondition::TableCount(EventType::Update, database_schema.users_schema().id, 2),
+        ])
         .await;
 
     // Insert a row.
@@ -517,7 +544,13 @@ async fn table_primary_key_update_rewrites_row() {
 
     users_state_notify.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Update,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
 
     // With default primary-key replica identity, changing the source primary
     // key is a valid PostgreSQL shape: the update carries an old key row plus
@@ -635,7 +668,9 @@ async fn table_full_replica_identity_update_preserves_unchanged_toasted_columns(
     // That means unchanged external TOAST values can be reconstructed and the
     // destination should receive a full new row image.
     let updated_name = "alicia".to_owned();
-    let update_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let update_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
 
     database
         .update_values_where(table_name.clone(), &["name"], &[&updated_name], &["id"], &["1"], "")
@@ -644,7 +679,9 @@ async fn table_full_replica_identity_update_preserves_unchanged_toasted_columns(
 
     update_notify.notified().await;
 
-    let delete_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let delete_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
 
     database.delete_values(table_name.clone(), &["id"], &["1"], "").await.unwrap();
 
@@ -733,10 +770,14 @@ async fn table_truncate_with_batching() {
     users_state_notify.notified().await;
     orders_state_notify.notified().await;
 
-    // Wait for the 8 inserts (4 per table + 4 after truncate) and 2 truncates (1
-    // per table).
+    // Wait for 4 inserts and 1 truncate per table.
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Insert, 8), (EventType::Truncate, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 4),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 4),
+            EventCondition::TableCount(EventType::Truncate, database_schema.users_schema().id, 1),
+            EventCondition::TableCount(EventType::Truncate, database_schema.orders_schema().id, 1),
+        ])
         .await;
 
     // Insert 2 rows per each table.
@@ -851,7 +892,9 @@ async fn table_nullable_scalar_columns() {
     table_sync_done_notification.notified().await;
 
     // Insert
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     database
         .insert_values(
@@ -890,7 +933,9 @@ async fn table_nullable_scalar_columns() {
     assert_eq!(parsed_table_rows, vec![NullableColsScalar::all_nulls(1),]);
 
     // Update
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
 
     // Define test values
     let updated_bool = true;
@@ -970,7 +1015,9 @@ async fn table_nullable_scalar_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // delete
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
@@ -1047,7 +1094,9 @@ async fn table_nullable_array_columns() {
     table_sync_done_notification.notified().await;
 
     // insert with null arrays
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     database
         .insert_values(
@@ -1089,7 +1138,9 @@ async fn table_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![NullableColsArray::all_empty(1),]);
 
     // update with array values
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
 
     // Define test array values
     let updated_bool_arr = vec![true, false, true];
@@ -1186,7 +1237,9 @@ async fn table_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // delete
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
@@ -1263,7 +1316,9 @@ async fn table_non_nullable_scalar_columns() {
     table_sync_done_notification.notified().await;
 
     // insert with non-null values
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     // Define test values - all non-null
     let test_bool = true;
@@ -1343,7 +1398,9 @@ async fn table_non_nullable_scalar_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // update with different non-null values
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
 
     // Define updated test values
     let updated_bool = false;
@@ -1423,7 +1480,9 @@ async fn table_non_nullable_scalar_columns() {
     assert_eq!(parsed_table_rows, vec![expected_updated_row]);
 
     // delete
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
@@ -1500,7 +1559,9 @@ async fn table_non_nullable_array_columns() {
     table_sync_done_notification.notified().await;
 
     // insert with non-null array values
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     // Define test array values - all non-null
     let test_bool_arr = vec![true, false, true];
@@ -1597,7 +1658,9 @@ async fn table_non_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // update with different non-null array values
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
 
     // Define updated test array values
     let updated_bool_arr = vec![false, true];
@@ -1694,7 +1757,9 @@ async fn table_non_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![expected_updated_row]);
 
     // delete
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
@@ -1807,7 +1872,9 @@ async fn table_array_with_null_values() {
     // expected to keep retrying while preserving the physical `*_0` table id.
     table_sync_done_notification.wait_for(BIGQUERY_RECREATED_TABLE_READY_TIMEOUT).notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     // Insert array without null values
     database
@@ -2099,7 +2166,10 @@ async fn schema_change_add_column_defaults() {
     table_ready.notified().await;
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -2203,7 +2273,10 @@ async fn schema_change_tolerates_nullability_and_default_divergence() {
     table_ready.notified().await;
 
     let set_not_null_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -2235,7 +2308,10 @@ async fn schema_change_tolerates_nullability_and_default_divergence() {
     set_not_null_notify.notified().await;
 
     let drop_not_null_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
         .await;
 
     database
@@ -2262,7 +2338,10 @@ async fn schema_change_tolerates_nullability_and_default_divergence() {
     drop_not_null_notify.notified().await;
 
     let drop_default_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     database
@@ -2370,7 +2449,9 @@ async fn table_schema_change() {
     let initial_snapshot_id = initial_state.snapshot_id;
 
     // Insert the initial row.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     database
         .insert_values(table_name.clone(), &["name", "age", "status"], &[&"Alice", &25, &"active"])
@@ -2391,7 +2472,10 @@ async fn table_schema_change() {
     // diffing in handle_relation_event then computes and applies all changes at
     // once.
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -109,17 +109,17 @@ async fn table_copy_and_streaming_with_restart() {
     );
 
     // Register notifications for table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -157,7 +157,7 @@ async fn table_copy_and_streaming_with_restart() {
     pipeline.start().await.unwrap();
 
     // We expect 2 insert events for each table.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
@@ -174,7 +174,7 @@ async fn table_copy_and_streaming_with_restart() {
     )
     .await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -241,12 +241,12 @@ async fn table_copy_reset_drops_destination_table_before_recopy() {
         destination.clone(),
     );
 
-    let users_ready =
+    let users_ready_notify =
         store.notify_on_table_state_type(users_schema.id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -277,7 +277,7 @@ async fn table_copy_reset_drops_destination_table_before_recopy() {
         destination.clone(),
     );
 
-    let users_ready =
+    let users_ready_notify =
         store.notify_on_table_state_type(users_schema.id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
@@ -285,7 +285,7 @@ async fn table_copy_reset_drops_destination_table_before_recopy() {
     // BigQuery can keep the default Storage Write stream for a dropped and
     // re-created table unavailable for several minutes. The destination is
     // expected to keep retrying while preserving the physical `*_0` table id.
-    users_ready.wait_for(BIGQUERY_RECREATED_TABLE_READY_TIMEOUT).notified().await;
+    users_ready_notify.wait_for(BIGQUERY_RECREATED_TABLE_READY_TIMEOUT).notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -326,16 +326,16 @@ async fn table_insert_update_delete() {
     );
 
     // Register notifications for table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     // Wait for the first insert.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
             EventType::Insert,
             database_schema.users_schema().id,
@@ -353,7 +353,7 @@ async fn table_insert_update_delete() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // We query BigQuery to check for the insert.
     let users_rows =
@@ -362,7 +362,7 @@ async fn table_insert_update_delete() {
     assert_eq!(parsed_users_rows, vec![BigQueryUser::new(1, "user_1", 1),]);
 
     // Wait for the update.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
             EventType::Update,
             database_schema.users_schema().id,
@@ -380,7 +380,7 @@ async fn table_insert_update_delete() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // We query BigQuery to check for the update.
     let users_rows =
@@ -389,7 +389,7 @@ async fn table_insert_update_delete() {
     assert_eq!(parsed_users_rows, vec![BigQueryUser::new(1, "user_10", 10),]);
 
     // Wait for the update.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
             EventType::Delete,
             database_schema.users_schema().id,
@@ -403,7 +403,7 @@ async fn table_insert_update_delete() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -441,16 +441,16 @@ async fn table_subsequent_updates() {
     );
 
     // Register notifications for table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     // Wait for the first insert.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 1),
             EventCondition::TableCount(EventType::Update, database_schema.users_schema().id, 2),
@@ -490,7 +490,7 @@ async fn table_subsequent_updates() {
         .unwrap();
     transaction_b.commit_transaction().await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -536,15 +536,15 @@ async fn table_primary_key_update_rewrites_row() {
         destination.clone(),
     );
 
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
             EventType::Update,
             database_schema.users_schema().id,
@@ -570,7 +570,7 @@ async fn table_primary_key_update_rewrites_row() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -758,20 +758,20 @@ async fn table_truncate_with_batching() {
     );
 
     // Register notifications for table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     // Wait for 4 inserts and 1 truncate per table.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 4),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 4),
@@ -804,7 +804,7 @@ async fn table_truncate_with_batching() {
     )
     .await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -884,15 +884,15 @@ async fn table_nullable_scalar_columns() {
         destination.clone(),
     );
 
-    let table_sync_done_notification =
+    let table_ready_notify =
         store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_sync_done_notification.notified().await;
+    table_ready_notify.notified().await;
 
     // Insert
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -926,14 +926,14 @@ async fn table_nullable_scalar_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NullableColsScalar>(table_rows);
     assert_eq!(parsed_table_rows, vec![NullableColsScalar::all_nulls(1),]);
 
     // Update
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
         .await;
 
@@ -986,7 +986,7 @@ async fn table_nullable_scalar_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NullableColsScalar>(table_rows);
@@ -1015,13 +1015,13 @@ async fn table_nullable_scalar_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // delete
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
         .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     assert!(bigquery_database.wait_for_no_rows(table_name.clone()).await);
 
@@ -1086,15 +1086,15 @@ async fn table_nullable_array_columns() {
         destination.clone(),
     );
 
-    let table_sync_done_notification =
+    let table_ready_notify =
         store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_sync_done_notification.notified().await;
+    table_ready_notify.notified().await;
 
     // insert with null arrays
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -1129,7 +1129,7 @@ async fn table_nullable_array_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NullableColsArray>(table_rows);
@@ -1138,7 +1138,7 @@ async fn table_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![NullableColsArray::all_empty(1),]);
 
     // update with array values
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
         .await;
 
@@ -1208,7 +1208,7 @@ async fn table_nullable_array_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NullableColsArray>(table_rows);
@@ -1237,13 +1237,13 @@ async fn table_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // delete
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
         .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     assert!(bigquery_database.wait_for_no_rows(table_name.clone()).await);
 
@@ -1308,15 +1308,15 @@ async fn table_non_nullable_scalar_columns() {
         destination.clone(),
     );
 
-    let table_sync_done_notification =
+    let table_ready_notify =
         store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_sync_done_notification.notified().await;
+    table_ready_notify.notified().await;
 
     // insert with non-null values
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -1369,7 +1369,7 @@ async fn table_non_nullable_scalar_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NonNullableColsScalar>(table_rows);
@@ -1398,7 +1398,7 @@ async fn table_non_nullable_scalar_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // update with different non-null values
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
         .await;
 
@@ -1451,7 +1451,7 @@ async fn table_non_nullable_scalar_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NonNullableColsScalar>(table_rows);
@@ -1480,13 +1480,13 @@ async fn table_non_nullable_scalar_columns() {
     assert_eq!(parsed_table_rows, vec![expected_updated_row]);
 
     // delete
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
         .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     assert!(bigquery_database.wait_for_no_rows(table_name.clone()).await);
 
@@ -1551,15 +1551,15 @@ async fn table_non_nullable_array_columns() {
         destination.clone(),
     );
 
-    let table_sync_done_notification =
+    let table_ready_notify =
         store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_sync_done_notification.notified().await;
+    table_ready_notify.notified().await;
 
     // insert with non-null array values
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -1629,7 +1629,7 @@ async fn table_non_nullable_array_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NullableColsArray>(table_rows);
@@ -1658,7 +1658,7 @@ async fn table_non_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![expected_row]);
 
     // update with different non-null array values
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
         .await;
 
@@ -1728,7 +1728,7 @@ async fn table_non_nullable_array_columns() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
     let parsed_table_rows = parse_bigquery_table_rows::<NullableColsArray>(table_rows);
@@ -1757,13 +1757,13 @@ async fn table_non_nullable_array_columns() {
     assert_eq!(parsed_table_rows, vec![expected_updated_row]);
 
     // delete
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
         .await;
 
     database.delete_values(table_name.clone(), &["id"], &["'1'"], "").await.unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     assert!(bigquery_database.wait_for_no_rows(table_name.clone()).await);
 
@@ -1804,12 +1804,12 @@ async fn table_array_with_null_values() {
         destination.clone(),
     );
 
-    let table_sync_done_notification =
+    let table_ready_notify =
         store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_sync_done_notification.notified().await;
+    table_ready_notify.notified().await;
 
     // Insert array with null value
     database
@@ -1858,7 +1858,7 @@ async fn table_array_with_null_values() {
         destination.clone(),
     );
 
-    let table_sync_done_notification =
+    let table_ready_notify =
         store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
@@ -1866,9 +1866,9 @@ async fn table_array_with_null_values() {
     // BigQuery can keep the default Storage Write stream for a dropped and
     // re-created table unavailable for several minutes. The destination is
     // expected to keep retrying while preserving the physical `*_0` table id.
-    table_sync_done_notification.wait_for(BIGQUERY_RECREATED_TABLE_READY_TIMEOUT).notified().await;
+    table_ready_notify.wait_for(BIGQUERY_RECREATED_TABLE_READY_TIMEOUT).notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -1887,7 +1887,7 @@ async fn table_array_with_null_values() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -2155,13 +2155,14 @@ async fn schema_change_add_column_defaults() {
         destination.clone(),
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -2191,7 +2192,7 @@ async fn schema_change_add_column_defaults() {
         .await
         .expect("failed to insert defaulted source row");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -2262,11 +2263,12 @@ async fn schema_change_tolerates_nullability_and_default_divergence() {
         destination.clone(),
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     let set_not_null_notify = destination
         .wait_for_events(vec![
@@ -2430,12 +2432,12 @@ async fn table_schema_change() {
         destination.clone(),
     );
 
-    let table_sync_done =
-        store.notify_on_table_state_type(table_id, TableStateType::SyncDone).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_sync_done.notified().await;
+    table_ready_notify.notified().await;
 
     let initial_state = store
         .get_applied_destination_table_metadata(table_id)
@@ -2445,7 +2447,7 @@ async fn table_schema_change() {
     let initial_snapshot_id = initial_state.snapshot_id;
 
     // Insert the initial row.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -2454,7 +2456,7 @@ async fn table_schema_change() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // Apply multiple schema changes:
     // 1. Rename name -> full_name
@@ -2466,9 +2468,9 @@ async fn table_schema_change() {
     // final schema when the next DML operation (INSERT) occurs. The schema
     // diffing in handle_relation_event then computes and applies all changes at
     // once.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
             EventCondition::TableCount(EventType::Insert, table_id, 2),
         ])
         .await;
@@ -2504,7 +2506,7 @@ async fn table_schema_change() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -1849,10 +1849,6 @@ async fn table_array_with_null_values() {
     // the CDC will contain the inserts and deletes, failing again.
     store.reset_table_state(table_id).await.unwrap();
 
-    // We also clear the events so that it's more idiomatic to wait for them, since
-    // we don't have the prior insert.
-    destination.clear_events().await;
-
     // We recreate the pipeline and try again.
     let mut pipeline = create_pipeline(
         &database.config,
@@ -2459,7 +2455,6 @@ async fn table_schema_change() {
         .unwrap();
 
     event_notify.notified().await;
-    destination.clear_events().await;
 
     // Apply multiple schema changes:
     // 1. Rename name -> full_name
@@ -2474,7 +2469,7 @@ async fn table_schema_change() {
     let event_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
         ])
         .await;
 

--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -4,6 +4,7 @@ use etl::{
     store::{StateStore, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
@@ -364,7 +365,9 @@ async fn updates_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
     pipeline.start().await.unwrap();
     table_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
 
     database
         .run_sql(&format!(
@@ -780,7 +783,9 @@ async fn deletes_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
     pipeline.start().await.unwrap();
     table_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
 
     database
         .run_sql(&format!("DELETE FROM {} WHERE id = 2", table_name.as_quoted_identifier(),))
@@ -902,7 +907,9 @@ async fn pipeline_restart_resumes_streaming_inner(engine: ClickHouseEngine) {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     database
         .run_sql(&format!(
@@ -1103,7 +1110,9 @@ async fn truncate_clears_table_and_accepts_new_inserts_inner(engine: ClickHouseE
     assert_eq!(rows.len(), 2, "table copy should produce two rows");
 
     // --- WHEN: truncate and insert a new row ---
-    let truncate_notify = destination.wait_for_events_count(vec![(EventType::Truncate, 1)]).await;
+    let truncate_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Truncate, table_id, 1)])
+        .await;
 
     database
         .truncate_table(table_name.clone())
@@ -1115,7 +1124,9 @@ async fn truncate_clears_table_and_accepts_new_inserts_inner(engine: ClickHouseE
     let rows: Vec<IdValueRow> = clickhouse_db.query(&truncate_query()).await;
     assert!(rows.is_empty(), "table should be empty after truncate");
 
-    let insert_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let insert_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     database
         .run_sql(&format!(
@@ -1314,7 +1325,12 @@ async fn multiple_tables_receive_independent_writes_inner(engine: ClickHouseEngi
     pipeline.start().await.unwrap();
     tokio::join!(table_a_ready.notified(), table_b_ready.notified());
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, table_a_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_b_id, 1),
+        ])
+        .await;
 
     // --- WHEN: insert one row into each table ---
     database
@@ -1490,7 +1506,10 @@ async fn delete_with_default_replica_identity_inner(engine: ClickHouseEngine) {
     table_ready.notified().await;
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Delete, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Delete, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     // --- WHEN: delete id=2, insert id=3 ---
@@ -1789,7 +1808,10 @@ async fn schema_change_add_column_inner(engine: ClickHouseEngine) {
 
     // --- WHEN: add column and insert with new schema ---
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1938,7 +1960,10 @@ async fn schema_change_add_column_defaults_merge_tree() {
     table_ready.notified().await;
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -2111,7 +2136,10 @@ async fn schema_change_add_drop_rename_inner(engine: ClickHouseEngine) {
 
     // --- WHEN: rename + drop + add and insert with new schema ---
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(

--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -228,7 +228,8 @@ async fn all_types_table_copy_inner(engine: ClickHouseEngine) {
     let pipeline_id: PipelineId = random();
     let destination = clickhouse_db.build_destination_with_engine(store.clone(), engine).await;
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -239,7 +240,7 @@ async fn all_types_table_copy_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- THEN: every column round-trips correctly ---
@@ -352,7 +353,8 @@ async fn updates_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -363,9 +365,9 @@ async fn updates_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
         .await;
 
@@ -377,7 +379,7 @@ async fn updates_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
         .await
         .expect("Failed to update update_flow row");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(engine, UPDATE_FLOW_TABLE, ID_VALUE_PROJECTION, &["id"], "id");
     let rows: Vec<IdValueRow> = clickhouse_db.query(&query).await;
@@ -504,7 +506,8 @@ async fn boundary_values_table_copy_inner(engine: ClickHouseEngine) {
     let pipeline_id: PipelineId = random();
     let destination = clickhouse_db.build_destination_with_engine(store.clone(), engine).await;
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -515,7 +518,7 @@ async fn boundary_values_table_copy_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- THEN: ClickHouse data matches Postgres exactly ---
@@ -657,7 +660,8 @@ async fn pre_1970_and_far_future_dates_round_trip_inner(engine: ClickHouseEngine
     let pipeline_id: PipelineId = random();
     let destination = clickhouse_db.build_destination_with_engine(store.clone(), engine).await;
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -668,7 +672,7 @@ async fn pre_1970_and_far_future_dates_round_trip_inner(engine: ClickHouseEngine
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- THEN: each date encodes as the expected signed day offset ---
@@ -770,7 +774,8 @@ async fn deletes_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -781,9 +786,9 @@ async fn deletes_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
         .await;
 
@@ -792,7 +797,7 @@ async fn deletes_are_streamed_to_clickhouse_inner(engine: ClickHouseEngine) {
         .await
         .expect("Failed to delete delete_flow row");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(engine, DELETE_FLOW_TABLE, ID_VALUE_PROJECTION, &["id"], "id");
     let rows: Vec<IdValueRow> = clickhouse_db.query(&query).await;
@@ -870,7 +875,8 @@ async fn pipeline_restart_resumes_streaming_inner(engine: ClickHouseEngine) {
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -881,7 +887,7 @@ async fn pipeline_restart_resumes_streaming_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Verify first run produced exactly one row.
@@ -907,7 +913,7 @@ async fn pipeline_restart_resumes_streaming_inner(engine: ClickHouseEngine) {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -919,7 +925,7 @@ async fn pipeline_restart_resumes_streaming_inner(engine: ClickHouseEngine) {
         .await
         .expect("Failed to insert post-restart row");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let rows: Vec<IdValueRow> = clickhouse_db.query(&restart_query()).await;
 
@@ -990,11 +996,12 @@ async fn table_copy_reset_drops_destination_table_before_recopy_inner(engine: Cl
         destination,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -1029,11 +1036,12 @@ async fn table_copy_reset_drops_destination_table_before_recopy_inner(engine: Cl
         destination.clone(),
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -1090,7 +1098,8 @@ async fn truncate_clears_table_and_accepts_new_inserts_inner(engine: ClickHouseE
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -1101,7 +1110,7 @@ async fn truncate_clears_table_and_accepts_new_inserts_inner(engine: ClickHouseE
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     // Verify both rows arrived from table copy.
     let truncate_query =
@@ -1204,7 +1213,8 @@ async fn intermediate_flush_preserves_all_rows_inner(engine: ClickHouseEngine) {
         )
         .await;
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     // --- WHEN: pipeline copies data with aggressive flush splitting ---
     let mut pipeline = create_pipeline(
@@ -1216,7 +1226,7 @@ async fn intermediate_flush_preserves_all_rows_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- THEN: all rows arrive despite being split across many INSERTs ---
@@ -1311,8 +1321,10 @@ async fn multiple_tables_receive_independent_writes_inner(engine: ClickHouseEngi
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_a_ready = store.notify_on_table_state_type(table_a_id, TableStateType::Ready).await;
-    let table_b_ready = store.notify_on_table_state_type(table_b_id, TableStateType::Ready).await;
+    let table_a_ready_notify =
+        store.notify_on_table_state_type(table_a_id, TableStateType::Ready).await;
+    let table_b_ready_notify =
+        store.notify_on_table_state_type(table_b_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -1323,9 +1335,9 @@ async fn multiple_tables_receive_independent_writes_inner(engine: ClickHouseEngi
     );
 
     pipeline.start().await.unwrap();
-    tokio::join!(table_a_ready.notified(), table_b_ready.notified());
+    tokio::join!(table_a_ready_notify.notified(), table_b_ready_notify.notified());
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, table_a_id, 1),
             EventCondition::TableCount(EventType::Insert, table_b_id, 1),
@@ -1349,7 +1361,7 @@ async fn multiple_tables_receive_independent_writes_inner(engine: ClickHouseEngi
         .await
         .expect("Failed to insert streamed row into multi_b");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query_a = current_state_query(engine, "test_multi__a", ID_VALUE_PROJECTION, &["id"], "id");
     let query_b = current_state_query(engine, "test_multi__b", ID_VALUE_PROJECTION, &["id"], "id");
@@ -1492,7 +1504,8 @@ async fn delete_with_default_replica_identity_inner(engine: ClickHouseEngine) {
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -1503,9 +1516,9 @@ async fn delete_with_default_replica_identity_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Delete, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1538,7 +1551,7 @@ async fn delete_with_default_replica_identity_inner(engine: ClickHouseEngine) {
         .await
         .expect("Failed to insert post-delete row");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(
         engine,
@@ -1622,7 +1635,8 @@ async fn exclusive_large_batch_table_copy_inner(engine: ClickHouseEngine) {
     let pipeline_id: PipelineId = random();
     let destination = clickhouse_db.build_destination_with_engine(store.clone(), engine).await;
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     // --- WHEN: pipeline copies all rows ---
     let mut pipeline = create_pipeline(
@@ -1634,7 +1648,7 @@ async fn exclusive_large_batch_table_copy_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- THEN: all rows arrive, spot-check a sample ---
@@ -1782,7 +1796,8 @@ async fn schema_change_add_column_inner(engine: ClickHouseEngine) {
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -1793,7 +1808,7 @@ async fn schema_change_add_column_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     // Verify initial state.
     let initial_columns = clickhouse_db.column_names(clickhouse_table_name).await;
@@ -1807,7 +1822,7 @@ async fn schema_change_add_column_inner(engine: ClickHouseEngine) {
     let initial_snapshot_id = initial_metadata.snapshot_id;
 
     // --- WHEN: add column and insert with new schema ---
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1835,7 +1850,7 @@ async fn schema_change_add_column_inner(engine: ClickHouseEngine) {
         .await
         .expect("Failed to insert Bob");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(
         engine,
@@ -1945,7 +1960,8 @@ async fn schema_change_add_column_defaults_merge_tree() {
             .await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -1957,9 +1973,9 @@ async fn schema_change_add_column_defaults_merge_tree() {
 
     pipeline.start().await.unwrap();
 
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1989,7 +2005,7 @@ async fn schema_change_add_column_defaults_merge_tree() {
         .await
         .expect("failed to insert defaulted source row");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -2110,7 +2126,8 @@ async fn schema_change_add_drop_rename_inner(engine: ClickHouseEngine) {
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -2121,7 +2138,7 @@ async fn schema_change_add_drop_rename_inner(engine: ClickHouseEngine) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     // Verify initial schema.
     let initial_columns = clickhouse_db.column_names(clickhouse_table_name).await;
@@ -2135,7 +2152,7 @@ async fn schema_change_add_drop_rename_inner(engine: ClickHouseEngine) {
     let initial_snapshot_id = initial_metadata.snapshot_id;
 
     // --- WHEN: rename + drop + add and insert with new schema ---
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -2171,7 +2188,7 @@ async fn schema_change_add_drop_rename_inner(engine: ClickHouseEngine) {
         .await
         .expect("Failed to insert Bob");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(
         engine,

--- a/crates/etl-destinations/tests/clickhouse/pipeline_large_rows.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline_large_rows.rs
@@ -141,7 +141,8 @@ async fn large_row_inner(engine: ClickHouseEngine, field_chars: usize) {
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -152,9 +153,9 @@ async fn large_row_inner(engine: ClickHouseEngine, field_chars: usize) {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -164,7 +165,7 @@ async fn large_row_inner(engine: ClickHouseEngine, field_chars: usize) {
         .await
         .expect("Failed to insert large JSONB row");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(engine, LARGE_ROW_TABLE, SUMMARY_PROJECTION, &["id"], "id");
     let rows: Vec<LargeRowSummary> = clickhouse_db.query(&query).await;

--- a/crates/etl-destinations/tests/clickhouse/pipeline_large_rows.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline_large_rows.rs
@@ -15,6 +15,7 @@ use etl::{
     store::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
@@ -153,7 +154,9 @@ async fn large_row_inner(engine: ClickHouseEngine, field_chars: usize) {
     pipeline.start().await.unwrap();
     table_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
 
     // Row 2 exercises the streaming INSERT-event path.
     database

--- a/crates/etl-destinations/tests/clickhouse/pipeline_merge_tree.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline_merge_tree.rs
@@ -82,7 +82,8 @@ async fn sequential_transactions_preserve_commit_order_merge_tree() {
             .await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database_1.config,
@@ -93,9 +94,9 @@ async fn sequential_transactions_preserve_commit_order_merge_tree() {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 2)])
         .await;
 
@@ -118,7 +119,7 @@ async fn sequential_transactions_preserve_commit_order_merge_tree() {
     .expect("Failed to execute update_b");
     tx_b.commit_transaction().await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let rows: Vec<EventLogRow> = clickhouse_db.query(TX_ORDER_SELECT).await;
 

--- a/crates/etl-destinations/tests/clickhouse/pipeline_merge_tree.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline_merge_tree.rs
@@ -9,6 +9,7 @@ use etl::{
     store::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
@@ -94,7 +95,9 @@ async fn sequential_transactions_preserve_commit_order_merge_tree() {
     pipeline.start().await.unwrap();
     table_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 2)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 2)])
+        .await;
 
     // --- WHEN: two transactions commit sequentially on separate connections ---
     let tx_a = database_1.begin_transaction().await;

--- a/crates/etl-destinations/tests/clickhouse/pipeline_replacing_merge_tree.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline_replacing_merge_tree.rs
@@ -75,7 +75,8 @@ async fn replacing_merge_tree_rejects_pkless_source_table() {
         .build_destination_with_engine(store.clone(), ClickHouseEngine::ReplacingMergeTree)
         .await;
 
-    let table_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+    let table_errored_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -86,7 +87,7 @@ async fn replacing_merge_tree_rejects_pkless_source_table() {
     );
 
     pipeline.start().await.unwrap();
-    table_errored.notified().await;
+    table_errored_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- THEN: the Errored state reason names the PK-less rejection ---
@@ -139,7 +140,8 @@ async fn replacing_merge_tree_same_lsn_tx_insert_then_update_keeps_update() {
             .await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -150,10 +152,10 @@ async fn replacing_merge_tree_same_lsn_tx_insert_then_update_keeps_update() {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     // --- WHEN: INSERT + UPDATE in the same transaction ---
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, table_id, 1),
             EventCondition::TableCount(EventType::Update, table_id, 1),
@@ -175,7 +177,7 @@ async fn replacing_merge_tree_same_lsn_tx_insert_then_update_keeps_update() {
     .expect("Failed to update");
     tx.commit_transaction().await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(
         ClickHouseEngine::ReplacingMergeTree,
@@ -242,7 +244,8 @@ async fn replacing_merge_tree_same_lsn_tx_delete_then_insert_keeps_insert() {
             .await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -253,10 +256,10 @@ async fn replacing_merge_tree_same_lsn_tx_delete_then_insert_keeps_insert() {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     // --- WHEN: DELETE + INSERT of the same id in one transaction ---
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Delete, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -275,7 +278,7 @@ async fn replacing_merge_tree_same_lsn_tx_delete_then_insert_keeps_insert() {
     .expect("Failed to re-insert");
     tx.commit_transaction().await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(
         ClickHouseEngine::ReplacingMergeTree,
@@ -333,7 +336,8 @@ async fn replacing_merge_tree_current_view_exposes_user_columns_and_current_stat
             .await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -344,9 +348,9 @@ async fn replacing_merge_tree_current_view_exposes_user_columns_and_current_stat
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
         .await;
     database
@@ -356,7 +360,7 @@ async fn replacing_merge_tree_current_view_exposes_user_columns_and_current_stat
         ))
         .await
         .expect("Failed to update row");
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // --- WHEN: read via the __current view ---
     let rows: Vec<IdValueRow> = clickhouse_db
@@ -433,7 +437,8 @@ async fn composite_pk_pk_order_by_matches_pk_ordinal() {
         .build_destination_with_engine(store.clone(), ClickHouseEngine::ReplacingMergeTree)
         .await;
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -444,7 +449,7 @@ async fn composite_pk_pk_order_by_matches_pk_ordinal() {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- WHEN: query system.tables for the created ReplacingMergeTree ORDER BY
@@ -516,7 +521,8 @@ async fn replacing_merge_tree_streamed_update_wins_over_initial_copy_row() {
             .await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -527,10 +533,10 @@ async fn replacing_merge_tree_streamed_update_wins_over_initial_copy_row() {
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     // --- WHEN: stream an UPDATE for the copied row ---
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
         .await;
     database
@@ -540,7 +546,7 @@ async fn replacing_merge_tree_streamed_update_wins_over_initial_copy_row() {
         ))
         .await
         .expect("Failed to update");
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     let query = current_state_query(
         ClickHouseEngine::ReplacingMergeTree,
@@ -605,7 +611,8 @@ async fn replacing_merge_tree_optimize_cleanup_physically_removes_tombstoned_row
             .await,
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -616,16 +623,16 @@ async fn replacing_merge_tree_optimize_cleanup_physically_removes_tombstoned_row
     );
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
         .await;
     database
         .run_sql(&format!("DELETE FROM {} WHERE id = 1", table_name.as_quoted_identifier()))
         .await
         .expect("Failed to delete");
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // --- WHEN: operator runs OPTIMIZE ... FINAL CLEANUP ---
     let optimize_sql = optimize_final_cleanup_sql("test_final__cleanup");
@@ -708,7 +715,8 @@ async fn engine_mismatch_runs(first: ClickHouseEngine, second: ClickHouseEngine)
         let store = NotifyingStore::new();
         let pipeline_id: PipelineId = random();
         let destination = clickhouse_db.build_destination_with_engine(store.clone(), first).await;
-        let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+        let table_ready_notify =
+            store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
         let mut pipeline = create_pipeline(
             &database.config,
             pipeline_id,
@@ -717,7 +725,7 @@ async fn engine_mismatch_runs(first: ClickHouseEngine, second: ClickHouseEngine)
             destination,
         );
         pipeline.start().await.unwrap();
-        table_ready.notified().await;
+        table_ready_notify.notified().await;
         pipeline.shutdown_and_wait().await.unwrap();
     }
 
@@ -726,7 +734,8 @@ async fn engine_mismatch_runs(first: ClickHouseEngine, second: ClickHouseEngine)
     let store = NotifyingStore::new();
     let pipeline_id: PipelineId = random();
     let destination = clickhouse_db.build_destination_with_engine(store.clone(), second).await;
-    let table_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+    let table_errored_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -736,7 +745,7 @@ async fn engine_mismatch_runs(first: ClickHouseEngine, second: ClickHouseEngine)
         destination,
     );
     pipeline.start().await.unwrap();
-    table_errored.notified().await;
+    table_errored_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // --- THEN: the Errored state reason names the engine mismatch ---

--- a/crates/etl-destinations/tests/clickhouse/pipeline_replacing_merge_tree.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline_replacing_merge_tree.rs
@@ -9,6 +9,7 @@ use etl::{
     store::{StateStore, TableState, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
@@ -153,7 +154,10 @@ async fn replacing_merge_tree_same_lsn_tx_insert_then_update_keeps_update() {
 
     // --- WHEN: INSERT + UPDATE in the same transaction ---
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Insert, 1), (EventType::Update, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Update, table_id, 1),
+        ])
         .await;
 
     let tx = database.begin_transaction().await;
@@ -253,7 +257,10 @@ async fn replacing_merge_tree_same_lsn_tx_delete_then_insert_keeps_insert() {
 
     // --- WHEN: DELETE + INSERT of the same id in one transaction ---
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Delete, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Delete, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     let tx = database.begin_transaction().await;
@@ -339,7 +346,9 @@ async fn replacing_merge_tree_current_view_exposes_user_columns_and_current_stat
     pipeline.start().await.unwrap();
     table_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
     database
         .run_sql(&format!(
             "UPDATE {} SET value = 'after' WHERE id = 1",
@@ -521,7 +530,9 @@ async fn replacing_merge_tree_streamed_update_wins_over_initial_copy_row() {
     table_ready.notified().await;
 
     // --- WHEN: stream an UPDATE for the copied row ---
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
+        .await;
     database
         .run_sql(&format!(
             "UPDATE {} SET value = 'streamed_value' WHERE id = 1",
@@ -607,7 +618,9 @@ async fn replacing_merge_tree_optimize_cleanup_physically_removes_tombstoned_row
     pipeline.start().await.unwrap();
     table_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
     database
         .run_sql(&format!("DELETE FROM {} WHERE id = 1", table_name.as_quoted_identifier()))
         .await

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -408,17 +408,17 @@ async fn table_copy_and_streaming_with_restart() {
         destination.clone(),
     );
 
-    let users_ready = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_ready = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
-    orders_ready.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
@@ -448,7 +448,7 @@ async fn table_copy_and_streaming_with_restart() {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
@@ -464,7 +464,7 @@ async fn table_copy_and_streaming_with_restart() {
     )
     .await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
@@ -526,12 +526,12 @@ async fn table_copy_reset_drops_destination_table_before_recopy() {
         destination.clone(),
     );
 
-    let users_ready =
+    let users_ready_notify =
         store.notify_on_table_state_type(users_schema.id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -566,12 +566,12 @@ async fn table_copy_reset_drops_destination_table_before_recopy() {
         destination.clone(),
     );
 
-    let users_ready =
+    let users_ready_notify =
         store.notify_on_table_state_type(users_schema.id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -620,19 +620,19 @@ async fn table_copy_and_streaming_without_restart() {
         destination.clone(),
     );
 
-    let users_ready = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_ready = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
-    orders_ready.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
@@ -648,7 +648,7 @@ async fn table_copy_and_streaming_without_restart() {
     )
     .await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
@@ -690,7 +690,7 @@ async fn table_insert_update_delete() {
 
     let store = NotifyingStore::new();
     let pipeline_id: PipelineId = random();
-    let users_ready = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
@@ -704,9 +704,9 @@ async fn table_insert_update_delete() {
     );
 
     pipeline.start().await.unwrap();
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
             EventType::Insert,
             database_schema.users_schema().id,
@@ -723,7 +723,7 @@ async fn table_insert_update_delete() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
     checkpoint_lake(&catalog_url, &data_url);
@@ -743,7 +743,7 @@ async fn table_insert_update_delete() {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
             EventType::Update,
             database_schema.users_schema().id,
@@ -760,7 +760,7 @@ async fn table_insert_update_delete() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
     checkpoint_lake(&catalog_url, &data_url);
@@ -780,7 +780,7 @@ async fn table_insert_update_delete() {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
             EventType::Delete,
             database_schema.users_schema().id,
@@ -793,7 +793,7 @@ async fn table_insert_update_delete() {
         .await
         .unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
     checkpoint_lake(&catalog_url, &data_url);
@@ -830,19 +830,19 @@ async fn cdc_streaming_with_truncate() {
         destination.clone(),
     );
 
-    let users_ready = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_ready = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
-    orders_ready.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
@@ -858,9 +858,9 @@ async fn cdc_streaming_with_truncate() {
     )
     .await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Truncate, database_schema.users_schema().id, 1),
             EventCondition::TableCount(EventType::Truncate, database_schema.orders_schema().id, 1),
@@ -870,9 +870,9 @@ async fn cdc_streaming_with_truncate() {
     database.truncate_table(database_schema.users_schema().name.clone()).await.unwrap();
     database.truncate_table(database_schema.orders_schema().name.clone()).await.unwrap();
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 4),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 4),
@@ -888,7 +888,7 @@ async fn cdc_streaming_with_truncate() {
     )
     .await;
 
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
@@ -947,10 +947,11 @@ async fn schema_change_add_column() {
         store.clone(),
         destination.clone(),
     );
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     let initial_metadata = store
         .get_applied_destination_table_metadata(table_id)
@@ -959,7 +960,7 @@ async fn schema_change_add_column() {
         .expect("metadata should exist after table creation");
     let initial_snapshot_id = initial_metadata.snapshot_id;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -987,7 +988,7 @@ async fn schema_change_add_column() {
         .await
         .expect("failed to insert Bob");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
     checkpoint_lake(&catalog_url, &data_url);
@@ -1057,10 +1058,11 @@ async fn schema_change_is_visible_to_already_open_connection() {
         store.clone(),
         destination.clone(),
     );
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     let initial_snapshot_id = store
         .get_applied_destination_table_metadata(table_id)
@@ -1073,7 +1075,7 @@ async fn schema_change_is_visible_to_already_open_connection() {
     let conn = open_lake_conn(&catalog_url, &data_url);
     assert_eq!(query_table_columns(&conn, &ducklake_table_name), vec!["id", "name", "age"]);
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1101,7 +1103,7 @@ async fn schema_change_is_visible_to_already_open_connection() {
         .await
         .expect("failed to insert Bob");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
     checkpoint_lake(&catalog_url, &data_url);
@@ -1175,12 +1177,13 @@ async fn schema_change_add_drop_rename() {
         store.clone(),
         destination.clone(),
     );
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1214,7 +1217,7 @@ async fn schema_change_add_drop_rename() {
         .await
         .expect("failed to insert Bob");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
     checkpoint_lake(&catalog_url, &data_url);
@@ -1281,12 +1284,13 @@ async fn schema_change_then_update_and_delete() {
         store.clone(),
         destination.clone(),
     );
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1332,7 +1336,7 @@ async fn schema_change_then_update_and_delete() {
         .await
         .expect("failed to delete Bob");
 
-    event_notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
     checkpoint_lake(&catalog_url, &data_url);
@@ -1384,12 +1388,13 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         store.clone(),
         destination.clone(),
     );
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1409,8 +1414,8 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         ))
         .await
         .expect("failed to insert row after generated column add");
-    event_notify.notified().await;
-    let event_notify = destination
+    events_notify.notified().await;
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 2),
             EventCondition::TableCount(EventType::Insert, table_id, 2),
@@ -1430,8 +1435,8 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         ))
         .await
         .expect("failed to insert row after generated column rename");
-    event_notify.notified().await;
-    let event_notify = destination
+    events_notify.notified().await;
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 3),
             EventCondition::TableCount(EventType::Insert, table_id, 3),
@@ -1448,8 +1453,8 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         ))
         .await
         .expect("failed to insert row after generated column drop");
-    event_notify.notified().await;
-    let event_notify = destination
+    events_notify.notified().await;
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 4),
             EventCondition::TableCount(EventType::Insert, table_id, 4),
@@ -1469,7 +1474,7 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         ))
         .await
         .expect("failed to insert row after generated column re-add");
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);
@@ -1530,12 +1535,13 @@ async fn schema_change_matches_simulator_generated_column_types() {
         store.clone(),
         destination.clone(),
     );
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -1555,8 +1561,8 @@ async fn schema_change_matches_simulator_generated_column_types() {
         ))
         .await
         .expect("failed to insert row after text generated column add");
-    event_notify.notified().await;
-    let event_notify = destination
+    events_notify.notified().await;
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 2),
             EventCondition::TableCount(EventType::Insert, table_id, 2),
@@ -1577,8 +1583,8 @@ async fn schema_change_matches_simulator_generated_column_types() {
         ))
         .await
         .expect("failed to insert row after integer generated column add");
-    event_notify.notified().await;
-    let event_notify = destination
+    events_notify.notified().await;
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 3),
             EventCondition::TableCount(EventType::Insert, table_id, 3),
@@ -1599,8 +1605,8 @@ async fn schema_change_matches_simulator_generated_column_types() {
         ))
         .await
         .expect("failed to insert row after boolean generated column add");
-    event_notify.notified().await;
-    let event_notify = destination
+    events_notify.notified().await;
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 4),
             EventCondition::TableCount(EventType::Insert, table_id, 4),
@@ -1621,8 +1627,8 @@ async fn schema_change_matches_simulator_generated_column_types() {
         ))
         .await
         .expect("failed to insert row after timestamptz generated column add");
-    event_notify.notified().await;
-    let event_notify = destination
+    events_notify.notified().await;
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 5),
             EventCondition::TableCount(EventType::Insert, table_id, 5),
@@ -1644,7 +1650,7 @@ async fn schema_change_matches_simulator_generated_column_types() {
         ))
         .await
         .expect("failed to insert row after numeric generated column add");
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
     drop(destination);

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -859,7 +859,6 @@ async fn cdc_streaming_with_truncate() {
     .await;
 
     event_notify.notified().await;
-    destination.clear_events().await;
 
     let event_notify = destination
         .wait_for_events(vec![
@@ -872,12 +871,11 @@ async fn cdc_streaming_with_truncate() {
     database.truncate_table(database_schema.orders_schema().name.clone()).await.unwrap();
 
     event_notify.notified().await;
-    destination.clear_events().await;
 
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
-            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 4),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 4),
         ])
         .await;
 
@@ -1412,12 +1410,10 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         .await
         .expect("failed to insert row after generated column add");
     event_notify.notified().await;
-
-    destination.clear_events().await;
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
         ])
         .await;
     database
@@ -1435,12 +1431,10 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         .await
         .expect("failed to insert row after generated column rename");
     event_notify.notified().await;
-
-    destination.clear_events().await;
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
         ])
         .await;
     database
@@ -1455,12 +1449,10 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
         .await
         .expect("failed to insert row after generated column drop");
     event_notify.notified().await;
-
-    destination.clear_events().await;
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 4),
+            EventCondition::TableCount(EventType::Insert, table_id, 4),
         ])
         .await;
     database
@@ -1564,12 +1556,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
         .await
         .expect("failed to insert row after text generated column add");
     event_notify.notified().await;
-
-    destination.clear_events().await;
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
         ])
         .await;
     database
@@ -1588,12 +1578,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
         .await
         .expect("failed to insert row after integer generated column add");
     event_notify.notified().await;
-
-    destination.clear_events().await;
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
         ])
         .await;
     database
@@ -1612,12 +1600,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
         .await
         .expect("failed to insert row after boolean generated column add");
     event_notify.notified().await;
-
-    destination.clear_events().await;
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 4),
+            EventCondition::TableCount(EventType::Insert, table_id, 4),
         ])
         .await;
     database
@@ -1636,12 +1622,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
         .await
         .expect("failed to insert row after timestamptz generated column add");
     event_notify.notified().await;
-
-    destination.clear_events().await;
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 5),
+            EventCondition::TableCount(EventType::Insert, table_id, 5),
         ])
         .await;
     database

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -10,6 +10,7 @@ use etl::{
     store::{StateStore, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
@@ -447,7 +448,12 @@ async fn table_copy_and_streaming_with_restart() {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     insert_mock_data(
         &mut database,
@@ -626,7 +632,12 @@ async fn table_copy_and_streaming_without_restart() {
     users_ready.notified().await;
     orders_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     insert_mock_data(
         &mut database,
@@ -695,7 +706,13 @@ async fn table_insert_update_delete() {
     pipeline.start().await.unwrap();
     users_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Insert,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
 
     database
         .insert_values(
@@ -726,7 +743,13 @@ async fn table_insert_update_delete() {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Update,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
 
     database
         .update_values(
@@ -757,7 +780,13 @@ async fn table_insert_update_delete() {
 
     pipeline.start().await.unwrap();
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Delete,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
 
     database
         .delete_values(database_schema.users_schema().name.clone(), &["id"], &["1"], "")
@@ -813,7 +842,12 @@ async fn cdc_streaming_with_truncate() {
     users_ready.notified().await;
     orders_ready.notified().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     insert_mock_data(
         &mut database,
@@ -827,7 +861,12 @@ async fn cdc_streaming_with_truncate() {
     event_notify.notified().await;
     destination.clear_events().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Truncate, 2)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Truncate, database_schema.users_schema().id, 1),
+            EventCondition::TableCount(EventType::Truncate, database_schema.orders_schema().id, 1),
+        ])
+        .await;
 
     database.truncate_table(database_schema.users_schema().name.clone()).await.unwrap();
     database.truncate_table(database_schema.orders_schema().name.clone()).await.unwrap();
@@ -835,7 +874,12 @@ async fn cdc_streaming_with_truncate() {
     event_notify.notified().await;
     destination.clear_events().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     insert_mock_data(
         &mut database,
@@ -918,7 +962,10 @@ async fn schema_change_add_column() {
     let initial_snapshot_id = initial_metadata.snapshot_id;
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -1029,7 +1076,10 @@ async fn schema_change_is_visible_to_already_open_connection() {
     assert_eq!(query_table_columns(&conn, &ducklake_table_name), vec!["id", "name", "age"]);
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -1133,7 +1183,10 @@ async fn schema_change_add_drop_rename() {
     table_ready.notified().await;
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -1236,11 +1289,11 @@ async fn schema_change_then_update_and_delete() {
     table_ready.notified().await;
 
     let event_notify = destination
-        .wait_for_events_count(vec![
-            (EventType::Relation, 1),
-            (EventType::Insert, 1),
-            (EventType::Update, 1),
-            (EventType::Delete, 1),
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Update, table_id, 1),
+            EventCondition::TableCount(EventType::Delete, table_id, 1),
         ])
         .await;
 
@@ -1339,7 +1392,10 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
     table_ready.notified().await;
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1359,7 +1415,10 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
 
     destination.clear_events().await;
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1379,7 +1438,10 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
 
     destination.clear_events().await;
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(table_name.clone(), &[TableModification::DropColumn { name: "ddl_col_0_1" }])
@@ -1396,7 +1458,10 @@ async fn schema_change_matches_simulator_generated_column_rotation() {
 
     destination.clear_events().await;
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1479,7 +1544,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
     table_ready.notified().await;
 
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1499,7 +1567,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
 
     destination.clear_events().await;
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1520,7 +1591,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
 
     destination.clear_events().await;
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1541,7 +1615,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
 
     destination.clear_events().await;
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(
@@ -1562,7 +1639,10 @@ async fn schema_change_matches_simulator_generated_column_types() {
 
     destination.clear_events().await;
     let event_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
     database
         .alter_table(

--- a/crates/etl-destinations/tests/iceberg/destination.rs
+++ b/crates/etl-destinations/tests/iceberg/destination.rs
@@ -284,7 +284,6 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
 
     // Wait for all CDC insert events to be written to Iceberg.
     event_notify.notified().await;
-    destination.clear_events().await;
 
     // === CDC UPDATE EVENTS ===
     // We'll expect 2 updates per table.
@@ -317,7 +316,6 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
 
     // Wait for all CDC update events to be written to Iceberg.
     event_notify.notified().await;
-    destination.clear_events().await;
 
     // === CDC DELETE EVENTS ===
     // We'll expect 1 delete per table.
@@ -570,7 +568,6 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
 
     // Wait for all expected insert events to be processed.
     event_notify.notified().await;
-    destination.clear_events().await;
 
     let event_notify = destination
         .wait_for_events(vec![
@@ -586,7 +583,6 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
 
     // Wait for all expected truncate events to be processed.
     event_notify.notified().await;
-    destination.clear_events().await;
 
     // base table names
     let users_table = table_name_to_iceberg_table_name(
@@ -609,8 +605,8 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     // We'll expect 2 inserts per table.
     let event_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
-            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 4),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 4),
         ])
         .await;
 
@@ -626,7 +622,6 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
 
     // Wait for all expected insert and truncate events to be processed.
     event_notify.notified().await;
-    destination.clear_events().await;
 
     // After truncate, pre-truncate CDC rows should be gone (tables were dropped).
     // Only post-truncate rows remain.

--- a/crates/etl-destinations/tests/iceberg/destination.rs
+++ b/crates/etl-destinations/tests/iceberg/destination.rs
@@ -101,17 +101,17 @@ async fn run_table_copy_test(destination_namespace: DestinationNamespace) {
     );
 
     // Register notifications for table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -250,22 +250,22 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     );
 
     // Register notifications for table copy completion (Ready for both tables).
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
     // Wait until initial sync is done before producing CDC events.
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     // === CDC INSERT EVENTS ===
     // We'll expect 2 inserts per table.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
@@ -283,11 +283,11 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     .await;
 
     // Wait for all CDC insert events to be written to Iceberg.
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // === CDC UPDATE EVENTS ===
     // We'll expect 2 updates per table.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Update, database_schema.users_schema().id, 2),
             EventCondition::TableCount(EventType::Update, database_schema.orders_schema().id, 2),
@@ -315,11 +315,11 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
         .unwrap();
 
     // Wait for all CDC update events to be written to Iceberg.
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // === CDC DELETE EVENTS ===
     // We'll expect 1 delete per table.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Delete, database_schema.users_schema().id, 1),
             EventCondition::TableCount(EventType::Delete, database_schema.orders_schema().id, 1),
@@ -339,7 +339,7 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
         .unwrap();
 
     // Wait for all CDC delete events to be written to Iceberg.
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // base table names
     let users_table = table_name_to_iceberg_table_name(
@@ -535,21 +535,21 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     );
 
     // Register notifications for table copy completion (Ready for both tables).
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
     // Wait until initial sync is done before producing CDC events.
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     // We'll expect 2 inserts per table.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
@@ -567,9 +567,9 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     .await;
 
     // Wait for all expected insert events to be processed.
-    event_notify.notified().await;
+    events_notify.notified().await;
 
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Truncate, database_schema.users_schema().id, 1),
             EventCondition::TableCount(EventType::Truncate, database_schema.orders_schema().id, 1),
@@ -582,7 +582,7 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     database.truncate_table(database_schema.orders_schema().name.clone()).await.unwrap();
 
     // Wait for all expected truncate events to be processed.
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // base table names
     let users_table = table_name_to_iceberg_table_name(
@@ -603,7 +603,7 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     assert!(actual_orders.is_empty());
 
     // We'll expect 2 inserts per table.
-    let event_notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 4),
             EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 4),
@@ -621,7 +621,7 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     .await;
 
     // Wait for all expected insert and truncate events to be processed.
-    event_notify.notified().await;
+    events_notify.notified().await;
 
     // After truncate, pre-truncate CDC rows should be gone (tables were dropped).
     // Only post-truncate rows remain.

--- a/crates/etl-destinations/tests/iceberg/destination.rs
+++ b/crates/etl-destinations/tests/iceberg/destination.rs
@@ -5,6 +5,7 @@ use etl::{
     store::TableStateType,
     test_utils::{
         database::spawn_source_database,
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
@@ -263,8 +264,13 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     orders_state_notify.notified().await;
 
     // === CDC INSERT EVENTS ===
-    // We'll expect 2 inserts per table -> 4 insert events total.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    // We'll expect 2 inserts per table.
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     // Insert rows AFTER Ready so they are captured as CDC events.
     insert_mock_data(
@@ -281,8 +287,13 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     destination.clear_events().await;
 
     // === CDC UPDATE EVENTS ===
-    // We'll expect 2 updates per table -> 4 update events total.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Update, 4)]).await;
+    // We'll expect 2 updates per table.
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Update, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Update, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     // Update users
     database
@@ -309,8 +320,13 @@ async fn run_cdc_streaming_test(destination_namespace: DestinationNamespace) {
     destination.clear_events().await;
 
     // === CDC DELETE EVENTS ===
-    // We'll expect 1 delete per table -> 2 delete events total.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Delete, 2)]).await;
+    // We'll expect 1 delete per table.
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Delete, database_schema.users_schema().id, 1),
+            EventCondition::TableCount(EventType::Delete, database_schema.orders_schema().id, 1),
+        ])
+        .await;
 
     // Delete user with id 1
     database
@@ -534,8 +550,13 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     users_state_notify.notified().await;
     orders_state_notify.notified().await;
 
-    // We'll expect 2 inserts per table -> 4 insert events total.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    // We'll expect 2 inserts per table.
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     // Insert 2 rows per each table (captured as CDC UPSERT events).
     insert_mock_data(
@@ -551,7 +572,12 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     event_notify.notified().await;
     destination.clear_events().await;
 
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Truncate, 2)]).await;
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Truncate, database_schema.users_schema().id, 1),
+            EventCondition::TableCount(EventType::Truncate, database_schema.orders_schema().id, 1),
+        ])
+        .await;
 
     // Truncate both tables in the source; destination should drop and recreate base
     // + CDC tables.
@@ -580,8 +606,13 @@ async fn run_cdc_streaming_with_truncate_test(destination_namespace: Destination
     assert!(actual_users.is_empty());
     assert!(actual_orders.is_empty());
 
-    // We'll expect 2 inserts per table -> 4 insert events total.
-    let event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    // We'll expect 2 inserts per table.
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 2),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 2),
+        ])
+        .await;
 
     // Insert 2 extra rows per each table after truncation.
     insert_mock_data(

--- a/crates/etl-destinations/tests/snowflake/pipeline.rs
+++ b/crates/etl-destinations/tests/snowflake/pipeline.rs
@@ -160,10 +160,11 @@ async fn schema_change_add_column_defaults() {
             store.clone(),
             destination.clone(),
         );
-        let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+        let table_ready_notify =
+            store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
         pipeline.start().await.unwrap();
-        table_ready.notified().await;
+        table_ready_notify.notified().await;
 
         let zero_offset = OffsetToken::zero();
         let committed = poll_destination_offset(
@@ -180,7 +181,7 @@ async fn schema_change_add_column_defaults() {
             wait_for_initial_row(&sql, config.database(), config.schema(), &snowflake_table).await;
         assert_eq!(initial_rows, vec![vec![serde_json::json!("1"), serde_json::json!("Alice")]]);
 
-        let event_notify = destination
+        let events_notify = destination
             .wait_for_events(vec![
                 EventCondition::TableCount(EventType::Relation, table_id, 1),
                 EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -212,7 +213,7 @@ async fn schema_change_add_column_defaults() {
             .await
             .expect("failed to insert defaulted source row");
 
-        event_notify.notified().await;
+        events_notify.notified().await;
         pipeline.shutdown_and_wait().await.unwrap();
 
         let expected = vec![

--- a/crates/etl-destinations/tests/snowflake/pipeline.rs
+++ b/crates/etl-destinations/tests/snowflake/pipeline.rs
@@ -7,6 +7,7 @@ use etl::{
     store::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         test_destination_wrapper::TestDestinationWrapper,
@@ -180,7 +181,10 @@ async fn schema_change_add_column_defaults() {
         assert_eq!(initial_rows, vec![vec![serde_json::json!("1"), serde_json::json!("Alice")]]);
 
         let event_notify = destination
-            .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+            .wait_for_events(vec![
+                EventCondition::TableCount(EventType::Relation, table_id, 1),
+                EventCondition::TableCount(EventType::Insert, table_id, 1),
+            ])
             .await;
 
         database

--- a/crates/etl/src/test_utils/event.rs
+++ b/crates/etl/src/test_utils/event.rs
@@ -9,10 +9,29 @@ use crate::{
 /// Condition for waiting on events in tests.
 #[derive(Clone, Debug)]
 pub enum EventCondition {
-    /// Wait for a count of events of the given type across all tables.
-    Any(EventType, u64),
-    /// Wait for a count of events of the given type for a specific table.
-    Table(EventType, TableId, u64),
+    /// Wait for at least a count of events of the given type across all tables.
+    AnyCount(EventType, u64),
+    /// Wait for at least a count of events of the given type for a table.
+    TableCount(EventType, TableId, u64),
+}
+
+/// Checks whether the recorded events satisfy every condition.
+pub fn check_event_conditions(events: &[Event], conditions: &[EventCondition]) -> bool {
+    let grouped_events_by_type = group_events_by_type(events);
+    let grouped_events_by_type_and_table = group_events_by_type_and_table_id(events);
+
+    conditions.iter().all(|condition| match condition {
+        EventCondition::AnyCount(event_type, expected_count) => {
+            grouped_events_by_type.get(event_type).map_or(0, |events| events.len() as u64)
+                >= *expected_count
+        }
+        EventCondition::TableCount(event_type, table_id, expected_count) => {
+            grouped_events_by_type_and_table
+                .get(&(event_type.clone(), *table_id))
+                .map_or(0, |events| events.len() as u64)
+                >= *expected_count
+        }
+    })
 }
 
 pub fn group_events_by_type(events: &[Event]) -> HashMap<EventType, Vec<Event>> {
@@ -57,21 +76,21 @@ pub fn group_events_by_type_and_table_id(
 /// counts.
 ///
 /// Supports two condition types:
-/// - [`EventCondition::Any`]: counts events across all tables
-/// - [`EventCondition::Table`]: counts events for a specific table only
+/// - [`EventCondition::AnyCount`]: counts events across all tables
+/// - [`EventCondition::TableCount`]: counts events for a specific table only
 ///
 /// For [`EventType::Insert`], both streaming insert events and table copy rows
 /// are counted. For other event types, only streaming events are counted.
-pub fn check_all_events_count(
+pub fn check_all_event_conditions(
     events: &[Event],
     table_rows: &HashMap<TableId, Vec<TableRow>>,
-    conditions: Vec<EventCondition>,
+    conditions: &[EventCondition],
 ) -> bool {
     let grouped_events_by_type = group_events_by_type(events);
     let grouped_events_by_type_and_table = group_events_by_type_and_table_id(events);
 
     conditions.iter().all(|condition| match condition {
-        EventCondition::Any(event_type, expected_count) => {
+        EventCondition::AnyCount(event_type, expected_count) => {
             let event_count =
                 grouped_events_by_type.get(event_type).map_or(0, |events| events.len() as u64);
 
@@ -83,7 +102,7 @@ pub fn check_all_events_count(
 
             event_count + table_row_count >= *expected_count
         }
-        EventCondition::Table(event_type, table_id, expected_count) => {
+        EventCondition::TableCount(event_type, table_id, expected_count) => {
             let event_count = grouped_events_by_type_and_table
                 .get(&(event_type.clone(), *table_id))
                 .map_or(0, |events| events.len() as u64);
@@ -97,4 +116,43 @@ pub fn check_all_events_count(
             event_count + table_row_count >= *expected_count
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_conditions_use_minimum_counts() {
+        let events = vec![Event::Unsupported, Event::Unsupported];
+
+        assert!(check_event_conditions(
+            &events,
+            &[EventCondition::AnyCount(EventType::Unsupported, 2)]
+        ));
+        assert!(!check_event_conditions(
+            &events,
+            &[EventCondition::AnyCount(EventType::Unsupported, 3)]
+        ));
+    }
+
+    #[test]
+    fn all_event_conditions_treat_copied_rows_as_inserts() {
+        let table_id = TableId::new(1);
+        let table_rows =
+            HashMap::from([(table_id, vec![TableRow::new(Vec::new()), TableRow::new(Vec::new())])]);
+
+        assert!(check_all_event_conditions(
+            &[],
+            &table_rows,
+            &[
+                EventCondition::AnyCount(EventType::Insert, 2),
+                EventCondition::TableCount(EventType::Insert, table_id, 2),
+            ],
+        ));
+        assert!(!check_event_conditions(
+            &[],
+            &[EventCondition::TableCount(EventType::Insert, table_id, 1)],
+        ));
+    }
 }

--- a/crates/etl/src/test_utils/event.rs
+++ b/crates/etl/src/test_utils/event.rs
@@ -9,9 +9,9 @@ use crate::{
 /// Condition for waiting on events in tests.
 #[derive(Clone, Debug)]
 pub enum EventCondition {
-    /// Wait for at least a count of events of the given type across all tables.
+    /// Wait for an exact count of events of the given type across all tables.
     AnyCount(EventType, u64),
-    /// Wait for at least a count of events of the given type for a table.
+    /// Wait for an exact count of events of the given type for a table.
     TableCount(EventType, TableId, u64),
 }
 
@@ -23,13 +23,13 @@ pub fn check_event_conditions(events: &[Event], conditions: &[EventCondition]) -
     conditions.iter().all(|condition| match condition {
         EventCondition::AnyCount(event_type, expected_count) => {
             grouped_events_by_type.get(event_type).map_or(0, |events| events.len() as u64)
-                >= *expected_count
+                == *expected_count
         }
         EventCondition::TableCount(event_type, table_id, expected_count) => {
             grouped_events_by_type_and_table
                 .get(&(event_type.clone(), *table_id))
                 .map_or(0, |events| events.len() as u64)
-                >= *expected_count
+                == *expected_count
         }
     })
 }
@@ -72,7 +72,7 @@ pub fn group_events_by_type_and_table_id(
     grouped
 }
 
-/// Checks if the combined count of events and table rows meets the expected
+/// Checks if the combined count of events and table rows equals the expected
 /// counts.
 ///
 /// Supports two condition types:
@@ -100,7 +100,7 @@ pub fn check_all_event_conditions(
                 0
             };
 
-            event_count + table_row_count >= *expected_count
+            event_count + table_row_count == *expected_count
         }
         EventCondition::TableCount(event_type, table_id, expected_count) => {
             let event_count = grouped_events_by_type_and_table
@@ -113,7 +113,7 @@ pub fn check_all_event_conditions(
                 0
             };
 
-            event_count + table_row_count >= *expected_count
+            event_count + table_row_count == *expected_count
         }
     })
 }
@@ -123,12 +123,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn event_conditions_use_minimum_counts() {
+    fn event_conditions_use_exact_counts() {
         let events = vec![Event::Unsupported, Event::Unsupported];
 
         assert!(check_event_conditions(
             &events,
             &[EventCondition::AnyCount(EventType::Unsupported, 2)]
+        ));
+        assert!(!check_event_conditions(
+            &events,
+            &[EventCondition::AnyCount(EventType::Unsupported, 1)]
         ));
         assert!(!check_event_conditions(
             &events,
@@ -149,6 +153,11 @@ mod tests {
                 EventCondition::AnyCount(EventType::Insert, 2),
                 EventCondition::TableCount(EventType::Insert, table_id, 2),
             ],
+        ));
+        assert!(!check_all_event_conditions(
+            &[],
+            &table_rows,
+            &[EventCondition::TableCount(EventType::Insert, table_id, 1)],
         ));
         assert!(!check_event_conditions(
             &[],

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -17,19 +17,18 @@ use crate::{
         PipelineDestination, WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
     error::EtlResult,
-    event::{Event, EventType},
+    event::Event,
     runtime::concurrency::TaskSet,
     schema::{ReplicatedTableSchema, TableId},
     test_utils::{
-        event::{EventCondition, check_all_events_count, group_events_by_type},
+        event::{EventCondition, check_all_event_conditions, check_event_conditions},
         faults::{FaultAction, FaultInjector, FaultyOp, HoldHandle, apply_response_fault},
         notify::TimedNotify,
     },
 };
 
-type EventCheckFn = Box<dyn Fn(&[Event]) -> bool + Send + Sync>;
-type TableRowCheckFn = Box<dyn Fn(&HashMap<TableId, Vec<TableRow>>) -> bool + Send + Sync>;
-type CombinedCheckFn =
+type EventsCheckFn = Box<dyn Fn(&[Event]) -> bool + Send + Sync>;
+type AllEventsCheckFn =
     Box<dyn Fn(&[Event], &HashMap<TableId, Vec<TableRow>>) -> bool + Send + Sync>;
 
 struct Inner<D> {
@@ -37,9 +36,8 @@ struct Inner<D> {
     events: Vec<Event>,
     table_rows: HashMap<TableId, Vec<TableRow>>,
     tables_dropped_for_copy: HashSet<TableId>,
-    event_conditions: Vec<(EventCheckFn, Arc<Notify>)>,
-    table_row_conditions: Vec<(TableRowCheckFn, Arc<Notify>)>,
-    combined_conditions: Vec<(CombinedCheckFn, Arc<Notify>)>,
+    event_notifications: Vec<(EventsCheckFn, Arc<Notify>)>,
+    all_event_notifications: Vec<(AllEventsCheckFn, Arc<Notify>)>,
     write_table_rows_called: u64,
     shutdown_called: bool,
 }
@@ -47,30 +45,19 @@ struct Inner<D> {
 impl<D> Inner<D> {
     fn check_conditions(&mut self) {
         // Check event conditions.
-        let events = self.events.clone();
-        self.event_conditions.retain(|(condition, notify)| {
-            let should_retain = !condition(&events);
+        let events = &self.events;
+        self.event_notifications.retain(|(condition, notify)| {
+            let should_retain = !condition(events);
             if !should_retain {
                 notify.notify_one();
             }
             should_retain
         });
 
-        // Check table row conditions.
-        let table_rows = self.table_rows.clone();
-        self.table_row_conditions.retain(|(condition, notify)| {
-            let should_retain = !condition(&table_rows);
-            if !should_retain {
-                notify.notify_one();
-            }
-            should_retain
-        });
-
-        // Check combined conditions.
-        let events = self.events.clone();
-        let table_rows = self.table_rows.clone();
-        self.combined_conditions.retain(|(condition, notify)| {
-            let should_retain = !condition(&events, &table_rows);
+        let table_rows = &self.table_rows;
+        // Check conditions spanning streaming events and table-copy rows.
+        self.all_event_notifications.retain(|(condition, notify)| {
+            let should_retain = !condition(events, table_rows);
             if !should_retain {
                 notify.notify_one();
             }
@@ -127,9 +114,8 @@ impl<D> TestDestinationWrapper<D> {
             events: Vec::new(),
             table_rows: HashMap::new(),
             tables_dropped_for_copy: HashSet::new(),
-            event_conditions: Vec::new(),
-            table_row_conditions: Vec::new(),
-            combined_conditions: Vec::new(),
+            event_notifications: Vec::new(),
+            all_event_notifications: Vec::new(),
             write_table_rows_called: 0,
             shutdown_called: false,
         };
@@ -163,51 +149,59 @@ impl<D> TestDestinationWrapper<D> {
     {
         let notify = Arc::new(Notify::new());
         let mut inner = self.inner.write().await;
-        inner.event_conditions.push((Box::new(condition), Arc::clone(&notify)));
+        inner.event_notifications.push((Box::new(condition), Arc::clone(&notify)));
 
         TimedNotify::new(notify)
     }
 
-    /// Registers a notification that fires when future events exactly match the
-    /// requested per-type counts.
+    /// Registers a notification that fires when future events satisfy all
+    /// requested conditions.
+    ///
+    /// Only streaming events are counted. Use
+    /// [`TestDestinationWrapper::wait_for_all_events`] when copied table rows
+    /// should also count as inserts.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the expected event count is not reached. This
     /// prevents tests from hanging indefinitely.
-    pub async fn wait_for_events_count(&self, conditions: Vec<(EventType, u64)>) -> TimedNotify {
-        self.notify_on_events(move |events| {
-            let grouped_events = group_events_by_type(events);
+    pub async fn wait_for_events(&self, conditions: Vec<EventCondition>) -> TimedNotify {
+        self.notify_on_events(move |events| check_event_conditions(events, &conditions)).await
+    }
 
-            conditions.iter().all(|(event_type, count)| {
-                grouped_events.get(event_type).is_some_and(|inner| inner.len() == *count as usize)
-            })
-        })
-        .await
+    /// Registers a notification that fires when future events and table-copy
+    /// rows satisfy a condition.
+    ///
+    /// Table-copy rows are presented separately from streaming events so the
+    /// condition can decide how to interpret them.
+    pub async fn notify_on_all_events<F>(&self, condition: F) -> TimedNotify
+    where
+        F: Fn(&[Event], &HashMap<TableId, Vec<TableRow>>) -> bool + Send + Sync + 'static,
+    {
+        let notify = Arc::new(Notify::new());
+        let mut inner = self.inner.write().await;
+        inner.all_event_notifications.push((Box::new(condition), Arc::clone(&notify)));
+
+        TimedNotify::new(notify)
     }
 
     /// Registers a notification that fires when future events and table rows
     /// satisfy all requested conditions.
     ///
     /// Supports two condition types:
-    /// - [`EventCondition::Any`]: counts events across all tables
-    /// - [`EventCondition::Table`]: counts events for a specific table only
+    /// - [`EventCondition::AnyCount`]: counts events across all tables
+    /// - [`EventCondition::TableCount`]: counts events for a specific table
+    ///   only
     ///
-    /// For insert events, both streaming events and table copy rows are
-    /// counted.
+    /// Copied table rows are treated as insert events. Other event types only
+    /// count streaming events.
     ///
     /// Returns a [`TimedNotify`] that will automatically timeout after the
     /// specified timeout if the expected count is not reached.
     pub async fn wait_for_all_events(&self, conditions: Vec<EventCondition>) -> TimedNotify {
-        let notify = Arc::new(Notify::new());
-        let mut inner = self.inner.write().await;
-
-        let condition: CombinedCheckFn = Box::new(move |events, table_rows| {
-            check_all_events_count(events, table_rows, conditions.clone())
-        });
-
-        inner.combined_conditions.push((condition, Arc::clone(&notify)));
-
-        TimedNotify::new(notify)
+        self.notify_on_all_events(move |events, table_rows| {
+            check_all_event_conditions(events, table_rows, &conditions)
+        })
+        .await
     }
 
     /// Clears the recorded table rows without touching the wrapped destination.

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -1195,8 +1195,6 @@ async fn publication_changes_are_correctly_handled() {
     let table_2_inserts = grouped.get(&(EventType::Insert, table_2_id)).cloned().unwrap();
     assert_eq!(table_2_inserts.len(), 1);
 
-    destination.clear_events().await;
-
     // Create table_3 which is going to be added to the publication.
     let table_3 = test_table_name("table_3");
     let table_3_id =
@@ -1222,7 +1220,7 @@ async fn publication_changes_are_correctly_handled() {
     // Insert one row in table_1 and table_3 and wait for the new events.
     let inserts_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Insert, table_1_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_1_id, 2),
             EventCondition::TableCount(EventType::Insert, table_3_id, 1),
         ])
         .await;
@@ -1250,7 +1248,7 @@ async fn publication_changes_are_correctly_handled() {
     let events = destination.get_events().await;
     let grouped = group_events_by_type_and_table_id(&events);
     let table_1_inserts = grouped.get(&(EventType::Insert, table_1_id)).cloned().unwrap();
-    assert_eq!(table_1_inserts.len(), 1);
+    assert_eq!(table_1_inserts.len(), 2);
     let table_3_inserts = grouped.get(&(EventType::Insert, table_3_id)).cloned().unwrap();
     assert_eq!(table_3_inserts.len(), 1);
 }
@@ -1455,9 +1453,6 @@ async fn publication_for_all_tables_in_schema_ignores_new_tables_until_restart()
     pipeline.start().await.unwrap();
 
     table_ready_notify.notified().await;
-
-    // We clear the events to make waiting more idiomatic down the line.
-    destination.clear_events().await;
 
     // Wait for an insert event in table 2.
     let insert_events_notify = destination
@@ -2043,9 +2038,6 @@ async fn pipeline_respects_column_level_publication() {
         }
     }
 
-    // Clear events and restart pipeline.
-    destination.clear_events().await;
-
     // Add email column to publication -> (id, name, age, email).
     database
         .run_sql(&format!(
@@ -2058,8 +2050,8 @@ async fn pipeline_respects_column_level_publication() {
     // Wait for 1 insert event with 4 columns.
     let insert_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
         ])
         .await;
 
@@ -2078,7 +2070,7 @@ async fn pipeline_respects_column_level_publication() {
     let events = destination.get_events().await;
     let grouped = group_events_by_type_and_table_id(&events);
     let inserts = grouped.get(&(EventType::Insert, table_id)).unwrap();
-    assert_eq!(inserts.len(), 1);
+    assert_eq!(inserts.len(), 2);
 
     let relation_after_adding_email = events
         .iter()
@@ -2091,7 +2083,9 @@ async fn pipeline_respects_column_level_publication() {
         })
         .expect("Expected relation event after adding email to publication");
 
-    if let Event::Insert(InsertEvent { replicated_table_schema, table_row, .. }) = &inserts[0] {
+    if let Event::Insert(InsertEvent { replicated_table_schema, table_row, .. }) =
+        inserts.last().unwrap()
+    {
         assert_eq!(table_row.values().len(), 4);
         let col_names: Vec<&str> =
             replicated_table_schema.column_schemas().map(|c| c.name.as_str()).collect();
@@ -2121,14 +2115,11 @@ async fn pipeline_respects_column_level_publication() {
         .await
         .unwrap();
 
-    // Clear events and restart pipeline.
-    destination.clear_events().await;
-
     // Wait for 1 insert event with 3 columns (different set than before).
     let insert_notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
         ])
         .await;
 
@@ -2160,9 +2151,11 @@ async fn pipeline_respects_column_level_publication() {
         .expect("Expected relation event after removing age from publication");
     let grouped = group_events_by_type_and_table_id(&events);
     let inserts = grouped.get(&(EventType::Insert, table_id)).unwrap();
-    assert_eq!(inserts.len(), 1);
+    assert_eq!(inserts.len(), 3);
 
-    if let Event::Insert(InsertEvent { replicated_table_schema, table_row, .. }) = &inserts[0] {
+    if let Event::Insert(InsertEvent { replicated_table_schema, table_row, .. }) =
+        inserts.last().unwrap()
+    {
         assert_eq!(table_row.values().len(), 3);
         let col_names: Vec<&str> =
             replicated_table_schema.column_schemas().map(|c| c.name.as_str()).collect();
@@ -2341,40 +2334,27 @@ async fn table_sync_drops_destination_table_after_state_reset() {
 
     // Verify state before reset: table_rows has initial data, events has CDC data.
     let table_rows_before = destination.get_table_rows().await;
-    assert_eq!(
-        table_rows_before.get(&database_schema.users_schema().id).unwrap().len(),
-        initial_rows
-    );
-    assert_eq!(
-        table_rows_before.get(&database_schema.orders_schema().id).unwrap().len(),
-        initial_rows
-    );
+    let users_rows_before =
+        table_rows_before.get(&database_schema.users_schema().id).unwrap().len();
+    let orders_rows_before =
+        table_rows_before.get(&database_schema.orders_schema().id).unwrap().len();
+    assert_eq!(users_rows_before, initial_rows);
+    assert_eq!(orders_rows_before, initial_rows);
 
     let events_before = destination.get_events().await;
     let grouped_events_before = group_events_by_type_and_table_id(&events_before);
-    assert_eq!(
-        grouped_events_before
-            .get(&(EventType::Insert, database_schema.users_schema().id))
-            .unwrap()
-            .len(),
-        cdc_rows
-    );
-    assert_eq!(
-        grouped_events_before
-            .get(&(EventType::Insert, database_schema.orders_schema().id))
-            .unwrap()
-            .len(),
-        cdc_rows
-    );
+    let users_events_before = grouped_events_before
+        .get(&(EventType::Insert, database_schema.users_schema().id))
+        .unwrap()
+        .len();
+    let orders_events_before = grouped_events_before
+        .get(&(EventType::Insert, database_schema.orders_schema().id))
+        .unwrap()
+        .len();
+    assert_eq!(users_events_before, cdc_rows);
+    assert_eq!(orders_events_before, cdc_rows);
 
-    // We clear the events and rows to check that only users data is written.
-    //
-    // This deletion becomes a bit confusing when used in the context of a
-    // destination drop that should take care of deleting data by itself. In
-    // this test we just want to make sure that the drop is called and that the
-    // data is rewritten from scratch.
-    destination.clear_events().await;
-    destination.clear_table_rows().await;
+    let orders_total_before = orders_rows_before + orders_events_before;
 
     // Register waits before resetting state so they observe the resync work from
     // this point on.
@@ -2390,12 +2370,12 @@ async fn table_sync_drops_destination_table_after_state_reset() {
     // Wait for all user events (table_rows + CDC) to be processed.
     // After the state reset, data can end up in either table_rows or events
     // depending on timing.
-    let total_expected_users = initial_rows + cdc_rows + new_rows_after_reset;
+    let expected_users_resync_writes = initial_rows + cdc_rows + new_rows_after_reset;
     let all_users_events_notify = destination
         .wait_for_all_events(vec![EventCondition::TableCount(
             EventType::Insert,
             database_schema.users_schema().id,
-            total_expected_users as u64,
+            expected_users_resync_writes as u64,
         )])
         .await;
 
@@ -2420,21 +2400,21 @@ async fn table_sync_drops_destination_table_after_state_reset() {
     let events_after = destination.get_events().await;
     let grouped_events_after = group_events_by_type_and_table_id(&events_after);
 
-    // Users: table_rows + events should equal the total expected (data can be in
-    // either).
+    // Dropping users for a fresh copy removes that table's prior history from
+    // the wrapper. The replacement writes may be split between copy and
+    // streaming events.
     let users_rows = table_rows_after.get(&database_schema.users_schema().id).unwrap().len();
     let users_events = grouped_events_after
         .get(&(EventType::Insert, database_schema.users_schema().id))
         .map_or(0, Vec::len);
-    assert_eq!(users_rows + users_events, total_expected_users);
+    assert_eq!(users_rows + users_events, expected_users_resync_writes);
 
-    // Orders: no data, since we cleared it before restart and nothing should happen
-    // on orders.
-    assert!(!table_rows_after.contains_key(&database_schema.orders_schema().id));
-    assert!(
-        !grouped_events_after
-            .contains_key(&(EventType::Insert, database_schema.orders_schema().id))
-    );
+    // Orders are not resynced, so their cumulative history remains unchanged.
+    let orders_rows = table_rows_after.get(&database_schema.orders_schema().id).map_or(0, Vec::len);
+    let orders_events = grouped_events_after
+        .get(&(EventType::Insert, database_schema.orders_schema().id))
+        .map_or(0, Vec::len);
+    assert_eq!(orders_rows + orders_events, orders_total_before);
 
     // Verify the destination table was dropped for users but not for orders.
     assert!(destination.was_table_dropped_for_copy(database_schema.users_schema().id).await);
@@ -2558,10 +2538,6 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
     let states = store.get_table_states().await;
     assert_eq!(states.get(&database_schema.users_schema().id), Some(&TableState::Ready));
     assert_eq!(states.get(&database_schema.orders_schema().id), Some(&TableState::Ready));
-
-    // Clear events and table rows to prepare for updates and deletes.
-    destination.clear_events().await;
-    destination.clear_table_rows().await;
 
     // Spawn a task to perform updates and deletes.
     let rows_to_update = 5;

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -1079,8 +1079,12 @@ async fn table_schema_copy_survives_pipeline_restarts() {
 
     // We wait for two inserts to be processed, one for `users` and one for
     // `orders`.
-    let insert_events_notify =
-        destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+    let insert_events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 1),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 1),
+        ])
+        .await;
 
     // Insert a single row for each table.
     insert_mock_data(
@@ -1156,7 +1160,12 @@ async fn publication_changes_are_correctly_handled() {
     table_2_ready_notify.notified().await;
 
     // Insert one row in each table and wait for two insert events.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+    let inserts_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, table_1_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_2_id, 1),
+        ])
+        .await;
 
     database.insert_values(table_1.clone(), &["value"], &[&1]).await.unwrap();
     database.insert_values(table_2.clone(), &["value"], &[&1]).await.unwrap();
@@ -1211,7 +1220,12 @@ async fn publication_changes_are_correctly_handled() {
     table_3_ready_notify.notified().await;
 
     // Insert one row in table_1 and table_3 and wait for the new events.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+    let inserts_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, table_1_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_3_id, 1),
+        ])
+        .await;
 
     database.insert_values(table_1.clone(), &["value"], &[&2]).await.unwrap();
     database.insert_values(table_3.clone(), &["value"], &[&1]).await.unwrap();
@@ -1270,7 +1284,13 @@ async fn streaming_reconnect_does_not_replay_already_flushed_events() {
     pipeline.start().await.unwrap();
     users_ready.notified().await;
 
-    let first_insert_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let first_insert_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Insert,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
     insert_users_data(&mut database, &database_schema.users_schema().name, 1..=1).await;
     first_insert_notify.notified().await;
 
@@ -1310,10 +1330,20 @@ async fn streaming_reconnect_does_not_replay_already_flushed_events() {
 
     wait_for_new_walsender(client, &apply_slot_name, terminated_pid).await;
 
-    let second_insert_notify =
-        destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
-    let duplicate_insert_notify =
-        destination.wait_for_events_count(vec![(EventType::Insert, 3)]).await;
+    let second_insert_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Insert,
+            database_schema.users_schema().id,
+            2,
+        )])
+        .await;
+    let duplicate_insert_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Insert,
+            database_schema.users_schema().id,
+            3,
+        )])
+        .await;
 
     insert_users_data(&mut database, &database_schema.users_schema().name, 2..=2).await;
     second_insert_notify.notified().await;
@@ -1375,8 +1405,9 @@ async fn publication_for_all_tables_in_schema_ignores_new_tables_until_restart()
     table_ready_notify.notified().await;
 
     // Wait for an insert event in table 1.
-    let insert_events_notify =
-        destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let insert_events_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_1_id, 1)])
+        .await;
 
     database.insert_values(table_1.clone(), &["name"], &[&"test_name_2".to_owned()]).await.unwrap();
 
@@ -1429,8 +1460,9 @@ async fn publication_for_all_tables_in_schema_ignores_new_tables_until_restart()
     destination.clear_events().await;
 
     // Wait for an insert event in table 2.
-    let insert_events_notify =
-        destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let insert_events_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_2_id, 1)])
+        .await;
 
     database.insert_values(table_2.clone(), &["value"], &[&2_i32]).await.unwrap();
 
@@ -1501,7 +1533,12 @@ async fn run_table_sync_copy_case<F>(
     orders_table_ready_notify.notified().await;
 
     // We wait for the two inserts.
-    let events_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+    let events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, users_table_id, 1),
+            EventCondition::TableCount(EventType::Insert, orders_table_id, 1),
+        ])
+        .await;
 
     // We insert additional data.
     insert_users_data(&mut database, &users_table_name, 1..=1).await;
@@ -1687,7 +1724,12 @@ async fn table_copy_and_sync_streams_new_data() {
     .await;
 
     // We wait for all the inserts to be received.
-    let events_notify = destination.wait_for_events_count(vec![(EventType::Insert, 8)]).await;
+    let events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Insert, database_schema.users_schema().id, 4),
+            EventCondition::TableCount(EventType::Insert, database_schema.orders_schema().id, 4),
+        ])
+        .await;
 
     // Insert more data to test apply worker processing.
     insert_mock_data(
@@ -1797,7 +1839,13 @@ async fn table_sync_streams_new_data_with_batch_timeout_expired() {
     insert_users_data(&mut database, &database_schema.users_schema().name, 1..=rows_inserted).await;
 
     // We wait for all the inserts to be received.
-    let events_notify = destination.wait_for_events_count(vec![(EventType::Insert, 5)]).await;
+    let events_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Insert,
+            database_schema.users_schema().id,
+            5,
+        )])
+        .await;
 
     events_notify.notified().await;
 
@@ -1930,7 +1978,10 @@ async fn pipeline_respects_column_level_publication() {
 
     // Wait for an insert event to be processed.
     let insert_events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     // Insert test data with all columns (including email and phone).
@@ -2006,7 +2057,10 @@ async fn pipeline_respects_column_level_publication() {
 
     // Wait for 1 insert event with 4 columns.
     let insert_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -2072,7 +2126,10 @@ async fn pipeline_respects_column_level_publication() {
 
     // Wait for 1 insert event with 3 columns (different set than before).
     let insert_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -2256,8 +2313,20 @@ async fn table_sync_drops_destination_table_after_state_reset() {
     orders_ready_notify.notified().await;
 
     // Insert CDC data (ids 6-7) for both tables.
-    let cdc_events_notify =
-        destination.wait_for_events_count(vec![(EventType::Insert, (cdc_rows * 2) as u64)]).await;
+    let cdc_events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(
+                EventType::Insert,
+                database_schema.users_schema().id,
+                cdc_rows as u64,
+            ),
+            EventCondition::TableCount(
+                EventType::Insert,
+                database_schema.orders_schema().id,
+                cdc_rows as u64,
+            ),
+        ])
+        .await;
 
     insert_mock_data(
         &mut database,
@@ -2323,7 +2392,7 @@ async fn table_sync_drops_destination_table_after_state_reset() {
     // depending on timing.
     let total_expected_users = initial_rows + cdc_rows + new_rows_after_reset;
     let all_users_events_notify = destination
-        .wait_for_all_events(vec![EventCondition::Table(
+        .wait_for_all_events(vec![EventCondition::TableCount(
             EventType::Insert,
             database_schema.users_schema().id,
             total_expected_users as u64,
@@ -2412,13 +2481,20 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
         .await;
 
     // Wait for all rows to be processed (either as table copy or streaming
-    // inserts). This waits for 20 total inserts across both tables (10 users +
-    // 10 orders).
+    // inserts), requiring the expected count for each table.
     let all_events_notify = destination
-        .wait_for_all_events(vec![EventCondition::Any(
-            EventType::Insert,
-            (rows_to_insert * 2) as u64,
-        )])
+        .wait_for_all_events(vec![
+            EventCondition::TableCount(
+                EventType::Insert,
+                database_schema.users_schema().id,
+                rows_to_insert as u64,
+            ),
+            EventCondition::TableCount(
+                EventType::Insert,
+                database_schema.orders_schema().id,
+                rows_to_insert as u64,
+            ),
+        ])
         .await;
 
     // Start the pipeline only after all notifications are registered so we
@@ -2495,9 +2571,27 @@ async fn pipeline_processes_concurrent_inserts_during_startup() {
 
     // Wait for all update and delete events to be processed.
     let updates_deletes_notify = destination
-        .wait_for_events_count(vec![
-            (EventType::Update, (rows_to_update * 2) as u64),
-            (EventType::Delete, (rows_to_delete * 2) as u64),
+        .wait_for_events(vec![
+            EventCondition::TableCount(
+                EventType::Update,
+                database_schema.users_schema().id,
+                rows_to_update as u64,
+            ),
+            EventCondition::TableCount(
+                EventType::Update,
+                database_schema.orders_schema().id,
+                rows_to_update as u64,
+            ),
+            EventCondition::TableCount(
+                EventType::Delete,
+                database_schema.users_schema().id,
+                rows_to_delete as u64,
+            ),
+            EventCondition::TableCount(
+                EventType::Delete,
+                database_schema.orders_schema().id,
+                rows_to_delete as u64,
+            ),
         ])
         .await;
 

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -80,7 +80,7 @@ struct DeferredCopyDestination<D> {
     /// Shared durability-control state.
     state: Arc<Mutex<DeferredCopyDestinationState>>,
     /// Notification emitted after the terminal barrier is held.
-    barrier_reached: Arc<Notify>,
+    barrier_reached_notify: Arc<Notify>,
 }
 
 impl<D> DeferredCopyDestination<D> {
@@ -89,13 +89,13 @@ impl<D> DeferredCopyDestination<D> {
         Self {
             inner,
             state: Arc::new(Mutex::new(DeferredCopyDestinationState::default())),
-            barrier_reached: Arc::new(Notify::new()),
+            barrier_reached_notify: Arc::new(Notify::new()),
         }
     }
 
     /// Returns a notification for the next terminal durability barrier.
     fn notify_on_barrier(&self) -> TimedNotify {
-        TimedNotify::new(Arc::clone(&self.barrier_reached))
+        TimedNotify::new(Arc::clone(&self.barrier_reached_notify))
     }
 
     /// Returns the number of nonempty copy writes received.
@@ -157,7 +157,7 @@ where
             state.barrier_result = Some(async_result);
             drop(state);
 
-            self.barrier_reached.notify_one();
+            self.barrier_reached_notify.notify_one();
 
             return Ok(());
         }
@@ -229,7 +229,7 @@ struct StalledCopyDestination<D> {
     /// Held result that keeps a table-copy write pending.
     pending_write_result: Arc<Mutex<Option<WriteTableRowsResult>>>,
     /// Notification emitted after the result is dropped or held.
-    stall_reached: Arc<Notify>,
+    stall_reached_notify: Arc<Notify>,
 }
 
 impl<D> StalledCopyDestination<D> {
@@ -241,13 +241,13 @@ impl<D> StalledCopyDestination<D> {
             mode,
             pending_drop_result: Arc::new(Mutex::new(None)),
             pending_write_result: Arc::new(Mutex::new(None)),
-            stall_reached: Arc::new(Notify::new()),
+            stall_reached_notify: Arc::new(Notify::new()),
         }
     }
 
     /// Returns a notification for the next stalled operation.
     fn notify_on_stall(&self) -> TimedNotify {
-        TimedNotify::new(Arc::clone(&self.stall_reached))
+        TimedNotify::new(Arc::clone(&self.stall_reached_notify))
     }
 }
 
@@ -285,7 +285,7 @@ where
             }
         }
 
-        self.stall_reached.notify_one();
+        self.stall_reached_notify.notify_one();
 
         Ok(())
     }
@@ -312,7 +312,7 @@ where
             }
         }
 
-        self.stall_reached.notify_one();
+        self.stall_reached_notify.notify_one();
 
         Ok(())
     }
@@ -390,11 +390,12 @@ async fn table_copy_errors_when_async_result_is_dropped() {
         destination,
     );
 
-    let table_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+    let table_errored_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
 
     pipeline.start().await.unwrap();
 
-    table_errored.notified().await;
+    table_errored_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -431,11 +432,11 @@ async fn table_copy_shutdown_interrupts_pending_result_wait() {
         destination.clone(),
     );
 
-    let write_reached = destination.notify_on_stall();
+    let write_reached_notify = destination.notify_on_stall();
 
     pipeline.start().await.unwrap();
 
-    write_reached.notified().await;
+    write_reached_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -469,11 +470,12 @@ async fn drop_table_for_copy_errors_when_async_result_is_dropped() {
         destination.clone(),
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -487,11 +489,12 @@ async fn drop_table_for_copy_errors_when_async_result_is_dropped() {
         destination,
     );
 
-    let table_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+    let table_errored_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
 
     pipeline.start().await.unwrap();
 
-    table_errored.notified().await;
+    table_errored_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -529,15 +532,16 @@ async fn drop_table_for_copy_shutdown_interrupts_pending_result_wait() {
         destination.clone(),
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
     pipeline.start().await.unwrap();
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let drop_reached = destination.notify_on_stall();
+    let drop_reached_notify = destination.notify_on_stall();
 
     store.reset_table_state(table_id).await.unwrap();
 
-    drop_reached.notified().await;
+    drop_reached_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -576,7 +580,8 @@ async fn reset_during_active_copy_is_overwritten_by_active_worker() {
         destination.clone(),
     );
 
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
@@ -590,7 +595,7 @@ async fn reset_during_active_copy_is_overwritten_by_active_worker() {
     held_write.release_ok();
 
     // The table becomes ready since naturally since the copy just continued.
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -919,13 +924,14 @@ async fn table_copy_waits_for_durable_terminal_barrier_after_accepted_write() {
 
     // Arm notifications before starting because they only observe future
     // transitions.
-    let barrier_reached = destination.notify_on_barrier();
-    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let barrier_reached_notify = destination.notify_on_barrier();
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
     // The destination now holds the terminal barrier result.
-    barrier_reached.notified().await;
+    barrier_reached_notify.notified().await;
 
     // A later Durable batch must not advance the table while the terminal
     // barrier remains pending.
@@ -938,7 +944,7 @@ async fn table_copy_waits_for_durable_terminal_barrier_after_accepted_write() {
 
     // Confirming the terminal barrier unlocks normal table-state progression.
     destination.complete_barrier(DestinationWriteStatus::Durable).await;
-    table_ready.notified().await;
+    table_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 }
@@ -1038,17 +1044,17 @@ async fn table_schema_copy_survives_pipeline_restarts() {
     );
 
     // We wait for both table states to be in sync done.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -1275,12 +1281,12 @@ async fn streaming_reconnect_does_not_replay_already_flushed_events() {
         destination.clone(),
     );
 
-    let users_ready = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     let first_insert_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(
@@ -1625,17 +1631,17 @@ async fn table_copy_replicates_existing_data() {
     );
 
     // Register notifications for table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -1696,17 +1702,17 @@ async fn table_copy_and_sync_streams_new_data() {
     );
 
     // Register notifications for initial table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
-    let orders_state_notify = store
+    let orders_ready_notify = store
         .notify_on_table_state_type(database_schema.orders_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
-    orders_state_notify.notified().await;
+    users_ready_notify.notified().await;
+    orders_ready_notify.notified().await;
 
     // Insert additional data to test streaming.
     insert_mock_data(
@@ -1821,13 +1827,13 @@ async fn table_sync_streams_new_data_with_batch_timeout_expired() {
     );
 
     // Register notifications for initial table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     // Insert additional data to test streaming.
     let rows_inserted = 5;
@@ -1891,13 +1897,13 @@ async fn table_processing_converges_to_apply_loop_with_no_events_coming() {
     );
 
     // Register notifications for initial table copy completion.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 

--- a/crates/etl/tests/pipeline_read_replica.rs
+++ b/crates/etl/tests/pipeline_read_replica.rs
@@ -290,7 +290,7 @@ async fn pipeline_replicates_table_copy_and_cdc_from_read_replica() {
     // while the primary should only own the physical standby slot.
     assert_replication_slot_absent(&primary, &apply_slot_name).await;
 
-    let users_inserted = destination
+    let users_insert_notify = destination
         .wait_for_all_events(vec![EventCondition::TableCount(
             EventType::Insert,
             database_schema.users_schema().id,
@@ -301,7 +301,7 @@ async fn pipeline_replicates_table_copy_and_cdc_from_read_replica() {
     insert_users_data(&mut primary, &database_schema.users_schema().name, 3..=3).await;
     wait_for_read_replica_to_catch_up(&primary, &replica_config).await;
 
-    users_inserted.notified().await;
+    users_insert_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 

--- a/crates/etl/tests/pipeline_read_replica.rs
+++ b/crates/etl/tests/pipeline_read_replica.rs
@@ -291,7 +291,7 @@ async fn pipeline_replicates_table_copy_and_cdc_from_read_replica() {
     assert_replication_slot_absent(&primary, &apply_slot_name).await;
 
     let users_inserted = destination
-        .wait_for_all_events(vec![EventCondition::Table(
+        .wait_for_all_events(vec![EventCondition::TableCount(
             EventType::Insert,
             database_schema.users_schema().id,
             3,

--- a/crates/etl/tests/pipeline_replica_identity.rs
+++ b/crates/etl/tests/pipeline_replica_identity.rs
@@ -5,6 +5,7 @@ use etl::{
     store::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
+        event::EventCondition,
         memory_destination::MemoryDestination,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
@@ -250,7 +251,9 @@ async fn run_replica_identity_scenario(
     let updated_large_text = generate_random_ascii_string(LARGE_TEXT_SIZE_BYTES);
     let final_large_text = generate_random_ascii_string(LARGE_TEXT_SIZE_BYTES);
 
-    let insert_event_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let insert_event_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
     database
         .insert_values(
             table_name.clone(),
@@ -270,8 +273,13 @@ async fn run_replica_identity_scenario(
         INITIAL_ID,
         quote_literal(INITIAL_SURNAME),
     );
-    let non_identity_update_notify =
-        destination.wait_for_events_count(vec![(EventType::Update, update_count + 1)]).await;
+    let non_identity_update_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Update,
+            table_id,
+            update_count + 1,
+        )])
+        .await;
     let non_identity_update = database.run_sql(&non_identity_update_sql).await;
     if non_identity_update.is_ok() {
         non_identity_update_notify.notified().await;
@@ -285,16 +293,26 @@ async fn run_replica_identity_scenario(
         INITIAL_ID,
         quote_literal(INITIAL_SURNAME),
     );
-    let toast_update_notify =
-        destination.wait_for_events_count(vec![(EventType::Update, update_count + 1)]).await;
+    let toast_update_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Update,
+            table_id,
+            update_count + 1,
+        )])
+        .await;
     let toast_update = database.run_sql(&toast_update_sql).await;
     if toast_update.is_ok() {
         toast_update_notify.notified().await;
         update_count += 1;
     }
 
-    let identity_update_notify =
-        destination.wait_for_events_count(vec![(EventType::Update, update_count + 1)]).await;
+    let identity_update_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Update,
+            table_id,
+            update_count + 1,
+        )])
+        .await;
     let identity_update = database
         .run_sql(
             &replica_identity
@@ -305,7 +323,9 @@ async fn run_replica_identity_scenario(
         identity_update_notify.notified().await;
     }
 
-    let delete_notify = destination.wait_for_events_count(vec![(EventType::Delete, 1)]).await;
+    let delete_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Delete, table_id, 1)])
+        .await;
     let delete =
         database.run_sql(&replica_identity.delete_sql(&table_name.as_quoted_identifier())).await;
     if delete.is_ok() {

--- a/crates/etl/tests/pipeline_with_failpoints.rs
+++ b/crates/etl/tests/pipeline_with_failpoints.rs
@@ -255,13 +255,13 @@ async fn table_sync_worker_panic_marks_table_errored() {
     );
 
     // Register notifications for table sync states.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Errored)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -309,13 +309,13 @@ async fn table_copy_fails_after_data_sync_threw_an_error_with_no_retry() {
     );
 
     // Register notifications for table sync states.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Errored)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -366,7 +366,7 @@ async fn table_copy_fails_after_timed_retry_exceeded_max_attempts() {
 
     // Register notifications for waiting on the manual retry which is expected to
     // be flipped by the max attempts handling.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state(database_schema.users_schema().id, |state| {
             matches!(state, TableState::Errored { retry_policy: TableRetryPolicy::ManualRetry, .. })
         })
@@ -374,7 +374,7 @@ async fn table_copy_fails_after_timed_retry_exceeded_max_attempts() {
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -422,13 +422,13 @@ async fn table_copy_is_consistent_after_data_sync_threw_an_error_with_timed_retr
     );
 
     // We register the interest in waiting for both table syncs to have started.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     // We expect no errors, since the same table sync worker task is retried.
     pipeline.shutdown_and_wait().await.unwrap();
@@ -478,13 +478,13 @@ async fn table_copy_is_consistent_during_data_sync_threw_an_error_with_timed_ret
     );
 
     // We register the interest in waiting for both table syncs to have started.
-    let users_state_notify = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_state_notify.notified().await;
+    users_ready_notify.notified().await;
 
     // We expect no errors, since the same table sync worker task is retried.
     pipeline.shutdown_and_wait().await.unwrap();
@@ -610,11 +610,11 @@ async fn table_sync_keepalive_completion_waits_for_durable_barrier() {
         destination.clone(),
     );
 
-    let finished_copy =
+    let finished_copy_notify =
         store.notify_on_table_state_type(table_id, TableStateType::FinishedCopy).await;
 
     pipeline.start().await.unwrap();
-    finished_copy.notified().await;
+    finished_copy_notify.notified().await;
 
     // Commit one published row at A while the table-sync worker is paused, then
     // advance cluster WAL to T in another database. Logical decoding skips that
@@ -648,8 +648,8 @@ async fn table_sync_keepalive_completion_waits_for_durable_barrier() {
     .await
     .expect("timed out waiting for the apply slot to acknowledge cross-database WAL");
 
-    let sync_done = store.notify_on_table_state_type(table_id, TableStateType::SyncDone).await;
-    let ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     fail::remove(START_TABLE_SYNC_AFTER_FINISHED_COPY_FP);
 
@@ -683,11 +683,9 @@ async fn table_sync_keepalive_completion_waits_for_durable_barrier() {
         Some(TableStateType::FinishedCopy)
     );
 
-    // Confirming the barrier must unblock both table-sync handoff and the apply
-    // worker transition to Ready.
+    // Confirming the barrier must unblock the transition to Ready.
     barrier_result.send(Ok(DestinationWriteStatus::Durable));
-    sync_done.notified().await;
-    ready.notified().await;
+    table_ready_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 }
@@ -782,19 +780,20 @@ async fn stored_durable_progress_prevents_replay_when_status_updates_are_skipped
         destination.clone(),
     );
 
-    let ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    ready.notified().await;
+    table_ready_notify.notified().await;
 
-    let initial_inserts = destination
+    let initial_inserts_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 2)])
         .await;
 
     insert_users_data(&mut database, &database_schema.users_schema().name, 1..=2).await;
 
-    initial_inserts.notified().await;
+    initial_inserts_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -829,7 +828,7 @@ async fn stored_durable_progress_prevents_replay_when_status_updates_are_skipped
 
     // We wait until 4 inserts have been reached, the previous ones + the current
     // ones.
-    let new_inserts = destination
+    let new_inserts_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 4)])
         .await;
 
@@ -837,7 +836,7 @@ async fn stored_durable_progress_prevents_replay_when_status_updates_are_skipped
 
     insert_users_data(&mut database, &database_schema.users_schema().name, 3..=4).await;
 
-    new_inserts.notified().await;
+    new_inserts_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -1460,7 +1459,7 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     // The reason for why we wait for two `Relation` messages is that since we have
     // a DDL event before DML statements, Postgres likely avoids sending an
     // initial `Relation` message since it's already sent given the DDL event.
-    let notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 2),
             EventCondition::TableCount(EventType::Insert, table_id, 2),
@@ -1499,7 +1498,7 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
         .await
         .unwrap();
 
-    notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Assert that we got all the events correctly.
@@ -1551,7 +1550,7 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
 
     pipeline.start().await.unwrap();
 
-    let notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 2),
             EventCondition::TableCount(EventType::Insert, table_id, 3),
@@ -1567,7 +1566,7 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
         .await
         .unwrap();
 
-    notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Assert that we got all the events correctly.
@@ -1706,11 +1705,12 @@ async fn table_schema_replication_masks_are_consistent_after_restart() {
     );
 
     // Wait for the table to finish syncing.
-    let sync_done_notify = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let table_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    sync_done_notify.notified().await;
+    table_ready_notify.notified().await;
 
     // We expect 3 relation events (one per publication change) and 3 insert events.
     let events_notify = destination
@@ -1902,7 +1902,7 @@ async fn table_schema_replication_masks_are_consistent_after_restart() {
     );
 
     // Wait for 3 relation events and 3 insert events again after restart.
-    let events_notify_restart = destination
+    let restart_events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 3),
             EventCondition::TableCount(EventType::Insert, table_id, 3),
@@ -1911,7 +1911,7 @@ async fn table_schema_replication_masks_are_consistent_after_restart() {
 
     pipeline.start().await.unwrap();
 
-    events_notify_restart.notified().await;
+    restart_events_notify.notified().await;
 
     // Verify the same events are received after restart.
     let events_after_restart = destination.get_events().await;

--- a/crates/etl/tests/pipeline_with_failpoints.rs
+++ b/crates/etl/tests/pipeline_with_failpoints.rs
@@ -551,7 +551,7 @@ async fn table_sync_streaming_replays_rows_written_after_copy_before_handoff() {
     .await;
 
     let all_rows_notify = destination
-        .wait_for_all_events(vec![EventCondition::Table(
+        .wait_for_all_events(vec![EventCondition::TableCount(
             EventType::Insert,
             table_id,
             (copied_rows + catchup_rows) as u64,
@@ -788,7 +788,9 @@ async fn stored_durable_progress_prevents_replay_when_status_updates_are_skipped
 
     ready.notified().await;
 
-    let initial_inserts = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+    let initial_inserts = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 2)])
+        .await;
 
     insert_users_data(&mut database, &database_schema.users_schema().name, 1..=2).await;
 
@@ -827,7 +829,9 @@ async fn stored_durable_progress_prevents_replay_when_status_updates_are_skipped
 
     // We wait until 4 inserts have been reached, the previous ones + the current
     // ones.
-    let new_inserts = destination.wait_for_events_count(vec![(EventType::Insert, 4)]).await;
+    let new_inserts = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 4)])
+        .await;
 
     pipeline.start().await.unwrap();
 
@@ -874,7 +878,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     .await;
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     let transaction = database.begin_transaction().await;
@@ -985,7 +992,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     );
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     pipeline.start().await.unwrap();
@@ -1021,7 +1031,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
         .await;
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     database.insert_values(table_name.clone(), &["name", "age"], &[&"first", &25]).await.unwrap();
@@ -1125,7 +1138,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     );
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     pipeline.start().await.unwrap();
@@ -1171,7 +1187,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     destination.clear_events().await;
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
         .await;
 
     let transaction = database.begin_transaction().await;
@@ -1267,7 +1286,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     );
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
         .await;
 
     pipeline.start().await.unwrap();
@@ -1303,7 +1325,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
         .await;
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
         .await;
 
     database
@@ -1395,7 +1420,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     );
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
         .await;
 
     pipeline.start().await.unwrap();
@@ -1433,7 +1461,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     // a DDL event before DML statements, Postgres likely avoids sending an
     // initial `Relation` message since it's already sent given the DDL event.
     let notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
         .await;
 
     // We immediately add a column to the table without any DML, to show the case
@@ -1521,7 +1552,10 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
     pipeline.start().await.unwrap();
 
     let notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     database
@@ -1558,7 +1592,10 @@ async fn schema_snapshots_are_pruned_after_confirmed_progress() {
         .await;
 
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 2), (EventType::Insert, 2)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
         .await;
 
     database
@@ -1677,7 +1714,10 @@ async fn table_schema_replication_masks_are_consistent_after_restart() {
 
     // We expect 3 relation events (one per publication change) and 3 insert events.
     let events_notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     // State 1: Insert with all 4 columns (id, name, age, email).
@@ -1848,7 +1888,7 @@ async fn table_schema_replication_masks_are_consistent_after_restart() {
     // progress, so the slot still holds all of run 1's WAL for replay; we no
     // longer need to suppress acks in run 2 (and doing so risks
     // wal_sender_timeout firing under slow CI and duplicating events, which
-    // would break the exact-count match in wait_for_events_count below).
+    // could duplicate events and invalidate the assertions below).
     fail::remove(SEND_STATUS_UPDATE_FP);
 
     // Restart the pipeline -- Postgres will resend the data since we don't
@@ -1863,7 +1903,10 @@ async fn table_schema_replication_masks_are_consistent_after_restart() {
 
     // Wait for 3 relation events and 3 insert events again after restart.
     let events_notify_restart = destination
-        .wait_for_events_count(vec![(EventType::Relation, 3), (EventType::Insert, 3)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
         .await;
 
     pipeline.start().await.unwrap();

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -61,13 +61,13 @@ async fn destination_shutdown_error_is_returned_by_shutdown_and_wait() {
         destination.clone(),
     );
 
-    let users_ready = store
+    let users_ready_notify = store
         .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
         .await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     // WHEN: the pipeline shuts down
     let result = pipeline.shutdown_and_wait().await;
@@ -103,11 +103,12 @@ async fn drop_table_for_copy_rejection_keeps_table_restartable_until_retry() {
         destination.clone(),
     );
 
-    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let users_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     // WHEN: a resync starts and the destination rejects the drop
     destination
@@ -117,11 +118,12 @@ async fn drop_table_for_copy_rejection_keeps_table_restartable_until_retry() {
         )
         .await;
 
-    let users_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+    let users_errored_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
 
     store.reset_table_state(table_id).await.unwrap();
 
-    users_errored.notified().await;
+    users_errored_notify.notified().await;
 
     // THEN: the table errors with a timed retry and nothing was torn down
     let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
@@ -136,9 +138,10 @@ async fn drop_table_for_copy_rejection_keeps_table_restartable_until_retry() {
     assert_eq!(memory_destination.table_rows().await.get(&table_id).unwrap().len(), initial_rows);
 
     // THEN: the timed retry drops and recopies the table cleanly
-    let users_ready_again = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let users_ready_again_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
-    users_ready_again.notified().await;
+    users_ready_again_notify.notified().await;
 
     assert!(destination.was_table_dropped_for_copy(table_id).await);
     let table_rows = destination.get_table_rows().await;
@@ -172,11 +175,12 @@ async fn drop_table_for_copy_failure_after_write_keeps_table_restartable_until_r
         destination.clone(),
     );
 
-    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let users_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     // WHEN: a resync starts and the drop fails after being applied
     destination
@@ -189,11 +193,12 @@ async fn drop_table_for_copy_failure_after_write_keeps_table_restartable_until_r
         )
         .await;
 
-    let users_errored = store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
+    let users_errored_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Errored).await;
 
     store.reset_table_state(table_id).await.unwrap();
 
-    users_errored.notified().await;
+    users_errored_notify.notified().await;
 
     // THEN: the table errors with a timed retry and ETL state was not cleared
     let table_state = store.get_table_state(table_id).await.unwrap().unwrap();
@@ -208,9 +213,10 @@ async fn drop_table_for_copy_failure_after_write_keeps_table_restartable_until_r
     assert!(!memory_destination.table_rows().await.contains_key(&table_id));
 
     // THEN: the timed retry replays the drop and recopies the table cleanly
-    let users_ready_again = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let users_ready_again_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
-    users_ready_again.notified().await;
+    users_ready_again_notify.notified().await;
 
     assert!(destination.was_table_dropped_for_copy(table_id).await);
     let table_rows = destination.get_table_rows().await;
@@ -241,11 +247,12 @@ async fn shutdown_drains_pending_write_events_before_destination_shutdown() {
         destination.clone(),
     );
 
-    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let users_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     let hold = destination.hold_next(FaultyOp::WriteEvents).await;
 
@@ -298,11 +305,12 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
         destination.clone(),
     );
 
-    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let users_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     let hold = destination.hold_next(FaultyOp::WriteEvents).await;
 
@@ -320,7 +328,7 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
     wait_for_new_walsender(client, &apply_slot_name, old_pid).await;
 
     // WHEN: the held response is released only after the reconnect
-    let replay_recorded = destination
+    let replay_recorded_notify = destination
         .wait_for_all_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 2)])
         .await;
 
@@ -328,7 +336,7 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
 
     // THEN: the insert replays because the acknowledgement never reached the
     // old apply loop
-    replay_recorded.notified().await;
+    replay_recorded_notify.notified().await;
 
     let commit_lsns = table_insert_commit_lsns(&destination.get_events().await, table_id);
     assert_eq!(commit_lsns.len(), 2);
@@ -339,7 +347,7 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
     assert!(flush_lsn_at_kill < first_commit_lsn);
 
     // THEN: streaming continues without loss after the replay
-    let second_insert = destination
+    let second_insert_notify = destination
         .notify_on_events(move |events| {
             table_insert_commit_lsns(events, table_id)
                 .last()
@@ -349,7 +357,7 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
 
     insert_users_data(&mut database, &database_schema.users_schema().name, 2..=2).await;
 
-    second_insert.notified().await;
+    second_insert_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -382,11 +390,12 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
         destination.clone(),
     );
 
-    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let users_ready_notify =
+        store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    users_ready.notified().await;
+    users_ready_notify.notified().await;
 
     let hold = destination.hold_next(FaultyOp::WriteEvents).await;
 
@@ -399,7 +408,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
     let (_, active_pid) = replication_slot_state(client, &apply_slot_name).await;
     let old_pid = active_pid.expect("apply walsender should be active");
 
-    let first_insert_recorded = destination
+    let first_insert_notify = destination
         .wait_for_all_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
@@ -407,7 +416,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
 
     hold.release_ok();
 
-    first_insert_recorded.notified().await;
+    first_insert_notify.notified().await;
     let first_commit_lsn = *table_insert_commit_lsns(&destination.get_events().await, table_id)
         .first()
         .expect("released insert should be recorded");
@@ -415,7 +424,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
     wait_for_new_walsender(client, &apply_slot_name, old_pid).await;
 
     // THEN: streaming continues without loss, replaying the insert at most once
-    let second_insert = destination
+    let second_insert_notify = destination
         .notify_on_events(move |events| {
             table_insert_commit_lsns(events, table_id)
                 .last()
@@ -425,7 +434,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
 
     insert_users_data(&mut database, &database_schema.users_schema().name, 2..=2).await;
 
-    second_insert.notified().await;
+    second_insert_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -321,7 +321,7 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
 
     // WHEN: the held response is released only after the reconnect
     let replay_recorded = destination
-        .wait_for_all_events(vec![EventCondition::Table(EventType::Insert, table_id, 2)])
+        .wait_for_all_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 2)])
         .await;
 
     hold.release_ok();
@@ -400,7 +400,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
     let old_pid = active_pid.expect("apply walsender should be active");
 
     let first_insert_recorded = destination
-        .wait_for_all_events(vec![EventCondition::Table(EventType::Insert, table_id, 1)])
+        .wait_for_all_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
     client.query_one("select pg_terminate_backend($1)", &[&old_pid]).await.unwrap();

--- a/crates/etl/tests/pipeline_with_partitioned_table.rs
+++ b/crates/etl/tests/pipeline_with_partitioned_table.rs
@@ -8,7 +8,7 @@ use etl::{
     store::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
-        event::group_events_by_type_and_table_id,
+        event::{EventCondition, group_events_by_type_and_table_id},
         memory_destination::MemoryDestination,
         notifying_store::NotifyingStore,
         pipeline::{PipelineBuilder, create_pipeline, create_pipeline_with_table_sync_copy_config},
@@ -131,7 +131,14 @@ async fn assert_selective_partition_initial_copy_case(
         notify.notified().await;
     }
 
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 2)]).await;
+    let event_conditions = expected_cdc_counts
+        .iter()
+        .filter(|(_, count)| *count > 0)
+        .map(|(table_id, count)| {
+            EventCondition::TableCount(EventType::Insert, *table_id, *count as u64)
+        })
+        .collect();
+    let inserts_notify = destination.wait_for_events(event_conditions).await;
 
     database
         .run_sql(&format!(
@@ -214,7 +221,6 @@ async fn assert_nested_partition_pipeline_case(
         (PublishedPartitionTarget::Leaf, _) => vec![(hierarchy.p_2026_01_table_id, 1)],
     };
     let expected_cdc_counts = expected_copy_counts.clone();
-    let expected_cdc_total = expected_cdc_counts.iter().map(|(_, count)| count).sum::<usize>();
 
     let state_store = NotifyingStore::new();
     let destination = TestDestinationWrapper::wrap(MemoryDestination::new(state_store.clone()));
@@ -249,9 +255,14 @@ async fn assert_nested_partition_pipeline_case(
     let table_rows = destination.get_table_rows().await;
     assert_table_row_counts(&table_rows, &expected_copy_counts);
 
-    let inserts_notify = destination
-        .wait_for_events_count(vec![(EventType::Insert, expected_cdc_total as u64)])
-        .await;
+    let event_conditions = expected_cdc_counts
+        .iter()
+        .filter(|(_, count)| *count > 0)
+        .map(|(table_id, count)| {
+            EventCondition::TableCount(EventType::Insert, *table_id, *count as u64)
+        })
+        .collect();
+    let inserts_notify = destination.wait_for_events(event_conditions).await;
 
     let cdc_insert_values = match published_partition_target {
         PublishedPartitionTarget::Top => {
@@ -541,7 +552,9 @@ async fn partitioned_table_copy_and_streams_new_data_from_new_partition() {
         .unwrap();
 
     // Wait for CDC to deliver the new row.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let inserts_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, parent_table_id, 1)])
+        .await;
 
     database
         .run_sql(&format!(
@@ -639,7 +652,9 @@ async fn partition_drop_does_not_emit_delete_or_truncate() {
 
     // Insert a row into an existing partition to ensure the pipeline is still
     // processing events.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let inserts_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, parent_table_id, 1)])
+        .await;
 
     database
         .run_sql(&format!(
@@ -711,7 +726,9 @@ async fn parent_table_truncate_does_emit_truncate_event() {
     parent_ready_notify.notified().await;
 
     // Wait for the parent table truncate to be replicated.
-    let truncate_notify = destination.wait_for_events_count(vec![(EventType::Truncate, 1)]).await;
+    let truncate_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Truncate, parent_table_id, 1)])
+        .await;
 
     // We truncate the parent table.
     database
@@ -785,7 +802,9 @@ async fn child_table_truncate_does_not_emit_truncate_event() {
 
     // Insert a row into an existing partition to ensure the pipeline is still
     // processing events.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let inserts_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, parent_table_id, 1)])
+        .await;
 
     database
         .run_sql(&format!(
@@ -887,7 +906,9 @@ async fn partition_detach_with_explicit_publication_does_not_replicate_detached_
         .unwrap();
 
     // Wait for the parent table insert to be replicated.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let inserts_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, parent_table_id, 1)])
+        .await;
 
     // Insert into the parent table (should be replicated to remaining partition
     // p2).
@@ -1248,7 +1269,9 @@ async fn partition_detach_with_schema_publication_does_not_replicate_detached_in
         .unwrap();
 
     // Wait for the parent table insert to be replicated.
-    let inserts_notify = destination.wait_for_events_count(vec![(EventType::Insert, 1)]).await;
+    let inserts_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, parent_table_id, 1)])
+        .await;
 
     // Insert into parent table (should be replicated).
     database

--- a/crates/etl/tests/pipelines_with_schema_changes.rs
+++ b/crates/etl/tests/pipelines_with_schema_changes.rs
@@ -96,7 +96,7 @@ async fn relation_message_updates_when_column_added() {
         )
         .await;
 
-    let events_received = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -120,7 +120,7 @@ async fn relation_message_updates_when_column_added() {
         .await
         .unwrap();
 
-    events_received.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
@@ -171,7 +171,7 @@ async fn relation_message_updates_when_column_removed() {
         )
         .await;
 
-    let events_received = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -185,7 +185,7 @@ async fn relation_message_updates_when_column_removed() {
 
     database.insert_values(table_name.clone(), &["name"], &[&"Bob"]).await.unwrap();
 
-    events_received.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
@@ -236,7 +236,7 @@ async fn relation_message_updates_when_column_renamed() {
         )
         .await;
 
-    let events_received = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -256,7 +256,7 @@ async fn relation_message_updates_when_column_renamed() {
         .await
         .unwrap();
 
-    events_received.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
@@ -307,7 +307,7 @@ async fn relation_message_updates_when_column_type_changes() {
         )
         .await;
 
-    let events_received = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -327,7 +327,7 @@ async fn relation_message_updates_when_column_type_changes() {
         .await
         .unwrap();
 
-    events_received.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
@@ -378,7 +378,7 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         )
         .await;
 
-    let schema_stored = store.notify_on_table_schema_count(table_id, 2).await;
+    let schema_stored_notify = store.notify_on_table_schema_count(table_id, 2).await;
 
     database
         .alter_table(
@@ -391,7 +391,7 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         .await
         .unwrap();
 
-    schema_stored.notified().await;
+    schema_stored_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -429,7 +429,7 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
 
     pipeline.start().await.unwrap();
 
-    let notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(
                 EventType::Relation,
@@ -449,7 +449,7 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         .await
         .unwrap();
 
-    notify.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -510,7 +510,7 @@ async fn default_expressions_round_trip_through_schema_changes_and_defaulted_ins
         )
         .await;
 
-    let events_received = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
@@ -578,7 +578,7 @@ async fn default_expressions_round_trip_through_schema_changes_and_defaulted_ins
         .await
         .unwrap();
 
-    events_received.notified().await;
+    events_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -1093,15 +1093,15 @@ async fn partitioned_table_schema_change_updates_relation_message() {
         destination.clone(),
     );
 
-    let parent_ready =
+    let parent_ready_notify =
         state_store.notify_on_table_state_type(parent_table_id, TableStateType::Ready).await;
 
     pipeline.start().await.unwrap();
 
-    parent_ready.notified().await;
+    parent_ready_notify.notified().await;
 
     // Wait for the Relation event (schema change) and Insert event.
-    let notify = destination
+    let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, parent_table_id, 1),
             EventCondition::TableCount(EventType::Insert, parent_table_id, 1),
@@ -1129,7 +1129,7 @@ async fn partitioned_table_schema_change_updates_relation_message() {
         .await
         .unwrap();
 
-    notify.notified().await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;

--- a/crates/etl/tests/pipelines_with_schema_changes.rs
+++ b/crates/etl/tests/pipelines_with_schema_changes.rs
@@ -419,13 +419,12 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
     );
 
+    // We take the relation events count after we applied the schema change so that
+    // we can use that for the next assertion.
     let events_before_restart = destination.get_events().await;
     let grouped_events_before_restart = group_events_by_type_and_table_id(&events_before_restart);
     let relation_count_before_restart =
         grouped_events_before_restart.get(&(EventType::Relation, table_id)).map_or(0, Vec::len);
-    let insert_count_before_restart =
-        grouped_events_before_restart.get(&(EventType::Insert, table_id)).map_or(0, Vec::len);
-    assert_eq!(insert_count_before_restart, 0);
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -444,11 +443,7 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
                 table_id,
                 (relation_count_before_restart + 1) as u64,
             ),
-            EventCondition::TableCount(
-                EventType::Insert,
-                table_id,
-                (insert_count_before_restart + 1) as u64,
-            ),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
         ])
         .await;
 
@@ -471,10 +466,7 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         grouped.get(&(EventType::Relation, table_id)).unwrap().len(),
         relation_count_before_restart + 1
     );
-    assert_eq!(
-        grouped.get(&(EventType::Insert, table_id)).unwrap().len(),
-        insert_count_before_restart + 1
-    );
+    assert_eq!(grouped.get(&(EventType::Insert, table_id)).unwrap().len(), 1);
 
     let Event::Relation(relation) = get_last_relation_event(&events, table_id) else {
         panic!("expected relation event");
@@ -483,8 +475,11 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         &relation.replicated_table_schema,
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
     );
-    let relation_email_column =
-        relation.replicated_table_schema.column_schemas().find(|column| column.name == "email").unwrap();
+    let relation_email_column = relation
+        .replicated_table_schema
+        .column_schemas()
+        .find(|column| column.name == "email")
+        .unwrap();
     assert_eq!(
         relation_email_column.default_expression.as_deref(),
         Some("'unknown@example.com'::text")
@@ -499,7 +494,6 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
     let snapshots = table_schemas.get(&table_id).unwrap();
     assert_eq!(snapshots.len(), 2);
     assert_schema_snapshots_ordering(snapshots, true);
-
     let (_, first_schema) = &snapshots[0];
     assert_table_schema_column_names_types(
         first_schema,

--- a/crates/etl/tests/pipelines_with_schema_changes.rs
+++ b/crates/etl/tests/pipelines_with_schema_changes.rs
@@ -8,7 +8,7 @@ use etl::{
     store::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
-        event::{group_events_by_type, group_events_by_type_and_table_id},
+        event::{EventCondition, group_events_by_type_and_table_id},
         memory_destination::MemoryDestination,
         notifying_store::NotifyingStore,
         pipeline::{create_database_and_ready_pipeline_with_table, create_pipeline},
@@ -87,20 +87,9 @@ fn find_snapshot_index_after(
 
 async fn wait_for_at_least_events(
     destination: &TestDestinationWrapper<MemoryDestination<NotifyingStore>>,
-    conditions: Vec<(EventType, u64)>,
+    conditions: Vec<EventCondition>,
 ) {
-    destination
-        .notify_on_events(move |events| {
-            let grouped = group_events_by_type(events);
-            conditions.iter().all(|(event_type, expected_count)| {
-                grouped
-                    .get(event_type)
-                    .is_some_and(|matched_events| matched_events.len() >= *expected_count as usize)
-            })
-        })
-        .await
-        .notified()
-        .await;
+    destination.wait_for_events(conditions).await.notified().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -115,7 +104,10 @@ async fn relation_message_updates_when_column_added() {
         .await;
 
     let events_received = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -187,7 +179,10 @@ async fn relation_message_updates_when_column_removed() {
         .await;
 
     let events_received = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -249,7 +244,10 @@ async fn relation_message_updates_when_column_renamed() {
         .await;
 
     let events_received = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -317,7 +315,10 @@ async fn relation_message_updates_when_column_type_changes() {
         .await;
 
     let events_received = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -430,7 +431,10 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
     pipeline.start().await.unwrap();
 
     let notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -500,7 +504,10 @@ async fn default_expressions_round_trip_through_schema_changes_and_defaulted_ins
         .await;
 
     let events_received = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
         .await;
 
     database
@@ -742,8 +749,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(&destination, vec![(EventType::Relation, 1), (EventType::Insert, 1)])
-        .await;
+    wait_for_at_least_events(
+        &destination,
+        vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ],
+    )
+    .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     destination.clear_events().await;
@@ -784,8 +797,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(&destination, vec![(EventType::Relation, 1), (EventType::Insert, 1)])
-        .await;
+    wait_for_at_least_events(
+        &destination,
+        vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ],
+    )
+    .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     destination.clear_events().await;
@@ -815,8 +834,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(&destination, vec![(EventType::Relation, 1), (EventType::Insert, 1)])
-        .await;
+    wait_for_at_least_events(
+        &destination,
+        vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ],
+    )
+    .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     destination.clear_events().await;
@@ -860,8 +885,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(&destination, vec![(EventType::Relation, 1), (EventType::Insert, 1)])
-        .await;
+    wait_for_at_least_events(
+        &destination,
+        vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ],
+    )
+    .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
@@ -1070,7 +1101,10 @@ async fn partitioned_table_schema_change_updates_relation_message() {
 
     // Wait for the Relation event (schema change) and Insert event.
     let notify = destination
-        .wait_for_events_count(vec![(EventType::Relation, 1), (EventType::Insert, 1)])
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, parent_table_id, 1),
+            EventCondition::TableCount(EventType::Insert, parent_table_id, 1),
+        ])
         .await;
 
     // Add a new column to the partitioned table.

--- a/crates/etl/tests/pipelines_with_schema_changes.rs
+++ b/crates/etl/tests/pipelines_with_schema_changes.rs
@@ -399,6 +399,7 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         .unwrap();
 
     schema_stored.notified().await;
+
     pipeline.shutdown_and_wait().await.unwrap();
 
     let table_schemas = store.get_table_schemas().await;
@@ -418,7 +419,13 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
     );
 
-    destination.clear_events().await;
+    let events_before_restart = destination.get_events().await;
+    let grouped_events_before_restart = group_events_by_type_and_table_id(&events_before_restart);
+    let relation_count_before_restart =
+        grouped_events_before_restart.get(&(EventType::Relation, table_id)).map_or(0, Vec::len);
+    let insert_count_before_restart =
+        grouped_events_before_restart.get(&(EventType::Insert, table_id)).map_or(0, Vec::len);
+    assert_eq!(insert_count_before_restart, 0);
 
     let mut pipeline = create_pipeline(
         &database.config,
@@ -432,8 +439,16 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
 
     let notify = destination
         .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(
+                EventType::Relation,
+                table_id,
+                (relation_count_before_restart + 1) as u64,
+            ),
+            EventCondition::TableCount(
+                EventType::Insert,
+                table_id,
+                (insert_count_before_restart + 1) as u64,
+            ),
         ])
         .await;
 
@@ -447,32 +462,38 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         .unwrap();
 
     notify.notified().await;
+
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
     let grouped = group_events_by_type_and_table_id(&events);
+    assert_eq!(
+        grouped.get(&(EventType::Relation, table_id)).unwrap().len(),
+        relation_count_before_restart + 1
+    );
+    assert_eq!(
+        grouped.get(&(EventType::Insert, table_id)).unwrap().len(),
+        insert_count_before_restart + 1
+    );
 
-    assert_eq!(grouped.get(&(EventType::Relation, table_id)).unwrap().len(), 1);
-    assert_eq!(grouped.get(&(EventType::Insert, table_id)).unwrap().len(), 1);
-
-    let Event::Relation(r) = get_last_relation_event(&events, table_id) else {
+    let Event::Relation(relation) = get_last_relation_event(&events, table_id) else {
         panic!("expected relation event");
     };
     assert_replicated_schema_column_names_types(
-        &r.replicated_table_schema,
+        &relation.replicated_table_schema,
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
     );
     let relation_email_column =
-        r.replicated_table_schema.column_schemas().find(|column| column.name == "email").unwrap();
+        relation.replicated_table_schema.column_schemas().find(|column| column.name == "email").unwrap();
     assert_eq!(
         relation_email_column.default_expression.as_deref(),
         Some("'unknown@example.com'::text")
     );
 
-    let Event::Insert(i) = get_last_insert_event(&events, table_id) else {
+    let Event::Insert(insert) = get_last_insert_event(&events, table_id) else {
         panic!("expected insert event");
     };
-    assert_eq!(i.table_row.values().len(), 4);
+    assert_eq!(insert.table_row.values().len(), 4);
 
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
@@ -484,7 +505,6 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
         first_schema,
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
     );
-
     let (_, second_schema) = &snapshots[1];
     assert_table_schema_column_names_types(
         second_schema,
@@ -759,8 +779,6 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
-    destination.clear_events().await;
-
     // Rename column + change type + insert, then restart.
     let mut pipeline = create_pipeline(
         &database.config,
@@ -800,14 +818,12 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     wait_for_at_least_events(
         &destination,
         vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
         ],
     )
     .await;
     pipeline.shutdown_and_wait().await.unwrap();
-
-    destination.clear_events().await;
 
     // Drop column + insert, then restart.
     let mut pipeline = create_pipeline(
@@ -837,14 +853,12 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     wait_for_at_least_events(
         &destination,
         vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
         ],
     )
     .await;
     pipeline.shutdown_and_wait().await.unwrap();
-
-    destination.clear_events().await;
 
     // Add another column + rename existing + insert, then verify.
     let mut pipeline = create_pipeline(
@@ -888,8 +902,8 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     wait_for_at_least_events(
         &destination,
         vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
+            EventCondition::TableCount(EventType::Relation, table_id, 4),
+            EventCondition::TableCount(EventType::Insert, table_id, 4),
         ],
     )
     .await;

--- a/crates/etl/tests/pipelines_with_schema_changes.rs
+++ b/crates/etl/tests/pipelines_with_schema_changes.rs
@@ -85,13 +85,6 @@ fn find_snapshot_index_after(
         .expect("expected schema snapshot in order")
 }
 
-async fn wait_for_at_least_events(
-    destination: &TestDestinationWrapper<MemoryDestination<NotifyingStore>>,
-    conditions: Vec<EventCondition>,
-) {
-    destination.wait_for_events(conditions).await.notified().await;
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn relation_message_updates_when_column_added() {
     init_test_tracing();
@@ -763,14 +756,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(
-        &destination,
-        vec![
+    destination
+        .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 1),
             EventCondition::TableCount(EventType::Insert, table_id, 1),
-        ],
-    )
-    .await;
+        ])
+        .await
+        .notified()
+        .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Rename column + change type + insert, then restart.
@@ -809,14 +802,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(
-        &destination,
-        vec![
+    destination
+        .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 2),
             EventCondition::TableCount(EventType::Insert, table_id, 2),
-        ],
-    )
-    .await;
+        ])
+        .await
+        .notified()
+        .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Drop column + insert, then restart.
@@ -844,14 +837,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(
-        &destination,
-        vec![
+    destination
+        .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 3),
             EventCondition::TableCount(EventType::Insert, table_id, 3),
-        ],
-    )
-    .await;
+        ])
+        .await
+        .notified()
+        .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Add another column + rename existing + insert, then verify.
@@ -893,14 +886,14 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    wait_for_at_least_events(
-        &destination,
-        vec![
+    destination
+        .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 4),
             EventCondition::TableCount(EventType::Insert, table_id, 4),
-        ],
-    )
-    .await;
+        ])
+        .await
+        .notified()
+        .await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;


### PR DESCRIPTION
## Summary

- Unify destination event waiting around shared `EventCondition` values
- Replace count-specific waiting helpers with `wait_for_events` and `wait_for_all_events`
- Add consistent `notify_on_events` and `notify_on_all_events` paths
- Make event conditions require exact counts rather than greater-than-or-equal counts
- Clarify that `wait_for_all_events` treats table-copy rows as insert events
- Prefer table-scoped `TableCount` conditions, including multiple conditions for multi-table tests
- Retain cumulative event history across normal test phases and clear events only when a test intentionally isolates a later phase
- Wait for tables to reach `Ready` instead of `SyncDone`
- Use consistent semantic `_notify` variable names throughout tests
- Invalidate BigQuery Storage Write API connections after dropping physical tables for recopy, preventing reuse of connections associated with the previous table incarnation