### PR TITLE
feat(snowflake): add append observability metrics

### DIFF
--- a/crates/etl-destinations/src/snowflake/error.rs
+++ b/crates/etl-destinations/src/snowflake/error.rs
@@ -35,6 +35,65 @@ pub enum Error {
     SchemaNotFound { database: String, schema: String },
 }
 
+/// Stable, low-cardinality classification for a failed Snowpipe append.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AppendFailureType {
+    /// Authentication or token refresh failed.
+    Authentication,
+    /// The HTTP request failed before Snowflake returned a response.
+    Transport,
+    /// Snowflake returned an unsuccessful HTTP or SQL response.
+    Provider,
+    /// Snowpipe returned a structured API failure.
+    SnowpipeApi,
+    /// Channel state or lifecycle validation failed.
+    Channel,
+    /// Request or response encoding failed.
+    Encoding,
+    /// Destination configuration is invalid or incomplete.
+    Configuration,
+}
+
+impl AppendFailureType {
+    /// Returns the stable metric label value for this failure type.
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Authentication => "authentication",
+            Self::Transport => "transport",
+            Self::Provider => "provider",
+            Self::SnowpipeApi => "snowpipe_api",
+            Self::Channel => "channel",
+            Self::Encoding => "encoding",
+            Self::Configuration => "configuration",
+        }
+    }
+}
+
+impl Error {
+    /// Classifies this error for append-failure metrics.
+    pub(super) const fn append_failure_type(&self) -> AppendFailureType {
+        match self {
+            Self::HttpTransport(_) => AppendFailureType::Transport,
+            Self::HttpStatus { .. } | Self::Sql { .. } => AppendFailureType::Provider,
+            Self::Auth(_) | Self::Snowpipe(SnowpipeError::AuthenticationExpired) => {
+                AppendFailureType::Authentication
+            }
+            Self::Snowpipe(
+                SnowpipeError::StaleContinuation
+                | SnowpipeError::ChannelHasUncommittedRows
+                | SnowpipeError::ChannelNotFound,
+            )
+            | Self::Channel(_) => AppendFailureType::Channel,
+            Self::Snowpipe(SnowpipeError::ApiStatus { .. }) => AppendFailureType::SnowpipeApi,
+            Self::Snowpipe(SnowpipeError::HttpStatus { .. }) => AppendFailureType::Provider,
+            Self::Encoding(_) => AppendFailureType::Encoding,
+            Self::Config(_) | Self::DatabaseNotFound(_) | Self::SchemaNotFound { .. } => {
+                AppendFailureType::Configuration
+            }
+        }
+    }
+}
+
 impl From<Error> for EtlError {
     fn from(err: Error) -> Self {
         let (kind, description) = match &err {

--- a/crates/etl-destinations/src/snowflake/metrics.rs
+++ b/crates/etl-destinations/src/snowflake/metrics.rs
@@ -7,6 +7,13 @@ static REGISTER_METRICS: Once = Once::new();
 pub(super) const ETL_SNOWFLAKE_BATCH_SIZE: &str = "etl_snowflake_batch_size";
 pub(super) const ETL_SNOWFLAKE_BATCH_BYTES: &str = "etl_snowflake_batch_bytes";
 pub(super) const ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL: &str = "etl_snowflake_insert_errors_total";
+pub(super) const ETL_SNOWFLAKE_APPEND_DURATION_SECONDS: &str =
+    "etl_snowflake_append_duration_seconds";
+pub(super) const ETL_SNOWFLAKE_ACCEPTED_BATCHES_TOTAL: &str =
+    "etl_snowflake_accepted_batches_total";
+pub(super) const ETL_SNOWFLAKE_ACCEPTED_ROWS_TOTAL: &str = "etl_snowflake_accepted_rows_total";
+pub(super) const ETL_SNOWFLAKE_REJECTED_ROWS_TOTAL: &str = "etl_snowflake_rejected_rows_total";
+pub(super) const FAILURE_TYPE_LABEL: &str = "failure_type";
 pub(super) const ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL: &str =
     "etl_snowflake_channel_recoveries_total";
 pub(super) const ETL_SNOWFLAKE_STREAMING_PENDING_BYTES: &str =
@@ -33,7 +40,33 @@ pub(super) fn register_metrics() {
         describe_counter!(
             ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL,
             Unit::Count,
-            "Total insert_rows errors from Snowpipe Streaming"
+            "Total failed Snowpipe append operations, labeled by failure_type."
+        );
+
+        describe_histogram!(
+            ETL_SNOWFLAKE_APPEND_DURATION_SECONDS,
+            Unit::Seconds,
+            "Duration of one Snowpipe append operation, including authentication refresh, \
+             retries, and stale-channel recovery."
+        );
+
+        describe_counter!(
+            ETL_SNOWFLAKE_ACCEPTED_BATCHES_TOTAL,
+            Unit::Count,
+            "Total row batches newly accepted by Snowflake; acceptance does not prove durability."
+        );
+
+        describe_counter!(
+            ETL_SNOWFLAKE_ACCEPTED_ROWS_TOTAL,
+            Unit::Count,
+            "Total rows in batches newly accepted by Snowflake; acceptance does not prove \
+             durability."
+        );
+
+        describe_counter!(
+            ETL_SNOWFLAKE_REJECTED_ROWS_TOTAL,
+            Unit::Count,
+            "Total rows newly reported as rejected by Snowflake channel status."
         );
 
         describe_counter!(

--- a/crates/etl-destinations/src/snowflake/streaming/channel.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/channel.rs
@@ -8,8 +8,10 @@ use tracing::warn;
 use crate::snowflake::{
     Error, OffsetToken, Result, RowBatch, SnowpipeError, StreamClient,
     metrics::{
-        ETL_SNOWFLAKE_BATCH_BYTES, ETL_SNOWFLAKE_BATCH_SIZE,
+        ETL_SNOWFLAKE_ACCEPTED_BATCHES_TOTAL, ETL_SNOWFLAKE_ACCEPTED_ROWS_TOTAL,
+        ETL_SNOWFLAKE_APPEND_DURATION_SECONDS, ETL_SNOWFLAKE_BATCH_BYTES, ETL_SNOWFLAKE_BATCH_SIZE,
         ETL_SNOWFLAKE_CHANNEL_RECOVERIES_TOTAL, ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL,
+        ETL_SNOWFLAKE_REJECTED_ROWS_TOTAL, FAILURE_TYPE_LABEL,
     },
     streaming::ChannelStatusResponse,
 };
@@ -159,16 +161,24 @@ struct ChannelProgress {
     committed_offset: Option<OffsetToken>,
     /// Cumulative inserted rows reported by Snowflake.
     rows_inserted: u64,
-    /// Cumulative row errors reported by Snowflake.
-    rows_error_count: u64,
+    /// Last cumulative row-error count observed in this process.
+    rows_error_count: Option<u64>,
 }
 
 impl ChannelProgress {
     /// Updates progress from a channel status response.
     fn observe(&mut self, status: &ChannelStatusResponse) {
+        if let Some(previous_rows_error_count) = self.rows_error_count
+            && let Some(rejected_rows) =
+                status.rows_error_count.checked_sub(previous_rows_error_count)
+            && rejected_rows > 0
+        {
+            counter!(ETL_SNOWFLAKE_REJECTED_ROWS_TOTAL).increment(rejected_rows);
+        }
+
         self.committed_offset = status.offset_token.clone();
         self.rows_inserted = status.rows_inserted;
-        self.rows_error_count = status.rows_error_count;
+        self.rows_error_count = Some(status.rows_error_count);
     }
 
     /// Returns whether `offset` has already committed.
@@ -536,6 +546,32 @@ impl<C: StreamClient> ChannelHandle<C> {
             return Ok(BatchAcceptance::AlreadyCommitted);
         }
 
+        let started_at = Instant::now();
+        let result = self.accept_batch_inner(batch).await;
+
+        histogram!(ETL_SNOWFLAKE_APPEND_DURATION_SECONDS)
+            .record(started_at.elapsed().as_secs_f64());
+
+        match &result {
+            Ok(BatchAcceptance::Accepted(accepted)) => {
+                counter!(ETL_SNOWFLAKE_ACCEPTED_BATCHES_TOTAL).increment(1);
+                counter!(ETL_SNOWFLAKE_ACCEPTED_ROWS_TOTAL).increment(accepted.rows);
+            }
+            Ok(BatchAcceptance::AlreadyCommitted) => {}
+            Err(error) => {
+                counter!(
+                    ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL,
+                    FAILURE_TYPE_LABEL => error.append_failure_type().as_str(),
+                )
+                .increment(1);
+            }
+        }
+
+        result
+    }
+
+    /// Performs one logical append after cached replay filtering.
+    async fn accept_batch_inner(&mut self, batch: &RowBatch) -> Result<BatchAcceptance> {
         if self.progress.is_committed(batch.start_offset()) {
             return Err(Error::Channel(format!(
                 "Snowflake batch {}..={} overlaps committed offset {:?}; replay filtering should \
@@ -547,7 +583,7 @@ impl<C: StreamClient> ChannelHandle<C> {
         }
 
         let baseline_rows_inserted = self.progress.rows_inserted;
-        let baseline_rows_error_count = self.progress.rows_error_count;
+        let baseline_rows_error_count = self.progress.rows_error_count.unwrap_or_default();
 
         histogram!(ETL_SNOWFLAKE_BATCH_SIZE).record(batch.row_count() as f64);
         histogram!(ETL_SNOWFLAKE_BATCH_BYTES).record(batch.size() as f64);
@@ -602,7 +638,7 @@ impl<C: StreamClient> ChannelHandle<C> {
                 }
 
                 let baseline_rows_inserted = self.progress.rows_inserted;
-                let baseline_rows_error_count = self.progress.rows_error_count;
+                let baseline_rows_error_count = self.progress.rows_error_count.unwrap_or_default();
                 self.append_batch(batch).await?;
 
                 Ok(BatchAcceptance::Accepted(AcceptedRowBatch::from_row_batch(
@@ -611,10 +647,7 @@ impl<C: StreamClient> ChannelHandle<C> {
                     baseline_rows_error_count,
                 )?))
             }
-            Err(error) => {
-                counter!(ETL_SNOWFLAKE_INSERT_ERRORS_TOTAL).increment(1);
-                Err(error)
-            }
+            Err(error) => Err(error),
         }
     }
 


### PR DESCRIPTION
## Summary

- record logical Snowpipe append latency and newly accepted batch/row totals
- classify terminal append failures with stable, low-cardinality labels
- export positive rejected-row deltas from cumulative channel status