### PR TITLE
feat(snowflake): support deferred durability for table copy

### DIFF
--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -25,83 +25,39 @@ use crate::snowflake::{
     sql_client::SqlClient,
     streaming::{
         AcceptedRowBatch, ChannelHandle, DEFAULT_COMMIT_POLL_INTERVAL, DEFAULT_COMMIT_WAIT_TIMEOUT,
-        OffsetToken, RestStreamClient, RowBatch, StreamClient, validate_committed_status,
+        OffsetToken, PendingDurabilityTarget, RestStreamClient, RowBatch, StreamClient,
+        validate_committed_status,
     },
 };
 
 type ChannelMap<C> = Arc<RwLock<HashMap<TableId, Arc<Mutex<ChannelHandle<C>>>>>>;
+
+/// Process-local state carried between the two phases of a table-copy reset.
+///
+/// With event admission blocked, [`Client::detach_table_for_copy`] runs inside
+/// the reset-preparation timeout: it discards the table's pending streaming
+/// target, removes its cached channel, and carries any removed channel together
+/// with its table name in this value.
+///
+/// [`Client::drop_detached_table_for_copy`] consumes the value outside that
+/// timeout to drop the Snowpipe channel and Snowflake table. This split keeps
+/// local draining and lock acquisition bounded without cancelling a remote
+/// drop whose outcome would then be unknown.
+///
+/// This value does not block event admission. The caller must retain its
+/// [`etl::destination::TaskSetDrainGuard`] until the remote drop returns.
+pub(super) struct DetachedTableForCopy<C> {
+    /// Previously cached channel handle, when one existed in this process.
+    channel: Option<Arc<Mutex<ChannelHandle<C>>>>,
+    /// Snowflake table name to drop after retiring local state.
+    table_name: String,
+}
 
 /// Maximum accepted Snowflake row batches before forcing a durability wait.
 const STREAMING_PENDING_MAX_ROW_BATCHES: usize = 64;
 
 /// Maximum accepted compressed bytes before forcing a durability wait.
 const STREAMING_PENDING_MAX_BYTES: usize = 256 * 1024 * 1024;
-
-/// Collapsed durability target for one Snowflake streaming channel.
-///
-/// Snowflake committed offsets are cumulative, so multiple accepted row
-/// batches can be represented by the latest target offset plus aggregate row
-/// and byte counts.
-#[derive(Debug, Clone)]
-struct PendingDurabilityTarget {
-    /// Latest accepted offset for this channel.
-    target_offset: OffsetToken,
-    /// Accepted rows since the baseline status.
-    rows: u64,
-    /// Compressed bytes accepted since the baseline status.
-    bytes: usize,
-    /// Snowflake row batches accepted since the baseline status.
-    row_batches: usize,
-    /// Cumulative inserted rows before the pending range began.
-    baseline_rows_inserted: u64,
-    /// Cumulative row errors before the pending range began.
-    baseline_rows_error_count: u64,
-}
-
-impl PendingDurabilityTarget {
-    /// Creates a pending durability target from the first accepted row batch.
-    fn new(batch: AcceptedRowBatch) -> Self {
-        Self {
-            target_offset: batch.target_offset,
-            rows: batch.rows,
-            bytes: batch.bytes,
-            row_batches: 1,
-            baseline_rows_inserted: batch.baseline_rows_inserted,
-            baseline_rows_error_count: batch.baseline_rows_error_count,
-        }
-    }
-
-    /// Extends this target with a later accepted row batch on the same channel.
-    fn record(&mut self, batch: AcceptedRowBatch) -> Result<()> {
-        let rows = self.rows.checked_add(batch.rows).ok_or_else(|| {
-            Error::Channel("Snowflake pending streaming row count overflowed.".into())
-        })?;
-        let bytes = self.bytes.checked_add(batch.bytes).ok_or_else(|| {
-            Error::Channel("Snowflake pending streaming byte count overflowed.".into())
-        })?;
-        let row_batches = self.row_batches.checked_add(1).ok_or_else(|| {
-            Error::Channel("Snowflake pending streaming batch count overflowed.".into())
-        })?;
-
-        self.target_offset = batch.target_offset;
-        self.rows = rows;
-        self.bytes = bytes;
-        self.row_batches = row_batches;
-
-        Ok(())
-    }
-
-    /// Converts this cumulative target into the validation input shape.
-    fn as_accepted_batch(&self) -> AcceptedRowBatch {
-        AcceptedRowBatch {
-            target_offset: self.target_offset.clone(),
-            rows: self.rows,
-            bytes: self.bytes,
-            baseline_rows_inserted: self.baseline_rows_inserted,
-            baseline_rows_error_count: self.baseline_rows_error_count,
-        }
-    }
-}
 
 /// Global accepted-but-not-durable Snowflake streaming state.
 #[derive(Debug, Default)]
@@ -163,19 +119,42 @@ impl PendingDurabilityState {
         self.targets.iter().map(|(table_id, target)| (*table_id, target.clone())).collect()
     }
 
+    /// Discards one table's pending target and updates aggregate accounting.
+    fn discard(&mut self, table_id: TableId) -> Result<()> {
+        let Some(target) = self.targets.get(&table_id) else {
+            return Ok(());
+        };
+        let target_row_batches = target.row_batches;
+        let target_bytes = target.bytes;
+
+        let row_batches = self.row_batches.checked_sub(target_row_batches).ok_or_else(|| {
+            Error::Channel("Snowflake pending streaming batch accounting underflowed.".into())
+        })?;
+        let bytes = self.bytes.checked_sub(target_bytes).ok_or_else(|| {
+            Error::Channel("Snowflake pending streaming byte accounting underflowed.".into())
+        })?;
+
+        self.targets.remove(&table_id);
+        self.row_batches = row_batches;
+        self.bytes = bytes;
+
+        Ok(())
+    }
+
     /// Removes targets whose current offset is covered by the proven target.
-    fn clear_committed(&mut self, committed: &[(TableId, OffsetToken)]) {
+    fn clear_committed(&mut self, committed: &[(TableId, OffsetToken)]) -> Result<()> {
         for (table_id, committed_target) in committed {
             let should_clear = self
                 .targets
                 .get(table_id)
                 .is_some_and(|target| &target.target_offset <= committed_target);
 
-            if should_clear && let Some(target) = self.targets.remove(table_id) {
-                self.row_batches = self.row_batches.saturating_sub(target.row_batches);
-                self.bytes = self.bytes.saturating_sub(target.bytes);
+            if should_clear {
+                self.discard(*table_id)?;
             }
         }
+
+        Ok(())
     }
 
     /// Records pending-window gauges.
@@ -447,9 +426,33 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         guard.reset().await
     }
 
-    /// Drop the table and destination-private replay state before a fresh copy.
-    pub async fn drop_table_for_copy(&self, table_id: TableId, table_name: &str) -> Result<()> {
-        let channel = self.channels.write().await.remove(&table_id);
+    /// Retires one table's process-local state before a fresh copy reset.
+    ///
+    /// Callers must first prevent new streaming tasks from being admitted and
+    /// wait for previously admitted tasks to finish. The returned token can
+    /// then be used to perform the potentially slow remote drop without
+    /// leaving a pending target that refers to a removed channel.
+    pub(super) async fn detach_table_for_copy(
+        &self,
+        table_id: TableId,
+        table_name: &str,
+    ) -> Result<DetachedTableForCopy<C>> {
+        let mut channels = self.channels.write().await;
+        let mut pending = self.pending_durability.lock().await;
+        pending.discard(table_id)?;
+
+        let channel = channels.remove(&table_id);
+        pending.observe_metrics();
+
+        Ok(DetachedTableForCopy { channel, table_name: table_name.to_owned() })
+    }
+
+    /// Drops the remote channel and table for previously detached local state.
+    pub(super) async fn drop_detached_table_for_copy(
+        &self,
+        detached: DetachedTableForCopy<C>,
+    ) -> Result<()> {
+        let DetachedTableForCopy { channel, table_name } = detached;
 
         let drop_channel_result = if let Some(channel) = channel {
             let mut guard = channel.lock().await;
@@ -460,7 +463,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
                 self.pipeline_id,
                 self.database.clone(),
                 self.schema.clone(),
-                table_name.to_owned(),
+                table_name.clone(),
             );
             handle.drop_channel().await
         };
@@ -470,7 +473,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
             Err(error) => return Err(error),
         }
 
-        self.sql_client.drop_table(table_name).await
+        self.sql_client.drop_table(&table_name).await
     }
 
     /// Refresh the table's ingestion state after a schema change.
@@ -487,13 +490,18 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         self.get_channel(*table_id).await?.lock().await.open().await.map(|_| ())
     }
 
-    /// Send table-copy row batches through the existing append-ack path.
+    /// Send table-copy row batches and retain their pending durability target.
     pub async fn send_table_copy_batches(
         &self,
         table_id: TableId,
         batches: Vec<RowBatch>,
     ) -> Result<()> {
-        self.get_channel(table_id).await?.lock().await.send_table_copy_batches(batches).await
+        self.get_channel(table_id).await?.lock().await.accept_table_copy_batches(batches).await
+    }
+
+    /// Wait until all accepted table-copy rows for one table are durable.
+    pub async fn wait_for_table_copy_durability(&self, table_id: TableId) -> Result<()> {
+        self.get_channel(table_id).await?.lock().await.wait_for_table_copy_durability().await
     }
 
     /// Send streaming row batches and record accepted-but-not-durable targets.
@@ -583,7 +591,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
 
             {
                 let mut pending = self.pending_durability.lock().await;
-                pending.clear_committed(&committed);
+                pending.clear_committed(&committed)?;
                 pending.observe_metrics();
                 if pending.is_empty() {
                     return Ok(());
@@ -622,6 +630,16 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
 mod tests {
     use super::*;
 
+    struct UnusedTokenProvider;
+
+    impl TokenProvider for UnusedTokenProvider {
+        async fn get_token(&self) -> Result<String> {
+            Err(Error::Auth("Unused test token provider.".to_owned()))
+        }
+
+        async fn invalidate_token(&self) {}
+    }
+
     fn accepted_batch(lsn: u64, ordinal: u64, rows: u64, bytes: usize) -> AcceptedRowBatch {
         AcceptedRowBatch {
             target_offset: OffsetToken::new(lsn.into(), ordinal),
@@ -630,6 +648,24 @@ mod tests {
             baseline_rows_inserted: 100,
             baseline_rows_error_count: 1,
         }
+    }
+
+    fn test_client() -> Client<UnusedTokenProvider, RestStreamClient<UnusedTokenProvider>> {
+        let config = Config::new("example-account", "test-user", "test-db", "test-schema").unwrap();
+        let auth = Arc::new(UnusedTokenProvider);
+        let http = reqwest::Client::new();
+        let sql_client =
+            SqlClient::new(config.clone_without_credentials(), Arc::clone(&auth), http.clone());
+        let stream_client =
+            Arc::new(RestStreamClient::new(config.account_url().to_owned(), auth, http));
+
+        Client::with_clients(
+            sql_client,
+            stream_client,
+            config.database().to_owned(),
+            config.schema().to_owned(),
+            PipelineId::from(1_u64),
+        )
     }
 
     #[test]
@@ -659,7 +695,7 @@ mod tests {
 
         state.record(first_table_id, accepted_batch(10, 1, 2, 20)).unwrap();
         state.record(second_table_id, accepted_batch(11, 1, 3, 30)).unwrap();
-        state.clear_committed(&[(first_table_id, OffsetToken::new(10_u64.into(), 1))]);
+        state.clear_committed(&[(first_table_id, OffsetToken::new(10_u64.into(), 1))]).unwrap();
 
         assert_eq!(state.targets.len(), 1);
         assert!(state.targets.contains_key(&second_table_id));
@@ -675,7 +711,7 @@ mod tests {
         state.record(table_id, accepted_batch(10, 1, 2, 20)).unwrap();
         let stale_committed_target = (table_id, OffsetToken::new(10_u64.into(), 1));
         state.record(table_id, accepted_batch(10, 2, 3, 30)).unwrap();
-        state.clear_committed(&[stale_committed_target]);
+        state.clear_committed(&[stale_committed_target]).unwrap();
 
         let target = state.targets.get(&table_id).unwrap();
         assert_eq!(target.target_offset, OffsetToken::new(10_u64.into(), 2));
@@ -696,5 +732,36 @@ mod tests {
 
         assert!(state.limits_reached());
         assert!(state.would_exceed_limits(1));
+    }
+
+    #[tokio::test]
+    async fn detach_table_for_copy_retires_channel_and_pending_target() {
+        let table_id = TableId::new(1);
+        let table_name = "TEST_TABLE";
+        let client = test_client();
+        let channel = Arc::new(Mutex::new(ChannelHandle::new(
+            Arc::clone(&client.stream_client),
+            client.pipeline_id,
+            client.database.clone(),
+            client.schema.clone(),
+            table_name.to_owned(),
+        )));
+        client.channels.write().await.insert(table_id, channel);
+        client
+            .pending_durability
+            .lock()
+            .await
+            .record(table_id, accepted_batch(10, 1, 2, 20))
+            .unwrap();
+
+        let detached = client.detach_table_for_copy(table_id, table_name).await.unwrap();
+
+        assert!(detached.channel.is_some());
+        assert_eq!(detached.table_name, table_name);
+        assert!(!client.channels.read().await.contains_key(&table_id));
+        let pending = client.pending_durability.lock().await;
+        assert!(pending.is_empty());
+        assert_eq!(pending.row_batches, 0);
+        assert_eq!(pending.bytes, 0);
     }
 }

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use etl::{
     bail,
@@ -13,6 +13,10 @@ use etl::{
     event::{DeleteEvent, Event, InsertEvent, UpdateEvent},
     schema::{ColumnSchema, ReplicatedTableSchema, TableId},
     store::DestinationStore,
+};
+use tokio::{
+    sync::{Mutex, Semaphore},
+    time::timeout,
 };
 use tracing::{info, warn};
 
@@ -30,20 +34,177 @@ use crate::{
 
 type EventIter = std::iter::Peekable<std::vec::IntoIter<Event>>;
 
+/// Maximum time allowed to drain Snowflake event tasks and retire local table
+/// state before a reset.
+const RESET_PREPARATION_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Coordinates the initial Snowflake setup of each table.
+///
+/// Copy partitions can concurrently observe missing destination metadata. A
+/// per-table gate gives one caller ownership of the complete `Applying` ->
+/// remote setup -> `Applied` transition so a stale caller cannot overwrite
+/// completed metadata with `Applying`. The registry mutex is released before a
+/// caller waits for its table gate.
+#[derive(Clone)]
+struct TableInitializer {
+    /// Stable initialization gates retained for this destination's lifetime.
+    gates: Arc<Mutex<HashMap<TableId, Arc<Semaphore>>>>,
+}
+
+impl TableInitializer {
+    /// Creates an empty table-initialization registry.
+    fn new() -> Self {
+        Self { gates: Arc::new(Mutex::new(HashMap::new())) }
+    }
+
+    /// Ensures the Snowflake table, channel, and durable metadata exist.
+    async fn ensure<S, T, C>(
+        &self,
+        client: &Client<T, C>,
+        store: &S,
+        table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()>
+    where
+        S: DestinationStore,
+        T: TokenProvider + 'static,
+        C: StreamClient,
+    {
+        let table_id = table_schema.id();
+        let table_name = try_stringify_table_name(table_schema.name())?.to_uppercase();
+        let columns: Vec<_> = table_schema.column_schemas().cloned().collect();
+
+        // Applied metadata needs no transition coordination, but this process
+        // may still need to reopen its local channel state.
+        if store
+            .get_destination_table_metadata(table_id)
+            .await?
+            .is_some_and(|metadata| metadata.is_applied())
+        {
+            client.ensure_table(table_id, &table_name, &columns).await.map_err(EtlError::from)?;
+            return Ok(());
+        }
+
+        // Hold the registry only long enough to obtain the stable gate for this
+        // table; unrelated tables must not wait on its remote setup.
+        let gate = {
+            let mut gates = self.gates.lock().await;
+            Arc::clone(gates.entry(table_id).or_insert_with(|| Arc::new(Semaphore::new(1))))
+        };
+
+        // The permit owns the complete Applying -> remote setup -> Applied
+        // transition for this table.
+        let _permit =
+            gate.acquire_owned().await.expect("table initialization gates are never closed");
+
+        // Re-read under the table gate because another copy partition may have
+        // completed setup after the fast-path read.
+        let snapshot_id = table_schema.inner().snapshot_id;
+        let replication_mask = table_schema.replication_mask().clone();
+        let applying_metadata = match store.get_destination_table_metadata(table_id).await? {
+            None => {
+                // Record ownership before creating remote state so a restart can
+                // find and remove a partial setup.
+                let metadata = DestinationTableMetadata::new_applying(
+                    table_name.clone(),
+                    snapshot_id,
+                    replication_mask.clone(),
+                );
+                store.store_destination_table_metadata(table_id, metadata.clone()).await?;
+                Some(metadata)
+            }
+            Some(metadata) if metadata.is_applied() => {
+                // Another copy partition completed setup while this caller waited.
+                None
+            }
+            Some(metadata) if metadata.previous_snapshot_id.is_none() => {
+                // Resume a matching initial setup left by an earlier failure or
+                // cancellation.
+                if metadata.destination_table_id != table_name
+                    || metadata.snapshot_id != snapshot_id
+                    || metadata.replication_mask != replication_mask
+                {
+                    bail!(
+                        ErrorKind::CorruptedTableSchema,
+                        "Interrupted Snowflake table setup metadata does not match current schema",
+                        format!(
+                            "Table {table_id} has interrupted initial setup metadata for snapshot \
+                             {}, but the current setup uses snapshot {snapshot_id}.",
+                            metadata.snapshot_id
+                        )
+                    );
+                }
+
+                Some(metadata)
+            }
+            Some(_) => {
+                // Applying metadata with a previous snapshot belongs to schema
+                // evolution, which requires its separate recovery path.
+                bail!(
+                    ErrorKind::InvalidState,
+                    "Snowflake table schema is still being applied",
+                    format!(
+                        "Table {table_id} has an interrupted schema change and cannot be prepared \
+                         for streaming until that change is recovered."
+                    )
+                );
+            }
+        };
+
+        // Remote setup is retry-safe and remains inside the per-table permit.
+        client.ensure_table(table_id, &table_name, &columns).await.map_err(EtlError::from)?;
+
+        // Publish completion only after both the table and channel exist.
+        if let Some(metadata) = applying_metadata {
+            store.store_destination_table_metadata(table_id, metadata.to_applied()).await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Execution context captured by Snowflake background event tasks.
+///
+/// Before resetting a table, [`Destination`] retains exclusive access to its
+/// [`TaskSet`] while waiting for every admitted event task to finish. A task
+/// that captured the complete destination could later access that same task
+/// registry, causing the reset to wait for the task while the task waits for
+/// the reset-held registry.
+///
+/// This type contains the state needed to execute writes but deliberately omits
+/// [`TaskSet`], making that recursive registry access unavailable through the
+/// task's execution context.
+struct DestinationWriter<S, T, C> {
+    /// Snowflake API client shared by foreground and event writes.
+    client: Client<T, C>,
+    /// Destination metadata store.
+    store: S,
+    /// Per-table initial-setup coordinator.
+    table_initializer: TableInitializer,
+}
+
+impl<S: Clone, T: TokenProvider, C: StreamClient> Clone for DestinationWriter<S, T, C> {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            store: self.store.clone(),
+            table_initializer: self.table_initializer.clone(),
+        }
+    }
+}
+
 /// Postgres replication to Snowflake via Snowpipe Streaming.
 ///
 /// Thin adapter between the ETL [`etl::destination::Destination`] trait and
 /// [`Client`]. Translates replication events into client operations and manages
 /// the state store bookkeeping.
 pub struct Destination<S, T = AuthManager<HttpExchanger>, C = RestStreamClient<T>> {
-    client: Client<T, C>,
-    store: S,
+    writer: DestinationWriter<S, T, C>,
     tasks: TaskSet,
 }
 
 impl<S: Clone, T: TokenProvider, C: StreamClient> Clone for Destination<S, T, C> {
     fn clone(&self) -> Self {
-        Self { client: self.client.clone(), store: self.store.clone(), tasks: self.tasks.clone() }
+        Self { writer: self.writer.clone(), tasks: self.tasks.clone() }
     }
 }
 
@@ -56,79 +217,44 @@ where
     /// Create a new destination.
     pub fn new(client: Client<T, C>, store: S) -> Self {
         register_metrics();
-        Self { client, store, tasks: TaskSet::new() }
+        Self {
+            writer: DestinationWriter { client, store, table_initializer: TableInitializer::new() },
+            tasks: TaskSet::new(),
+        }
     }
 
-    /// Ensure the Snowflake table and streaming channel exist for this table.
-    /// Operation is idempotent.
-    pub async fn prepare_table_for_streaming(
+    /// Fetches the latest committed offset for this table's channel.
+    pub async fn fetch_committed_offset(
+        &self,
+        table_id: TableId,
+    ) -> EtlResult<Option<OffsetToken>> {
+        self.writer.client.fetch_committed_offset(table_id).await.map_err(EtlError::from)
+    }
+}
+
+impl<S, T, C> DestinationWriter<S, T, C>
+where
+    S: DestinationStore,
+    T: TokenProvider + 'static,
+    C: StreamClient,
+{
+    /// Ensures the Snowflake table and streaming channel exist for this table.
+    async fn prepare_table_for_streaming(
         &self,
         table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
-        let table_id = table_schema.id();
-        let table_name = try_stringify_table_name(table_schema.name())?.to_uppercase();
-        let columns: Vec<_> = table_schema.column_schemas().cloned().collect();
-
-        let table_is_new = self
-            .client
-            .ensure_table(table_id, &table_name, &columns)
-            .await
-            .map_err(EtlError::from)?;
-
-        if table_is_new {
-            let snapshot_id = table_schema.inner().snapshot_id;
-            let replication_mask = table_schema.replication_mask().clone();
-            let metadata = DestinationTableMetadata::new_applied(
-                table_name.clone(),
-                snapshot_id,
-                replication_mask,
-            );
-            self.store.store_destination_table_metadata(table_id, metadata).await?;
-        }
-
-        Ok(())
+        self.table_initializer.ensure(&self.client, &self.store, table_schema).await
     }
 
-    /// Write rows during the initial snapshot (table copy) phase.
+    /// Processes an event batch after its task was admitted into [`TaskSet`].
     ///
-    /// All rows are stamped as inserts with a zero offset since the table
-    /// starts empty.
-    pub async fn write_table_rows(
+    /// This execution context intentionally cannot access the task registry. A
+    /// table reset may retain that registry while waiting for this method to
+    /// finish.
+    async fn process_admitted_events(
         &self,
-        schema: &ReplicatedTableSchema,
-        rows: Vec<TableRow>,
-    ) -> EtlResult<()> {
-        // Table must exist even for empty snapshots, CDC events may arrive later.
-        self.prepare_table_for_streaming(schema).await?;
-
-        if rows.is_empty() {
-            return Ok(());
-        }
-
-        let table_id = schema.id();
-        let columns: Vec<_> = schema.column_schemas().cloned().collect();
-
-        // Build row batches. Snowflake has limits on max size of input, so we slice
-        // into proper batches, when necessary.
-        let zero = OffsetToken::zero();
-        let mut builder = RowBatchBuilder::new();
-        for row in &rows {
-            builder
-                .push_row(&columns, row, CdcMeta::new(CdcOperation::Insert, zero.as_ref()), &zero)
-                .map_err(EtlError::from)?;
-        }
-
-        let batches = builder.finish().map_err(EtlError::from)?;
-        self.client.send_table_copy_batches(table_id, batches).await.map_err(EtlError::from)?;
-
-        Ok(())
-    }
-
-    /// Process  CDC events.
-    ///
-    /// All events (inserts, updates, deletes, truncates, and schema changes)
-    /// from the replication stream are processed here.
-    pub async fn process_events(&self, events: Vec<Event>) -> EtlResult<DestinationWriteStatus> {
+        events: Vec<Event>,
+    ) -> EtlResult<DestinationWriteStatus> {
         let mut iter = events.into_iter().peekable();
         // Schema and truncate side effects must close the pending streaming window.
         let mut requires_durability_wait = false;
@@ -148,14 +274,6 @@ where
         } else {
             Ok(DestinationWriteStatus::Accepted)
         }
-    }
-
-    /// Fetches the latest committed offset for this table's channel.
-    pub async fn fetch_committed_offset(
-        &self,
-        table_id: TableId,
-    ) -> EtlResult<Option<OffsetToken>> {
-        self.client.fetch_committed_offset(table_id).await.map_err(EtlError::from)
     }
 
     async fn accumulate_data_events(
@@ -493,15 +611,37 @@ where
         replicated_table_schema: &ReplicatedTableSchema,
         async_result: DropTableForCopyResult<()>,
     ) -> EtlResult<()> {
-        self.tasks.try_reap().await?;
-
         let table_name = try_stringify_table_name(replicated_table_schema.name())?.to_uppercase();
-        let result = self
-            .client
-            .drop_table_for_copy(replicated_table_schema.id(), &table_name)
-            .await
-            .map_err(EtlError::from);
+        let (task_guard, detached) = timeout(RESET_PREPARATION_TIMEOUT, async {
+            // Acquire the task registry before any client lock. Event tasks have no
+            // registry access, so they can finish while reset waits for them.
+            let task_guard = self.tasks.drain().await?;
+            let detached = self
+                .writer
+                .client
+                .detach_table_for_copy(replicated_table_schema.id(), &table_name)
+                .await
+                .map_err(EtlError::from)?;
+            Ok::<_, EtlError>((task_guard, detached))
+        })
+        .await
+        .map_err(|error| {
+            etl_error!(
+                ErrorKind::DestinationTimeout,
+                "Snowflake table reset preparation timed out",
+                source: error
+            )
+        })??;
+
+        // Keep event registration closed through the remote drop. This operation
+        // stays outside the local drain timeout because cancelling remote SQL does
+        // not prove whether Snowflake completed it.
+        let result =
+            self.writer.client.drop_detached_table_for_copy(detached).await.map_err(EtlError::from);
+
+        // Publish the remote result before allowing another event task to run.
         async_result.send(result);
+        drop(task_guard);
 
         Ok(())
     }
@@ -512,8 +652,49 @@ where
         table_rows: Vec<TableRow>,
         async_result: WriteTableRowsResult,
     ) -> EtlResult<()> {
-        let result = self.write_table_rows(replicated_table_schema, table_rows).await;
-        async_result.send(result.map(|_| DestinationWriteStatus::Durable));
+        let result: EtlResult<DestinationWriteStatus> = async {
+            // Table must exist even for empty snapshots, CDC events may arrive later.
+            self.writer.prepare_table_for_streaming(replicated_table_schema).await?;
+
+            if table_rows.is_empty() {
+                self.writer
+                    .client
+                    .wait_for_table_copy_durability(replicated_table_schema.id())
+                    .await
+                    .map_err(EtlError::from)?;
+                return Ok(DestinationWriteStatus::Durable);
+            }
+
+            let table_id = replicated_table_schema.id();
+            let columns: Vec<_> = replicated_table_schema.column_schemas().cloned().collect();
+
+            // Build row batches. Snowflake has limits on max size of input, so we slice
+            // into proper batches, when necessary.
+            let zero = OffsetToken::zero();
+            let mut builder = RowBatchBuilder::new();
+            for row in &table_rows {
+                builder
+                    .push_row(
+                        &columns,
+                        row,
+                        CdcMeta::new(CdcOperation::Insert, zero.as_ref()),
+                        &zero,
+                    )
+                    .map_err(EtlError::from)?;
+            }
+
+            let batches = builder.finish().map_err(EtlError::from)?;
+            self.writer
+                .client
+                .send_table_copy_batches(table_id, batches)
+                .await
+                .map_err(EtlError::from)?;
+
+            Ok(DestinationWriteStatus::Accepted)
+        }
+        .await;
+
+        async_result.send(result);
         Ok(())
     }
 
@@ -525,15 +706,15 @@ where
     ) -> EtlResult<()> {
         self.tasks.try_reap().await?;
 
-        let destination = self.clone();
+        let writer = self.writer.clone();
         self.tasks
             .spawn(async move {
                 let result = async {
-                    let status = destination.process_events(events).await?;
+                    let status = writer.process_admitted_events(events).await?;
                     if durability == WriteEventsDurability::RequireDurable
                         && status == DestinationWriteStatus::Accepted
                     {
-                        destination
+                        writer
                             .client
                             .wait_for_pending_durability()
                             .await
@@ -559,10 +740,50 @@ mod tests {
 
     use etl::{
         data::{Cell, PartialTableRow},
+        pipeline::PipelineId,
         schema::{IdentityMask, ReplicationMask, TableName, TableSchema, Type},
+        store::StateStore,
+        test_utils::notifying_store::NotifyingStore,
     };
 
     use super::*;
+    use crate::snowflake::{Config, Error, SqlClient};
+
+    /// Token provider that fails if a no-network unit test reaches HTTP setup.
+    struct UnusedTokenProvider;
+
+    impl TokenProvider for UnusedTokenProvider {
+        async fn get_token(&self) -> crate::snowflake::Result<String> {
+            Err(Error::Auth("Unused test token provider.".to_owned()))
+        }
+
+        async fn invalidate_token(&self) {}
+    }
+
+    /// Builds a destination whose HTTP clients must remain unused.
+    fn test_destination() -> (
+        Destination<NotifyingStore, UnusedTokenProvider, RestStreamClient<UnusedTokenProvider>>,
+        NotifyingStore,
+    ) {
+        let config = Config::new("example-account", "test-user", "test-db", "test-schema").unwrap();
+        let auth = Arc::new(UnusedTokenProvider);
+        let http = reqwest::Client::new();
+        let sql_client =
+            SqlClient::new(config.clone_without_credentials(), Arc::clone(&auth), http.clone());
+        let stream_client =
+            Arc::new(RestStreamClient::new(config.account_url().to_owned(), auth, http));
+        let client = Client::with_clients(
+            sql_client,
+            stream_client,
+            config.database().to_owned(),
+            config.schema().to_owned(),
+            PipelineId::from(1_u64),
+        );
+        let store = NotifyingStore::new();
+        let destination = Destination::new(client, store.clone());
+
+        (destination, store)
+    }
 
     fn replicated_schema() -> ReplicatedTableSchema {
         let table_schema = Arc::new(TableSchema::new(
@@ -577,6 +798,34 @@ mod tests {
         let identity_mask = IdentityMask::from_bytes(vec![1, 0]);
 
         ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask)
+    }
+
+    #[tokio::test]
+    async fn initial_setup_failure_leaves_metadata_applying() {
+        let (destination, store) = test_destination();
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(2),
+            TableName::new("public".to_owned(), "reserved_column".to_owned()),
+            vec![ColumnSchema::new("_cdc_operation".to_owned(), Type::TEXT, -1, 1, true)],
+        ));
+        let schema = ReplicatedTableSchema::all(table_schema);
+
+        let error = destination.writer.prepare_table_for_streaming(&schema).await.unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ConfigError);
+        let metadata = store
+            .get_destination_table_metadata(schema.id())
+            .await
+            .unwrap()
+            .expect("initial setup metadata should remain available for recovery");
+        assert!(metadata.is_applying());
+        assert_eq!(metadata.previous_snapshot_id, None);
+        assert_eq!(metadata.snapshot_id, schema.inner().snapshot_id);
+        assert_eq!(metadata.replication_mask, *schema.replication_mask());
+        assert_eq!(
+            metadata.destination_table_id,
+            try_stringify_table_name(schema.name()).unwrap().to_uppercase()
+        );
     }
 
     #[test]

--- a/crates/etl-destinations/src/snowflake/streaming/batch.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/batch.rs
@@ -99,6 +99,16 @@ impl RowBatch {
     pub fn end_offset(&self) -> &OffsetToken {
         &self.offset_range.end
     }
+
+    /// Assigns the single Snowpipe request offset for this encoded batch.
+    ///
+    /// Copy batches are encoded before the channel reserves their attempt-local
+    /// offset. Both request-range endpoints are set to `offset` while the
+    /// encoded `_cdc_sequence_number` remains unchanged.
+    pub(crate) fn with_request_offset(mut self, offset: OffsetToken) -> Self {
+        self.offset_range = OffsetRange { start: offset.clone(), end: offset };
+        self
+    }
 }
 
 /// Builds compressed row batches with streaming zstd compression.

--- a/crates/etl-destinations/src/snowflake/streaming/channel.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/channel.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use etl::pipeline::PipelineId;
+use etl::{pipeline::PipelineId, schema::PgLsn};
 use metrics::{counter, histogram};
 use tokio::time::{Instant, sleep};
 use tracing::warn;
@@ -27,7 +27,19 @@ pub(crate) const DEFAULT_COMMIT_POLL_INTERVAL: Duration = Duration::from_millis(
 /// reporting durability or reopening/dropping a channel destructively.
 pub(crate) const DEFAULT_COMMIT_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
 
-/// Row batch accepted by a streaming channel.
+/// Maximum pending table-copy row batches before a durability wait.
+///
+/// This matches streaming's 64-batch bound and forces periodic waits when
+/// small batches do not reach the byte bound.
+const COPY_PENDING_MAX_ROW_BATCHES: usize = 64;
+
+/// Maximum pending compressed table-copy bytes before a durability wait.
+///
+/// This matches streaming's 256 MiB bound and limits unconfirmed data for
+/// large batches. It is not a Snowflake service limit.
+const COPY_PENDING_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// Row batch accepted by a Snowpipe channel.
 #[derive(Debug, Clone)]
 pub(crate) struct AcceptedRowBatch {
     /// Final offset accepted by Snowflake for this row batch.
@@ -57,6 +69,86 @@ impl AcceptedRowBatch {
             baseline_rows_inserted,
             baseline_rows_error_count,
         })
+    }
+}
+
+/// Collapsed durability target for one Snowpipe channel.
+///
+/// Snowflake committed offsets are cumulative, so multiple accepted row
+/// batches can be represented by the latest target offset plus aggregate row
+/// and byte counts.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingDurabilityTarget {
+    /// Latest accepted offset for this channel.
+    pub target_offset: OffsetToken,
+    /// Accepted rows since the baseline status.
+    pub rows: u64,
+    /// Compressed bytes accepted since the baseline status.
+    pub bytes: usize,
+    /// Snowflake row batches accepted since the baseline status.
+    pub row_batches: usize,
+    /// Cumulative inserted rows before the pending range began.
+    pub baseline_rows_inserted: u64,
+    /// Cumulative row errors before the pending range began.
+    pub baseline_rows_error_count: u64,
+}
+
+impl PendingDurabilityTarget {
+    /// Starts a pending durability target with its first accepted row batch.
+    pub(crate) fn new(batch: AcceptedRowBatch) -> Self {
+        Self {
+            target_offset: batch.target_offset,
+            rows: batch.rows,
+            bytes: batch.bytes,
+            row_batches: 1,
+            baseline_rows_inserted: batch.baseline_rows_inserted,
+            baseline_rows_error_count: batch.baseline_rows_error_count,
+        }
+    }
+
+    /// Extends this target with a later batch from the same channel while
+    /// preserving the original channel-status baseline.
+    pub(crate) fn record(&mut self, batch: AcceptedRowBatch) -> Result<()> {
+        let rows = self
+            .rows
+            .checked_add(batch.rows)
+            .ok_or_else(|| Error::Channel("Snowflake pending row count overflowed.".into()))?;
+        let bytes = self
+            .bytes
+            .checked_add(batch.bytes)
+            .ok_or_else(|| Error::Channel("Snowflake pending byte count overflowed.".into()))?;
+        let row_batches = self
+            .row_batches
+            .checked_add(1)
+            .ok_or_else(|| Error::Channel("Snowflake pending batch count overflowed.".into()))?;
+
+        self.target_offset = batch.target_offset;
+        self.rows = rows;
+        self.bytes = bytes;
+        self.row_batches = row_batches;
+
+        Ok(())
+    }
+
+    /// Returns whether accepting another batch of `batch_bytes` bytes requires
+    /// waiting for this target to become durable first.
+    fn would_exceed_limits(&self, batch_bytes: usize) -> bool {
+        self.row_batches >= COPY_PENDING_MAX_ROW_BATCHES
+            || self.bytes >= COPY_PENDING_MAX_BYTES
+            || self.row_batches.saturating_add(1) > COPY_PENDING_MAX_ROW_BATCHES
+            || self.bytes.saturating_add(batch_bytes) > COPY_PENDING_MAX_BYTES
+    }
+
+    /// Returns aggregate batch metadata for validating this target against
+    /// channel status.
+    pub(crate) fn as_accepted_batch(&self) -> AcceptedRowBatch {
+        AcceptedRowBatch {
+            target_offset: self.target_offset.clone(),
+            rows: self.rows,
+            bytes: self.bytes,
+            baseline_rows_inserted: self.baseline_rows_inserted,
+            baseline_rows_error_count: self.baseline_rows_error_count,
+        }
     }
 }
 
@@ -117,6 +209,26 @@ pub(crate) struct ChannelHandle<C> {
     /// Last durable status observed for this channel.
     progress: ChannelProgress,
 
+    /// Whether this handle has entered copy writes without completing the
+    /// terminal copy durability barrier.
+    ///
+    /// This remains set across intermediate durability waits. While set,
+    /// streaming writes are rejected; a failed copy must reset the channel.
+    copy_barrier_pending: bool,
+
+    /// Last synthetic table-copy offset reserved for the current live sequence.
+    ///
+    /// `None` means no live copy sequence is retained. This cursor is
+    /// process-local and must never be used to resume a failed table copy.
+    copy_offset_ordinal: Option<u64>,
+
+    /// Cumulative durability target for copy batches accepted by Snowflake but
+    /// not yet confirmed committed.
+    ///
+    /// `None` means there is no outstanding copy durability debt. The copy
+    /// attempt may still be active.
+    copy_durability_target: Option<PendingDurabilityTarget>,
+
     /// Continuation token for the next API call on this channel.
     continuation_token: Option<String>,
 
@@ -125,22 +237,6 @@ pub(crate) struct ChannelHandle<C> {
 
     /// Maximum time to wait for Snowflake commit proof.
     wait_timeout: Duration,
-}
-
-impl<C> Clone for ChannelHandle<C> {
-    fn clone(&self) -> Self {
-        Self {
-            client: Arc::clone(&self.client),
-            database: self.database.clone(),
-            schema: self.schema.clone(),
-            table: self.table.clone(),
-            channel: self.channel.clone(),
-            progress: self.progress.clone(),
-            continuation_token: self.continuation_token.clone(),
-            poll_interval: self.poll_interval,
-            wait_timeout: self.wait_timeout,
-        }
-    }
 }
 
 impl<C: StreamClient> ChannelHandle<C> {
@@ -160,6 +256,9 @@ impl<C: StreamClient> ChannelHandle<C> {
             table,
             channel,
             progress: ChannelProgress::default(),
+            copy_offset_ordinal: None,
+            copy_barrier_pending: false,
+            copy_durability_target: None,
             continuation_token: None,
             poll_interval: DEFAULT_COMMIT_POLL_INTERVAL,
             wait_timeout: DEFAULT_COMMIT_WAIT_TIMEOUT,
@@ -210,6 +309,9 @@ impl<C: StreamClient> ChannelHandle<C> {
             {
                 Ok(()) => {
                     self.progress = ChannelProgress::default();
+                    self.copy_offset_ordinal = None;
+                    self.copy_barrier_pending = false;
+                    self.copy_durability_target = None;
                     self.continuation_token = None;
                     return Ok(());
                 }
@@ -257,31 +359,31 @@ impl<C: StreamClient> ChannelHandle<C> {
         self.refresh_status().await.map(|status| status.offset_token)
     }
 
-    /// Send all batches with immediate append-ack semantics.
+    /// Accepts table-copy batches into a bounded deferred-durability window.
     ///
-    /// This is kept for table-copy callers. Copy rows do not carry stable WAL
-    /// offsets, so streaming committed-offset filtering and deferred
-    /// durability tracking must not be applied here (just yet).
-    pub async fn send_table_copy_batches(&mut self, batches: Vec<RowBatch>) -> Result<()> {
-        for batch in &batches {
-            histogram!(ETL_SNOWFLAKE_BATCH_SIZE).record(batch.row_count() as f64);
-            histogram!(ETL_SNOWFLAKE_BATCH_BYTES).record(batch.size() as f64);
+    /// Each encoded batch retains its zero CDC sequence and receives the next
+    /// attempt-local `0/N` request offset. Before a batch would exceed the
+    /// pending batch-count or byte limit, this method waits for the current
+    /// cumulative target to become durable.
+    pub async fn accept_table_copy_batches(&mut self, batches: Vec<RowBatch>) -> Result<()> {
+        for batch in batches {
+            if self
+                .copy_durability_target
+                .as_ref()
+                .is_some_and(|target| target.would_exceed_limits(batch.size()))
+            {
+                self.wait_for_pending_copy_durability().await?;
+            }
 
-            match self.append_batch(batch).await {
-                Ok(()) => {}
-                Err(Error::Snowpipe(error)) if error.is_reopenable_channel_error() => {
-                    counter!(ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL).increment(1);
-                    warn!(
-                        table = %self.table,
-                        channel = %self.channel,
-                        "channel was stale, reopening and retrying insert"
-                    );
-                    self.open().await?;
-                    self.append_batch(batch).await?;
-                }
-                Err(error) => {
-                    counter!(ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL).increment(1);
-                    return Err(error);
+            let offset = self.reserve_copy_offset()?;
+            let batch = batch.with_request_offset(offset);
+
+            if let BatchAcceptance::Accepted(accepted) = self.accept_batch(&batch).await? {
+                match &mut self.copy_durability_target {
+                    Some(target) => target.record(accepted)?,
+                    None => {
+                        self.copy_durability_target = Some(PendingDurabilityTarget::new(accepted));
+                    }
                 }
             }
         }
@@ -289,14 +391,52 @@ impl<C: StreamClient> ChannelHandle<C> {
         Ok(())
     }
 
-    /// Accept streaming batches, returning accepted-but-not-durable metadata.
+    /// Waits until every table-copy row accepted by this handle is durable.
+    ///
+    /// Success completes the terminal copy barrier and permits streaming. The
+    /// last synthetic offset remains cached until streaming begins, allowing
+    /// repeated barrier calls to validate observed channel progress. Failed
+    /// copies must reset the table and channel rather than resume from that
+    /// offset.
+    pub async fn wait_for_table_copy_durability(&mut self) -> Result<()> {
+        match self.copy_offset_ordinal {
+            Some(_) => {
+                if let Some(committed) = self.progress.committed_offset.as_ref() {
+                    self.validate_copy_committed_offset(committed)?;
+                }
+            }
+            None if self.progress.committed_offset.is_some() => {
+                return Err(Error::Channel(
+                    "Snowflake table copy must start from a reset channel.".into(),
+                ));
+            }
+            None => {}
+        }
+
+        self.wait_for_pending_copy_durability().await?;
+        self.copy_barrier_pending = false;
+        Ok(())
+    }
+
+    /// Accepts streaming batches when no copy durability barrier is pending.
+    ///
+    /// Returns metadata for newly accepted batches that are not yet durable;
+    /// already committed batches are omitted. Starting streaming retires the
+    /// completed copy offset sequence.
     pub async fn accept_streaming_batches(
         &mut self,
         batches: Vec<RowBatch>,
     ) -> Result<Vec<AcceptedRowBatch>> {
+        if self.copy_barrier_pending || self.copy_durability_target.is_some() {
+            return Err(Error::Channel(
+                "Snowflake streaming cannot start before the table-copy durability barrier.".into(),
+            ));
+        }
+        self.copy_offset_ordinal = None;
+
         let mut accepted = Vec::new();
         for batch in &batches {
-            match self.accept_streaming_batch(batch).await? {
+            match self.accept_batch(batch).await? {
                 BatchAcceptance::Accepted(batch) => accepted.push(batch),
                 BatchAcceptance::AlreadyCommitted => {}
             }
@@ -305,7 +445,93 @@ impl<C: StreamClient> ChannelHandle<C> {
         Ok(accepted)
     }
 
-    async fn accept_streaming_batch(&mut self, batch: &RowBatch) -> Result<BatchAcceptance> {
+    /// Reserves the next attempt-local `0/N` copy offset and marks the terminal
+    /// copy barrier pending.
+    fn reserve_copy_offset(&mut self) -> Result<OffsetToken> {
+        let ordinal = match self.copy_offset_ordinal {
+            Some(ordinal) => {
+                if let Some(committed) = self.progress.committed_offset.as_ref() {
+                    self.validate_copy_committed_offset(committed)?;
+                }
+                ordinal.checked_add(1).ok_or_else(|| {
+                    Error::Channel("Snowflake table-copy offset ordinal overflowed.".into())
+                })?
+            }
+            None => {
+                if self.progress.committed_offset.is_some() {
+                    return Err(Error::Channel(
+                        "Snowflake table copy must start from a reset channel.".into(),
+                    ));
+                }
+                1
+            }
+        };
+
+        self.copy_offset_ordinal = Some(ordinal);
+        self.copy_barrier_pending = true;
+        Ok(OffsetToken::new(PgLsn::from(0_u64), ordinal))
+    }
+
+    /// Validates a committed offset against the synthetic range reserved
+    /// locally for the current copy sequence.
+    fn validate_copy_committed_offset(&self, offset: &OffsetToken) -> Result<()> {
+        let last_reserved = self.copy_offset_ordinal.ok_or_else(|| {
+            Error::Channel("Snowflake table copy has no live offset sequence.".into())
+        })?;
+        let (lsn, ordinal) = offset.decode()?;
+
+        if u64::from(lsn) != 0 || ordinal == 0 || ordinal > last_reserved {
+            return Err(Error::Channel(format!(
+                "Snowflake committed offset {offset} does not belong to the current table-copy \
+                 attempt."
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Waits for valid commit proof for the pending copy target, then clears
+    /// it.
+    async fn wait_for_pending_copy_durability(&mut self) -> Result<()> {
+        let Some(target) = self.copy_durability_target.clone() else {
+            return Ok(());
+        };
+        let deadline = Instant::now() + self.wait_timeout;
+        let accepted = target.as_accepted_batch();
+
+        loop {
+            let status = self.refresh_status().await?;
+            if let Some(committed) = status.offset_token.as_ref() {
+                self.validate_copy_committed_offset(committed)?;
+            }
+            validate_committed_status(&status, &accepted)?;
+
+            if status.offset_token.as_ref().is_some_and(|offset| offset >= &target.target_offset) {
+                self.copy_durability_target = None;
+                return Ok(());
+            }
+
+            if Instant::now() >= deadline {
+                return Err(Error::Channel(
+                    "Timed out waiting for Snowflake table-copy rows to commit.".into(),
+                ));
+            }
+
+            sleep(self.poll_interval).await;
+        }
+    }
+
+    /// Sends one batch unless cached or refreshed channel progress covers it.
+    ///
+    /// A stale continuation token reopens the channel before deciding whether
+    /// to retry the append.
+    async fn accept_batch(&mut self, batch: &RowBatch) -> Result<BatchAcceptance> {
+        if self.copy_barrier_pending
+            && let Some(committed) = self.progress.committed_offset.as_ref()
+        {
+            self.validate_copy_committed_offset(committed)?;
+        }
+
         if self.progress.is_committed(batch.end_offset()) {
             return Ok(BatchAcceptance::AlreadyCommitted);
         }
@@ -340,6 +566,12 @@ impl<C: StreamClient> ChannelHandle<C> {
                     "channel was stale, reopening and retrying insert"
                 );
                 let status = self.open().await?;
+
+                if self.copy_barrier_pending
+                    && let Some(committed) = status.offset_token.as_ref()
+                {
+                    self.validate_copy_committed_offset(committed)?;
+                }
 
                 if status
                     .offset_token

--- a/crates/etl-destinations/src/snowflake/streaming/mod.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/mod.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 pub use batch::{RowBatch, RowBatchBuilder};
 pub(crate) use channel::{
     AcceptedRowBatch, ChannelHandle, DEFAULT_COMMIT_POLL_INTERVAL, DEFAULT_COMMIT_WAIT_TIMEOUT,
-    validate_committed_status,
+    PendingDurabilityTarget, validate_committed_status,
 };
 pub use offset_token::OffsetToken;
 pub use rest_client::RestStreamClient;

--- a/crates/etl-destinations/tests/snowflake/destination.rs
+++ b/crates/etl-destinations/tests/snowflake/destination.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use etl::{
     data::{Cell, OldTableRow, TableRow, UpdatedTableRow},
-    destination::DestinationTableMetadata,
+    destination::{DestinationTableMetadata, DestinationWriteStatus, WriteEventsDurability},
     event::{DeleteEvent, Event, InsertEvent, RelationEvent, UpdateEvent},
     pipeline::PipelineId,
     schema::{
@@ -10,7 +10,12 @@ use etl::{
         Type,
     },
     store::{SchemaStore, StateStore},
-    test_utils::notifying_store::NotifyingStore,
+    test_utils::{
+        destination::{
+            write_events as invoke_write_events, write_table_rows as invoke_write_table_rows,
+        },
+        notifying_store::NotifyingStore,
+    },
 };
 use etl_destinations::snowflake::{
     AuthManager, Client, Config, Destination, HttpExchanger, OffsetToken, RestStreamClient,
@@ -59,6 +64,29 @@ fn snowflake_table_name(src_schema: &str, src_table: &str) -> String {
     let escaped_schema = src_schema.replace('_', "__");
     let escaped_table = src_table.replace('_', "__");
     format!("{escaped_schema}_{escaped_table}").to_uppercase()
+}
+
+fn first_copy_request_offset() -> OffsetToken {
+    OffsetToken::new(PgLsn::from(0_u64), 1)
+}
+
+/// Writes one nonempty copy batch and completes its terminal durability
+/// barrier.
+async fn write_table_copy_and_wait(
+    destination: &SnowflakeTestDestination,
+    schema: &ReplicatedTableSchema,
+    rows: Vec<TableRow>,
+) {
+    assert!(!rows.is_empty(), "table-copy test batch should not be empty");
+
+    let status =
+        invoke_write_table_rows(destination, schema, rows).await.expect("table-copy write failed");
+    assert_eq!(status, DestinationWriteStatus::Accepted);
+
+    let barrier = invoke_write_table_rows(destination, schema, vec![])
+        .await
+        .expect("table-copy durability barrier failed");
+    assert_eq!(barrier, DestinationWriteStatus::Durable);
 }
 
 async fn poll_and_query_rows(
@@ -135,15 +163,18 @@ async fn apply_relation_event(
     lsn: u64,
     context: &str,
 ) {
-    destination
-        .process_events(vec![Event::Relation(RelationEvent {
+    invoke_write_events(
+        destination,
+        WriteEventsDurability::MayDefer,
+        vec![Event::Relation(RelationEvent {
             start_lsn: PgLsn::from(lsn),
             commit_lsn: PgLsn::from(lsn),
             tx_ordinal: 0,
             replicated_table_schema,
-        })])
-        .await
-        .unwrap_or_else(|error| panic!("process_events ({context}) failed: {error}"));
+        })],
+    )
+    .await
+    .unwrap_or_else(|error| panic!("write_events ({context}) failed: {error}"));
 }
 
 /// Inserts a row while omitting `status`, allowing Snowflake defaults to apply.
@@ -213,11 +244,10 @@ async fn create_table_with_simulator_defaults() {
     harness.store.store_table_schema(table_schema).await.unwrap();
 
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .write_table_rows(&schema, vec![])
+        let status = invoke_write_table_rows(&harness.destination, &schema, vec![])
             .await
             .expect("write_table_rows with simulator defaults failed");
+        assert_eq!(status, DestinationWriteStatus::Durable);
 
         let exists = harness.sql.table_exists(&sf_table).await.expect("table_exists failed");
         assert!(exists, "table with simulator defaults should have been created");
@@ -238,35 +268,51 @@ async fn write_table_rows_basic() {
 
     harness.store.store_table_schema(table_schema).await.unwrap();
 
-    // Write 2 rows, poll,  verify rows are there `_cdc_operation = "insert"`.
+    // The nonempty copy write transfers ownership before Snowflake commits it.
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .write_table_rows(
-                &schema,
-                vec![
-                    TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())]),
-                    TableRow::new(vec![Cell::I32(2), Cell::String("Bob".into())]),
-                ],
-            )
-            .await
-            .expect("write_table_rows failed");
+        let status = invoke_write_table_rows(
+            &harness.destination,
+            &schema,
+            vec![
+                TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())]),
+                TableRow::new(vec![Cell::I32(2), Cell::String("Bob".into())]),
+            ],
+        )
+        .await
+        .expect("write_table_rows failed");
+        assert_eq!(status, DestinationWriteStatus::Accepted);
 
-        let zero_offset = OffsetToken::zero();
-        let rows = poll_and_query_rows(&harness, table_id, &sf_table, &zero_offset).await;
+        let metadata = harness
+            .store
+            .get_destination_table_metadata(table_id)
+            .await
+            .unwrap()
+            .expect("successful table setup should store destination metadata");
+        assert!(metadata.is_applied());
+        assert_eq!(metadata.snapshot_id, schema.inner().snapshot_id);
+        assert_eq!(&metadata.replication_mask, schema.replication_mask());
+
+        // The empty write is the table-wide durability barrier.
+        let status = invoke_write_table_rows(&harness.destination, &schema, vec![])
+            .await
+            .expect("table-copy durability barrier failed");
+        assert_eq!(status, DestinationWriteStatus::Durable);
+
+        let copy_offset = first_copy_request_offset();
+        let rows = poll_and_query_rows(&harness, table_id, &sf_table, &copy_offset).await;
         assert_eq!(rows.len(), 2, "expected 2 rows");
 
-        let zero_offset = zero_offset.to_string();
+        let zero_sequence = OffsetToken::zero().to_string();
         // Column order: id, name, _cdc_operation, _cdc_sequence_number
         assert_eq!(rows[0][0], serde_json::json!("1"));
         assert_eq!(rows[0][1], serde_json::json!("Alice"));
         assert_eq!(rows[0][2], serde_json::json!("insert"));
-        assert_eq!(rows[0][3], serde_json::json!(zero_offset));
+        assert_eq!(rows[0][3], serde_json::json!(zero_sequence));
 
         assert_eq!(rows[1][0], serde_json::json!("2"));
         assert_eq!(rows[1][1], serde_json::json!("Bob"));
         assert_eq!(rows[1][2], serde_json::json!("insert"));
-        assert_eq!(rows[1][3], serde_json::json!(zero_offset));
+        assert_eq!(rows[1][3], serde_json::json!(zero_sequence));
     })
     .await;
 }
@@ -283,13 +329,12 @@ async fn write_table_rows_empty() {
 
     harness.store.store_table_schema(table_schema).await.unwrap();
 
-    // Write empty vec. Verify table is created but has no rows.
+    // An empty copy initializes the table and is immediately durable.
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .write_table_rows(&schema, vec![])
+        let status = invoke_write_table_rows(&harness.destination, &schema, vec![])
             .await
             .expect("write_table_rows with empty rows failed");
+        assert_eq!(status, DestinationWriteStatus::Durable);
 
         let exists = harness.sql.table_exists(&sf_table).await.expect("table_exists failed");
         assert!(exists, "table should have been created even with empty row set");
@@ -323,9 +368,10 @@ async fn write_events_insert_update_delete() {
     // Send Insert, Update (Full), Delete (Full) events.
     // Poll and verify 3 rows with operations "insert", "update", "delete".
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .process_events(vec![
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![
                 Event::Insert(InsertEvent {
                     start_lsn: PgLsn::from(1u64),
                     commit_lsn: PgLsn::from(1u64),
@@ -357,9 +403,10 @@ async fn write_events_insert_update_delete() {
                         Cell::String("Bob".into()),
                     ]))),
                 }),
-            ])
-            .await
-            .expect("process_events failed");
+            ],
+        )
+        .await
+        .expect("write_events failed");
 
         let expected_offset = OffsetToken::new(PgLsn::from(3u64), 0);
         let rows = poll_and_query_rows(&harness, table_id, &sf_table, &expected_offset).await;
@@ -398,17 +445,19 @@ async fn write_events_delete_key_only() {
     // Delete event with `OldTableRow::Key`.
     // Verify the delete row has PK value present but non-PK columns are NULL.
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .process_events(vec![Event::Delete(DeleteEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Delete(DeleteEvent {
                 start_lsn: PgLsn::from(1u64),
                 commit_lsn: PgLsn::from(1u64),
                 tx_ordinal: 0,
                 replicated_table_schema: schema.clone(),
                 old_table_row: Some(OldTableRow::Key(TableRow::new(vec![Cell::I32(42)]))),
-            })])
-            .await
-            .expect("process_events failed");
+            })],
+        )
+        .await
+        .expect("write_events failed");
 
         let expected_offset = OffsetToken::new(PgLsn::from(1u64), 0);
         let rows = poll_and_query_rows(&harness, table_id, &sf_table, &expected_offset).await;
@@ -430,7 +479,7 @@ async fn schema_evolution_add_column() {
     let sf_table = snowflake_table_name("public", &src_table);
 
     let table_id = TableId::new(1006);
-    let zero = OffsetToken::zero();
+    let copy_offset = first_copy_request_offset();
 
     let initial_schema = TableSchema::new(
         table_id,
@@ -463,21 +512,19 @@ async fn schema_evolution_add_column() {
     // Finally, insert a row with the new column.
     // Verify the new column exists in Snowflake.
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .write_table_rows(
-                &initial_replicated,
-                vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
-            )
-            .await
-            .expect("initial write_table_rows failed");
+        write_table_copy_and_wait(
+            &harness.destination,
+            &initial_replicated,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
+        )
+        .await;
 
         // Wait for initial data to commit before DDL, channel refresh loses uncommitted
         // rows.
         let committed = poll_destination_offset(
             &harness.destination,
             table_id,
-            &zero,
+            &copy_offset,
             DESTINATION_OFFSET_POLL_INTERVAL,
             DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
@@ -491,20 +538,23 @@ async fn schema_evolution_add_column() {
         );
         harness.store.store_destination_table_metadata(table_id, initial_metadata).await.unwrap();
 
-        harness
-            .destination
-            .process_events(vec![Event::Relation(RelationEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Relation(RelationEvent {
                 start_lsn: PgLsn::from(100u64),
                 commit_lsn: PgLsn::from(100u64),
                 tx_ordinal: 0,
                 replicated_table_schema: evolved_replicated.clone(),
-            })])
-            .await
-            .expect("process_events (RelationEvent) failed");
+            })],
+        )
+        .await
+        .expect("write_events (RelationEvent) failed");
 
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(101u64),
                 commit_lsn: PgLsn::from(101u64),
                 tx_ordinal: 0,
@@ -514,9 +564,10 @@ async fn schema_evolution_add_column() {
                     Cell::String("Bob".into()),
                     Cell::String("bob@example.com".into()),
                 ]),
-            })])
-            .await
-            .expect("process_events (Insert with new column) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert with new column) failed");
 
         let expected_offset = OffsetToken::new(PgLsn::from(101u64), 0);
         let committed = poll_destination_offset(
@@ -558,7 +609,7 @@ async fn schema_evolution_add_column_defaults() {
     let sf_table = snowflake_table_name("public", &src_table);
 
     let table_id = TableId::new(1011);
-    let zero = OffsetToken::zero();
+    let copy_offset = first_copy_request_offset();
 
     let initial_schema = TableSchema::new(
         table_id,
@@ -592,19 +643,17 @@ async fn schema_evolution_add_column_defaults() {
     harness.store.store_table_schema(evolved_schema).await.unwrap();
 
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .write_table_rows(
-                &initial_replicated,
-                vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
-            )
-            .await
-            .expect("initial write_table_rows failed");
+        write_table_copy_and_wait(
+            &harness.destination,
+            &initial_replicated,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
+        )
+        .await;
 
         let committed = poll_destination_offset(
             &harness.destination,
             table_id,
-            &zero,
+            &copy_offset,
             DESTINATION_OFFSET_POLL_INTERVAL,
             DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
@@ -618,20 +667,23 @@ async fn schema_evolution_add_column_defaults() {
         );
         harness.store.store_destination_table_metadata(table_id, initial_metadata).await.unwrap();
 
-        harness
-            .destination
-            .process_events(vec![Event::Relation(RelationEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Relation(RelationEvent {
                 start_lsn: PgLsn::from(100u64),
                 commit_lsn: PgLsn::from(100u64),
                 tx_ordinal: 0,
                 replicated_table_schema: evolved_replicated.clone(),
-            })])
-            .await
-            .expect("process_events (RelationEvent defaults) failed");
+            })],
+        )
+        .await
+        .expect("write_events (RelationEvent defaults) failed");
 
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(101u64),
                 commit_lsn: PgLsn::from(101u64),
                 tx_ordinal: 0,
@@ -643,9 +695,10 @@ async fn schema_evolution_add_column_defaults() {
                     Cell::I32(15),
                     Cell::Bool(true),
                 ]),
-            })])
-            .await
-            .expect("process_events (Insert with defaults) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert with defaults) failed");
 
         let expected_offset = OffsetToken::new(PgLsn::from(101u64), 0);
         let committed = poll_destination_offset(
@@ -733,11 +786,10 @@ async fn schema_evolution_existing_column_default_changes() {
     harness.store.store_table_schema(drop_default_schema).await.unwrap();
 
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .prepare_table_for_streaming(&initial_replicated)
+        let status = invoke_write_table_rows(&harness.destination, &initial_replicated, vec![])
             .await
-            .expect("prepare table for streaming failed");
+            .expect("initial table write failed");
+        assert_eq!(status, DestinationWriteStatus::Durable);
 
         let fqn = format!(
             "\"{}\".\"{}\".\"{sf_table}\"",
@@ -809,7 +861,7 @@ async fn schema_evolution_rename_column() {
     let sf_table = snowflake_table_name("public", &src_table);
 
     let table_id = TableId::new(1007);
-    let zero = OffsetToken::zero();
+    let copy_offset = first_copy_request_offset();
 
     let initial_schema = TableSchema::new(
         table_id,
@@ -837,21 +889,19 @@ async fn schema_evolution_rename_column() {
     harness.store.store_table_schema(evolved_schema).await.unwrap();
 
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .write_table_rows(
-                &initial_replicated,
-                vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
-            )
-            .await
-            .expect("initial write_table_rows failed");
+        write_table_copy_and_wait(
+            &harness.destination,
+            &initial_replicated,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
+        )
+        .await;
 
         // Wait for initial data to commit before DDL -- channel refresh loses
         // uncommitted rows.
         let committed = poll_destination_offset(
             &harness.destination,
             table_id,
-            &zero,
+            &copy_offset,
             DESTINATION_OFFSET_POLL_INTERVAL,
             DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
@@ -865,28 +915,32 @@ async fn schema_evolution_rename_column() {
         );
         harness.store.store_destination_table_metadata(table_id, initial_metadata).await.unwrap();
 
-        harness
-            .destination
-            .process_events(vec![Event::Relation(RelationEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Relation(RelationEvent {
                 start_lsn: PgLsn::from(100u64),
                 commit_lsn: PgLsn::from(100u64),
                 tx_ordinal: 0,
                 replicated_table_schema: evolved_replicated.clone(),
-            })])
-            .await
-            .expect("process_events (RelationEvent rename) failed");
+            })],
+        )
+        .await
+        .expect("write_events (RelationEvent rename) failed");
 
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(101u64),
                 commit_lsn: PgLsn::from(101u64),
                 tx_ordinal: 0,
                 replicated_table_schema: evolved_replicated.clone(),
                 table_row: TableRow::new(vec![Cell::I32(2), Cell::String("Bob".into())]),
-            })])
-            .await
-            .expect("process_events (Insert with renamed column) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert with renamed column) failed");
 
         let expected_offset = OffsetToken::new(PgLsn::from(101u64), 0);
         let committed = poll_destination_offset(
@@ -936,7 +990,7 @@ async fn schema_evolution_drop_column() {
     let sf_table = snowflake_table_name("public", &src_table);
 
     let table_id = TableId::new(1008);
-    let zero = OffsetToken::zero();
+    let copy_offset = first_copy_request_offset();
 
     let initial_schema = TableSchema::new(
         table_id,
@@ -965,25 +1019,23 @@ async fn schema_evolution_drop_column() {
     harness.store.store_table_schema(evolved_schema).await.unwrap();
 
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
-        harness
-            .destination
-            .write_table_rows(
-                &initial_replicated,
-                vec![TableRow::new(vec![
-                    Cell::I32(1),
-                    Cell::String("Alice".into()),
-                    Cell::String("alice@test.com".into()),
-                ])],
-            )
-            .await
-            .expect("initial write_table_rows failed");
+        write_table_copy_and_wait(
+            &harness.destination,
+            &initial_replicated,
+            vec![TableRow::new(vec![
+                Cell::I32(1),
+                Cell::String("Alice".into()),
+                Cell::String("alice@test.com".into()),
+            ])],
+        )
+        .await;
 
         // Wait for initial data to commit before DDL -- channel refresh loses
         // uncommitted rows.
         let committed = poll_destination_offset(
             &harness.destination,
             table_id,
-            &zero,
+            &copy_offset,
             DESTINATION_OFFSET_POLL_INTERVAL,
             DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
@@ -997,28 +1049,32 @@ async fn schema_evolution_drop_column() {
         );
         harness.store.store_destination_table_metadata(table_id, initial_metadata).await.unwrap();
 
-        harness
-            .destination
-            .process_events(vec![Event::Relation(RelationEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Relation(RelationEvent {
                 start_lsn: PgLsn::from(100u64),
                 commit_lsn: PgLsn::from(100u64),
                 tx_ordinal: 0,
                 replicated_table_schema: evolved_replicated.clone(),
-            })])
-            .await
-            .expect("process_events (RelationEvent drop) failed");
+            })],
+        )
+        .await
+        .expect("write_events (RelationEvent drop) failed");
 
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(101u64),
                 commit_lsn: PgLsn::from(101u64),
                 tx_ordinal: 0,
                 replicated_table_schema: evolved_replicated.clone(),
                 table_row: TableRow::new(vec![Cell::I32(2), Cell::String("Bob".into())]),
-            })])
-            .await
-            .expect("process_events (Insert after column drop) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert after column drop) failed");
 
         let expected_offset = OffsetToken::new(PgLsn::from(101u64), 0);
         let committed = poll_destination_offset(
@@ -1133,21 +1189,19 @@ async fn schema_evolution_interleaved_ddl_dml() {
 
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
         // Initial table copy with v1 schema.
-        harness
-            .destination
-            .write_table_rows(
-                &replicated_v1,
-                vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
-            )
-            .await
-            .expect("initial write_table_rows failed");
+        write_table_copy_and_wait(
+            &harness.destination,
+            &replicated_v1,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
+        )
+        .await;
 
         // Wait for initial data to commit before DDL.
-        let zero = OffsetToken::zero();
+        let copy_offset = first_copy_request_offset();
         let committed = poll_destination_offset(
             &harness.destination,
             table_id,
-            &zero,
+            &copy_offset,
             DESTINATION_OFFSET_POLL_INTERVAL,
             DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
@@ -1162,34 +1216,39 @@ async fn schema_evolution_interleaved_ddl_dml() {
         harness.store.store_destination_table_metadata(table_id, initial_metadata).await.unwrap();
 
         // Phase 1: Insert(v1) + ADD COLUMN
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(1u64),
                 commit_lsn: PgLsn::from(1u64),
                 tx_ordinal: 0,
                 replicated_table_schema: replicated_v1.clone(),
                 table_row: TableRow::new(vec![Cell::I32(2), Cell::String("Bob".into())]),
-            })])
-            .await
-            .expect("process_events (Insert v1) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert v1) failed");
         poll(1, 0).await;
 
-        harness
-            .destination
-            .process_events(vec![Event::Relation(RelationEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Relation(RelationEvent {
                 start_lsn: PgLsn::from(100u64),
                 commit_lsn: PgLsn::from(100u64),
                 tx_ordinal: 0,
                 replicated_table_schema: replicated_v2.clone(),
-            })])
-            .await
-            .expect("process_events (Relation v2) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Relation v2) failed");
 
         // Phase 2: Insert(v2) + RENAME
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(101u64),
                 commit_lsn: PgLsn::from(101u64),
                 tx_ordinal: 0,
@@ -1199,26 +1258,30 @@ async fn schema_evolution_interleaved_ddl_dml() {
                     Cell::String("Charlie".into()),
                     Cell::String("charlie@test.com".into()),
                 ]),
-            })])
-            .await
-            .expect("process_events (Insert v2) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert v2) failed");
         poll(101, 0).await;
 
-        harness
-            .destination
-            .process_events(vec![Event::Relation(RelationEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Relation(RelationEvent {
                 start_lsn: PgLsn::from(200u64),
                 commit_lsn: PgLsn::from(200u64),
                 tx_ordinal: 0,
                 replicated_table_schema: replicated_v3.clone(),
-            })])
-            .await
-            .expect("process_events (Relation v3) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Relation v3) failed");
 
         // Phase 3: Insert(v3) + DROP COLUMN
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(201u64),
                 commit_lsn: PgLsn::from(201u64),
                 tx_ordinal: 0,
@@ -1228,34 +1291,39 @@ async fn schema_evolution_interleaved_ddl_dml() {
                     Cell::String("Diana".into()),
                     Cell::String("diana@test.com".into()),
                 ]),
-            })])
-            .await
-            .expect("process_events (Insert v3) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert v3) failed");
         poll(201, 0).await;
 
-        harness
-            .destination
-            .process_events(vec![Event::Relation(RelationEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Relation(RelationEvent {
                 start_lsn: PgLsn::from(300u64),
                 commit_lsn: PgLsn::from(300u64),
                 tx_ordinal: 0,
                 replicated_table_schema: replicated_v4.clone(),
-            })])
-            .await
-            .expect("process_events (Relation v4) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Relation v4) failed");
 
         // Phase 4: Final insert after all DDL.
-        harness
-            .destination
-            .process_events(vec![Event::Insert(InsertEvent {
+        invoke_write_events(
+            &harness.destination,
+            WriteEventsDurability::MayDefer,
+            vec![Event::Insert(InsertEvent {
                 start_lsn: PgLsn::from(301u64),
                 commit_lsn: PgLsn::from(301u64),
                 tx_ordinal: 0,
                 replicated_table_schema: replicated_v4.clone(),
                 table_row: TableRow::new(vec![Cell::I32(5), Cell::String("Eve".into())]),
-            })])
-            .await
-            .expect("process_events (Insert v4) failed");
+            })],
+        )
+        .await
+        .expect("write_events (Insert v4) failed");
         poll(301, 0).await;
 
         let fqn = format!(

--- a/crates/etl-destinations/tests/snowflake/pipeline.rs
+++ b/crates/etl-destinations/tests/snowflake/pipeline.rs
@@ -164,16 +164,16 @@ async fn schema_change_add_column_defaults() {
         pipeline.start().await.unwrap();
         table_ready.notified().await;
 
-        let zero_offset = OffsetToken::zero();
+        let copy_offset = OffsetToken::new(0_u64.into(), 1);
         let committed = poll_destination_offset(
             &destination_for_polling,
             table_id,
-            &zero_offset,
+            &copy_offset,
             DESTINATION_OFFSET_POLL_INTERVAL,
             DESTINATION_OFFSET_MAX_ATTEMPTS,
         )
         .await;
-        assert_eq!(committed, Some(zero_offset), "initial data should commit before source DDL");
+        assert_eq!(committed, Some(copy_offset), "initial data should commit before source DDL");
 
         let initial_rows =
             wait_for_initial_row(&sql, config.database(), config.schema(), &snowflake_table).await;

--- a/crates/etl/src/test_utils/destination.rs
+++ b/crates/etl/src/test_utils/destination.rs
@@ -1,0 +1,42 @@
+//! Test helpers for invoking destination trait methods.
+
+use crate::{
+    data::TableRow,
+    destination::{
+        Destination, DestinationWriteStatus, WriteEventsDurability, WriteEventsResult,
+        WriteTableRowsResult,
+    },
+    error::EtlResult,
+    event::Event,
+    schema::ReplicatedTableSchema,
+};
+
+/// Invokes [`Destination::write_events`] and waits for its completion.
+///
+/// This mirrors ETL's streaming-write call boundary without exposing the
+/// private pending-result implementation.
+pub async fn write_events<D: Destination>(
+    destination: &D,
+    durability: WriteEventsDurability,
+    events: Vec<Event>,
+) -> EtlResult<DestinationWriteStatus> {
+    let (async_result, pending_result) = WriteEventsResult::new(());
+    Destination::write_events(destination, events, durability, async_result).await?;
+
+    pending_result.await.into_result()
+}
+
+/// Invokes [`Destination::write_table_rows`] and waits for its completion.
+///
+/// This mirrors ETL's table-copy call boundary without exposing the private
+/// pending-result implementation.
+pub async fn write_table_rows<D: Destination>(
+    destination: &D,
+    schema: &ReplicatedTableSchema,
+    rows: Vec<TableRow>,
+) -> EtlResult<DestinationWriteStatus> {
+    let (async_result, pending_result) = WriteTableRowsResult::new(());
+    Destination::write_table_rows(destination, schema, rows, async_result).await?;
+
+    pending_result.await.into_result()
+}

--- a/crates/etl/src/test_utils/mod.rs
+++ b/crates/etl/src/test_utils/mod.rs
@@ -6,6 +6,7 @@
 //! worker lifecycle coordination, and data consistency validation.
 
 pub mod database;
+pub mod destination;
 pub mod event;
 pub mod faults;
 pub mod materialize;


### PR DESCRIPTION
## Summary

- pipeline Snowflake table-copy batches through bounded deferred-durability windows
- use attempt-local request offsets while preserving encoded CDC sequence metadata
- report `Durable` only after Snowpipe confirms the cumulative terminal barrier
- safely reset per-table channel state before a new copy attempt
- update tests to exercise the destination's real async-result contract

## Why

Snowpipe accepts copy batches before they are durably committed. Waiting after every batch serializes table copy, while treating acceptance as durability can advance progress prematurely.

This preserves pipelining and bounded backpressure while acknowledging copy completion only after Snowflake confirms durability.