### PR TITLE
fix(snowflake): skip stale schema snapshots during replay

### DIFF
--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -472,6 +472,21 @@ where
         let current_replication_mask = metadata.replication_mask.clone();
         let new_replication_mask = new_schema.replication_mask().clone();
 
+        // Snowflake waits for all preceding row batches to become durable
+        // before applying schema DDL. On replay, those rows are at or below the
+        // channel's restored committed offset and will be skipped. The older
+        // relation event is therefore already reflected in the destination,
+        // diffing backwards could drop newer columns and delete their data.
+        if new_snapshot_id < current_snapshot_id {
+            info!(
+                table_id = %table_id,
+                received_snapshot_id = %new_snapshot_id,
+                applied_snapshot_id = %current_snapshot_id,
+                "skipping stale Snowflake relation event"
+            );
+            return Ok(false);
+        }
+
         if current_snapshot_id == new_snapshot_id
             && current_replication_mask == new_replication_mask
         {
@@ -740,8 +755,9 @@ mod tests {
 
     use etl::{
         data::{Cell, PartialTableRow},
+        event::RelationEvent,
         pipeline::PipelineId,
-        schema::{IdentityMask, ReplicationMask, TableName, TableSchema, Type},
+        schema::{IdentityMask, PgLsn, ReplicationMask, SnapshotId, TableName, TableSchema, Type},
         store::StateStore,
         test_utils::notifying_store::NotifyingStore,
     };
@@ -826,6 +842,55 @@ mod tests {
             metadata.destination_table_id,
             try_stringify_table_name(schema.name()).unwrap().to_uppercase()
         );
+    }
+
+    /// A stale relation event must not drive reverse Snowflake DDL.
+    #[tokio::test]
+    async fn stale_relation_event_is_skipped() {
+        let (destination, store) = test_destination();
+        let table_id = TableId::new(3);
+        let table_name = TableName::new("public".to_owned(), "users".to_owned());
+        let stale_table_schema = Arc::new(TableSchema::with_snapshot_id(
+            table_id,
+            table_name.clone(),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+            ],
+            SnapshotId::new(PgLsn::from(100_u64)),
+        ));
+        let stale_schema = ReplicatedTableSchema::all(stale_table_schema);
+        let applied_table_schema = Arc::new(TableSchema::with_snapshot_id(
+            table_id,
+            table_name,
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("name".to_owned(), Type::TEXT, -1, 2, true),
+                ColumnSchema::new("email".to_owned(), Type::TEXT, -1, 3, true),
+            ],
+            SnapshotId::new(PgLsn::from(200_u64)),
+        ));
+        let applied_schema = ReplicatedTableSchema::all(applied_table_schema);
+        let metadata = DestinationTableMetadata::new_applied(
+            "PUBLIC_USERS".to_owned(),
+            applied_schema.inner().snapshot_id,
+            applied_schema.replication_mask().clone(),
+        );
+        store.store_destination_table_metadata(table_id, metadata.clone()).await.unwrap();
+
+        let status = destination
+            .writer
+            .process_admitted_events(vec![Event::Relation(RelationEvent {
+                start_lsn: PgLsn::from(100_u64),
+                commit_lsn: PgLsn::from(100_u64),
+                tx_ordinal: 0,
+                replicated_table_schema: stale_schema,
+            })])
+            .await
+            .expect("stale relation event should be skipped");
+
+        assert_eq!(status, DestinationWriteStatus::Durable);
+        assert_eq!(store.get_destination_table_metadata(table_id).await.unwrap(), Some(metadata));
     }
 
     #[test]

--- a/crates/etl-destinations/tests/snowflake/destination.rs
+++ b/crates/etl-destinations/tests/snowflake/destination.rs
@@ -471,9 +471,11 @@ async fn write_events_delete_key_only() {
     .await;
 }
 
+/// A restart replay must skip an older relation snapshot and its committed
+/// rows without executing reverse DDL.
 #[tokio::test]
 #[ignore = "requires Snowflake credentials"]
-async fn schema_evolution_add_column() {
+async fn schema_evolution_add_column_skips_stale_replay() {
     let harness = TestHarness::new();
     let src_table = format!("ETL_TEST_{}", uuid::Uuid::new_v4().simple()).to_uppercase();
     let sf_table = snowflake_table_name("public", &src_table);
@@ -580,23 +582,108 @@ async fn schema_evolution_add_column() {
         .await;
         assert_eq!(committed, Some(expected_offset), "data should commit within 90s");
 
+        // Recreate the destination to restore the channel's durable offset,
+        // then replay the stream from before the schema change. Both rows are
+        // already committed, and the stale relation must not remove `email`.
+        let restarted_destination = Destination::new(
+            Client::new(build_auth(), PipelineId::from(1_u64)),
+            harness.store.clone(),
+        );
+        let replay_status = invoke_write_events(
+            &restarted_destination,
+            WriteEventsDurability::MayDefer,
+            vec![
+                Event::Relation(RelationEvent {
+                    start_lsn: PgLsn::from(0_u64),
+                    commit_lsn: PgLsn::from(0_u64),
+                    tx_ordinal: 0,
+                    replicated_table_schema: initial_replicated.clone(),
+                }),
+                Event::Insert(InsertEvent {
+                    start_lsn: PgLsn::from(1_u64),
+                    commit_lsn: PgLsn::from(1_u64),
+                    tx_ordinal: 0,
+                    replicated_table_schema: initial_replicated.clone(),
+                    table_row: TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())]),
+                }),
+                Event::Relation(RelationEvent {
+                    start_lsn: PgLsn::from(100_u64),
+                    commit_lsn: PgLsn::from(100_u64),
+                    tx_ordinal: 0,
+                    replicated_table_schema: evolved_replicated.clone(),
+                }),
+                Event::Insert(InsertEvent {
+                    start_lsn: PgLsn::from(101_u64),
+                    commit_lsn: PgLsn::from(101_u64),
+                    tx_ordinal: 0,
+                    replicated_table_schema: evolved_replicated.clone(),
+                    table_row: TableRow::new(vec![
+                        Cell::I32(2),
+                        Cell::String("Bob".into()),
+                        Cell::String("bob@example.com".into()),
+                    ]),
+                }),
+            ],
+        )
+        .await
+        .expect("replayed events should be skipped");
+        assert_eq!(replay_status, DestinationWriteStatus::Durable);
+
+        let resumed_status = invoke_write_events(
+            &restarted_destination,
+            WriteEventsDurability::RequireDurable,
+            vec![Event::Insert(InsertEvent {
+                start_lsn: PgLsn::from(102_u64),
+                commit_lsn: PgLsn::from(102_u64),
+                tx_ordinal: 0,
+                replicated_table_schema: evolved_replicated.clone(),
+                table_row: TableRow::new(vec![
+                    Cell::I32(3),
+                    Cell::String("Charlie".into()),
+                    Cell::String("charlie@example.com".into()),
+                ]),
+            })],
+        )
+        .await
+        .expect("streaming should resume after stale replay");
+        assert_eq!(resumed_status, DestinationWriteStatus::Durable);
+
         let fqn = format!(
             "\"{}\".\"{}\".\"{sf_table}\"",
             harness.config.database(),
             harness.config.schema()
         );
-        let rows =
-            query_rows(&harness.sql, &format!("SELECT \"email\" FROM {fqn} WHERE \"id\" = '2'"))
-                .await
-                .expect("query_rows for email column failed");
+        let rows = query_rows(
+            &harness.sql,
+            &format!("SELECT \"id\", \"email\" FROM {fqn} ORDER BY \"id\""),
+        )
+        .await
+        .expect("query_rows after stale replay failed");
 
-        assert_eq!(rows.len(), 1, "expected one row for id=2");
+        assert_eq!(rows.len(), 3, "replay must not duplicate committed rows");
+        assert_eq!(rows[0][0], serde_json::Value::String("1".into()));
+        assert_eq!(rows[0][1], serde_json::Value::Null);
+        assert_eq!(rows[1][0], serde_json::Value::String("2".into()));
         assert_eq!(
-            rows[0][0],
+            rows[1][1],
             serde_json::Value::String("bob@example.com".into()),
-            "expected email = 'bob@example.com', got: {:?}",
-            rows[0][0]
+            "newer column data must survive stale replay"
         );
+        assert_eq!(rows[2][0], serde_json::Value::String("3".into()));
+        assert_eq!(
+            rows[2][1],
+            serde_json::Value::String("charlie@example.com".into()),
+            "streaming must resume with the applied schema"
+        );
+
+        let final_metadata = harness
+            .store
+            .get_applied_destination_table_metadata(table_id)
+            .await
+            .unwrap()
+            .expect("destination metadata should remain applied");
+        assert_eq!(final_metadata.snapshot_id, new_snapshot_id);
+        assert_eq!(final_metadata.replication_mask, *evolved_replicated.replication_mask());
     })
     .await;
 }

--- a/docs/src/content/docs/explanation/schema-changes.md
+++ b/docs/src/content/docs/explanation/schema-changes.md
@@ -76,7 +76,7 @@ ETL has one shared schema-change signal, but **DDL behavior is implemented per d
 | BigQuery | Supports add, drop, rename, `REQUIRED` to `NULLABLE` relaxation, and supported literal default metadata. BigQuery requires added columns to be nullable and does not backfill existing rows for `ADD COLUMN ... DEFAULT`. PostgreSQL remains responsible for enforcing later `SET NOT NULL` changes because BigQuery cannot tighten an existing column in place. |
 | ClickHouse | Supports add, drop, rename, and supported literal defaults. `ReplacingMergeTree` rejects primary-key drops or renames because the ordering expression cannot be rewritten safely. ClickHouse default expressions are metadata-only unless explicitly materialized; ETL does not issue `MATERIALIZE COLUMN`. Relation events whose schema snapshot is older than the applied destination snapshot are rejected instead of executing reverse DDL; recovering from that state requires resynchronizing the table. |
 | DuckLake | Supports add, drop, rename, and supported literal defaults. DuckLake records supported add-time defaults as metadata without rewriting existing data files. |
-| Snowflake | Supports add, drop, rename, create-table literal defaults, and literal add-column defaults. Literal defaults are included in `ADD COLUMN` so Snowflake can expose add-time default values for existing rows; non-literal defaults and later default changes are skipped with a warning. |
+| Snowflake | Supports add, drop, rename, create-table literal defaults, and literal add-column defaults. Literal defaults are included in `ADD COLUMN` so Snowflake can expose add-time default values for existing rows; non-literal defaults and later default changes are skipped with a warning. Relation events whose schema snapshot is older than the applied destination snapshot are skipped because Snowflake's durable channel offset safely deduplicates their replayed row events. |
 | Iceberg | Deprecated for now. Schema-change DDL is not a supported path for new deployments. |
 | Custom destinations | Destination authors decide which `Event::Relation` changes to apply, reject, or handle manually. |
 
@@ -315,6 +315,14 @@ These behaviors are **not full destination DDL semantics** yet:
   confirmed replays the stream from before the change and triggers the
   same error. Replication mask changes carry no ordering, so a replayed
   stale mask cannot be detected the same way.
+- Snowflake skips stale schema snapshots instead of rewinding. Before applying
+  schema DDL, Snowflake waits for all preceding row batches to become durable.
+  On restart, reopening the table's channel restores its committed offset, so
+  row events associated with an older relation snapshot are deduplicated. The
+  older relation is therefore already reflected in the destination, while
+  executing its backwards diff could drop newer columns and delete their data.
+  Replication mask changes carry no ordering, so a replayed stale mask cannot
+  be detected the same way.
 - Sessions can set `supabase_etl.skip_ddl_log = 'true'` as an emergency
   opt-out while recovering a system. DDL executed with that setting enabled is
   not logged for ETL.


### PR DESCRIPTION
## Summary

- Skip relation events older than Snowflake's applied schema snapshot instead of executing reverse DDL.
- Rely on the pre-DDL durability barrier and restored channel offset to deduplicate replayed rows.
- Add unit and restart-replay regression coverage, and document the behavior.

NB: This PR is a follow-up to #925, which prevented stale relation replays from executing reverse ClickHouse DDL.