### PR TITLE
fix(core): prevent starting a pipeline twice

### DIFF
--- a/crates/etl/src/pipeline.rs
+++ b/crates/etl/src/pipeline.rs
@@ -136,7 +136,14 @@ where
     /// table metadata and schemas, creates the worker pool for table
     /// synchronization, and starts the apply worker for processing replication
     /// stream events.
+    ///
+    /// After this method succeeds, subsequent calls return
+    /// [`ErrorKind::InvalidState`] without performing any startup work.
     pub async fn start(&mut self) -> EtlResult<()> {
+        if !matches!(&self.state, PipelineState::NotStarted) {
+            bail!(ErrorKind::InvalidState, "Pipeline has already been started");
+        }
+
         info!(
             publication_name = %self.config.publication_name,
             pipeline_id = %self.config.id,

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -16,7 +16,7 @@ use etl::{
             replication_slot_state, spawn_source_database, test_table_name, wait_for_new_walsender,
         },
         event::{EventCondition, group_events_by_type_and_table_id},
-        faults::FaultyOp,
+        faults::{FaultAction, FaultyOp},
         memory_destination::MemoryDestination,
         notify::TimedNotify,
         notifying_store::NotifyingStore,
@@ -325,6 +325,49 @@ where
     ) -> EtlResult<()> {
         self.inner.write_events(events, durability, async_result).await
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pipeline_rejects_second_start_before_destination_startup() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+
+    let store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+
+    let pipeline_id: PipelineId = random();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+
+    let table_ready_notify = store
+        .notify_on_table_state_type(database_schema.users_schema().id, TableStateType::Ready)
+        .await;
+
+    pipeline.start().await.unwrap();
+    table_ready_notify.notified().await;
+
+    destination
+        .inject_fault(
+            FaultyOp::Startup,
+            FaultAction::reject(
+                ErrorKind::DestinationError,
+                "Second destination startup should not run",
+            ),
+        )
+        .await;
+
+    let second_start_result = pipeline.start().await;
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let err = second_start_result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidState);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

- Reject a second `Pipeline::start()` with `InvalidState` before any startup side effects.
- Preserve supervision of the original worker generation.
- Add regression coverage proving destination startup is not invoked again and shutdown remains clean.

Failed startup attempts remain retryable, this only guards pipelines that have already started successfully.

## Why?

`Pipeline::start()` currently ignores its lifecycle state. Calling it twice can rerun destination startup and replace the stored worker and pool handles while the original tasks continue running. `wait()` then supervises only the newer generation, which can break graceful shutdown ordering.

PostgreSQL slot exclusivity limits the likelihood of simultaneous replication, so this is definitely not a production issue. It is still a public API lifecycle footgun with a small, low-risk fix.