### PR TITLE
harden scheduled fuzzing and corpus caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           key: ${{ matrix.check }}
           workspaces: |
             . -> target
-            fuzz -> fuzz/target
+            fuzz -> target
 
       - name: Install cargo-sort
         if: matrix.check == 'sort'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           key: fuzz
           workspaces: |
-            fuzz -> fuzz/target
+            fuzz -> target
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
@@ -49,22 +49,28 @@ jobs:
       # The corpus evolves across runs: each run restores the newest saved
       # corpus for its target and saves the grown one under a unique key.
       - name: Restore Corpus
+        id: restore_corpus
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fuzz/corpus/${{ matrix.target }}
-          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             fuzz-corpus-${{ matrix.target }}-
 
       - name: Run Fuzz Target
-        run: cargo +nightly-2026-04-15 fuzz run ${{ matrix.target }} -- -max_total_time=120
+        # The prebuilt cargo-fuzz binary is musl-linked, and cargo-fuzz
+        # defaults --target to its own compile-time triple. Build for the
+        # runner's real host triple so ASan links against glibc.
+        run: |
+          host="$(rustc +nightly-2026-04-15 --print host-tuple)"
+          cargo +nightly-2026-04-15 fuzz run ${{ matrix.target }} --target "$host" -- -max_total_time=120
 
       - name: Save Corpus
-        if: always()
+        if: always() && steps.restore_corpus.outcome == 'success'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fuzz/corpus/${{ matrix.target }}
-          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Upload Crash Artifacts
         if: failure()

--- a/crates/etl/src/fuzzing.rs
+++ b/crates/etl/src/fuzzing.rs
@@ -14,6 +14,10 @@ use crate::{
 ///
 /// Covers every dedicated codec branch, scalar and array, plus the generic
 /// array fallback (`varchar[]`) and the scalar text fallback.
+///
+/// Hand-written corpus seeds use in-range selector bytes as direct indices into
+/// this table. Preserve existing order and append new types so those seeds keep
+/// their meaning; arbitrary selectors continue to wrap modulo the table length.
 const TEXT_CELL_FUZZ_TYPES: &[Type] = &[
     Type::BOOL,
     Type::BOOL_ARRAY,
@@ -90,7 +94,7 @@ pub fn parse_copy_row(data: &[u8]) -> EtlResult<TableRow> {
                 format!("column_{index}"),
                 text_cell_fuzz_type(*selector).clone(),
                 -1,
-                i32::try_from(index).expect("column count is at most 8"),
+                i32::try_from(index + 1).expect("column count is at most 8"),
                 true,
             )
         })

--- a/crates/etl/src/postgres/codec/text.rs
+++ b/crates/etl/src/postgres/codec/text.rs
@@ -155,9 +155,10 @@ pub(crate) fn parse_cell_from_postgres_text(typ: &Type, str: &str) -> EtlResult<
 /// Strips the explicit dimensions prefix from an array literal, if present.
 ///
 /// Postgres prefixes array output with dimensions whenever a lower bound is
-/// not 1, e.g. `[0:1]={7,8}`. Bounds carry no value information for a
-/// one-dimensional array, so the prefix is validated and skipped. More than
-/// one dimension group means a multidimensional value, which [`ArrayCell`]
+/// not 1, e.g. `[0:1]={7,8}`. [`ArrayCell`] stores one-dimensional arrays
+/// as ordered elements without subscript bounds, so the prefix syntax is
+/// validated and its bounds are intentionally discarded. More than one
+/// dimension group means a multidimensional value, which [`ArrayCell`]
 /// cannot represent and the codec rejects.
 fn strip_array_dimensions_prefix(input: &str) -> EtlResult<&str> {
     // Skips an optionally negative ASCII integer, returning the index just

--- a/crates/etl/tests/value_roundtrip.rs
+++ b/crates/etl/tests/value_roundtrip.rs
@@ -126,9 +126,9 @@ async fn shifted_lower_bound_arrays_roundtrip_through_text_codec() {
     let render = client.prepare("select (($1::text)::int8[])::text").await.unwrap();
 
     // Postgres renders arrays whose lower bound is not 1 with an explicit
-    // dimensions prefix, e.g. `[0:1]={7,8}`. Subscripts carry no value
-    // information for a one-dimensional array, so the codec must skip the
-    // prefix and preserve the elements.
+    // dimensions prefix, e.g. `[0:1]={7,8}`. `ArrayCell` represents these
+    // arrays as ordered elements without subscript bounds, so the codec
+    // intentionally discards the prefix while preserving the elements.
     let strategy = (-8i16..=8, proptest::collection::vec(option::of(any::<i64>()), 1..=8));
     run_property("shifted lower bound int8[] text roundtrip", &strategy, |(lower, values)| {
         let literal = shifted_bounds_literal(*lower, values);


### PR DESCRIPTION
 - Cache the correct fuzz target directory.
 - Preserve grown corpora across workflow reruns with attempt-unique keys.
 - Clarify that array bounds are intentionally discarded when normalizing to ArrayCell.