### PR TITLE
fix(core): Improve handling of apply slot recreation

### DIFF
--- a/crates/etl/src/postgres/client/raw.rs
+++ b/crates/etl/src/postgres/client/raw.rs
@@ -22,10 +22,7 @@ use super::{
     child::ChildPgReplicationClient,
     query::PgReplicationQueryTarget,
     transaction::PgReplicationTransaction,
-    types::{
-        CreateSlotResult, GetOrCreateSlotResult, GetSlotResult, PostgresConnectionUpdate,
-        SlotState, SnapshotAction,
-    },
+    types::{CreateSlotResult, GetSlotResult, PostgresConnectionUpdate, SlotState, SnapshotAction},
     utils::get_row_value,
 };
 use crate::{
@@ -512,29 +509,6 @@ impl PgReplicationClient {
             "Replication slot not found",
             format!("Replication slot '{}' not found in database", slot_name)
         );
-    }
-
-    /// Gets an existing replication slot or creates a new one if it doesn't
-    /// exist.
-    ///
-    /// This method first attempts to get the slot by name. If the slot doesn't
-    /// exist, it creates a new one.
-    ///
-    /// Returns an enum indicating whether the slot was created or already
-    /// existed.
-    pub(crate) async fn get_or_create_slot(
-        &self,
-        slot_name: &str,
-    ) -> EtlResult<GetOrCreateSlotResult> {
-        match self.get_slot(slot_name).await {
-            Ok(slot) => Ok(GetOrCreateSlotResult::GetSlot(slot)),
-            Err(err) if err.kind() == ErrorKind::ReplicationSlotNotFound => {
-                let create_result = self.create_slot(slot_name).await?;
-
-                Ok(GetOrCreateSlotResult::CreateSlot(create_result))
-            }
-            Err(e) => Err(e),
-        }
     }
 
     /// Deletes a replication slot with the specified name.

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -2774,7 +2774,7 @@ where
     let states = store.get_table_states().await?;
     Ok(states
         .iter()
-        .filter(|(_, state)| !state.as_type().is_done())
+        .filter(|(_, state)| state.as_type().is_syncing())
         .map(|(id, state)| (*id, state.clone()))
         .collect())
 }
@@ -2844,9 +2844,13 @@ mod apply_worker {
         D: PipelineDestination,
     {
         for (table_id, table_state) in get_syncing_tables(&ctx.store).await? {
-            let exit_intent =
-                process_single_syncing_table_after_commit(ctx, table_id, table_state, current_lsn)
-                    .await?;
+            let exit_intent = process_single_syncing_table_after_commit_event(
+                ctx,
+                table_id,
+                table_state,
+                current_lsn,
+            )
+            .await?;
 
             if exit_intent.is_some() {
                 return Ok(exit_intent);
@@ -2949,7 +2953,7 @@ mod apply_worker {
     /// Handles SyncWait → Catchup transitions, waits for workers already in
     /// Catchup, and spawns new workers.
     /// Does NOT handle SyncDone → Ready transitions.
-    async fn process_single_syncing_table_after_commit<S, D>(
+    async fn process_single_syncing_table_after_commit_event<S, D>(
         ctx: &mut ApplyWorkerContext<S, D>,
         table_id: TableId,
         table_state: TableState,

--- a/crates/etl/src/replication/state/lifecycle.rs
+++ b/crates/etl/src/replication/state/lifecycle.rs
@@ -228,22 +228,30 @@ impl TableStateType {
         }
     }
 
-    /// Returns `true` if a table with this state is done processing, `false`
-    /// otherwise.
+    /// Returns whether a table with this state is still synchronizing.
     ///
-    /// A table is done processing, when its events are being processed by the
-    /// apply worker instead of a table sync worker or when it has errored.
-    pub fn is_done(&self) -> bool {
-        match self {
-            Self::Init => false,
-            Self::DataSync => false,
-            Self::FinishedCopy => false,
-            Self::SyncWait => false,
-            Self::Catchup => false,
-            Self::SyncDone => false,
-            Self::Ready => true,
-            Self::Errored => true,
-        }
+    /// Synchronization includes the handoff to the apply worker, so
+    /// [`TableStateType::SyncDone`] remains a syncing state until it
+    /// transitions to [`TableStateType::Ready`]. Errored tables are not
+    /// actively syncing.
+    pub fn is_syncing(&self) -> bool {
+        !matches!(self, Self::Ready | Self::Errored)
+    }
+
+    /// Returns whether a table has completed its initial table sync.
+    ///
+    /// Tables in these states keep their existing destination data when the
+    /// pipeline restarts. Earlier non-error syncing states restart the table
+    /// copy from a fresh snapshot. Errored tables are neither completed nor
+    /// automatically recopied.
+    ///
+    /// [`TableStateType::FinishedCopy`] is deliberately excluded because the
+    /// bulk copy completed without a durable catchup handoff, so restart
+    /// repeats the copy. [`TableStateType::SyncDone`] is included because
+    /// catchup completed durably even though the final transition to
+    /// [`TableStateType::Ready`] remains.
+    pub fn has_completed_table_sync(&self) -> bool {
+        matches!(self, Self::SyncDone | Self::Ready)
     }
 
     /// Returns `true` if a table with this state is in error, `false`
@@ -408,6 +416,37 @@ mod tests {
             TableStateType::Ready.to_storage_type().unwrap();
 
         assert_eq!(state_type, table_state::StoredTableStateType::Ready);
+    }
+
+    #[test]
+    fn state_type_classifies_sync_lifecycle() {
+        let syncing_states = [
+            TableStateType::Init,
+            TableStateType::DataSync,
+            TableStateType::FinishedCopy,
+            TableStateType::SyncWait,
+            TableStateType::Catchup,
+            TableStateType::SyncDone,
+        ];
+        assert!(syncing_states.iter().all(TableStateType::is_syncing));
+
+        let non_syncing_states = [TableStateType::Ready, TableStateType::Errored];
+        assert!(non_syncing_states.iter().all(|state| !state.is_syncing()));
+
+        let states_without_completed_sync = [
+            TableStateType::Init,
+            TableStateType::DataSync,
+            TableStateType::FinishedCopy,
+            TableStateType::SyncWait,
+            TableStateType::Catchup,
+            TableStateType::Errored,
+        ];
+        assert!(
+            states_without_completed_sync.iter().all(|state| !state.has_completed_table_sync())
+        );
+
+        let completed_states = [TableStateType::SyncDone, TableStateType::Ready];
+        assert!(completed_states.iter().all(TableStateType::has_completed_table_sync));
     }
 
     #[test]

--- a/crates/etl/src/runtime/apply/worker.rs
+++ b/crates/etl/src/runtime/apply/worker.rs
@@ -21,8 +21,7 @@ use crate::{
         client::{GetOrCreateSlotResult, PgReplicationClient, SlotState},
     },
     replication::{
-        ApplyLoop, ApplyLoopResult, ApplyWorkerContext, SharedTableCache, WorkerContext,
-        WorkerType, state::TableStateType,
+        ApplyLoop, ApplyLoopResult, ApplyWorkerContext, SharedTableCache, WorkerContext, WorkerType,
     },
     runtime::{
         BatchBudgetController, MemoryMonitor, TableSyncWorkerPool,
@@ -361,10 +360,9 @@ where
 /// - [`InvalidatedSlotBehavior::Recreate`]: Deletes the slot, resets all tables
 ///   to Init, clears stale apply progress, and creates a new slot
 ///
-/// When creating a new slot, this function validates that all tables are in the
-/// Init state. If any table is not in Init state when creating a new slot, it
-/// indicates that data was synchronized based on a different apply worker
-/// lineage, which would break replication correctness.
+/// When creating a new slot, this function warns if any tables already depend
+/// on the apply worker for replication. Those tables can miss changes between
+/// the previous slot stopping and the new slot being created.
 async fn get_start_lsn<S: StateStore + TableStateLifecycleStore>(
     pipeline_id: PipelineId,
     replication_client: &PgReplicationClient,
@@ -374,9 +372,24 @@ async fn get_start_lsn<S: StateStore + TableStateLifecycleStore>(
     let slot_name: String = EtlReplicationSlot::for_apply_worker(pipeline_id).try_into()?;
     let worker_type = WorkerType::Apply;
 
-    // We try to get or create the slot. Both operations will return an LSN that we
-    // can use to start streaming events.
-    let slot = replication_client.get_or_create_slot(&slot_name).await?;
+    // Inspect the slot before creating it so stale progress from the previous
+    // lineage can be deleted first. Creating the slot before cleanup would leave
+    // a crash window where a later restart could pair the new slot with old
+    // durable progress.
+    let slot = match replication_client.get_slot(&slot_name).await {
+        Ok(slot) => GetOrCreateSlotResult::GetSlot(slot),
+        Err(err) if err.kind() == ErrorKind::ReplicationSlotNotFound => {
+            warn_if_tables_may_have_missed_changes(store).await?;
+            store.delete_replication_progress(worker_type).await?;
+
+            let slot = replication_client.create_slot(&slot_name).await?;
+            GetOrCreateSlotResult::CreateSlot(slot)
+        }
+        Err(err) => return Err(err),
+    };
+
+    // Once we have the slot, we determine the start lsn, which is the consistent
+    // point from which Postgres tells us to start streaming from.
     let slot_start_lsn = slot.get_start_lsn();
 
     match &slot {
@@ -385,7 +398,7 @@ async fn get_start_lsn<S: StateStore + TableStateLifecycleStore>(
                 slot_name,
                 %slot_start_lsn,
                 confirmed_flush_lsn = %result.confirmed_flush_lsn,
-                "apply worker resume position selected from existing replication slot"
+                "apply worker replication position selected from existing replication slot"
             );
         }
         GetOrCreateSlotResult::CreateSlot(result) => {
@@ -393,7 +406,7 @@ async fn get_start_lsn<S: StateStore + TableStateLifecycleStore>(
                 slot_name,
                 %slot_start_lsn,
                 consistent_point = %result.consistent_point,
-                "apply worker resume position selected from new replication slot"
+                "apply worker replication position selected from new replication slot"
             );
         }
     }
@@ -414,68 +427,42 @@ async fn get_start_lsn<S: StateStore + TableStateLifecycleStore>(
         }
     }
 
-    // When creating a new apply worker slot, all tables must be in the `Init`
-    // state. If any table is not in Init state, it means the table was
-    // synchronized based on another apply worker lineage (different slot) which
-    // will break correctness.
-    if let GetOrCreateSlotResult::CreateSlot(_) = &slot
-        && let Err(err) = validate_tables_in_init_state(store).await
-    {
-        // Delete the slot before failing, otherwise the system will restart and skip
-        // validation since the slot will already exist.
-        replication_client.delete_slot_if_exists(&slot_name).await?;
-
-        return Err(err);
-    }
-
-    // A newly created slot is a new lineage. Any existing durable progress for
-    // the apply worker belongs to an older slot and must not influence startup.
+    // If the slot was created, we don't need to do any invalidation check and since
+    // durable progress should be gone before a new slot is created, we can
+    // immediately start replication from the start lsn determined by the new
+    // slot.
     if matches!(slot, GetOrCreateSlotResult::CreateSlot(_)) {
-        if let Err(err) = store.delete_replication_progress(worker_type).await {
-            warn!(
-                slot_name,
-                error = %err,
-                "failed to delete stale apply worker durable progress after creating a new slot"
-            );
-
-            replication_client.delete_slot_if_exists(&slot_name).await?;
-
-            return Err(err);
-        }
-
         return Ok(slot_start_lsn);
     }
 
+    // If there is durable replication progress, we also consider that to determine
+    // the start lsn, otherwise we return the slot start lsn directly.
     let durable_flush_lsn = store.get_replication_progress(worker_type).await?;
-    if let Some(durable_flush_lsn) = durable_flush_lsn {
-        // Durable progress and slot progress can legitimately differ. During idle
-        // periods we keep sending PostgreSQL feedback with the received LSN, but
-        // we do not persist those idle-only advances to the state database to
-        // avoid extra customer-database writes. Conversely, durable progress can
-        // be ahead if ETL flushed a batch but PostgreSQL did not confirm the
-        // feedback yet. Startup uses the latest boundary available from either
-        // source as a resume floor, which guarantees no event older than the
-        // chosen start LSN is emitted.
-        let start_lsn = durable_flush_lsn.max(slot_start_lsn);
+    let Some(durable_flush_lsn) = durable_flush_lsn else {
+        return Ok(slot_start_lsn);
+    };
 
+    // Durable progress and slot progress can legitimately differ. During idle
+    // periods we keep sending PostgreSQL feedback with the received LSN, but
+    // we do not persist those idle-only advances to the state database to
+    // avoid extra customer-database writes. Conversely, durable progress can
+    // be ahead if ETL flushed a batch but PostgreSQL did not confirm the
+    // feedback yet. Startup uses the latest boundary available from either
+    // source as a resume floor, which guarantees no event older than the
+    // chosen start LSN is emitted.
+    let start_lsn = durable_flush_lsn.max(slot_start_lsn);
+
+    if durable_flush_lsn > slot_start_lsn {
         info!(
             slot_name,
             %durable_flush_lsn,
             %slot_start_lsn,
             %start_lsn,
-            "apply worker resume position selected from durable replication progress and replication slot"
+            "apply worker replication position was overridden by the durable replication progress because it was ahead"
         );
-
-        Ok(start_lsn)
-    } else {
-        info!(
-            slot_name,
-            %slot_start_lsn,
-            "apply worker durable replication progress not found, using slot fallback"
-        );
-
-        Ok(slot_start_lsn)
     }
+
+    Ok(start_lsn)
 }
 
 /// Handles the case when the apply worker slot is found to be invalidated.
@@ -539,38 +526,37 @@ async fn handle_invalidated_slot<S: TableStateLifecycleStore>(
     }
 }
 
-/// Validates that all tables are in the Init state.
-///
-/// This validation is required when creating a new apply worker slot to ensure
-/// replication correctness. If any table has progressed beyond Init state, it
-/// indicates the table was synchronized based on a different apply worker
-/// lineage.
-async fn validate_tables_in_init_state<S: StateStore>(store: &S) -> EtlResult<()> {
+/// Warns when a new apply slot may skip changes for tables that will not be
+/// recopied on restart.
+async fn warn_if_tables_may_have_missed_changes<S: StateStore>(store: &S) -> EtlResult<()> {
     let table_states = store.get_table_states().await?;
 
-    let non_init_tables: Vec<_> = table_states
+    let tables_at_risk: Vec<_> = table_states
         .iter()
-        .filter(|(_, state)| state.as_type() != TableStateType::Init)
+        .filter(|(_, state)| state.as_type().has_completed_table_sync())
         .map(|(table_id, state)| (*table_id, state.as_type()))
         .collect();
 
-    if non_init_tables.is_empty() {
+    if tables_at_risk.is_empty() {
         return Ok(());
     }
 
-    let table_details: Vec<String> =
-        non_init_tables.iter().map(|(id, state)| format!("table {id} in state {state}")).collect();
+    let table_ids =
+        tables_at_risk.iter().map(|(id, _)| id.to_string()).collect::<Vec<_>>().join(",");
+    let table_state_types = tables_at_risk
+        .iter()
+        .map(|(_, state)| <&'static str>::from(*state))
+        .collect::<Vec<_>>()
+        .join(",");
 
-    bail!(
-        ErrorKind::InvalidState,
-        "Cannot create apply worker slot when tables are not in Init state",
-        format!(
-            "Creating a new apply worker replication slot requires all tables to be in Init \
-             state, but found {} table(s) in non-Init states: {}. This indicates that tables were \
-             synchronized based on a different apply worker lineage. To fix this, either restore \
-             the original apply worker slot or reset all tables to Init state.",
-            non_init_tables.len(),
-            table_details.join(", ")
-        )
+    warn!(
+        table_count = tables_at_risk.len(),
+        %table_ids,
+        %table_state_types,
+        "creating a new apply worker replication slot for tables already in the apply phase; \
+         destination data may be inconsistent if replicated table data changed after the \
+         previous slot stopped and before the new slot was created"
     );
+
+    Ok(())
 }

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -7,10 +7,11 @@ use etl::{
         WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
     error::{ErrorKind, EtlResult},
+    etl_error,
     event::{Event, EventType, InsertEvent},
     pipeline::PipelineId,
     schema::{ColumnSchema, ReplicatedTableSchema, TableId},
-    store::{SchemaStore, StateStore, TableState, TableStateType},
+    store::{SchemaStore, StateStore, TableRetryPolicy, TableState, TableStateType, WorkerType},
     test_utils::{
         database::{
             replication_slot_state, spawn_source_database, test_table_name, wait_for_new_walsender,
@@ -47,7 +48,7 @@ use tokio::{
     sync::{Mutex, Notify},
     time::sleep,
 };
-use tokio_postgres::types::Type;
+use tokio_postgres::types::{PgLsn, Type};
 
 /// Creates a test column schema with sensible defaults.
 fn test_column(
@@ -646,11 +647,13 @@ async fn reset_during_active_copy_is_overwritten_by_active_worker() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn pipeline_fails_when_slot_deleted_with_non_init_tables() {
+async fn pipeline_recreates_missing_apply_slot_with_mixed_table_states() {
     init_test_tracing();
 
-    let database = spawn_source_database().await;
+    let mut database = spawn_source_database().await;
     let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+
+    insert_users_data(&mut database, &database_schema.users_schema().name, 1..=3).await;
 
     let store = NotifyingStore::new();
     let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
@@ -677,7 +680,37 @@ async fn pipeline_fails_when_slot_deleted_with_non_init_tables() {
 
     table_ready_notify.notified().await;
 
+    // Add two tables while the original apply slot is still active. Publication
+    // membership is reconciled on restart, when one table will be initialized as
+    // `Init` and the other will already have a persisted `Errored` state.
+    let init_table_name = test_table_name("init_before_slot_loss");
+    let init_table_id = database
+        .create_table(init_table_name.clone(), true, &[("value", "int4 not null")])
+        .await
+        .unwrap();
+    database.insert_values(init_table_name.clone(), &["value"], &[&1]).await.unwrap();
+
+    let errored_table_name = test_table_name("errored_before_slot_loss");
+    let errored_table_id = database
+        .create_table(errored_table_name.clone(), true, &[("value", "int4 not null")])
+        .await
+        .unwrap();
+    database.insert_values(errored_table_name.clone(), &["value"], &[&1]).await.unwrap();
+
+    database
+        .run_sql(&format!(
+            "alter publication {} add table {}, {}",
+            quote_identifier(&database_schema.publication_name()),
+            init_table_name.as_quoted_identifier(),
+            errored_table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
     pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_rows = destination.get_table_rows().await;
+    assert_eq!(table_rows[&database_schema.users_schema().id].len(), 3);
 
     // Verify that the replication slot for the apply worker exists and is inactive.
     database.wait_for_slot_inactive(&apply_slot_name).await;
@@ -685,7 +718,27 @@ async fn pipeline_fails_when_slot_deleted_with_non_init_tables() {
     let slot_state = database.get_replication_slot_state(&apply_slot_name).await.unwrap();
     assert_eq!(slot_state, Some(ReplicationSlotState::Inactive));
 
-    // Delete the apply worker slot to simulate slot loss.
+    store
+        .update_table_state(
+            errored_table_id,
+            TableState::Errored {
+                reason: "Injected test error".to_owned(),
+                solution: None,
+                retry_policy: TableRetryPolicy::NoRetry,
+                source_err: etl_error!(ErrorKind::Unknown, "Injected test error"),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Simulate durable progress from an unrelated WAL lineage. The replacement
+    // slot must not use this position even when it is ahead of the new slot's
+    // consistent point.
+    let stale_durable_progress = PgLsn::from(u64::MAX);
+    store.upsert_replication_progress(WorkerType::Apply, stale_durable_progress).await.unwrap();
+
+    // Delete the apply worker slot after pausing the pipeline. No source changes
+    // occur between the pause and slot recreation.
     database
         .run_sql(&format!("select pg_drop_replication_slot({})", quote_literal(&apply_slot_name)))
         .await
@@ -693,7 +746,8 @@ async fn pipeline_fails_when_slot_deleted_with_non_init_tables() {
     let slot_state = database.get_replication_slot_state(&apply_slot_name).await.unwrap();
     assert_eq!(slot_state, None);
 
-    // Restart the pipeline, it should fail because tables are not in Init state.
+    // The Init table should be copied, the Ready users table should continue
+    // from the new slot, and the Errored table should remain stopped.
     let mut pipeline = create_pipeline(
         &database.config,
         pipeline_id,
@@ -702,17 +756,57 @@ async fn pipeline_fails_when_slot_deleted_with_non_init_tables() {
         destination.clone(),
     );
 
+    let init_table_ready_notify =
+        store.notify_on_table_state_type(init_table_id, TableStateType::Ready).await;
+
     pipeline.start().await.unwrap();
 
-    // The error surfaces when we wait for the pipeline to complete.
-    let wait_result = pipeline.shutdown_and_wait().await;
-    assert!(wait_result.is_err());
-    let err = wait_result.unwrap_err();
-    assert!(err.kinds().contains(&ErrorKind::InvalidState));
+    init_table_ready_notify.notified().await;
 
-    // Verify that the slot was cleaned up (deleted) after the validation failure.
-    let slot_state = database.get_replication_slot_state(&apply_slot_name).await.unwrap();
-    assert_eq!(slot_state, None);
+    let users_insert_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(
+            EventType::Insert,
+            database_schema.users_schema().id,
+            1,
+        )])
+        .await;
+
+    // Put both changes in one transaction so observing the users event also
+    // proves the apply worker processed the errored-table change.
+    let mut transaction = database.begin_transaction().await;
+    transaction.insert_values(errored_table_name, &["value"], &[&2]).await.unwrap();
+    insert_users_data(&mut transaction, &database_schema.users_schema().name, 4..=4).await;
+    transaction.commit_transaction().await;
+
+    users_insert_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    // The Ready table was not recopied, the Init table was copied, and the
+    // Errored table remained stopped.
+    let table_rows = destination.get_table_rows().await;
+    assert_eq!(table_rows[&database_schema.users_schema().id].len(), 3);
+    assert_eq!(table_rows[&init_table_id].len(), 1);
+    assert!(!table_rows.contains_key(&errored_table_id));
+
+    let errored_table_state =
+        store.get_table_state(errored_table_id).await.unwrap().expect("table state should exist");
+    assert!(matches!(
+        errored_table_state,
+        TableState::Errored { retry_policy: TableRetryPolicy::NoRetry, .. }
+    ));
+
+    let events = destination.get_events().await;
+    let grouped_events = group_events_by_type_and_table_id(&events);
+    let users_inserts =
+        grouped_events.get(&(EventType::Insert, database_schema.users_schema().id)).unwrap();
+    let expected_users_inserts =
+        build_expected_users_inserts(4, &database_schema.users_schema(), vec![("user_4", 4)]);
+    assert_events_equal(users_inserts, &expected_users_inserts);
+    assert!(!grouped_events.contains_key(&(EventType::Insert, errored_table_id)));
+
+    let durable_progress = store.get_replication_progress(WorkerType::Apply).await.unwrap();
+    assert_ne!(durable_progress, Some(stale_durable_progress));
 }
 
 // Serialized via nextest test-group "shared-pg" (shares the source PG cluster).


### PR DESCRIPTION
This PR reworks how ETL handles replication slot creation. Instead of checking the synchronization state of tables and failing when certain conditions are not met, ETL now proceeds with slot creation and emits a warning when a new apply slot is created after some tables have already completed their initial sync.

It also fixes an edge case in which durable progress could incorrectly override the starting position of a newly created slot because of the use of `max`.

For example, suppose an old slot has durable progress at `LSN 100`, while a newly created slot has a consistent point at `LSN 40`. If the slot is created successfully but the process fails before the old durable progress is updated or deleted, the next restart finds the new slot already in place and resumes from `max(40, 100) = 100`.

This skips the changes between `LSN 40` and `LSN 100`, potentially resulting in data loss.