### PR TITLE
Add durable write duration metric to apply loop

### DIFF
--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -94,6 +94,10 @@ pub enum WriteEventsDurability {
     /// stream. ETL may use this with an empty event vector as a durability-only
     /// barrier. The destination may return `Durable` immediately only when no
     /// covered durability debt remains, returning `Accepted` is invalid.
+    ///
+    /// The apply loop may also require a subsequent nonempty write after its
+    /// bounded accepted-write timing queue fills. That write is a cumulative
+    /// durability barrier for all earlier accepted writes.
     RequireDurable,
 }
 
@@ -143,7 +147,7 @@ pub(crate) struct ApplyLoopAsyncResultMetadata {
 /// side immediately or later, depending on the method.
 #[derive(Debug)]
 pub struct AsyncResult<T> {
-    tx: Option<oneshot::Sender<EtlResult<T>>>,
+    tx: Option<oneshot::Sender<(Instant, EtlResult<T>)>>,
 }
 
 impl<T> AsyncResult<T> {
@@ -158,13 +162,14 @@ impl<T> AsyncResult<T> {
         (Self { tx: Some(tx) }, PendingAsyncResult { metadata: Some(metadata), rx })
     }
 
-    /// Sends the final result to the waiting receiver.
+    /// Sends the final result to the waiting receiver and records its completion instant.
     pub fn send(mut self, result: EtlResult<T>) {
         let Some(tx) = self.tx.take() else {
             return;
         };
 
-        if tx.send(result).is_err() {
+        let completed_at = Instant::now();
+        if tx.send((completed_at, result)).is_err() {
             debug!("async result receiver was already closed");
         }
     }
@@ -177,7 +182,7 @@ pin_project! {
     pub(crate) struct PendingAsyncResult<T, M> {
         metadata: Option<M>,
         #[pin]
-        rx: oneshot::Receiver<EtlResult<T>>,
+        rx: oneshot::Receiver<(Instant, EtlResult<T>)>,
     }
 }
 
@@ -188,11 +193,14 @@ impl<T, M> Future for PendingAsyncResult<T, M> {
         let this = self.project();
 
         match this.rx.poll(cx) {
-            Poll::Ready(Ok(result)) => {
-                Poll::Ready(CompletedAsyncResult { metadata: this.metadata.take(), result })
-            }
+            Poll::Ready(Ok((completed_at, result))) => Poll::Ready(CompletedAsyncResult {
+                metadata: this.metadata.take(),
+                completed_at,
+                result,
+            }),
             Poll::Ready(Err(_)) => Poll::Ready(CompletedAsyncResult {
                 metadata: this.metadata.take(),
+                completed_at: Instant::now(),
                 result: Err(etl_error!(
                     ErrorKind::DestinationError,
                     "Async result channel closed before sending"
@@ -223,6 +231,9 @@ impl<T, M> PendingAsyncResult<T, M> {
 #[derive(Debug)]
 pub(crate) struct CompletedAsyncResult<T, M> {
     metadata: Option<M>,
+    /// Instant at which the sender reported completion.
+    completed_at: Instant,
+    /// Final operation result.
     result: EtlResult<T>,
 }
 
@@ -233,8 +244,14 @@ impl<T, M> CompletedAsyncResult<T, M> {
     }
 
     /// Returns the metadata and final result.
+    #[cfg(test)]
     pub(crate) fn into_parts(self) -> (Option<M>, EtlResult<T>) {
         (self.metadata, self.result)
+    }
+
+    /// Returns metadata, the completion instant, and the final result.
+    pub(crate) fn into_parts_with_completion(self) -> (Option<M>, Instant, EtlResult<T>) {
+        (self.metadata, self.completed_at, self.result)
     }
 }
 
@@ -281,7 +298,7 @@ mod tests {
         let mut pending_result =
             PendingAsyncResult::<u64, ApplyLoopAsyncResultMetadata> { metadata: None, rx };
 
-        result_tx.send(Ok(7)).unwrap();
+        result_tx.send((Instant::now(), Ok(7))).unwrap();
 
         let completed = std::future::poll_fn(|cx| Pin::new(&mut pending_result).poll(cx)).await;
         let (metadata, result) = completed.into_parts();

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -94,10 +94,6 @@ pub enum WriteEventsDurability {
     /// stream. ETL may use this with an empty event vector as a durability-only
     /// barrier. The destination may return `Durable` immediately only when no
     /// covered durability debt remains, returning `Accepted` is invalid.
-    ///
-    /// The apply loop may also require a subsequent nonempty write after its
-    /// bounded accepted-write timing queue fills. That write is a cumulative
-    /// durability barrier for all earlier accepted writes.
     RequireDurable,
 }
 
@@ -162,7 +158,8 @@ impl<T> AsyncResult<T> {
         (Self { tx: Some(tx) }, PendingAsyncResult { metadata: Some(metadata), rx })
     }
 
-    /// Sends the final result to the waiting receiver and records its completion instant.
+    /// Sends the final result to the waiting receiver and records its
+    /// completion instant.
     pub fn send(mut self, result: EtlResult<T>) {
         let Some(tx) = self.tx.take() else {
             return;

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -180,6 +180,11 @@ pub trait Destination {
     /// cumulative: it must mean that later write and all earlier `Accepted`
     /// writes in the same apply-loop stream are durable.
     ///
+    /// Once ETL's bounded accepted-write timing queue fills, the next nonempty
+    /// streaming write is also required to be durable. That write is a
+    /// cumulative barrier for all earlier accepted writes and keeps timing
+    /// state bounded without dropping samples.
+    ///
     /// If no later streaming write is dispatched before shutdown, ETL normally
     /// exits without acknowledging accepted-but-not-durable progress. Restart
     /// then replays from the last durable checkpoint. A terminal table-sync

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -180,11 +180,6 @@ pub trait Destination {
     /// cumulative: it must mean that later write and all earlier `Accepted`
     /// writes in the same apply-loop stream are durable.
     ///
-    /// Once ETL's bounded accepted-write timing queue fills, the next nonempty
-    /// streaming write is also required to be durable. That write is a
-    /// cumulative barrier for all earlier accepted writes and keeps timing
-    /// state bounded without dropping samples.
-    ///
     /// If no later streaming write is dispatched before shutdown, ETL normally
     /// exits without acknowledging accepted-but-not-durable progress. Restart
     /// then replays from the last durable checkpoint. A terminal table-sync

--- a/crates/etl/src/observability.rs
+++ b/crates/etl/src/observability.rs
@@ -9,6 +9,8 @@ pub(crate) const ETL_BATCH_ITEMS_SEND_DURATION_SECONDS: &str =
     "etl_batch_items_send_duration_seconds";
 pub(crate) const ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS: &str =
     "etl_batch_items_durable_duration_seconds";
+pub(crate) const ETL_BATCH_ITEMS_DURABLE_WAIT_DURATION_SECONDS: &str =
+    "etl_batch_items_durable_wait_duration_seconds";
 pub(crate) const ETL_TRANSACTION_DURATION_SECONDS: &str = "etl_transaction_duration_seconds";
 pub(crate) const ETL_TRANSACTIONS_TOTAL: &str = "etl_transactions_total";
 pub(crate) const ETL_TRANSACTION_SIZE: &str = "etl_transaction_size";
@@ -95,6 +97,14 @@ pub(crate) fn register_metrics() {
             "Time taken in seconds from dispatching a batch of items to the destination until the \
              destination confirms the batch durable, labeled by worker_type, action and \
              confirmation; covers streaming writes only"
+        );
+
+        describe_histogram!(
+            ETL_BATCH_ITEMS_DURABLE_WAIT_DURATION_SECONDS,
+            Unit::Seconds,
+            "Time taken in seconds from the destination accepting a batch of items until a later \
+             durable result confirms the batch durable, labeled by worker_type and action; covers \
+             deferred streaming writes only"
         );
 
         describe_histogram!(

--- a/crates/etl/src/observability.rs
+++ b/crates/etl/src/observability.rs
@@ -7,6 +7,8 @@ static REGISTER_METRICS: Once = Once::new();
 pub(crate) const ETL_TABLES_TOTAL: &str = "etl_tables_total";
 pub(crate) const ETL_BATCH_ITEMS_SEND_DURATION_SECONDS: &str =
     "etl_batch_items_send_duration_seconds";
+pub(crate) const ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS: &str =
+    "etl_batch_items_durable_duration_seconds";
 pub(crate) const ETL_TRANSACTION_DURATION_SECONDS: &str = "etl_transaction_duration_seconds";
 pub(crate) const ETL_TRANSACTIONS_TOTAL: &str = "etl_transactions_total";
 pub(crate) const ETL_TRANSACTION_SIZE: &str = "etl_transaction_size";
@@ -70,6 +72,8 @@ pub(crate) const OUTCOME_LABEL: &str = "outcome";
 pub(crate) const ERROR_TYPE_LABEL: &str = "error_type";
 /// Label key for transition direction ("activate" or "resume").
 pub(crate) const DIRECTION_LABEL: &str = "direction";
+/// Label key for how durability was confirmed ("direct" or "deferred").
+pub(crate) const CONFIRMATION_LABEL: &str = "confirmation";
 
 /// Register metrics emitted by etl. This should be called before starting a
 /// pipeline. It is safe to call this method multiple times. It is guaranteed to
@@ -83,6 +87,14 @@ pub(crate) fn register_metrics() {
             Unit::Seconds,
             "Time taken in seconds to send a batch of items to the destination, labeled by \
              worker_type and action"
+        );
+
+        describe_histogram!(
+            ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS,
+            Unit::Seconds,
+            "Time taken in seconds from dispatching a batch of items to the destination until the \
+             destination confirms the batch durable, labeled by worker_type, action and \
+             confirmation; covers streaming writes only"
         );
 
         describe_histogram!(

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -709,9 +709,10 @@ struct ApplyLoopState {
     ///
     /// A durable write result confirms all earlier accepted writes in the same
     /// ordered apply-loop stream, so their durable write durations are
-    /// recorded once the next durable result arrives. The queue is bounded
-    /// because deferred destinations must bound their accepted-but-not-durable
-    /// work.
+    /// recorded once the next durable result arrives. The queue has no
+    /// explicit bound: the loop keeps at most one write in flight, so it
+    /// grows by at most one entry per completed write and drains at the
+    /// next durable result.
     pending_durable_dispatches: VecDeque<Instant>,
     /// The LSN of the commit WAL entry of the transaction that is currently
     /// being processed.

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -123,6 +123,8 @@ const MIN_KEEP_ALIVE_DEADLINE_DURATION: Duration = Duration::from_millis(100);
 /// progress points where durable ETL progress may have advanced. The next
 /// deadline is scheduled when the previous cleanup task finishes.
 const SCHEMA_CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
+/// Maximum accepted-but-not-durable streaming writes tracked per apply loop.
+const MAX_PENDING_DURABLE_DISPATCHES: usize = 1024;
 
 /// Result type for the apply loop execution.
 ///
@@ -719,10 +721,12 @@ struct ApplyLoopState {
     ///
     /// A durable write result confirms all earlier accepted writes in the same
     /// ordered apply-loop stream, so their durable durations are recorded once
-    /// the next durable result arrives. The queue has no explicit bound: the
-    /// loop keeps at most one write in flight, so it grows by at most one
-    /// entry per completed write and drains at the next durable result.
+    /// the next durable result arrives. The queue is capped and the next
+    /// nonempty write becomes a cumulative durability barrier when the cap is
+    /// reached, so no timing entries are dropped.
     pending_durable_dispatches: VecDeque<PendingDurableDispatch>,
+    /// Whether the next nonempty streaming write must confirm cumulative durability.
+    require_durable_next_write: bool,
     /// The LSN of the commit WAL entry of the transaction that is currently
     /// being processed.
     remote_final_lsn: Option<PgLsn>,
@@ -790,6 +794,7 @@ impl ApplyLoopState {
         Self {
             last_commit_end_lsn: None,
             pending_durable_dispatches: VecDeque::new(),
+            require_durable_next_write: false,
             remote_final_lsn: None,
             replication_progress,
             replication_lag_metrics,
@@ -1793,7 +1798,7 @@ where
         let processing_paused = self.state.resume_processing();
 
         // Explode the result into parts which are used for handling the flush result.
-        let (metadata, result) = flush_result.into_parts();
+        let (metadata, completed_at, result) = flush_result.into_parts_with_completion();
 
         // If there was an error in the flushing, we return it immediately.
         let status = result?;
@@ -1830,10 +1835,25 @@ where
                     // its durable durations can be recorded once a later
                     // durable result covers it.
                     if metadata.event_count > 0 {
+                        if self.state.pending_durable_dispatches.len()
+                            >= MAX_PENDING_DURABLE_DISPATCHES
+                        {
+                            bail!(
+                                ErrorKind::DestinationError,
+                                "Destination exceeded the pending durability queue limit"
+                            );
+                        }
+
                         self.state.pending_durable_dispatches.push_back(PendingDurableDispatch {
                             dispatched_at: metadata.dispatched_at,
-                            accepted_at: Instant::now(),
+                            accepted_at: completed_at,
                         });
+
+                        if self.state.pending_durable_dispatches.len()
+                            == MAX_PENDING_DURABLE_DISPATCHES
+                        {
+                            self.state.require_durable_next_write = true;
+                        }
                     }
 
                     self.state.update_last_commit_end_lsn(metadata.commit_end_lsn);
@@ -1854,10 +1874,16 @@ where
                             ACTION_LABEL => "table_streaming",
                         );
                         for dispatch in self.state.pending_durable_dispatches.drain(..) {
-                            deferred_durable_histogram
-                                .record(dispatch.dispatched_at.elapsed().as_secs_f64());
-                            durable_wait_histogram
-                                .record(dispatch.accepted_at.elapsed().as_secs_f64());
+                            deferred_durable_histogram.record(
+                                completed_at
+                                    .saturating_duration_since(dispatch.dispatched_at)
+                                    .as_secs_f64(),
+                            );
+                            durable_wait_histogram.record(
+                                completed_at
+                                    .saturating_duration_since(dispatch.accepted_at)
+                                    .as_secs_f64(),
+                            );
                         }
                     }
 
@@ -1870,7 +1896,11 @@ where
                             ACTION_LABEL => "table_streaming",
                             CONFIRMATION_LABEL => "direct",
                         )
-                        .record(metadata.dispatched_at.elapsed().as_secs_f64());
+                        .record(
+                            completed_at
+                                .saturating_duration_since(metadata.dispatched_at)
+                                .as_secs_f64(),
+                        );
                     }
 
                     // We process the syncing tables with the last end lsn that the batch contains.
@@ -2046,10 +2076,17 @@ where
         let (events, event_count, streaming_payload_metadata) = event_batch.into_parts();
         // `Complete` is terminal, so no later write is guaranteed to settle an
         // `Accepted` result. Its final batch must confirm cumulative durability
-        // before the apply loop can complete.
-        let durability = match self.state.exit_intent {
-            Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
-            Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,
+        // before the apply loop can complete. The queue cap applies the same
+        // requirement to the next nonempty streaming write.
+        let require_durable_next_write =
+            event_count > 0 && std::mem::take(&mut self.state.require_durable_next_write);
+        let durability = if require_durable_next_write {
+            WriteEventsDurability::RequireDurable
+        } else {
+            match self.state.exit_intent {
+                Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
+                Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,
+            }
         };
         debug!(
             worker_type = %self.worker_context.worker_type(),

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -53,9 +53,10 @@ use crate::{
         ACTION_LABEL, COMMAND_TAG_LABEL, CONFIRMATION_LABEL,
         ETL_APPLY_LOOP_EFFECTIVE_FLUSH_LAG_BYTES, ETL_APPLY_LOOP_END_TO_END_LAG_BYTES,
         ETL_APPLY_LOOP_FLUSH_LAG_BYTES, ETL_APPLY_LOOP_RECEIVED_LAG_BYTES,
-        ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS, ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
-        ETL_DDL_SCHEMA_CHANGE_COLUMNS, ETL_DDL_SCHEMA_CHANGES_TOTAL, ETL_EVENTS_PROCESSED_TOTAL,
-        ETL_EVENTS_RECEIVED_TOTAL, ETL_REPLICATION_MESSAGES_TOTAL, ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
+        ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS, ETL_BATCH_ITEMS_DURABLE_WAIT_DURATION_SECONDS,
+        ETL_BATCH_ITEMS_SEND_DURATION_SECONDS, ETL_DDL_SCHEMA_CHANGE_COLUMNS,
+        ETL_DDL_SCHEMA_CHANGES_TOTAL, ETL_EVENTS_PROCESSED_TOTAL, ETL_EVENTS_RECEIVED_TOTAL,
+        ETL_REPLICATION_MESSAGES_TOTAL, ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
         ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL, ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
         ETL_SCHEMA_CLEANUPS_TOTAL, ETL_TRANSACTION_DURATION_SECONDS, ETL_TRANSACTION_SIZE,
         ETL_TRANSACTIONS_TOTAL, OUTCOME_LABEL, WORKER_TYPE_LABEL,
@@ -694,6 +695,15 @@ impl EventBatch {
     }
 }
 
+/// Timing anchors for one accepted-but-not-durable destination write.
+#[derive(Debug, Clone, Copy)]
+struct PendingDurableDispatch {
+    /// Instant at which the write was handed off to the destination.
+    dispatched_at: Instant,
+    /// Instant at which the apply loop processed the accepted result.
+    accepted_at: Instant,
+}
+
 /// Mutable runtime state that evolves throughout the apply loop.
 #[derive(Debug)]
 struct ApplyLoopState {
@@ -705,15 +715,14 @@ struct ApplyLoopState {
     /// commit end LSN is re-attached here so a later durable write can advance
     /// through it.
     last_commit_end_lsn: Option<PgLsn>,
-    /// Dispatch instants of accepted-but-not-durable destination writes.
+    /// Timing anchors of accepted-but-not-durable destination writes.
     ///
     /// A durable write result confirms all earlier accepted writes in the same
-    /// ordered apply-loop stream, so their durable write durations are
-    /// recorded once the next durable result arrives. The queue has no
-    /// explicit bound: the loop keeps at most one write in flight, so it
-    /// grows by at most one entry per completed write and drains at the
-    /// next durable result.
-    pending_durable_dispatches: VecDeque<Instant>,
+    /// ordered apply-loop stream, so their durable durations are recorded once
+    /// the next durable result arrives. The queue has no explicit bound: the
+    /// loop keeps at most one write in flight, so it grows by at most one
+    /// entry per completed write and drains at the next durable result.
+    pending_durable_dispatches: VecDeque<PendingDurableDispatch>,
     /// The LSN of the commit WAL entry of the transaction that is currently
     /// being processed.
     remote_final_lsn: Option<PgLsn>,
@@ -1817,11 +1826,14 @@ where
 
             match status {
                 DestinationWriteStatus::Accepted => {
-                    // Remember when this write was dispatched so its durable
-                    // write duration can be recorded once a later durable
-                    // result covers it.
+                    // Remember when this write was dispatched and accepted so
+                    // its durable durations can be recorded once a later
+                    // durable result covers it.
                     if metadata.event_count > 0 {
-                        self.state.pending_durable_dispatches.push_back(metadata.dispatched_at);
+                        self.state.pending_durable_dispatches.push_back(PendingDurableDispatch {
+                            dispatched_at: metadata.dispatched_at,
+                            accepted_at: Instant::now(),
+                        });
                     }
 
                     self.state.update_last_commit_end_lsn(metadata.commit_end_lsn);
@@ -1836,9 +1848,16 @@ where
                             ACTION_LABEL => "table_streaming",
                             CONFIRMATION_LABEL => "deferred",
                         );
-                        for dispatched_at in self.state.pending_durable_dispatches.drain(..) {
+                        let durable_wait_histogram = histogram!(
+                            ETL_BATCH_ITEMS_DURABLE_WAIT_DURATION_SECONDS,
+                            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+                            ACTION_LABEL => "table_streaming",
+                        );
+                        for dispatch in self.state.pending_durable_dispatches.drain(..) {
                             deferred_durable_histogram
-                                .record(dispatched_at.elapsed().as_secs_f64());
+                                .record(dispatch.dispatched_at.elapsed().as_secs_f64());
+                            durable_wait_histogram
+                                .record(dispatch.accepted_at.elapsed().as_secs_f64());
                         }
                     }
 

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -8,7 +8,7 @@
 //! cycle.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     future::Future,
     pin::Pin,
     str::FromStr,
@@ -50,9 +50,10 @@ use crate::{
     etl_error,
     event::{Event, RelationEvent},
     observability::{
-        ACTION_LABEL, COMMAND_TAG_LABEL, ETL_APPLY_LOOP_EFFECTIVE_FLUSH_LAG_BYTES,
-        ETL_APPLY_LOOP_END_TO_END_LAG_BYTES, ETL_APPLY_LOOP_FLUSH_LAG_BYTES,
-        ETL_APPLY_LOOP_RECEIVED_LAG_BYTES, ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
+        ACTION_LABEL, COMMAND_TAG_LABEL, CONFIRMATION_LABEL,
+        ETL_APPLY_LOOP_EFFECTIVE_FLUSH_LAG_BYTES, ETL_APPLY_LOOP_END_TO_END_LAG_BYTES,
+        ETL_APPLY_LOOP_FLUSH_LAG_BYTES, ETL_APPLY_LOOP_RECEIVED_LAG_BYTES,
+        ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS, ETL_BATCH_ITEMS_SEND_DURATION_SECONDS,
         ETL_DDL_SCHEMA_CHANGE_COLUMNS, ETL_DDL_SCHEMA_CHANGES_TOTAL, ETL_EVENTS_PROCESSED_TOTAL,
         ETL_EVENTS_RECEIVED_TOTAL, ETL_REPLICATION_MESSAGES_TOTAL, ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
         ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL, ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
@@ -704,6 +705,14 @@ struct ApplyLoopState {
     /// commit end LSN is re-attached here so a later durable write can advance
     /// through it.
     last_commit_end_lsn: Option<PgLsn>,
+    /// Dispatch instants of accepted-but-not-durable destination writes.
+    ///
+    /// A durable write result confirms all earlier accepted writes in the same
+    /// ordered apply-loop stream, so their durable write durations are
+    /// recorded once the next durable result arrives. The queue is bounded
+    /// because deferred destinations must bound their accepted-but-not-durable
+    /// work.
+    pending_durable_dispatches: VecDeque<Instant>,
     /// The LSN of the commit WAL entry of the transaction that is currently
     /// being processed.
     remote_final_lsn: Option<PgLsn>,
@@ -770,6 +779,7 @@ impl ApplyLoopState {
     ) -> Self {
         Self {
             last_commit_end_lsn: None,
+            pending_durable_dispatches: VecDeque::new(),
             remote_final_lsn: None,
             replication_progress,
             replication_lag_metrics,
@@ -1806,9 +1816,43 @@ where
 
             match status {
                 DestinationWriteStatus::Accepted => {
+                    // Remember when this write was dispatched so its durable
+                    // write duration can be recorded once a later durable
+                    // result covers it.
+                    if metadata.event_count > 0 {
+                        self.state.pending_durable_dispatches.push_back(metadata.dispatched_at);
+                    }
+
                     self.state.update_last_commit_end_lsn(metadata.commit_end_lsn);
                 }
                 DestinationWriteStatus::Durable => {
+                    // A durable result also confirms every earlier accepted
+                    // write in the same ordered apply-loop stream.
+                    if !self.state.pending_durable_dispatches.is_empty() {
+                        let deferred_durable_histogram = histogram!(
+                            ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS,
+                            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+                            ACTION_LABEL => "table_streaming",
+                            CONFIRMATION_LABEL => "deferred",
+                        );
+                        for dispatched_at in self.state.pending_durable_dispatches.drain(..) {
+                            deferred_durable_histogram
+                                .record(dispatched_at.elapsed().as_secs_f64());
+                        }
+                    }
+
+                    // Empty durability barriers carry no items, so only writes
+                    // with items are recorded for the current result.
+                    if metadata.event_count > 0 {
+                        histogram!(
+                            ETL_BATCH_ITEMS_DURABLE_DURATION_SECONDS,
+                            WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
+                            ACTION_LABEL => "table_streaming",
+                            CONFIRMATION_LABEL => "direct",
+                        )
+                        .record(metadata.dispatched_at.elapsed().as_secs_f64());
+                    }
+
                     // We process the syncing tables with the last end lsn that the batch contains.
                     //
                     // Note that it could be that there is no end lsn for a specific batch, which

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -721,12 +721,10 @@ struct ApplyLoopState {
     ///
     /// A durable write result confirms all earlier accepted writes in the same
     /// ordered apply-loop stream, so their durable durations are recorded once
-    /// the next durable result arrives. The queue is capped and the next
-    /// nonempty write becomes a cumulative durability barrier when the cap is
-    /// reached, so no timing entries are dropped.
+    /// the next durable result arrives. The queue is capped at
+    /// [`MAX_PENDING_DURABLE_DISPATCHES`]. Timing entries are metric-only
+    /// state, so overflow skips new entries instead of affecting replication.
     pending_durable_dispatches: VecDeque<PendingDurableDispatch>,
-    /// Whether the next nonempty streaming write must confirm cumulative durability.
-    require_durable_next_write: bool,
     /// The LSN of the commit WAL entry of the transaction that is currently
     /// being processed.
     remote_final_lsn: Option<PgLsn>,
@@ -794,7 +792,6 @@ impl ApplyLoopState {
         Self {
             last_commit_end_lsn: None,
             pending_durable_dispatches: VecDeque::new(),
-            require_durable_next_write: false,
             remote_final_lsn: None,
             replication_progress,
             replication_lag_metrics,
@@ -1833,26 +1830,25 @@ where
                 DestinationWriteStatus::Accepted => {
                     // Remember when this write was dispatched and accepted so
                     // its durable durations can be recorded once a later
-                    // durable result covers it.
+                    // durable result covers it. The queue is metric-only
+                    // state, so overflow must never fail the apply loop; the
+                    // write's samples are skipped instead.
                     if metadata.event_count > 0 {
                         if self.state.pending_durable_dispatches.len()
-                            >= MAX_PENDING_DURABLE_DISPATCHES
+                            < MAX_PENDING_DURABLE_DISPATCHES
                         {
-                            bail!(
-                                ErrorKind::DestinationError,
-                                "Destination exceeded the pending durability queue limit"
+                            self.state.pending_durable_dispatches.push_back(
+                                PendingDurableDispatch {
+                                    dispatched_at: metadata.dispatched_at,
+                                    accepted_at: completed_at,
+                                },
                             );
-                        }
-
-                        self.state.pending_durable_dispatches.push_back(PendingDurableDispatch {
-                            dispatched_at: metadata.dispatched_at,
-                            accepted_at: completed_at,
-                        });
-
-                        if self.state.pending_durable_dispatches.len()
-                            == MAX_PENDING_DURABLE_DISPATCHES
-                        {
-                            self.state.require_durable_next_write = true;
+                        } else {
+                            warn!(
+                                pending_durable_dispatches = MAX_PENDING_DURABLE_DISPATCHES,
+                                "pending durable dispatch queue is full, skipping durable \
+                                 duration samples for this write",
+                            );
                         }
                     }
 
@@ -2076,17 +2072,10 @@ where
         let (events, event_count, streaming_payload_metadata) = event_batch.into_parts();
         // `Complete` is terminal, so no later write is guaranteed to settle an
         // `Accepted` result. Its final batch must confirm cumulative durability
-        // before the apply loop can complete. The queue cap applies the same
-        // requirement to the next nonempty streaming write.
-        let require_durable_next_write =
-            event_count > 0 && std::mem::take(&mut self.state.require_durable_next_write);
-        let durability = if require_durable_next_write {
-            WriteEventsDurability::RequireDurable
-        } else {
-            match self.state.exit_intent {
-                Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
-                Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,
-            }
+        // before the apply loop can complete.
+        let durability = match self.state.exit_intent {
+            Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
+            Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,
         };
         debug!(
             worker_type = %self.worker_context.worker_type(),


### PR DESCRIPTION
Add the `etl_batch_items_durable_duration_seconds` histogram. It measures the time from batch dispatch until the destination confirms the batch durable.

The existing send-duration metric records the time until the write result completes. Deferred destinations complete with `Accepted` before the data is durable. Synchronous destinations complete with `Durable`. The two groups report different quantities, so a per-destination latency comparison of that metric is biased.

The apply loop now stores the dispatch instant of each accepted write. A later durable result covers all earlier accepted writes in the same ordered stream. The loop records one sample per covered write with `confirmation="deferred"`, and one sample for the durable write itself with `confirmation="direct"`.

Empty durability barriers are not recorded. The metric covers streaming writes only. Table-copy writes settle at a table-wide barrier and are out of scope here.