### PR TITLE
ref(performance): Add SIMD-based UTF-8 validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "simdutf8",
  "sqlx",
  "sysinfo",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ sentry = { version = "0.42.0" }
 serde = { version = "1.0.219", default-features = false }
 serde_json = { version = "1.0.141", default-features = false }
 sha2 = { version = "0.11", default-features = false }
+simdutf8 = { version = "0.1.5" }
 sqlx = { version = "0.9.0", default-features = false }
 sysinfo = { version = "0.38.2", default-features = false }
 tempfile = { version = "3.23.0", default-features = false }

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -34,6 +34,7 @@ rand = { workspace = true, features = ["thread_rng"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 serde_json = { workspace = true, features = ["arbitrary_precision", "std"] }
+simdutf8 = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
 sysinfo = { workspace = true, features = ["system"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }

--- a/crates/etl/src/error.rs
+++ b/crates/etl/src/error.rs
@@ -607,6 +607,20 @@ impl From<std::str::Utf8Error> for EtlError {
     }
 }
 
+/// Converts [`simdutf8::basic::Utf8Error`] to [`EtlError`] with
+/// [`ErrorKind::ConversionError`].
+impl From<simdutf8::basic::Utf8Error> for EtlError {
+    fn from(err: simdutf8::basic::Utf8Error) -> EtlError {
+        let source = Arc::new(err);
+        EtlError::from_components(
+            ErrorKind::ConversionError,
+            Cow::Borrowed("UTF-8 conversion failed"),
+            None,
+            Some(source),
+        )
+    }
+}
+
 /// Converts [`std::string::FromUtf8Error`] to [`EtlError`] with
 /// [`ErrorKind::ConversionError`].
 impl From<std::string::FromUtf8Error> for EtlError {

--- a/crates/etl/src/postgres/codec/table_row.rs
+++ b/crates/etl/src/postgres/codec/table_row.rs
@@ -43,12 +43,22 @@ fn find_next_special(haystack: &[u8]) -> Option<usize> {
 /// Returns an error if the row data is not valid UTF-8, the column count
 /// doesn't match the schema, the row is not properly terminated, or a cell
 /// value cannot be parsed according to its column type.
+#[inline]
 pub(crate) fn parse_table_row_from_postgres_copy_bytes(
     row: &[u8],
     column_schemas: &[ColumnSchema],
 ) -> EtlResult<TableRow> {
+    let row_str = simdutf8::basic::from_utf8(row)?;
+    parse_table_row_from_postgres_copy_str(row_str, column_schemas)
+}
+
+/// Parses a Postgres COPY row whose UTF-8 validity has already been
+/// established.
+fn parse_table_row_from_postgres_copy_str(
+    row_str: &str,
+    column_schemas: &[ColumnSchema],
+) -> EtlResult<TableRow> {
     let expected_column_count = column_schemas.len();
-    let row_str = str::from_utf8(row)?;
     let bytes = row_str.as_bytes();
 
     // Parsed cells in schema order.


### PR DESCRIPTION
## Summary

Use `simdutf8` to validate PostgreSQL COPY rows before parsing them.

The COPY parser operates primarily on bytes, but it still needs a valid `&str` to borrow unescaped field values without allocating. Previously, this conversion used `std::str::from_utf8`; it now uses `simdutf8::basic::from_utf8`, which can validate larger inputs more efficiently using SIMD instructions.

Validation is still performed for every row, so the parser preserves the same UTF-8 correctness guarantees. The returned `&str` and subsequent `as_bytes()` call are zero-copy views over the original input.

## Changes

- Add `simdutf8` as an ETL dependency.
- Use SIMD UTF-8 validation in the PostgreSQL COPY row parser.
- Preserve the existing conversion-error behavior for invalid UTF-8.
- Separate validation from the parser’s already-validated string path.