### PR TITLE
ref(etl): defer tracked task construction

### DIFF
--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -731,7 +731,7 @@ impl Destination for BenchDestination {
             }
             #[cfg(feature = "bigquery")]
             Self::BigQuery(destination) => {
-                Box::pin(destination.write_events(events, durability, async_result)).await
+                destination.write_events(events, durability, async_result).await
             }
             #[cfg(feature = "clickhouse")]
             Self::ClickHouse(destination) => {

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1205,7 +1205,7 @@ where
             let client = self.client.clone();
             let dataset_id = self.dataset_id.clone();
             self.tasks
-                .spawn(async move {
+                .spawn_with(move || async move {
                     if let Err(err) = client
                         .drop_table_if_exists(&dataset_id, &sequenced_bigquery_table_id.to_string())
                         .await
@@ -1378,7 +1378,7 @@ where
 
         let destination = self.clone();
         self.tasks
-            .spawn(async move {
+            .spawn_with(move || async move {
                 let result = destination.write_events(events).await;
                 async_result.send(result.map(|_| DestinationWriteStatus::Durable));
             })

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -352,7 +352,7 @@ where
 
         let destination = self.clone();
         self.tasks
-            .spawn(async move {
+            .spawn_with(move || async move {
                 let result = destination.write_events(events).await;
                 async_result.send(result.map(|_| DestinationWriteStatus::Durable));
             })
@@ -1228,7 +1228,7 @@ where
         let shutdown_signal_manager = Arc::clone(&manager);
         destination
             .tasks
-            .spawn(async move {
+            .spawn_with(move || async move {
                 interrupt_duckdb_connections_on_process_shutdown(shutdown_signal_manager).await;
             })
             .await;
@@ -1250,7 +1250,7 @@ where
                 let watcher_destination = destination.clone();
                 destination
                     .tasks
-                    .spawn(async move {
+                    .spawn_with(move || async move {
                         if let Err(error) =
                             run_kubernetes_external_maintenance_watcher(watcher_destination).await
                         {
@@ -1270,7 +1270,7 @@ where
                 let pipeline_id = external_maintenance.pipeline_id as i64;
                 destination
                     .tasks
-                    .spawn(async move {
+                    .spawn_with(move || async move {
                         if let Err(error) = run_postgres_external_maintenance_watcher(
                             watcher_destination,
                             pipeline_id,

--- a/crates/etl-destinations/src/iceberg/core.rs
+++ b/crates/etl-destinations/src/iceberg/core.rs
@@ -622,7 +622,7 @@ where
 
         let destination = self.clone();
         self.tasks
-            .spawn(async move {
+            .spawn_with(move || async move {
                 let result = destination.write_events(events).await;
                 async_result.send(result.map(|_| DestinationWriteStatus::Durable));
             })

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -723,7 +723,7 @@ where
 
         let writer = self.writer.clone();
         self.tasks
-            .spawn(async move {
+            .spawn_with(move || async move {
                 let result = async {
                     let status = writer.process_admitted_events(events).await?;
                     if durability == WriteEventsDurability::RequireDurable

--- a/crates/etl/src/runtime/concurrency/task_set.rs
+++ b/crates/etl/src/runtime/concurrency/task_set.rs
@@ -65,6 +65,23 @@ impl TaskSet {
         inner.join_set.spawn(task);
     }
 
+    /// Constructs and spawns a tracked background task after registration is
+    /// admitted.
+    ///
+    /// Unlike [`Self::spawn`], this method does not retain the constructed task
+    /// future while waiting for access to the registry. The factory runs
+    /// synchronously while the registry is locked and should only construct the
+    /// returned future. This keeps large task futures out of callers' async
+    /// state while they wait for registration.
+    pub async fn spawn_with<F, Fut>(&self, task_factory: F)
+    where
+        F: FnOnce() -> Fut + Send,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let mut inner = self.inner.lock().await;
+        inner.join_set.spawn(task_factory());
+    }
+
     /// Reaps completed tasks once enough of them may have accumulated to
     /// justify the lock.
     pub async fn try_reap(&self) -> EtlResult<()> {
@@ -84,8 +101,8 @@ impl TaskSet {
     ///
     /// Use this when resources used by registered tasks must be changed after
     /// all previously registered work has finished and before later work can
-    /// start. The returned guard blocks [`TaskSet::spawn`] and other registry
-    /// operations until dropped.
+    /// start. The returned guard blocks [`TaskSet::spawn`],
+    /// [`TaskSet::spawn_with`], and other registry operations until dropped.
     ///
     /// This method neither aborts tasks nor imposes a timeout. Cancelling it
     /// releases the registry and leaves unfinished tasks tracked.

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -395,7 +395,7 @@ where
         // the code continue and do something else in the meanwhile.
         let inner = Arc::clone(&self.inner);
         self.tasks
-            .spawn(async move {
+            .spawn_with(move || async move {
                 // We send the result back before doing the internal checks for this utility, to
                 // avoid checking before the apply loop received the result.
                 let result =


### PR DESCRIPTION
## Summary

`TaskSet::spawn` accepts a fully constructed task future before awaiting task-registry admission. This embeds the destination task future into the caller’s async state and caused the Snowflake release benchmark to overflow rustc’s layout-query depth.

- Add `TaskSet::spawn_with` to construct tasks only after registry admission.
- Migrate internal `TaskSet` callers to the factory API.
- Remove BigQuery’s benchmark-specific `Box::pin` workaround.

This preserves existing scheduling, draining, cancellation, and shutdown semantics while avoiding an additional heap allocation.

Related to #884.