### PR TITLE
clickhouse: Prevent unsafe schema rewind during CDC replay

### DIFF
--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -300,6 +300,14 @@ impl ClickHouseClient {
                     )
                     .with_option("http_send_timeout", floor_secs(config.insert_timeout))
                     .with_option("http_receive_timeout", floor_secs(config.insert_timeout))
+                    // Force durable insert acknowledgements: when a server or
+                    // user profile enables `async_insert` with
+                    // `wait_for_async_insert = 0`, ClickHouse acks inserts
+                    // before writing them to disk, letting a following schema
+                    // change overtake acked rows. Pinning the setting keeps
+                    // every ack durable; it is a no-op when async inserts are
+                    // disabled.
+                    .with_option("wait_for_async_insert", "1")
             }),
             config,
         }

--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -300,13 +300,14 @@ impl ClickHouseClient {
                     )
                     .with_option("http_send_timeout", floor_secs(config.insert_timeout))
                     .with_option("http_receive_timeout", floor_secs(config.insert_timeout))
-                    // Force durable insert acknowledgements: when a server or
-                    // user profile enables `async_insert` with
+                    // Force synchronous insert acknowledgements: when a server
+                    // or user profile enables `async_insert` with
                     // `wait_for_async_insert = 0`, ClickHouse acks inserts
-                    // before writing them to disk, letting a following schema
-                    // change overtake acked rows. Pinning the setting keeps
-                    // every ack durable; it is a no-op when async inserts are
-                    // disabled.
+                    // before flushing the async-insert buffer into the table,
+                    // letting a following schema change overtake acked rows.
+                    // Pinning the setting makes every ack imply the rows were
+                    // flushed into the table; it is a no-op when async inserts
+                    // are disabled.
                     .with_option("wait_for_async_insert", "1")
             }),
             config,

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -635,6 +635,24 @@ where
 
         match metadata.previous_snapshot_id {
             Some(prev_snapshot_id) => {
+                // Recovery replays the interrupted diff from the previous
+                // snapshot to the target snapshot recorded in the metadata. A
+                // schema arriving with any other snapshot is a stale replay
+                // and must not drive DDL: diffing against it could execute
+                // reverse DDL or wrongly mark the interrupted change applied.
+                let arriving_snapshot_id = schema.inner().snapshot_id;
+                if arriving_snapshot_id != metadata.snapshot_id {
+                    return Err(etl_error!(
+                        ErrorKind::DestinationSchemaRewind,
+                        "ClickHouse schema recovery received a stale schema snapshot",
+                        format!(
+                            "Table {} has an interrupted schema change targeting snapshot {}, but \
+                             received snapshot {}. Resynchronize the table to recover.",
+                            table_id, metadata.snapshot_id, arriving_snapshot_id
+                        )
+                    ));
+                }
+
                 let old_table_schema =
                     self.store.get_table_schema(&table_id, prev_snapshot_id).await?.ok_or_else(
                         || {
@@ -697,6 +715,16 @@ where
         table_rows: Vec<TableRow>,
     ) -> EtlResult<()> {
         self.write_table_rows_inner(schema, table_rows).await
+    }
+    /// Writes a streaming event batch directly to the destination, awaiting
+    /// the write inline instead of reporting through the trait's async
+    /// completion result.
+    ///
+    /// Test-only entrypoint for exercising the production write path without
+    /// pipeline plumbing.
+    #[cfg(feature = "test-utils")]
+    pub async fn write_events(&self, events: Vec<Event>) -> EtlResult<()> {
+        self.write_events_inner(events).await
     }
 
     async fn write_table_rows_inner(
@@ -761,6 +789,25 @@ where
 
         let current_snapshot_id = metadata.snapshot_id;
         let current_replication_mask = metadata.replication_mask.clone();
+
+        // Reject stale schema snapshots replayed after a restart. At-least-once
+        // delivery can re-send a relation event whose snapshot predates the
+        // schema already applied at the destination. Diffing backwards would
+        // execute reverse DDL (e.g. DROP COLUMN) and physically delete newer
+        // column data, and ClickHouse has no ETL-owned durable per-table DML
+        // watermark that would make replaying the following old events safe.
+        if new_snapshot_id < current_snapshot_id {
+            return Err(etl_error!(
+                ErrorKind::DestinationSchemaRewind,
+                "ClickHouse destination schema is newer than the replayed schema snapshot",
+                format!(
+                    "Table {} received schema snapshot {}, but the destination already applied \
+                     snapshot {}. Reverse DDL is not executed because it could delete newer \
+                     column data; resynchronize the table to recover.",
+                    table_id, new_snapshot_id, current_snapshot_id
+                )
+            ));
+        }
 
         if current_snapshot_id == new_snapshot_id
             && current_replication_mask == new_replication_mask
@@ -998,6 +1045,12 @@ where
     /// 2. Writes those rows concurrently.
     /// 3. Processes any Relation events (schema changes) sequentially.
     /// 4. Drains consecutive Truncate events (deduplicated) and executes them.
+    ///
+    /// Schema changes are applied only after all preceding inserts in the
+    /// batch finished durably: step 2 awaits every INSERT before step 3 runs
+    /// any DDL, and the client pins `wait_for_async_insert = 1`, so an insert
+    /// acknowledgement implies the rows are written to disk and cannot be
+    /// overtaken by a following `ALTER TABLE`.
     async fn write_events_inner(&self, events: Vec<Event>) -> EtlResult<()> {
         let mut event_iter = events.into_iter().peekable();
 

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -32,6 +32,7 @@ use crate::{
             supports_column_default, trailing_cdc_column_names,
         },
     },
+    recovery::previous_replication_mask_for_recovery,
     table_name::try_stringify_table_name,
 };
 
@@ -667,10 +668,17 @@ where
                             )
                         },
                     )?;
-                let old_schema = ReplicatedTableSchema::from_mask(
-                    old_table_schema,
-                    metadata.replication_mask.clone(),
+                // The metadata records the target mask, not the previous one,
+                // so project it back onto the previous schema; a raw copy has
+                // the wrong width whenever the change added or dropped
+                // columns.
+                let previous_replication_mask = previous_replication_mask_for_recovery(
+                    &old_table_schema,
+                    schema.inner(),
+                    &metadata.replication_mask,
                 );
+                let old_schema =
+                    ReplicatedTableSchema::from_mask(old_table_schema, previous_replication_mask);
                 let diff = old_schema.diff(schema);
                 self.apply_schema_diff(clickhouse_table_name, &diff, &old_schema, schema).await?;
             }

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -1056,10 +1056,10 @@ where
     /// 4. Drains consecutive Truncate events (deduplicated) and executes them.
     ///
     /// Schema changes are applied only after all preceding inserts in the
-    /// batch finished durably: step 2 awaits every INSERT before step 3 runs
-    /// any DDL, and the client pins `wait_for_async_insert = 1`, so an insert
-    /// acknowledgement implies the rows are written to disk and cannot be
-    /// overtaken by a following `ALTER TABLE`.
+    /// batch are complete: step 2 awaits every INSERT before step 3 runs any
+    /// DDL, and the client pins `wait_for_async_insert = 1`, so an insert
+    /// acknowledgement implies the rows were flushed into the table and
+    /// cannot be overtaken by a following `ALTER TABLE`.
     async fn write_events_inner(&self, events: Vec<Event>) -> EtlResult<()> {
         let mut event_iter = events.into_iter().peekable();
 

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -724,6 +724,7 @@ where
     ) -> EtlResult<()> {
         self.write_table_rows_inner(schema, table_rows).await
     }
+
     /// Writes a streaming event batch directly to the destination, awaiting
     /// the write inline instead of reporting through the trait's async
     /// completion result.

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -17,8 +17,8 @@ use etl::{
     etl_error,
     event::{Event, EventSequenceKey},
     schema::{
-        ColumnModification, ColumnSchema, ReplicatedTableSchema, ReplicationMask, SchemaDiff,
-        SnapshotId, TableId, TableName, TableSchema,
+        ColumnModification, ColumnSchema, ReplicatedTableSchema, SchemaDiff, SnapshotId, TableId,
+        TableName, TableSchema,
     },
     store::{DestinationStore, TableStateType},
 };
@@ -41,44 +41,48 @@ use tokio::{
 use tracing::{debug, info, warn};
 use url::Url;
 
-use crate::ducklake::{
-    ATTACH_DATA_INLINING_ROW_LIMIT, COPY_DATA_INLINING_ROW_LIMIT, DuckLakeTableName, LAKE_CATALOG,
-    S3Config,
-    batches::{
-        TableMutation, TrackedTableMutation, TrackedTruncateEvent, apply_table_batch_with_retry,
-        apply_table_batches_with_retry, ensure_applied_batches_table_exists,
-        ensure_streaming_progress_table_exists, prepare_copy_complete_table_batch,
-        prepare_copy_table_batch, prepare_mutation_table_batches, prepare_truncate_table_batch,
-        read_table_streaming_progress_sequence_key, retain_mutations_after_sequence_key,
-        retain_truncates_after_sequence_key,
+use crate::{
+    ducklake::{
+        ATTACH_DATA_INLINING_ROW_LIMIT, COPY_DATA_INLINING_ROW_LIMIT, DuckLakeTableName,
+        LAKE_CATALOG, S3Config,
+        batches::{
+            TableMutation, TrackedTableMutation, TrackedTruncateEvent,
+            apply_table_batch_with_retry, apply_table_batches_with_retry,
+            ensure_applied_batches_table_exists, ensure_streaming_progress_table_exists,
+            prepare_copy_complete_table_batch, prepare_copy_table_batch,
+            prepare_mutation_table_batches, prepare_truncate_table_batch,
+            read_table_streaming_progress_sequence_key, retain_mutations_after_sequence_key,
+            retain_truncates_after_sequence_key,
+        },
+        client::{
+            DuckLakeConnectionManager, DuckLakeInterruptRegistry, build_warm_ducklake_pool,
+            format_query_error_detail, run_duckdb_blocking,
+        },
+        config::{
+            MAINTENANCE_TARGET_FILE_SIZE, MIN_EXPIRE_SNAPSHOTS_OLDER_THAN, build_setup_plan,
+            current_duckdb_extension_strategy, maintenance_target_file_size_sql,
+            resolve_expire_snapshots_older_than, validate_expire_snapshots_older_than_sql,
+        },
+        external_maintenance::ExternalMaintenanceOperations,
+        inline_size::DuckLakePendingInlineSizeSampler,
+        metrics::{
+            DuckLakeMetricsSampler, ETL_DUCKLAKE_POOL_SIZE, query_catalog_maintenance_metrics,
+            query_table_storage_metrics, register_metrics,
+            resolve_ducklake_metadata_schema_blocking, spawn_ducklake_metrics_sampler,
+        },
+        replay_epoch::{
+            begin_table_replay_epoch_transition, complete_table_replay_epoch_transition,
+            ensure_replay_epoch_table_exists, read_table_replay_epoch,
+        },
+        schema::{
+            build_add_column_sql_ducklake, build_create_table_sql_ducklake,
+            build_drop_column_sql_ducklake, build_drop_default_sql_ducklake,
+            build_rename_column_sql_ducklake, build_set_default_sql_ducklake,
+            supports_column_default_ducklake,
+        },
+        sql::qualified_lake_table_name,
     },
-    client::{
-        DuckLakeConnectionManager, DuckLakeInterruptRegistry, build_warm_ducklake_pool,
-        format_query_error_detail, run_duckdb_blocking,
-    },
-    config::{
-        MAINTENANCE_TARGET_FILE_SIZE, MIN_EXPIRE_SNAPSHOTS_OLDER_THAN, build_setup_plan,
-        current_duckdb_extension_strategy, maintenance_target_file_size_sql,
-        resolve_expire_snapshots_older_than, validate_expire_snapshots_older_than_sql,
-    },
-    external_maintenance::ExternalMaintenanceOperations,
-    inline_size::DuckLakePendingInlineSizeSampler,
-    metrics::{
-        DuckLakeMetricsSampler, ETL_DUCKLAKE_POOL_SIZE, query_catalog_maintenance_metrics,
-        query_table_storage_metrics, register_metrics, resolve_ducklake_metadata_schema_blocking,
-        spawn_ducklake_metrics_sampler,
-    },
-    replay_epoch::{
-        begin_table_replay_epoch_transition, complete_table_replay_epoch_transition,
-        ensure_replay_epoch_table_exists, read_table_replay_epoch,
-    },
-    schema::{
-        build_add_column_sql_ducklake, build_create_table_sql_ducklake,
-        build_drop_column_sql_ducklake, build_drop_default_sql_ducklake,
-        build_rename_column_sql_ducklake, build_set_default_sql_ducklake,
-        supports_column_default_ducklake,
-    },
-    sql::qualified_lake_table_name,
+    recovery::previous_replication_mask_for_recovery,
 };
 
 /// Shared Postgres metadata pool size for DuckLake background samplers.
@@ -819,35 +823,6 @@ fn plan_schema_diff_sql_ducklake(
     }
 
     Ok(DuckLakeSchemaDiffPlan { statements, column_names })
-}
-
-/// Builds the best previous-schema replication mask available during recovery.
-///
-/// [`DestinationTableMetadata`] stores the target mask, not the previous mask.
-/// For a source-schema change we project target bits back by ordinal position.
-/// Columns that no longer exist in the target schema are treated as previously
-/// replicated so the idempotent DDL planner can drop them if they exist.
-fn previous_replication_mask_for_recovery(
-    previous_schema: &TableSchema,
-    target_schema: &TableSchema,
-    target_replication_mask: &ReplicationMask,
-) -> ReplicationMask {
-    let mask = previous_schema
-        .column_schemas
-        .iter()
-        .map(|previous_column| {
-            target_schema
-                .column_schemas
-                .iter()
-                .position(|target_column| {
-                    target_column.ordinal_position == previous_column.ordinal_position
-                })
-                .and_then(|index| target_replication_mask.as_slice().get(index).copied())
-                .unwrap_or(1)
-        })
-        .collect();
-
-    ReplicationMask::from_bytes(mask)
 }
 
 /// Returns target replicated columns that are missing from DuckLake.
@@ -2796,7 +2771,7 @@ mod tests {
         data::{Cell, PartialTableRow, TableRow},
         schema::{
             ColumnChange, ColumnModification, ColumnSchema, IdentityMask, ReplicationMask,
-            SchemaDiff, SnapshotId, TableSchema, Type as PgType,
+            SchemaDiff, TableSchema, Type as PgType,
         },
         store::{MemoryStore, SchemaStore},
     };
@@ -3245,62 +3220,6 @@ mod tests {
             missing_columns.iter().map(|column| column.name.as_str()).collect();
 
         assert_eq!(missing_column_names, vec!["email"]);
-    }
-
-    #[test]
-    fn previous_replication_mask_for_recovery_matches_previous_schema_width() {
-        let previous_schema = TableSchema::new(
-            TableId::new(4),
-            TableName::new("public".to_owned(), "users".to_owned()),
-            vec![
-                ColumnSchema::new("id".to_owned(), PgType::INT4, -1, 1, false).with_primary_key(1),
-                ColumnSchema::new("hidden".to_owned(), PgType::TEXT, -1, 2, true),
-            ],
-        );
-        let target_schema = TableSchema::with_snapshot_id(
-            previous_schema.id,
-            previous_schema.name.clone(),
-            vec![
-                ColumnSchema::new("id".to_owned(), PgType::INT4, -1, 1, false).with_primary_key(1),
-                ColumnSchema::new("hidden".to_owned(), PgType::TEXT, -1, 2, true),
-                ColumnSchema::new("email".to_owned(), PgType::TEXT, -1, 3, true),
-            ],
-            SnapshotId::from(42_u64),
-        );
-        let target_mask = ReplicationMask::from_bytes(vec![1, 0, 1]);
-
-        let previous_mask =
-            previous_replication_mask_for_recovery(&previous_schema, &target_schema, &target_mask);
-
-        assert_eq!(previous_mask.to_bytes(), vec![1, 0]);
-    }
-
-    #[test]
-    fn previous_replication_mask_for_recovery_keeps_removed_columns_for_drop_diff() {
-        let previous_schema = TableSchema::new(
-            TableId::new(5),
-            TableName::new("public".to_owned(), "users".to_owned()),
-            vec![
-                ColumnSchema::new("id".to_owned(), PgType::INT4, -1, 1, false).with_primary_key(1),
-                ColumnSchema::new("name".to_owned(), PgType::TEXT, -1, 2, true),
-                ColumnSchema::new("old_col".to_owned(), PgType::TEXT, -1, 3, true),
-            ],
-        );
-        let target_schema = TableSchema::with_snapshot_id(
-            previous_schema.id,
-            previous_schema.name.clone(),
-            vec![
-                ColumnSchema::new("id".to_owned(), PgType::INT4, -1, 1, false).with_primary_key(1),
-                ColumnSchema::new("name".to_owned(), PgType::TEXT, -1, 2, true),
-            ],
-            SnapshotId::from(43_u64),
-        );
-        let target_mask = ReplicationMask::from_bytes(vec![1, 1]);
-
-        let previous_mask =
-            previous_replication_mask_for_recovery(&previous_schema, &target_schema, &target_mask);
-
-        assert_eq!(previous_mask.to_bytes(), vec![1, 1, 1]);
     }
 
     fn path_to_file_url(path: &Path) -> Url {

--- a/crates/etl-destinations/src/lib.rs
+++ b/crates/etl-destinations/src/lib.rs
@@ -4,6 +4,8 @@
 //! warehouses and analytics platforms, enabling data replication from Postgres
 //! to cloud services.
 
+#[cfg(any(feature = "clickhouse", feature = "ducklake"))]
+mod recovery;
 #[cfg(any(feature = "bigquery", feature = "ducklake", feature = "snowflake"))]
 mod retry;
 #[cfg(any(feature = "ducklake", feature = "snowflake"))]

--- a/crates/etl-destinations/src/recovery.rs
+++ b/crates/etl-destinations/src/recovery.rs
@@ -1,0 +1,98 @@
+//! Shared helpers for recovering interrupted destination schema changes.
+
+use etl::schema::{ReplicationMask, TableSchema};
+
+/// Builds the best previous-schema replication mask available during recovery.
+///
+/// [`etl::destination::DestinationTableMetadata`] stores the target mask, not
+/// the previous mask. For a source-schema change we project target bits back
+/// by ordinal position. Columns that no longer exist in the target schema are
+/// treated as previously replicated so the idempotent DDL planner can drop
+/// them if they exist.
+pub(crate) fn previous_replication_mask_for_recovery(
+    previous_schema: &TableSchema,
+    target_schema: &TableSchema,
+    target_replication_mask: &ReplicationMask,
+) -> ReplicationMask {
+    let mask = previous_schema
+        .column_schemas
+        .iter()
+        .map(|previous_column| {
+            target_schema
+                .column_schemas
+                .iter()
+                .position(|target_column| {
+                    target_column.ordinal_position == previous_column.ordinal_position
+                })
+                .and_then(|index| target_replication_mask.as_slice().get(index).copied())
+                .unwrap_or(1)
+        })
+        .collect();
+
+    ReplicationMask::from_bytes(mask)
+}
+
+#[cfg(test)]
+mod tests {
+    use etl::schema::{
+        ColumnSchema, ReplicationMask, SnapshotId, TableId, TableName, TableSchema, Type,
+    };
+
+    use crate::recovery::previous_replication_mask_for_recovery;
+
+    #[test]
+    fn previous_replication_mask_for_recovery_matches_previous_schema_width() {
+        let previous_schema = TableSchema::new(
+            TableId::new(4),
+            TableName::new("public".to_owned(), "users".to_owned()),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("hidden".to_owned(), Type::TEXT, -1, 2, true),
+            ],
+        );
+        let target_schema = TableSchema::with_snapshot_id(
+            previous_schema.id,
+            previous_schema.name.clone(),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("hidden".to_owned(), Type::TEXT, -1, 2, true),
+                ColumnSchema::new("email".to_owned(), Type::TEXT, -1, 3, true),
+            ],
+            SnapshotId::from(42_u64),
+        );
+        let target_mask = ReplicationMask::from_bytes(vec![1, 0, 1]);
+
+        let previous_mask =
+            previous_replication_mask_for_recovery(&previous_schema, &target_schema, &target_mask);
+
+        assert_eq!(previous_mask.to_bytes(), vec![1, 0]);
+    }
+
+    #[test]
+    fn previous_replication_mask_for_recovery_keeps_removed_columns_for_drop_diff() {
+        let previous_schema = TableSchema::new(
+            TableId::new(5),
+            TableName::new("public".to_owned(), "users".to_owned()),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+                ColumnSchema::new("old_col".to_owned(), Type::TEXT, -1, 3, true),
+            ],
+        );
+        let target_schema = TableSchema::with_snapshot_id(
+            previous_schema.id,
+            previous_schema.name.clone(),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+            ],
+            SnapshotId::from(43_u64),
+        );
+        let target_mask = ReplicationMask::from_bytes(vec![1, 1]);
+
+        let previous_mask =
+            previous_replication_mask_for_recovery(&previous_schema, &target_schema, &target_mask);
+
+        assert_eq!(previous_mask.to_bytes(), vec![1, 1, 1]);
+    }
+}

--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -2255,6 +2255,7 @@ async fn schema_change_add_drop_rename_inner(engine: ClickHouseEngine) {
         );
     }
 }
+
 /// Row struct for the stale-replay test after the add-column change.
 #[derive(clickhouse::Row, serde::Deserialize, Debug)]
 struct StaleReplayRow {

--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -1,7 +1,15 @@
+use std::sync::Arc;
+
 use etl::{
-    event::EventType,
+    destination::{DestinationTableMetadata, DestinationTableSchemaStatus},
+    error::ErrorKind,
+    event::{Event, EventType, RelationEvent},
     pipeline::PipelineId,
-    store::{StateStore, TableStateType},
+    schema::{
+        ColumnSchema, PgLsn, ReplicatedTableSchema, ReplicationMask, SnapshotId, TableId,
+        TableName, TableSchema, Type,
+    },
+    store::{SchemaStore, StateStore, TableStateType},
     test_utils::{
         database::{spawn_source_database, test_table_name},
         event::EventCondition,
@@ -2246,4 +2254,256 @@ async fn schema_change_add_drop_rename_inner(engine: ClickHouseEngine) {
             "__current view should match the evolved ReplacingMergeTree schema"
         );
     }
+}
+/// Row struct for the stale-replay test after the add-column change.
+#[derive(clickhouse::Row, serde::Deserialize, Debug)]
+struct StaleReplayRow {
+    id: i64,
+    name: String,
+    email: Option<String>,
+}
+
+/// Tests that a stale relation event replayed after a restart is rejected
+/// instead of rewinding the destination schema.
+///
+/// # GIVEN
+///
+/// A Postgres table (id, name) copied to ClickHouse, then `ADD COLUMN email`
+/// and one streamed row carrying data in the new column, so the destination
+/// applied the newer schema snapshot and holds data in `email`.
+///
+/// # WHEN
+///
+/// A fresh destination built on the same store (simulating a process restart
+/// that replays from an older LSN) receives a relation event carrying the
+/// retained pre-change schema snapshot.
+///
+/// # THEN
+///
+/// The write fails with `ErrorKind::DestinationSchemaRewind`, no reverse DDL
+/// runs (the `email` column and its data survive), and destination metadata
+/// still points at the newer snapshot.
+///
+/// # Regression
+///
+/// Without the rewind guard, the destination diffed the applied schema against
+/// the stale one and executed `DROP COLUMN email`, physically deleting the
+/// newer column data before the newer relation event re-added it as empty.
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_relation_replay_rejected_merge_tree() {
+    stale_relation_replay_rejected_inner(ClickHouseEngine::MergeTree).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_relation_replay_rejected_replacing_merge_tree() {
+    stale_relation_replay_rejected_inner(ClickHouseEngine::ReplacingMergeTree).await;
+}
+
+async fn stale_relation_replay_rejected_inner(engine: ClickHouseEngine) {
+    init_test_tracing();
+    install_crypto_provider();
+
+    // --- GIVEN: table with one row, copied to ClickHouse ---
+    let database = spawn_source_database().await;
+    let table_name = test_table_name("schema_stale_replay");
+
+    let table_id = database
+        .create_table(table_name.clone(), true, &[("name", "text not null")])
+        .await
+        .expect("Failed to create table");
+
+    let publication_name = "test_pub_ch_stale_replay";
+    database
+        .create_publication(publication_name, std::slice::from_ref(&table_name))
+        .await
+        .expect("Failed to create publication");
+
+    database
+        .run_sql(&format!(
+            "INSERT INTO {} (name) VALUES ('Alice')",
+            table_name.as_quoted_identifier(),
+        ))
+        .await
+        .expect("Failed to insert Alice");
+
+    let clickhouse_db = setup_clickhouse_database().await;
+    let store = NotifyingStore::new();
+    let pipeline_id: PipelineId = random();
+    let destination = TestDestinationWrapper::wrap(
+        clickhouse_db.build_destination_with_engine(store.clone(), engine).await,
+    );
+
+    let table_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        publication_name.to_owned(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    pipeline.start().await.unwrap();
+    table_ready.notified().await;
+
+    let initial_metadata = store
+        .get_applied_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("metadata should exist after table creation");
+    let initial_snapshot_id = initial_metadata.snapshot_id;
+
+    // Add a column and stream one row that carries data in it.
+    let event_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
+        .await;
+    database
+        .alter_table(
+            table_name.clone(),
+            &[TableModification::AddColumn { name: "email", data_type: "text" }],
+        )
+        .await
+        .unwrap();
+    database
+        .run_sql(&format!(
+            "INSERT INTO {} (name, email) VALUES ('Bob', 'bob@example.com')",
+            table_name.as_quoted_identifier(),
+        ))
+        .await
+        .expect("Failed to insert Bob");
+    event_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let applied_metadata = store
+        .get_applied_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("metadata should exist after schema change");
+    let applied_snapshot_id = applied_metadata.snapshot_id;
+    assert!(
+        applied_snapshot_id > initial_snapshot_id,
+        "snapshot_id should increase after schema change"
+    );
+    let clickhouse_table_name = applied_metadata.destination_table_id.clone();
+
+    // --- WHEN: a fresh destination on the same store replays the old relation ---
+    let stale_table_schema = store
+        .get_table_schema(&table_id, initial_snapshot_id)
+        .await
+        .unwrap()
+        .expect("pre-change schema snapshot should still be retained");
+    let stale_schema = ReplicatedTableSchema::from_mask(
+        stale_table_schema,
+        initial_metadata.replication_mask.clone(),
+    );
+
+    let restarted_destination =
+        clickhouse_db.build_destination_with_engine(store.clone(), engine).await;
+    let result = restarted_destination
+        .write_events(vec![Event::Relation(RelationEvent {
+            start_lsn: PgLsn::from(0),
+            commit_lsn: PgLsn::from(0),
+            tx_ordinal: 0,
+            replicated_table_schema: stale_schema,
+        })])
+        .await;
+
+    // --- THEN: the stale snapshot is rejected and no reverse DDL ran ---
+    let err = result.expect_err("stale relation replay should be rejected");
+    assert_eq!(err.kind(), ErrorKind::DestinationSchemaRewind);
+
+    let columns = clickhouse_db.column_names(&clickhouse_table_name).await;
+    assert_eq!(columns, vec!["id", "name", "email"], "email column must survive the stale replay");
+
+    let query =
+        current_state_query(engine, &clickhouse_table_name, "id, name, email", &["id"], "id");
+    let rows: Vec<StaleReplayRow> = clickhouse_db.query(&query).await;
+    assert_eq!(rows.len(), 2, "expected Alice + Bob");
+    assert_eq!(rows[0].id, 1);
+    assert_eq!(rows[0].name, "Alice");
+    assert_eq!(rows[1].id, 2);
+    assert_eq!(rows[1].name, "Bob");
+    assert_eq!(
+        rows[1].email,
+        Some("bob@example.com".to_owned()),
+        "newer column data must survive the stale replay"
+    );
+
+    let final_metadata = store
+        .get_applied_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("metadata should still exist after the rejected replay");
+    assert_eq!(
+        final_metadata.snapshot_id, applied_snapshot_id,
+        "metadata must stay at the newer snapshot"
+    );
+}
+
+/// Tests that interrupted schema-change recovery rejects a stale schema
+/// snapshot instead of replaying DDL against it.
+///
+/// # GIVEN
+///
+/// Destination metadata in `Applying` state targeting snapshot 200 with
+/// previous snapshot 100 (an interrupted schema change).
+///
+/// # WHEN
+///
+/// The recovery path runs with a schema carrying snapshot 100 -- a stale
+/// replay arriving before the interrupted change's relation event.
+///
+/// # THEN
+///
+/// The write fails with `ErrorKind::DestinationSchemaRewind` instead of
+/// diffing against the stale schema and wrongly marking the interrupted
+/// change as applied.
+#[tokio::test(flavor = "multi_thread")]
+async fn schema_change_recovery_rejects_stale_snapshot_merge_tree() {
+    init_test_tracing();
+    install_crypto_provider();
+
+    let clickhouse_db = setup_clickhouse_database().await;
+    let store = NotifyingStore::new();
+
+    let table_id = TableId::new(4242);
+    let table_schema = Arc::new(TableSchema::with_snapshot_id(
+        table_id,
+        TableName::new("public".to_owned(), "stale_recovery".to_owned()),
+        vec![
+            ColumnSchema::new("id".to_owned(), Type::INT8, -1, 1, false).with_primary_key(1),
+            ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+        ],
+        SnapshotId::new(PgLsn::from(100)),
+    ));
+    let replication_mask = ReplicationMask::all(&table_schema);
+    let stale_schema =
+        ReplicatedTableSchema::from_mask(Arc::clone(&table_schema), replication_mask.clone());
+
+    // Interrupted schema change: metadata targets snapshot 200, previous 100.
+    let metadata = DestinationTableMetadata::new_applied(
+        "public_stale_recovery".to_owned(),
+        SnapshotId::new(PgLsn::from(100)),
+        replication_mask.clone(),
+    )
+    .with_schema_change(
+        SnapshotId::new(PgLsn::from(200)),
+        replication_mask,
+        DestinationTableSchemaStatus::Applying,
+    );
+    store.store_destination_table_metadata(table_id, metadata).await.unwrap();
+
+    let destination = clickhouse_db
+        .build_destination_with_engine(store.clone(), ClickHouseEngine::MergeTree)
+        .await;
+
+    let err = destination
+        .write_table_rows(&stale_schema, vec![])
+        .await
+        .expect_err("recovery with a stale schema snapshot should be rejected");
+    assert_eq!(err.kind(), ErrorKind::DestinationSchemaRewind);
 }

--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -2507,3 +2507,110 @@ async fn schema_change_recovery_rejects_stale_snapshot_merge_tree() {
         .expect_err("recovery with a stale schema snapshot should be rejected");
     assert_eq!(err.kind(), ErrorKind::DestinationSchemaRewind);
 }
+
+/// Tests that interrupted schema-change recovery replays the diff and marks
+/// the change applied when the arriving schema matches the recovery target.
+///
+/// # GIVEN
+///
+/// A destination table physically created at snapshot 100 (id, name) whose
+/// metadata was then flipped to `Applying` targeting snapshot 200 (id, name,
+/// email) with previous snapshot 100 -- the state a crash leaves behind after
+/// `handle_relation_event` recorded the change but before the DDL completed.
+///
+/// # WHEN
+///
+/// A write arrives carrying the target snapshot 200, as happens when the
+/// rows following the interrupted relation event replay after a restart.
+///
+/// # THEN
+///
+/// Recovery replays the interrupted diff (adds `email`), transitions the
+/// metadata to `Applied` at snapshot 200, and the write succeeds.
+#[tokio::test(flavor = "multi_thread")]
+async fn schema_change_recovery_replays_interrupted_diff_merge_tree() {
+    init_test_tracing();
+    install_crypto_provider();
+
+    let clickhouse_db = setup_clickhouse_database().await;
+    let store = NotifyingStore::new();
+
+    let table_id = TableId::new(4243);
+    let table_name = TableName::new("public".to_owned(), "recovery_replay".to_owned());
+    let old_columns = vec![
+        ColumnSchema::new("id".to_owned(), Type::INT8, -1, 1, false).with_primary_key(1),
+        ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+    ];
+    // Recovery loads the previous snapshot from the schema store, so the old
+    // schema must be stored, not just passed to the write call.
+    let old_table_schema = store
+        .store_table_schema(TableSchema::with_snapshot_id(
+            table_id,
+            table_name.clone(),
+            old_columns.clone(),
+            SnapshotId::new(PgLsn::from(100)),
+        ))
+        .await
+        .unwrap();
+    let old_mask = ReplicationMask::all(&old_table_schema);
+    let old_schema = ReplicatedTableSchema::from_mask(old_table_schema, old_mask.clone());
+
+    let destination = clickhouse_db
+        .build_destination_with_engine(store.clone(), ClickHouseEngine::MergeTree)
+        .await;
+
+    // Create the physical table and `Applied` metadata at snapshot 100.
+    destination.write_table_rows(&old_schema, vec![]).await.unwrap();
+
+    let mut new_columns = old_columns;
+    new_columns.push(ColumnSchema::new("email".to_owned(), Type::TEXT, -1, 3, true));
+    let new_table_schema = Arc::new(TableSchema::with_snapshot_id(
+        table_id,
+        table_name,
+        new_columns,
+        SnapshotId::new(PgLsn::from(200)),
+    ));
+    let new_mask = ReplicationMask::all(&new_table_schema);
+    let new_schema = ReplicatedTableSchema::from_mask(new_table_schema, new_mask.clone());
+
+    // Simulate a crash after the change was recorded as `Applying` but before
+    // the DDL completed.
+    let applied_metadata = store
+        .get_applied_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("metadata should exist after table creation");
+    let clickhouse_table_name = applied_metadata.destination_table_id.clone();
+    let interrupted_metadata = DestinationTableMetadata::new_applied(
+        clickhouse_table_name.clone(),
+        SnapshotId::new(PgLsn::from(100)),
+        old_mask,
+    )
+    .with_schema_change(
+        SnapshotId::new(PgLsn::from(200)),
+        new_mask,
+        DestinationTableSchemaStatus::Applying,
+    );
+    store.store_destination_table_metadata(table_id, interrupted_metadata).await.unwrap();
+
+    // A restarted destination (empty table cache, so metadata is consulted)
+    // receiving the target snapshot must replay the interrupted diff.
+    let restarted_destination = clickhouse_db
+        .build_destination_with_engine(store.clone(), ClickHouseEngine::MergeTree)
+        .await;
+    restarted_destination.write_table_rows(&new_schema, vec![]).await.unwrap();
+
+    let columns = clickhouse_db.column_names(&clickhouse_table_name).await;
+    assert_eq!(columns, vec!["id", "name", "email"], "recovery must add the interrupted column");
+
+    let recovered_metadata = store
+        .get_applied_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("metadata should be applied after recovery");
+    assert_eq!(
+        recovered_metadata.snapshot_id,
+        SnapshotId::new(PgLsn::from(200)),
+        "recovery must mark the target snapshot applied"
+    );
+}

--- a/crates/etl/src/error.rs
+++ b/crates/etl/src/error.rs
@@ -120,6 +120,8 @@ pub enum ErrorKind {
     DestinationNamespaceMissing,
     /// The destination table does not exist.
     DestinationTableMissing,
+    /// The destination schema is newer than a replayed schema snapshot.
+    DestinationSchemaRewind,
 
     // Data & Transformation Errors
     /// A value could not be converted between source and destination formats.

--- a/crates/etl/src/runtime/error_policy.rs
+++ b/crates/etl/src/runtime/error_policy.rs
@@ -103,6 +103,14 @@ pub(crate) fn build_error_handling_policy(error: &EtlError) -> ErrorHandlingPoli
             RetryDirective::Manual,
             Some("Check replication slot status and database configuration."),
         ),
+        ErrorKind::DestinationSchemaRewind => ErrorHandlingPolicy::new(
+            RetryDirective::Manual,
+            Some(
+                "Resynchronize the affected table. The destination schema is ahead of the \
+                 replayed replication stream, so the replayed schema snapshot cannot be applied \
+                 safely.",
+            ),
+        ),
         ErrorKind::TableSyncWorkerPanic => ErrorHandlingPolicy::new(
             RetryDirective::Manual,
             Some("Inspect the table sync worker panic logs and manually retry the table."),

--- a/docs/src/content/docs/explanation/schema-changes.md
+++ b/docs/src/content/docs/explanation/schema-changes.md
@@ -309,8 +309,12 @@ These behaviors are **not full destination DDL semantics** yet:
   newer columns and physically delete their data. ClickHouse has no ETL-owned
   durable per-table watermark that would make replaying the following old
   events safe, so the pipeline fails with a schema-rewind error and the
-  affected table must be resynchronized. Replication mask changes carry no
-  ordering, so a replayed stale mask cannot be detected the same way.
+  affected table must be resynchronized. This is not limited to exotic
+  replays: a single crash after a schema change was applied at the
+  destination but before the corresponding replication progress was
+  confirmed replays the stream from before the change and triggers the
+  same error. Replication mask changes carry no ordering, so a replayed
+  stale mask cannot be detected the same way.
 - Sessions can set `supabase_etl.skip_ddl_log = 'true'` as an emergency
   opt-out while recovering a system. DDL executed with that setting enabled is
   not logged for ETL.

--- a/docs/src/content/docs/explanation/schema-changes.md
+++ b/docs/src/content/docs/explanation/schema-changes.md
@@ -74,7 +74,7 @@ ETL has one shared schema-change signal, but **DDL behavior is implemented per d
 | Destination | Current DDL behavior |
 |-------------|----------------------|
 | BigQuery | Supports add, drop, rename, `REQUIRED` to `NULLABLE` relaxation, and supported literal default metadata. BigQuery requires added columns to be nullable and does not backfill existing rows for `ADD COLUMN ... DEFAULT`. PostgreSQL remains responsible for enforcing later `SET NOT NULL` changes because BigQuery cannot tighten an existing column in place. |
-| ClickHouse | Supports add, drop, rename, and supported literal defaults. `ReplacingMergeTree` rejects primary-key drops or renames because the ordering expression cannot be rewritten safely. ClickHouse default expressions are metadata-only unless explicitly materialized; ETL does not issue `MATERIALIZE COLUMN`. |
+| ClickHouse | Supports add, drop, rename, and supported literal defaults. `ReplacingMergeTree` rejects primary-key drops or renames because the ordering expression cannot be rewritten safely. ClickHouse default expressions are metadata-only unless explicitly materialized; ETL does not issue `MATERIALIZE COLUMN`. Relation events whose schema snapshot is older than the applied destination snapshot are rejected instead of executing reverse DDL; recovering from that state requires resynchronizing the table. |
 | DuckLake | Supports add, drop, rename, and supported literal defaults. DuckLake records supported add-time defaults as metadata without rewriting existing data files. |
 | Snowflake | Supports add, drop, rename, create-table literal defaults, and literal add-column defaults. Literal defaults are included in `ADD COLUMN` so Snowflake can expose add-time default values for existing rows; non-literal defaults and later default changes are skipped with a warning. |
 | Iceberg | Deprecated for now. Schema-change DDL is not a supported path for new deployments. |
@@ -303,6 +303,14 @@ These behaviors are **not full destination DDL semantics** yet:
 - The trigger payload includes `current_query` for debugging only. It can
   contain literals and multiple statements, so it must not be treated as
   replayable DDL.
+- ClickHouse rejects stale schema snapshots instead of rewinding. When a
+  restart replays a relation event whose snapshot is older than the schema
+  already applied at the destination, executing the backwards diff would drop
+  newer columns and physically delete their data. ClickHouse has no ETL-owned
+  durable per-table watermark that would make replaying the following old
+  events safe, so the pipeline fails with a schema-rewind error and the
+  affected table must be resynchronized. Replication mask changes carry no
+  ordering, so a replayed stale mask cannot be detected the same way.
 - Sessions can set `supabase_etl.skip_ddl_log = 'true'` as an emergency
   opt-out while recovering a system. DDL executed with that setting enabled is
   not logged for ETL.


### PR DESCRIPTION
Prevents ClickHouse from executing reverse DDL when a
restart replays a relation event with an old schema snapshot. Before this
change, the replayed event drove a backwards schema diff that dropped
newer columns and deleted their data.