### PR TITLE
test(snowflake): reduce credentialed warehouse queries

### DIFF
--- a/crates/etl-destinations/src/snowflake/test_utils.rs
+++ b/crates/etl-destinations/src/snowflake/test_utils.rs
@@ -5,7 +5,10 @@ pub fn load_test_config() -> Config {
     Config::require_tests_env().unwrap_or_else(|error| panic!("{error}"))
 }
 
-/// Execute a SELECT query and return result rows. Requires an active warehouse.
+/// Executes a SQL statement and returns its result rows.
+///
+/// Data queries require an active warehouse, while metadata commands such as
+/// `SHOW` do not.
 pub async fn query_rows<T: TokenProvider>(
     client: &SqlClient<T>,
     sql: &str,

--- a/crates/etl-destinations/tests/snowflake/destination.rs
+++ b/crates/etl-destinations/tests/snowflake/destination.rs
@@ -177,20 +177,37 @@ async fn apply_relation_event(
     .unwrap_or_else(|error| panic!("write_events ({context}) failed: {error}"));
 }
 
-/// Inserts a row while omitting `status`, allowing Snowflake defaults to apply.
-async fn insert_row_omitting_status(
+/// Returns column names from warehouse-free Snowflake metadata.
+async fn column_names(sql: &SqlClient<AuthManager<HttpExchanger>>, fqn: &str) -> Vec<String> {
+    query_rows(sql, &format!("show columns in table {fqn}"))
+        .await
+        .expect("show columns failed")
+        .into_iter()
+        .map(|row| {
+            row.get(2)
+                .and_then(serde_json::Value::as_str)
+                .expect("show columns should return a column name")
+                .to_owned()
+        })
+        .collect()
+}
+
+/// Asserts that `status` has no default without resuming the warehouse.
+async fn assert_status_default_absent(
     sql: &SqlClient<AuthManager<HttpExchanger>>,
     fqn: &str,
-    id: i32,
-    sequence_number: &str,
     context: &str,
 ) {
-    sql.execute_ddl(&format!(
-        "INSERT INTO {fqn} (\"id\", \"_cdc_operation\", \"_cdc_sequence_number\") VALUES ({id}, \
-         'insert', '{sequence_number}')"
-    ))
-    .await
-    .unwrap_or_else(|error| panic!("insert {context} failed: {error}"));
+    let rows = query_rows(sql, &format!("show columns like 'status' in table {fqn}"))
+        .await
+        .unwrap_or_else(|error| panic!("show columns ({context}) failed: {error}"));
+    assert_eq!(rows.len(), 1, "{context}: expected exactly one status column");
+
+    let default = rows[0].get(5).expect("show columns should return a default value");
+    assert!(
+        default.is_null() || default.as_str() == Some(""),
+        "{context}: status should not have a default"
+    );
 }
 
 #[tokio::test]
@@ -338,16 +355,6 @@ async fn write_table_rows_empty() {
 
         let exists = harness.sql.table_exists(&sf_table).await.expect("table_exists failed");
         assert!(exists, "table should have been created even with empty row set");
-
-        let fqn = format!(
-            "\"{}\".\"{}\".\"{sf_table}\"",
-            harness.config.database(),
-            harness.config.schema()
-        );
-        let rows = query_rows(&harness.sql, &format!("SELECT * FROM {fqn}"))
-            .await
-            .expect("query_rows failed");
-        assert_eq!(rows.len(), 0, "table should be empty");
     })
     .await;
 }
@@ -886,8 +893,7 @@ async fn schema_evolution_existing_column_default_changes() {
 
         apply_relation_event(&harness.destination, set_default_replicated, 100, "set default")
             .await;
-        insert_row_omitting_status(&harness.sql, &fqn, 1, "manual-1", "after skipped set default")
-            .await;
+        assert_status_default_absent(&harness.sql, &fqn, "after skipped set default").await;
 
         apply_relation_event(
             &harness.destination,
@@ -896,46 +902,16 @@ async fn schema_evolution_existing_column_default_changes() {
             "unsupported default",
         )
         .await;
-        insert_row_omitting_status(
-            &harness.sql,
-            &fqn,
-            2,
-            "manual-2",
-            "after unsupported default is skipped",
-        )
-        .await;
+        assert_status_default_absent(&harness.sql, &fqn, "after unsupported default is skipped")
+            .await;
 
         apply_relation_event(&harness.destination, reset_default_replicated, 300, "reset default")
             .await;
-        insert_row_omitting_status(
-            &harness.sql,
-            &fqn,
-            3,
-            "manual-3",
-            "after skipped reset default",
-        )
-        .await;
+        assert_status_default_absent(&harness.sql, &fqn, "after skipped reset default").await;
 
         apply_relation_event(&harness.destination, drop_default_replicated, 400, "drop default")
             .await;
-        insert_row_omitting_status(&harness.sql, &fqn, 4, "manual-4", "after skipped drop default")
-            .await;
-
-        let rows = query_rows(
-            &harness.sql,
-            &format!("SELECT \"id\"::VARCHAR, \"status\" FROM {fqn} ORDER BY \"id\""),
-        )
-        .await
-        .expect("query for existing-column default rows failed");
-        assert_eq!(
-            rows,
-            vec![
-                vec![serde_json::json!("1"), serde_json::Value::Null],
-                vec![serde_json::json!("2"), serde_json::Value::Null],
-                vec![serde_json::json!("3"), serde_json::Value::Null],
-                vec![serde_json::json!("4"), serde_json::Value::Null],
-            ]
-        );
+        assert_status_default_absent(&harness.sql, &fqn, "after skipped drop default").await;
     })
     .await;
 }
@@ -1046,25 +1022,20 @@ async fn schema_evolution_rename_column() {
             harness.config.schema()
         );
 
-        // New row uses the renamed column.
         let rows = query_rows(
             &harness.sql,
-            &format!("SELECT \"full_name\" FROM {fqn} WHERE \"id\" = '2'"),
+            &format!("select \"id\", \"full_name\" from {fqn} order by \"id\""),
         )
         .await
         .expect("query for renamed column failed");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0][0], serde_json::json!("Bob"));
-
-        // Initial row data is preserved under the new column name.
-        let rows = query_rows(
-            &harness.sql,
-            &format!("SELECT \"full_name\" FROM {fqn} WHERE \"id\" = '1'"),
-        )
-        .await
-        .expect("query for initial row after rename failed");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0][0], serde_json::json!("Alice"));
+        assert_eq!(
+            rows,
+            vec![
+                vec![serde_json::json!("1"), serde_json::json!("Alice")],
+                vec![serde_json::json!("2"), serde_json::json!("Bob")],
+            ],
+            "the rename should preserve initial data and accept new rows"
+        );
     })
     .await;
 }
@@ -1180,17 +1151,23 @@ async fn schema_evolution_drop_column() {
             harness.config.schema()
         );
 
-        // New row landed with remaining columns.
-        let rows =
-            query_rows(&harness.sql, &format!("SELECT \"name\" FROM {fqn} WHERE \"id\" = '2'"))
-                .await
-                .expect("query after drop failed");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0][0], serde_json::json!("Bob"));
+        let rows = query_rows(
+            &harness.sql,
+            &format!("select \"id\", \"name\" from {fqn} order by \"id\""),
+        )
+        .await
+        .expect("query after drop failed");
+        assert_eq!(
+            rows,
+            vec![
+                vec![serde_json::json!("1"), serde_json::json!("Alice")],
+                vec![serde_json::json!("2"), serde_json::json!("Bob")],
+            ],
+            "the drop should preserve initial data and accept new rows"
+        );
 
-        // Dropped column is gone from the table.
-        let result = query_rows(&harness.sql, &format!("SELECT \"email\" FROM {fqn}")).await;
-        assert!(result.is_err(), "column 'email' should not exist after DROP COLUMN");
+        let columns = column_names(&harness.sql, &fqn).await;
+        assert!(!columns.iter().any(|column| column == "email"), "email column should be dropped");
     })
     .await;
 }
@@ -1423,7 +1400,7 @@ async fn schema_evolution_interleaved_ddl_dml() {
         // renamed.
         let rows = query_rows(
             &harness.sql,
-            &format!("SELECT \"id\", \"full_name\" FROM {fqn} ORDER BY \"id\""),
+            &format!("select \"id\", \"full_name\" from {fqn} order by \"id\""),
         )
         .await
         .expect("final query failed");
@@ -1441,13 +1418,14 @@ async fn schema_evolution_interleaved_ddl_dml() {
         assert_eq!(rows[4][0], serde_json::json!("5"));
         assert_eq!(rows[4][1], serde_json::json!("Eve"));
 
-        // Dropped column should not exist.
-        let result = query_rows(&harness.sql, &format!("SELECT \"email\" FROM {fqn}")).await;
-        assert!(result.is_err(), "column 'email' should not exist after DROP COLUMN");
-
-        // Old column name should not exist.
-        let result = query_rows(&harness.sql, &format!("SELECT \"name\" FROM {fqn}")).await;
-        assert!(result.is_err(), "column 'name' should not exist after RENAME");
+        let columns = column_names(&harness.sql, &fqn).await;
+        assert!(columns.iter().any(|column| column == "id"), "id column should remain");
+        assert!(
+            columns.iter().any(|column| column == "full_name"),
+            "renamed full_name column should remain"
+        );
+        assert!(!columns.iter().any(|column| column == "email"), "email column should be dropped");
+        assert!(!columns.iter().any(|column| column == "name"), "name column should be renamed");
     })
     .await;
 }

--- a/crates/etl-destinations/tests/snowflake/pipeline.rs
+++ b/crates/etl-destinations/tests/snowflake/pipeline.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use etl::{
-    event::EventType,
+    event::{Event, EventType},
     pipeline::PipelineId,
     schema::TableName,
     store::TableStateType,
@@ -20,12 +20,10 @@ use etl_destinations::snowflake::{
 use etl_postgres::tokio::test_utils::TableModification;
 use rand::random;
 use serde_json::Value;
-use tokio::time::{Duration, sleep};
+use tokio::time::Duration;
 
 use super::common::{build_auth, poll_destination_offset, with_table_cleanup};
 
-const QUERY_POLL_INTERVAL: Duration = Duration::from_secs(1);
-const QUERY_MAX_ATTEMPTS: usize = 90;
 const DESTINATION_OFFSET_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const DESTINATION_OFFSET_MAX_ATTEMPTS: usize = 90;
 
@@ -51,66 +49,6 @@ async fn query_default_rows(
     )
     .await
     .expect("query for defaulted rows failed")
-}
-
-/// Queries the initial row copied before the source schema change.
-async fn query_initial_row(
-    sql: &SqlClient<AuthManager<HttpExchanger>>,
-    database: &str,
-    schema: &str,
-    table: &str,
-) -> Vec<Vec<Value>> {
-    let fqn = format!("\"{database}\".\"{schema}\".\"{table}\"");
-    query_rows(sql, &format!("select \"id\"::varchar, \"name\" from {fqn} where \"id\" = '1'"))
-        .await
-        .expect("query for initial row failed")
-}
-
-/// Waits until the pre-existing source row is visible in Snowflake.
-async fn wait_for_initial_row(
-    sql: &SqlClient<AuthManager<HttpExchanger>>,
-    database: &str,
-    schema: &str,
-    table: &str,
-) -> Vec<Vec<Value>> {
-    let expected = vec![vec![serde_json::json!("1"), serde_json::json!("Alice")]];
-    let mut last_rows = Vec::new();
-
-    for attempt in 0..QUERY_MAX_ATTEMPTS {
-        if attempt > 0 {
-            sleep(QUERY_POLL_INTERVAL).await;
-        }
-
-        last_rows = query_initial_row(sql, database, schema, table).await;
-        if last_rows == expected {
-            return last_rows;
-        }
-    }
-
-    last_rows
-}
-
-async fn wait_for_default_rows(
-    sql: &SqlClient<AuthManager<HttpExchanger>>,
-    database: &str,
-    schema: &str,
-    table: &str,
-    expected: &[Vec<Value>],
-) -> Vec<Vec<Value>> {
-    let mut last_rows = Vec::new();
-
-    for attempt in 0..QUERY_MAX_ATTEMPTS {
-        if attempt > 0 {
-            sleep(QUERY_POLL_INTERVAL).await;
-        }
-
-        last_rows = query_default_rows(sql, database, schema, table).await;
-        if last_rows == expected {
-            return last_rows;
-        }
-    }
-
-    last_rows
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -177,10 +115,6 @@ async fn schema_change_add_column_defaults() {
         .await;
         assert_eq!(committed, Some(copy_offset), "initial data should commit before source DDL");
 
-        let initial_rows =
-            wait_for_initial_row(&sql, config.database(), config.schema(), &snowflake_table).await;
-        assert_eq!(initial_rows, vec![vec![serde_json::json!("1"), serde_json::json!("Alice")]]);
-
         let events_notify = destination
             .wait_for_events(vec![
                 EventCondition::TableCount(EventType::Relation, table_id, 1),
@@ -214,7 +148,34 @@ async fn schema_change_add_column_defaults() {
             .expect("failed to insert defaulted source row");
 
         events_notify.notified().await;
+        let expected_offset = destination
+            .get_events()
+            .await
+            .into_iter()
+            .rev()
+            .find_map(|event| match event {
+                Event::Insert(event) if event.replicated_table_schema.id() == table_id => {
+                    Some(OffsetToken::new(event.commit_lsn, event.tx_ordinal))
+                }
+                _ => None,
+            })
+            .expect("expected a replicated insert event");
+
         pipeline.shutdown_and_wait().await.unwrap();
+
+        let committed = poll_destination_offset(
+            &destination_for_polling,
+            table_id,
+            &expected_offset,
+            DESTINATION_OFFSET_POLL_INTERVAL,
+            DESTINATION_OFFSET_MAX_ATTEMPTS,
+        )
+        .await;
+        assert_eq!(
+            committed,
+            Some(expected_offset),
+            "defaulted row should commit before the final query"
+        );
 
         let expected = vec![
             vec![
@@ -230,14 +191,8 @@ async fn schema_change_add_column_defaults() {
                 serde_json::json!("true"),
             ],
         ];
-        let rows = wait_for_default_rows(
-            &sql,
-            config.database(),
-            config.schema(),
-            &snowflake_table,
-            &expected,
-        )
-        .await;
+        let rows =
+            query_default_rows(&sql, config.database(), config.schema(), &snowflake_table).await;
         assert_eq!(rows, expected);
     })
     .await;

--- a/crates/etl-destinations/tests/snowflake/stream_client.rs
+++ b/crates/etl-destinations/tests/snowflake/stream_client.rs
@@ -200,16 +200,13 @@ async fn continuation_token() {
 
         let fqn = format!("\"{}\".\"{}\".\"{table}\"", config.database(), config.schema());
 
-        #[allow(clippy::too_many_arguments)]
-        async fn verify(
+        /// Waits for a stream offset without using a virtual warehouse.
+        async fn wait_for_offset(
             stream: &RestStreamClient<AuthManager<HttpExchanger>>,
-            sql: &SqlClient<AuthManager<HttpExchanger>>,
             config: &Config,
             table: &str,
             channel: &str,
-            fqn: &str,
             expected_offset: &OffsetToken,
-            expected_rows: usize,
         ) {
             let committed = poll_stream_offset(
                 stream,
@@ -226,7 +223,15 @@ async fn continuation_token() {
                 Some(expected_offset.clone()),
                 "expected offset not committed within timeout"
             );
-            let rows = query_rows(sql, &format!("SELECT * FROM {fqn} ORDER BY \"id\""))
+        }
+
+        /// Checks the materialized row count after an offset is durable.
+        async fn assert_row_count(
+            sql: &SqlClient<AuthManager<HttpExchanger>>,
+            fqn: &str,
+            expected_rows: usize,
+        ) {
+            let rows = query_rows(sql, &format!("select * from {fqn} order by \"id\""))
                 .await
                 .expect("query_rows failed");
             assert_eq!(rows.len(), expected_rows, "unexpected row count: {rows:?}");
@@ -261,7 +266,7 @@ async fn continuation_token() {
             .await
             .expect("insert batch 1 failed");
 
-        verify(&stream, &sql, &config, &table, &channel, &fqn, &offset1, 1).await;
+        wait_for_offset(&stream, &config, &table, &channel, &offset1).await;
 
         // Batch 2: uses continuation_token from batch 1.
         let offset2: OffsetToken = "0000000000000001/0000000000000001".parse().unwrap();
@@ -286,8 +291,7 @@ async fn continuation_token() {
             insert1.continuation_token, insert2.continuation_token,
             "continuation_token must advance after each batch"
         );
-        // 2 rows expected, offset2 must be committed.
-        verify(&stream, &sql, &config, &table, &channel, &fqn, &offset2, 2).await;
+        wait_for_offset(&stream, &config, &table, &channel, &offset2).await;
 
         // Batch 3: use STALE token from batch 1 (already consumed by batch 2).
         let offset3: OffsetToken = "0000000000000001/0000000000000002".parse().unwrap();
@@ -314,7 +318,7 @@ async fn continuation_token() {
             "stale token should not advance the sequencer"
         );
         // Still 2 rows, offset token is not advanced to offset3.
-        verify(&stream, &sql, &config, &table, &channel, &fqn, &offset2, 2).await;
+        assert_row_count(&sql, &fqn, 2).await;
 
         // Retry batch 3 with the CORRECT token, data commits, offset is updated.
         let insert3_retry = stream
@@ -333,7 +337,8 @@ async fn continuation_token() {
             insert3_retry.continuation_token, insert2.continuation_token,
             "correct token should advance the sequencer"
         );
-        verify(&stream, &sql, &config, &table, &channel, &fqn, &offset3, 3).await;
+        wait_for_offset(&stream, &config, &table, &channel, &offset3).await;
+        assert_row_count(&sql, &fqn, 3).await;
 
         // Cleanup
         let _ = stream.drop_channel(config.database(), config.schema(), &table, &channel).await;


### PR DESCRIPTION
## Summary

- Replace repeated SQL polling with committed-offset waits and one final data assertion.
- Use warehouse-free `SHOW COLUMNS` checks for column and default validation.
- Consolidate duplicate row queries and remove test-only Snowflake inserts.
- Replace intermediate continuation-token reads with offset checks while retaining stale-token and final-state assertions.
- Avoid querying a freshly initialized empty table after durability and existence are confirmed.
- Provision a dedicated Gen1 X-Small, single-cluster `ETL_CI_WH` + configure auto-resume, a 30-second auto-suspend, and a resource monitor on Snowflake side.

## Impact

- Reduce warehouse-backed statements from 24 to 11 (54%).
- Reduce cumulative query execution time from 7.68s to approximately 3.4s.
- Confirm that 30-second auto-suspend does not cause mid-suite resumes.
- Model approximately 25% lower credits per isolated credentialed test run.