### PR TITLE
Recover interrupted schema changes from stored prev replication mask

### DIFF
--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -32,7 +32,6 @@ use crate::{
             supports_column_default, trailing_cdc_column_names,
         },
     },
-    recovery::previous_replication_mask_for_recovery,
     table_name::try_stringify_table_name,
 };
 
@@ -623,8 +622,9 @@ where
 
     /// Re-runs an interrupted DDL idempotently and transitions metadata to
     /// `Applied`. Distinguishes between an interrupted schema change (replays
-    /// the diff against the previous snapshot) and an interrupted initial
-    /// creation (re-issues `CREATE TABLE IF NOT EXISTS`).
+    /// the diff from the previous endpoint `(previous_snapshot_id,
+    /// previous_replication_mask)`) and an interrupted initial creation
+    /// (re-issues `CREATE TABLE IF NOT EXISTS`).
     async fn recover_applying_metadata(
         &self,
         table_id: TableId,
@@ -654,6 +654,23 @@ where
                     ));
                 }
 
+                // Fail closed instead of guessing: recovering with the target
+                // mask would reconstruct the wrong previous endpoint whenever
+                // the mask changed, silently mark the change Applied, and
+                // leave the physical table diverged from the metadata.
+                let Some(previous_replication_mask) = metadata.previous_replication_mask.clone()
+                else {
+                    return Err(etl_error!(
+                        ErrorKind::InvalidState,
+                        "Previous replication mask missing for ClickHouse schema recovery",
+                        format!(
+                            "Table {} has an interrupted schema change towards snapshot {}, but \
+                             the previous replication mask needed to recover the destination \
+                             table was not stored. Manual intervention may be required.",
+                            table_id, metadata.snapshot_id
+                        )
+                    ));
+                };
                 let old_table_schema =
                     self.store.get_table_schema(&table_id, prev_snapshot_id).await?.ok_or_else(
                         || {
@@ -668,15 +685,7 @@ where
                             )
                         },
                     )?;
-                // The metadata records the target mask, not the previous one,
-                // so project it back onto the previous schema; a raw copy has
-                // the wrong width whenever the change added or dropped
-                // columns.
-                let previous_replication_mask = previous_replication_mask_for_recovery(
-                    &old_table_schema,
-                    schema.inner(),
-                    &metadata.replication_mask,
-                );
+
                 let old_schema =
                     ReplicatedTableSchema::from_mask(old_table_schema, previous_replication_mask);
                 let diff = old_schema.diff(schema);

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -686,6 +686,27 @@ where
                         },
                     )?;
 
+                // A floor-semantics schema lookup or a stale mask written by
+                // an older binary can disagree with the stored mask width;
+                // from_mask only debug-asserts, so a mismatch would compute a
+                // silently wrong diff.
+                if previous_replication_mask.len() != old_table_schema.column_schemas.len() {
+                    return Err(etl_error!(
+                        ErrorKind::InvalidState,
+                        "Previous replication mask width mismatch for ClickHouse schema recovery",
+                        format!(
+                            "Table {} stored a previous replication mask of length {}, but schema \
+                             snapshot {} (requested {}) has {} columns. Manual intervention may \
+                             be required.",
+                            table_id,
+                            previous_replication_mask.len(),
+                            old_table_schema.snapshot_id,
+                            prev_snapshot_id,
+                            old_table_schema.column_schemas.len()
+                        )
+                    ));
+                }
+
                 let old_schema =
                     ReplicatedTableSchema::from_mask(old_table_schema, previous_replication_mask);
                 let diff = old_schema.diff(schema);

--- a/crates/etl-destinations/src/lib.rs
+++ b/crates/etl-destinations/src/lib.rs
@@ -4,7 +4,7 @@
 //! warehouses and analytics platforms, enabling data replication from Postgres
 //! to cloud services.
 
-#[cfg(any(feature = "clickhouse", feature = "ducklake"))]
+#[cfg(feature = "ducklake")]
 mod recovery;
 #[cfg(any(feature = "bigquery", feature = "ducklake", feature = "snowflake"))]
 mod retry;

--- a/crates/etl-destinations/tests/clickhouse/destination.rs
+++ b/crates/etl-destinations/tests/clickhouse/destination.rs
@@ -192,3 +192,67 @@ async fn fails_closed_when_previous_replication_mask_missing() {
         .expect("destination metadata should exist");
     assert!(metadata.is_applying());
 }
+
+/// Recovery fails closed when the stored previous replication mask width
+/// disagrees with the schema snapshot returned for `previous_snapshot_id`.
+///
+/// The schema lookup has at-or-before semantics and an older binary can leave
+/// a stale mask, so the stored mask can pair with a schema of a different
+/// width. `from_mask` only debug-asserts the widths, so recovery must reject
+/// the mismatch instead of computing a silently wrong diff, and keep the
+/// metadata in `Applying`.
+#[tokio::test(flavor = "multi_thread")]
+async fn fails_closed_when_previous_replication_mask_width_mismatches() {
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = setup_clickhouse_database().await;
+    let store = MemoryStore::new();
+
+    let table_schema = users_table_schema("maskwidthmismatch");
+    let table_id = table_schema.id;
+    store.store_table_schema(table_schema.clone()).await.unwrap();
+
+    let table_schema = Arc::new(table_schema);
+    let new_replicated = ReplicatedTableSchema::from_mask(
+        Arc::clone(&table_schema),
+        ReplicationMask::from_bytes(vec![1, 0, 1]),
+    );
+
+    // --- GIVEN: an interrupted schema change whose stored previous mask has
+    // width 2, while the schema at the previous snapshot has 3 columns ---
+    let applying_metadata = DestinationTableMetadata {
+        destination_table_id: "public_maskwidthmismatch".to_owned(),
+        snapshot_id: SnapshotId::from(100_u64),
+        previous_snapshot_id: Some(SnapshotId::from(100_u64)),
+        previous_replication_mask: Some(ReplicationMask::from_bytes(vec![1, 1])),
+        schema_status: DestinationTableSchemaStatus::Applying,
+        replication_mask: new_replicated.replication_mask().clone(),
+    };
+    store.store_destination_table_metadata(table_id, applying_metadata).await.unwrap();
+
+    // --- WHEN: a restarted destination attempts to write for the table ---
+    let destination =
+        database.build_destination_with_engine(store.clone(), ClickHouseEngine::MergeTree).await;
+    let err = destination
+        .write_table_rows(
+            &new_replicated,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("alice@example.com".to_owned())])],
+        )
+        .await
+        .unwrap_err();
+
+    // --- THEN: the error fails closed and metadata stays in Applying ---
+    assert_eq!(err.kind(), ErrorKind::InvalidState);
+    assert_eq!(
+        err.description(),
+        Some("Previous replication mask width mismatch for ClickHouse schema recovery")
+    );
+
+    let metadata = store
+        .get_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("destination metadata should exist");
+    assert!(metadata.is_applying());
+}

--- a/crates/etl-destinations/tests/clickhouse/destination.rs
+++ b/crates/etl-destinations/tests/clickhouse/destination.rs
@@ -1,0 +1,194 @@
+//! Direct destination tests for ClickHouse crash recovery of interrupted
+//! schema changes.
+
+use std::sync::Arc;
+
+use etl::{
+    data::{Cell, TableRow},
+    destination::{DestinationTableMetadata, DestinationTableSchemaStatus},
+    error::ErrorKind,
+    schema::{
+        ColumnSchema, ReplicatedTableSchema, ReplicationMask, SnapshotId, TableId, TableName,
+        TableSchema, Type as PgType,
+    },
+    store::{MemoryStore, SchemaStore, StateStore},
+};
+use etl_config::shared::ClickHouseEngine;
+use etl_destinations::clickhouse::test_utils::setup_clickhouse_database;
+use etl_telemetry::tracing::init_test_tracing;
+
+use crate::support::crypto::install_crypto_provider;
+
+/// An `(id, email)` row read back from the recovered users table.
+#[derive(clickhouse::Row, serde::Deserialize, Debug, PartialEq)]
+struct UserRow {
+    id: i32,
+    email: Option<String>,
+}
+
+/// Builds the shared source schema for the recovery tests: a users table at
+/// snapshot 100 with columns `[id, name, email]`. The publication initially
+/// replicates `[id, name]` and later switches to `[id, email]`, so the mask
+/// changes while the snapshot stays the same.
+fn users_table_schema(table_name: &str) -> TableSchema {
+    TableSchema::with_snapshot_id(
+        TableId::new(71),
+        TableName::new("public".to_owned(), table_name.to_owned()),
+        vec![
+            ColumnSchema::new("id".to_owned(), PgType::INT4, -1, 1, false).with_primary_key(1),
+            ColumnSchema::new("name".to_owned(), PgType::TEXT, -1, 2, true),
+            ColumnSchema::new("email".to_owned(), PgType::TEXT, -1, 3, true),
+        ],
+        SnapshotId::from(100_u64),
+    )
+}
+
+/// Recovery of a publication-mask-only schema change interrupted by a crash.
+///
+/// The mask can change without a new schema snapshot when the publication's
+/// column list changes, so the previous physical endpoint is identified by
+/// `(previous_snapshot_id, previous_replication_mask)`. Recovery must replay
+/// the `[id, name] -> [id, email]` diff from the stored previous mask;
+/// reconstructing the previous endpoint from the target mask would produce an
+/// empty diff, mark the change applied, and leave the physical table diverged.
+#[tokio::test(flavor = "multi_thread")]
+async fn recovers_interrupted_mask_only_schema_change() {
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = setup_clickhouse_database().await;
+    let store = MemoryStore::new();
+
+    // --- GIVEN: users applied at (snapshot 100, mask [1, 1, 0]) = [id, name] ---
+    let table_schema = users_table_schema("maskrecovery");
+    let table_id = table_schema.id;
+    store.store_table_schema(table_schema.clone()).await.unwrap();
+
+    let table_schema = Arc::new(table_schema);
+    let old_replicated = ReplicatedTableSchema::from_mask(
+        Arc::clone(&table_schema),
+        ReplicationMask::from_bytes(vec![1, 1, 0]),
+    );
+    let new_replicated = ReplicatedTableSchema::from_mask(
+        Arc::clone(&table_schema),
+        ReplicationMask::from_bytes(vec![1, 0, 1]),
+    );
+
+    let destination =
+        database.build_destination_with_engine(store.clone(), ClickHouseEngine::MergeTree).await;
+    destination
+        .write_table_rows(
+            &old_replicated,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".to_owned())])],
+        )
+        .await
+        .unwrap();
+
+    // --- GIVEN: the publication switched to [id, email] and the schema change
+    // crashed before any DDL ran ---
+    let applied_metadata = store.get_destination_table_metadata(table_id).await.unwrap().unwrap();
+    let applying_metadata = applied_metadata.with_schema_change(
+        SnapshotId::from(100_u64),
+        new_replicated.replication_mask().clone(),
+        DestinationTableSchemaStatus::Applying,
+    );
+    store.store_destination_table_metadata(table_id, applying_metadata).await.unwrap();
+
+    // --- WHEN: a restarted destination writes rows for the target schema ---
+    let restarted =
+        database.build_destination_with_engine(store.clone(), ClickHouseEngine::MergeTree).await;
+    restarted
+        .write_table_rows(
+            &new_replicated,
+            vec![TableRow::new(vec![Cell::I32(2), Cell::String("bob@example.com".to_owned())])],
+        )
+        .await
+        .unwrap();
+
+    // --- THEN: the physical table converged to the target endpoint [id, email] ---
+    assert_eq!(database.column_names("public_maskrecovery").await, vec!["id", "email"]);
+
+    let metadata = store
+        .get_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("destination metadata should exist");
+    assert!(metadata.is_applied());
+    assert_eq!(metadata.snapshot_id, SnapshotId::from(100_u64));
+    assert_eq!(metadata.replication_mask, ReplicationMask::from_bytes(vec![1, 0, 1]));
+    assert_eq!(metadata.previous_snapshot_id, None);
+    assert_eq!(metadata.previous_replication_mask, None);
+
+    // Alice pre-dates the email column, so she keeps NULL; Bob lands with his
+    // replicated email.
+    let rows: Vec<UserRow> =
+        database.query("select id, email from public_maskrecovery order by id").await;
+    assert_eq!(
+        rows,
+        vec![
+            UserRow { id: 1, email: None },
+            UserRow { id: 2, email: Some("bob@example.com".to_owned()) },
+        ]
+    );
+}
+
+/// Recovery fails closed when an interrupted schema change has no stored
+/// previous replication mask (rows persisted before the mask was tracked).
+///
+/// Guessing the previous endpoint from the target mask could silently mark
+/// the change applied while the physical table diverges, so the destination
+/// must surface an invalid-state error and keep the metadata in `Applying`.
+#[tokio::test(flavor = "multi_thread")]
+async fn fails_closed_when_previous_replication_mask_missing() {
+    init_test_tracing();
+    install_crypto_provider();
+
+    let database = setup_clickhouse_database().await;
+    let store = MemoryStore::new();
+
+    let table_schema = users_table_schema("maskfailclosed");
+    let table_id = table_schema.id;
+    store.store_table_schema(table_schema.clone()).await.unwrap();
+
+    let table_schema = Arc::new(table_schema);
+    let new_replicated = ReplicatedTableSchema::from_mask(
+        Arc::clone(&table_schema),
+        ReplicationMask::from_bytes(vec![1, 0, 1]),
+    );
+
+    // --- GIVEN: an interrupted schema change without a previous mask ---
+    let applying_metadata = DestinationTableMetadata {
+        destination_table_id: "public_maskfailclosed".to_owned(),
+        snapshot_id: SnapshotId::from(100_u64),
+        previous_snapshot_id: Some(SnapshotId::from(100_u64)),
+        previous_replication_mask: None,
+        schema_status: DestinationTableSchemaStatus::Applying,
+        replication_mask: new_replicated.replication_mask().clone(),
+    };
+    store.store_destination_table_metadata(table_id, applying_metadata).await.unwrap();
+
+    // --- WHEN: a restarted destination attempts to write for the table ---
+    let destination =
+        database.build_destination_with_engine(store.clone(), ClickHouseEngine::MergeTree).await;
+    let err = destination
+        .write_table_rows(
+            &new_replicated,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("alice@example.com".to_owned())])],
+        )
+        .await
+        .unwrap_err();
+
+    // --- THEN: the error fails closed and metadata stays in Applying ---
+    assert_eq!(err.kind(), ErrorKind::InvalidState);
+    assert_eq!(
+        err.description(),
+        Some("Previous replication mask missing for ClickHouse schema recovery")
+    );
+
+    let metadata = store
+        .get_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("destination metadata should exist");
+    assert!(metadata.is_applying());
+}

--- a/crates/etl-destinations/tests/clickhouse/mod.rs
+++ b/crates/etl-destinations/tests/clickhouse/mod.rs
@@ -1,3 +1,4 @@
+mod destination;
 mod pipeline;
 mod pipeline_large_rows;
 mod pipeline_merge_tree;

--- a/crates/etl-postgres/src/store/destination_table_metadata.rs
+++ b/crates/etl-postgres/src/store/destination_table_metadata.rs
@@ -46,6 +46,9 @@ pub struct StoredDestinationTableMetadataRow {
     pub snapshot_id: SnapshotId,
     /// The schema version before the current change. None for initial schemas.
     pub previous_snapshot_id: Option<SnapshotId>,
+    /// The replication mask before the current change. None for initial
+    /// schemas.
+    pub previous_replication_mask: Option<Vec<u8>>,
     /// Current destination schema application status.
     pub schema_status: StoredDestinationTableSchemaStatus,
     /// Column replication mask stored as raw bytes.
@@ -65,6 +68,7 @@ pub async fn store_destination_table_metadata(
     destination_table_id: &str,
     snapshot_id: SnapshotId,
     previous_snapshot_id: Option<SnapshotId>,
+    previous_replication_mask: Option<&[u8]>,
     schema_status: StoredDestinationTableSchemaStatus,
     replication_mask: &[u8],
 ) -> Result<(), sqlx::Error> {
@@ -72,8 +76,8 @@ pub async fn store_destination_table_metadata(
         r#"
         insert into etl.destination_tables_metadata
             (pipeline_id, table_id, destination_table_id, snapshot_id,
-             previous_snapshot_id, schema_status, replication_mask)
-        values ($1, $2, $3, $4::pg_lsn, $5::pg_lsn, $6, $7)
+             previous_snapshot_id, schema_status, replication_mask, previous_replication_mask)
+        values ($1, $2, $3, $4::pg_lsn, $5::pg_lsn, $6, $7, $8)
         on conflict (pipeline_id, table_id)
         do update set
             destination_table_id = excluded.destination_table_id,
@@ -81,6 +85,7 @@ pub async fn store_destination_table_metadata(
             previous_snapshot_id = excluded.previous_snapshot_id,
             schema_status = excluded.schema_status,
             replication_mask = excluded.replication_mask,
+            previous_replication_mask = excluded.previous_replication_mask,
             updated_at = now()
         "#,
     )
@@ -91,6 +96,7 @@ pub async fn store_destination_table_metadata(
     .bind(previous_snapshot_id.map(SnapshotId::to_pg_lsn_string))
     .bind(schema_status)
     .bind(replication_mask)
+    .bind(previous_replication_mask)
     .execute(pool)
     .await?;
 
@@ -107,7 +113,8 @@ pub async fn load_destination_tables_metadata(
     let rows = sqlx::query(
         r#"
         select table_id, destination_table_id, snapshot_id::text as snapshot_id,
-               previous_snapshot_id::text as previous_snapshot_id, schema_status, replication_mask
+               previous_snapshot_id::text as previous_snapshot_id, schema_status,
+               replication_mask, previous_replication_mask
         from etl.destination_tables_metadata
         where pipeline_id = $1
         "#,
@@ -134,6 +141,7 @@ pub async fn load_destination_tables_metadata(
                 previous_snapshot_id,
                 schema_status: row.get("schema_status"),
                 replication_mask: row.get("replication_mask"),
+                previous_replication_mask: row.get("previous_replication_mask"),
             },
         );
     }
@@ -150,7 +158,8 @@ pub async fn get_destination_table_metadata(
     let row = sqlx::query(
         r#"
         select table_id, destination_table_id, snapshot_id::text as snapshot_id,
-               previous_snapshot_id::text as previous_snapshot_id, schema_status, replication_mask
+               previous_snapshot_id::text as previous_snapshot_id, schema_status,
+               replication_mask, previous_replication_mask
         from etl.destination_tables_metadata
         where pipeline_id = $1 and table_id = $2
         "#,
@@ -175,6 +184,7 @@ pub async fn get_destination_table_metadata(
                 previous_snapshot_id,
                 schema_status: r.get("schema_status"),
                 replication_mask: r.get("replication_mask"),
+                previous_replication_mask: r.get("previous_replication_mask"),
             }))
         }
         None => Ok(None),

--- a/crates/etl/migrations/postgres_store/20260721000000_previous_replication_mask.down.sql
+++ b/crates/etl/migrations/postgres_store/20260721000000_previous_replication_mask.down.sql
@@ -1,0 +1,2 @@
+alter table etl.destination_tables_metadata
+    drop column if exists previous_replication_mask;

--- a/crates/etl/migrations/postgres_store/20260721000000_previous_replication_mask.up.sql
+++ b/crates/etl/migrations/postgres_store/20260721000000_previous_replication_mask.up.sql
@@ -1,0 +1,2 @@
+alter table etl.destination_tables_metadata
+    add column if not exists previous_replication_mask bytea;

--- a/crates/etl/src/destination/metadata.rs
+++ b/crates/etl/src/destination/metadata.rs
@@ -28,10 +28,20 @@ pub struct DestinationTableMetadata {
     pub snapshot_id: SnapshotId,
     /// The schema version before the current change. None for initial schemas.
     ///
-    /// Destinations that support atomic DDL can use this for recovery: if
-    /// `schema_status` is `Applying` on startup, the destination knows the
-    /// DDL was rolled back and can reset to this snapshot to retry.
+    /// Together with [`DestinationTableMetadata::previous_replication_mask`],
+    /// this identifies the physical destination schema that was applied before
+    /// the in-flight change. If `schema_status` is `Applying` on startup,
+    /// destinations use this pair to reconstruct the previous endpoint and
+    /// recover the interrupted DDL.
     pub previous_snapshot_id: Option<SnapshotId>,
+    /// The replication mask before the current change. None for initial
+    /// schemas.
+    ///
+    /// The mask can change without a new schema snapshot (for example when
+    /// the publication's column list changes), so `previous_snapshot_id`
+    /// alone cannot identify the previously applied destination schema. Both
+    /// previous fields are set and cleared together.
+    pub previous_replication_mask: Option<ReplicationMask>,
     /// Status of the current schema change operation.
     ///
     /// If `Applying` is found on startup, the destination schema may be in
@@ -60,6 +70,7 @@ impl DestinationTableMetadata {
             destination_table_id,
             snapshot_id,
             previous_snapshot_id: None,
+            previous_replication_mask: None,
             schema_status: DestinationTableSchemaStatus::Applying,
             replication_mask,
         }
@@ -77,6 +88,7 @@ impl DestinationTableMetadata {
             destination_table_id,
             snapshot_id,
             previous_snapshot_id: None,
+            previous_replication_mask: None,
             schema_status: DestinationTableSchemaStatus::Applied,
             replication_mask,
         }
@@ -94,18 +106,19 @@ impl DestinationTableMetadata {
 
     /// Transitions this metadata to applied status.
     ///
-    /// Clears the previous_snapshot_id since the change completed successfully.
+    /// Clears both previous fields since the change completed successfully.
     pub fn to_applied(mut self) -> Self {
         self.schema_status = DestinationTableSchemaStatus::Applied;
         self.previous_snapshot_id = None;
+        self.previous_replication_mask = None;
         self
     }
 
     /// Updates the schema state for a new schema change.
     ///
-    /// Sets `previous_snapshot_id` to the current snapshot before updating,
-    /// enabling recovery if the change fails on destinations that support
-    /// atomic DDL.
+    /// Sets `previous_snapshot_id` and `previous_replication_mask` to the
+    /// current values before updating, enabling recovery of the interrupted
+    /// DDL if the change fails partway through.
     pub fn with_schema_change(
         mut self,
         snapshot_id: SnapshotId,
@@ -113,6 +126,7 @@ impl DestinationTableMetadata {
         status: DestinationTableSchemaStatus,
     ) -> Self {
         self.previous_snapshot_id = Some(self.snapshot_id);
+        self.previous_replication_mask = Some(self.replication_mask.clone());
         self.snapshot_id = snapshot_id;
         self.replication_mask = replication_mask;
         self.schema_status = status;
@@ -162,4 +176,65 @@ pub struct AppliedDestinationTableMetadata {
     pub snapshot_id: SnapshotId,
     /// The replication mask indicating which columns are replicated.
     pub replication_mask: ReplicationMask,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn applied_metadata() -> DestinationTableMetadata {
+        DestinationTableMetadata::new_applied(
+            "dest_table".to_owned(),
+            SnapshotId::from(100_u64),
+            ReplicationMask::from_bytes(vec![1, 1, 0]),
+        )
+    }
+
+    #[test]
+    fn with_schema_change_captures_previous_snapshot_and_mask() {
+        let metadata = applied_metadata().with_schema_change(
+            SnapshotId::from(100_u64),
+            ReplicationMask::from_bytes(vec![1, 0, 1]),
+            DestinationTableSchemaStatus::Applying,
+        );
+
+        assert!(metadata.is_applying());
+        assert_eq!(metadata.snapshot_id, SnapshotId::from(100_u64));
+        assert_eq!(metadata.replication_mask, ReplicationMask::from_bytes(vec![1, 0, 1]));
+        assert_eq!(metadata.previous_snapshot_id, Some(SnapshotId::from(100_u64)));
+        assert_eq!(
+            metadata.previous_replication_mask,
+            Some(ReplicationMask::from_bytes(vec![1, 1, 0]))
+        );
+    }
+
+    #[test]
+    fn to_applied_clears_both_previous_fields() {
+        let metadata = applied_metadata()
+            .with_schema_change(
+                SnapshotId::from(101_u64),
+                ReplicationMask::from_bytes(vec![1, 0, 1]),
+                DestinationTableSchemaStatus::Applying,
+            )
+            .to_applied();
+
+        assert!(metadata.is_applied());
+        assert_eq!(metadata.previous_snapshot_id, None);
+        assert_eq!(metadata.previous_replication_mask, None);
+    }
+
+    #[test]
+    fn new_metadata_has_no_previous_fields() {
+        let applying = DestinationTableMetadata::new_applying(
+            "dest_table".to_owned(),
+            SnapshotId::initial(),
+            ReplicationMask::from_bytes(vec![1]),
+        );
+        assert_eq!(applying.previous_snapshot_id, None);
+        assert_eq!(applying.previous_replication_mask, None);
+
+        let applied = applied_metadata();
+        assert_eq!(applied.previous_snapshot_id, None);
+        assert_eq!(applied.previous_replication_mask, None);
+    }
 }

--- a/crates/etl/src/store/both/postgres.rs
+++ b/crates/etl/src/store/both/postgres.rs
@@ -437,6 +437,9 @@ impl StateStore for PostgresStore {
                     destination_table_id: row.destination_table_id,
                     snapshot_id: row.snapshot_id,
                     previous_snapshot_id: row.previous_snapshot_id,
+                    previous_replication_mask: row
+                        .previous_replication_mask
+                        .map(ReplicationMask::from_bytes),
                     schema_status: row.schema_status.into(),
                     replication_mask: ReplicationMask::from_bytes(row.replication_mask),
                 },
@@ -471,6 +474,7 @@ impl StateStore for PostgresStore {
             &metadata.destination_table_id,
             metadata.snapshot_id,
             metadata.previous_snapshot_id,
+            metadata.previous_replication_mask.as_ref().map(ReplicationMask::as_slice),
             metadata.schema_status.into(),
             metadata.replication_mask.as_slice(),
         )

--- a/crates/etl/tests/postgres_store.rs
+++ b/crates/etl/tests/postgres_store.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use etl::{
-    destination::DestinationTableMetadata,
+    destination::{DestinationTableMetadata, DestinationTableSchemaStatus},
     error::ErrorKind,
     etl_error,
     schema::{ColumnSchema, ReplicationMask, SnapshotId, TableId, TableName, TableSchema},
@@ -1283,4 +1283,60 @@ async fn replication_mask_roundtrip() {
         original_mask.as_slice(),
         "Roundtrip should preserve replication mask exactly"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn destination_metadata_previous_fields_roundtrip() {
+    init_test_tracing();
+
+    let database = spawn_source_database().await;
+    let pipeline_id = 1;
+    let table_id = TableId::new(54322);
+
+    // Store metadata for an in-flight schema change that only alters the
+    // replication mask (same snapshot, different mask).
+    let previous_mask = ReplicationMask::from_bytes(vec![1, 1, 0]);
+    let target_mask = ReplicationMask::from_bytes(vec![1, 0, 1]);
+    let applying_metadata = DestinationTableMetadata::new_applied(
+        "previous_fields_table".to_owned(),
+        SnapshotId::from(100u64),
+        previous_mask.clone(),
+    )
+    .with_schema_change(
+        SnapshotId::from(100u64),
+        target_mask.clone(),
+        DestinationTableSchemaStatus::Applying,
+    );
+
+    let store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    store.store_destination_table_metadata(table_id, applying_metadata.clone()).await.unwrap();
+
+    // A fresh store must reload both previous fields exactly.
+    let new_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    new_store.load_destination_tables_metadata().await.unwrap();
+
+    let loaded_metadata = new_store
+        .get_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("Metadata should exist after loading");
+    assert_eq!(loaded_metadata, applying_metadata);
+    assert_eq!(loaded_metadata.previous_snapshot_id, Some(SnapshotId::from(100u64)));
+    assert_eq!(loaded_metadata.previous_replication_mask, Some(previous_mask));
+
+    // Completing the change clears both previous fields durably.
+    store.store_destination_table_metadata(table_id, loaded_metadata.to_applied()).await.unwrap();
+
+    let reloaded_store = PostgresStore::new(pipeline_id, database.config.clone()).await.unwrap();
+    reloaded_store.load_destination_tables_metadata().await.unwrap();
+
+    let applied_metadata = reloaded_store
+        .get_destination_table_metadata(table_id)
+        .await
+        .unwrap()
+        .expect("Metadata should exist after completion");
+    assert!(applied_metadata.is_applied());
+    assert_eq!(applied_metadata.previous_snapshot_id, None);
+    assert_eq!(applied_metadata.previous_replication_mask, None);
+    assert_eq!(applied_metadata.replication_mask, target_mask);
 }

--- a/docs/src/content/docs/explanation/schema-changes.md
+++ b/docs/src/content/docs/explanation/schema-changes.md
@@ -315,6 +315,13 @@ These behaviors are **not full destination DDL semantics** yet:
   confirmed replays the stream from before the change and triggers the
   same error. Replication mask changes carry no ordering, so a replayed
   stale mask cannot be detected the same way.
+- ClickHouse recovers interrupted schema changes from durable metadata. While
+  a change is applying, the previous `(snapshot, replication mask)` endpoint
+  is stored alongside the target, so a crash mid-DDL replays the interrupted
+  diff idempotently — including publication column-list changes that alter
+  the mask without a new schema snapshot. If the previous mask is missing
+  (metadata written before it was tracked), the pipeline fails closed instead
+  of guessing, and the table requires manual recovery.
 - Snowflake skips stale schema snapshots instead of rewinding. Before applying
   schema DDL, Snowflake waits for all preceding row batches to become durable.
   On restart, reopening the table's channel restores its committed offset, so


### PR DESCRIPTION
`SnapshotId` identifies the source `TableSchema`, but the physical ClickHouse schema is identified by the pair `(snapshot_id, replication_mask)`: a publication column-list change alters the mask without a new snapshot.

`with_schema_change` was overwriting the mask in place, so crash recovery of an Applying change reconstructed the previous endpoint from the target mask, computed an empty or wrong diff, marked the change Applied, and left the table wedged behind the column-integrity check.

The recovery mask-projection helper is no longer used by ClickHouse, so the shared recovery module is now gated to its only consumer, DuckLake.