### PR TITLE
feat(api): Add selector and tolerations config

### DIFF
--- a/crates/etl-api/README.md
+++ b/crates/etl-api/README.md
@@ -85,6 +85,13 @@ replicator and Vector containers:
 
 ```yaml
 k8s:
+  replicator_node_selectors:
+    - key: example.com/node-pool
+      value: data
+  replicator_tolerations:
+    - key: example.com/node-pool
+      value: data
+      effect: NoSchedule
   replicator_resources:
     cpu_request_millicores: 500
     memory_request_mib: 2000
@@ -96,6 +103,14 @@ k8s:
     cpu_request_millicores: 75
     memory_request_mib: 192
 ```
+
+`replicator_node_selectors` and `replicator_tolerations` are optional and passed
+through independently to generated replicator Pods. When omitted, replicators
+do not receive scheduling constraints from the ETL API. The ETL API does not
+validate that selectors and tolerations correspond to one another or to
+available cluster nodes. Replicator tolerations always use Kubernetes'
+`Equal` operator; selector `key` and `value` and toleration `key`, `value`, and
+`effect` are passed through unchanged.
 
 The global replicator and Vector defaults are mandatory and request-only.
 Destination defaults are optional and may override either request field for

--- a/crates/etl-api/README.md
+++ b/crates/etl-api/README.md
@@ -35,6 +35,15 @@ Before running the API, you must have:
 
 - A running Postgres instance reachable via `DATABASE_URL`.
 - The `etl-api` database schema applied (SQLx migrations).
+- An active Kubernetes cluster accessible through the runtime's default
+  Kubernetes client configuration. Local development uses the `orbstack`
+  context.
+- The configured replicator namespace and ServiceAccount already created in
+  that cluster.
+
+ETL API validates its Kubernetes connection and shared prerequisites during
+startup. It exits instead of serving requests when Kubernetes initialization or
+preflight validation fails.
 
 For the full local development stack, use the setup script to start Postgres,
 run migrations, and apply the local Kubernetes resources.
@@ -85,6 +94,8 @@ replicator and Vector containers:
 
 ```yaml
 k8s:
+  replicator_namespace: etl-data-plane
+  replicator_service_account_name: etl-replicator
   replicator_node_selectors:
     - key: example.com/node-pool
       value: data
@@ -99,10 +110,16 @@ k8s:
       ducklake:
         cpu_request_millicores: 1000
         memory_request_mib: 4000
+  vector_image: timberio/vector:0.55.0-distroless-libc
   vector_resources:
     cpu_request_millicores: 75
     memory_request_mib: 192
 ```
+
+`replicator_namespace` controls where all generated replicator StatefulSets,
+ConfigMaps, Secrets, and DuckLake maintenance resources are created.
+`replicator_service_account_name` is assigned to generated replicator Pods, and
+`vector_image` selects the Vector sidecar image.
 
 `replicator_node_selectors` and `replicator_tolerations` are optional and passed
 through independently to generated replicator Pods. When omitted, replicators

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -52,6 +52,12 @@ pub struct ApiConfig {
 /// Kubernetes-specific API configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct K8sConfig {
+    /// Node selector applied to every replicator pod.
+    #[serde(default)]
+    pub replicator_node_selectors: Vec<NodeSelectorConfig>,
+    /// Tolerations applied to every replicator pod.
+    #[serde(default)]
+    pub replicator_tolerations: Vec<TolerationConfig>,
     /// Default request sizing for replicator workloads.
     ///
     /// This key remains `replicator_resources` in API configuration files. It
@@ -61,6 +67,26 @@ pub struct K8sConfig {
     pub replicator_resources: DefaultReplicatorResourcesConfig,
     /// Default request sizing for the Vector sidecar.
     pub vector_resources: DefaultVectorResourcesConfig,
+}
+
+/// Simplified Kubernetes node selector configuration.
+///
+/// The ETL API passes these strings through without validation.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct NodeSelectorConfig {
+    pub key: String,
+    pub value: String,
+}
+
+/// Simplified Kubernetes toleration configuration.
+///
+/// The ETL API passes these strings through without validation and emits an
+/// `Equal` toleration operator.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct TolerationConfig {
+    pub key: String,
+    pub value: String,
+    pub effect: String,
 }
 
 /// Mandatory default request sizing for replicator workloads.
@@ -414,6 +440,55 @@ mod tests {
                 cpu_request_millicores: 500,
             }
         );
+    }
+
+    #[test]
+    fn replicator_scheduling_constraints_are_optional_and_independent() {
+        let unpinned: K8sConfig = serde_json::from_value(json!({
+            "replicator_resources": {
+                "memory_request_mib": 2000,
+                "cpu_request_millicores": 500
+            },
+            "vector_resources": {
+                "memory_request_mib": 192,
+                "cpu_request_millicores": 75
+            }
+        }))
+        .unwrap();
+        assert!(unpinned.replicator_node_selectors.is_empty());
+        assert!(unpinned.replicator_tolerations.is_empty());
+
+        let configured: K8sConfig = serde_json::from_value(json!({
+            "replicator_node_selectors": [{
+                "key": "example.com/node-pool",
+                "value": "data"
+            }, {
+                "key": "kubernetes.io/arch",
+                "value": "arm64"
+            }],
+            "replicator_tolerations": [{
+                "key": "example.com/dedicated",
+                "value": "analytics",
+                "effect": "CustomEffect"
+            }],
+            "replicator_resources": {
+                "memory_request_mib": 2000,
+                "cpu_request_millicores": 500
+            },
+            "vector_resources": {
+                "memory_request_mib": 192,
+                "cpu_request_millicores": 75
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(configured.replicator_node_selectors[0].key, "example.com/node-pool");
+        assert_eq!(configured.replicator_node_selectors[0].value, "data");
+        assert_eq!(configured.replicator_node_selectors[1].key, "kubernetes.io/arch");
+        assert_eq!(configured.replicator_node_selectors[1].value, "arm64");
+        assert_eq!(configured.replicator_tolerations[0].key, "example.com/dedicated");
+        assert_eq!(configured.replicator_tolerations[0].value, "analytics");
+        assert_eq!(configured.replicator_tolerations[0].effect, "CustomEffect");
     }
 
     #[test]

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -52,6 +52,12 @@ pub struct ApiConfig {
 /// Kubernetes-specific API configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct K8sConfig {
+    /// Namespace where all per-replicator Kubernetes resources are created.
+    #[serde(default = "default_replicator_namespace")]
+    pub replicator_namespace: String,
+    /// ServiceAccount assigned to every replicator pod.
+    #[serde(default = "default_replicator_service_account_name")]
+    pub replicator_service_account_name: String,
     /// Node selector applied to every replicator pod.
     #[serde(default)]
     pub replicator_node_selectors: Vec<NodeSelectorConfig>,
@@ -65,8 +71,23 @@ pub struct K8sConfig {
     /// replicator pod unless a destination-kind default or pipeline-level
     /// override supplies one of those request values.
     pub replicator_resources: DefaultReplicatorResourcesConfig,
+    /// Vector image used by the logging sidecar.
+    #[serde(default = "default_vector_image")]
+    pub vector_image: String,
     /// Default request sizing for the Vector sidecar.
     pub vector_resources: DefaultVectorResourcesConfig,
+}
+
+fn default_replicator_namespace() -> String {
+    "etl-data-plane".to_owned()
+}
+
+fn default_replicator_service_account_name() -> String {
+    "etl-replicator".to_owned()
+}
+
+fn default_vector_image() -> String {
+    "timberio/vector:0.55.0-distroless-libc".to_owned()
 }
 
 /// Simplified Kubernetes node selector configuration.
@@ -455,10 +476,15 @@ mod tests {
             }
         }))
         .unwrap();
+        assert_eq!(unpinned.replicator_namespace, "etl-data-plane");
+        assert_eq!(unpinned.replicator_service_account_name, "etl-replicator");
         assert!(unpinned.replicator_node_selectors.is_empty());
         assert!(unpinned.replicator_tolerations.is_empty());
+        assert_eq!(unpinned.vector_image, "timberio/vector:0.55.0-distroless-libc");
 
         let configured: K8sConfig = serde_json::from_value(json!({
+            "replicator_namespace": "custom-data-plane",
+            "replicator_service_account_name": "custom-replicator",
             "replicator_node_selectors": [{
                 "key": "example.com/node-pool",
                 "value": "data"
@@ -471,6 +497,7 @@ mod tests {
                 "value": "analytics",
                 "effect": "CustomEffect"
             }],
+            "vector_image": "example.com/vector:custom",
             "replicator_resources": {
                 "memory_request_mib": 2000,
                 "cpu_request_millicores": 500
@@ -482,6 +509,8 @@ mod tests {
         }))
         .unwrap();
 
+        assert_eq!(configured.replicator_namespace, "custom-data-plane");
+        assert_eq!(configured.replicator_service_account_name, "custom-replicator");
         assert_eq!(configured.replicator_node_selectors[0].key, "example.com/node-pool");
         assert_eq!(configured.replicator_node_selectors[0].value, "data");
         assert_eq!(configured.replicator_node_selectors[1].key, "kubernetes.io/arch");
@@ -489,6 +518,7 @@ mod tests {
         assert_eq!(configured.replicator_tolerations[0].key, "example.com/dedicated");
         assert_eq!(configured.replicator_tolerations[0].value, "analytics");
         assert_eq!(configured.replicator_tolerations[0].effect, "CustomEffect");
+        assert_eq!(configured.vector_image, "example.com/vector:custom");
     }
 
     #[test]

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -251,14 +251,10 @@ pub async fn should_reconcile_replicator_resources(
 
 /// Returns `true` when the replicator is active in Kubernetes.
 pub async fn is_replicator_active(
-    k8s_client: Option<&dyn K8sClient>,
+    k8s_client: &dyn K8sClient,
     tenant_id: &str,
     replicator_id: i64,
 ) -> Result<bool, K8sCoreError> {
-    let Some(k8s_client) = k8s_client else {
-        return Ok(false);
-    };
-
     let prefix = create_k8s_object_prefix(tenant_id, replicator_id);
     let pod_status = k8s_client.get_replicator_pod_status(&prefix).await?;
 
@@ -275,7 +271,7 @@ pub async fn is_replicator_active(
 /// Returns the first active pipeline id, if any pipeline is currently active in
 /// Kubernetes.
 pub async fn first_active_pipeline_id(
-    k8s_client: Option<&dyn K8sClient>,
+    k8s_client: &dyn K8sClient,
     tenant_id: &str,
     pipelines: &[PipelineDeletion],
 ) -> Result<Option<i64>, K8sCoreError> {
@@ -853,7 +849,7 @@ mod tests {
         let pipeline =
             PipelineDeletion { id: 1, source_id: 2, destination_id: 3, replicator_id: 4 };
 
-        let is_active = is_replicator_active(Some(&client), "tenant-42", pipeline.replicator_id)
+        let is_active = is_replicator_active(&client, "tenant-42", pipeline.replicator_id)
             .await
             .expect("failed to inspect pipeline status");
 

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -249,6 +249,8 @@ fn test_k8s_config(environment: &Environment) -> K8sConfig {
         _ => (250, 125),
     };
     K8sConfig {
+        replicator_node_selectors: Default::default(),
+        replicator_tolerations: Default::default(),
         replicator_resources: DefaultReplicatorResourcesConfig {
             memory_request_mib,
             cpu_request_millicores,
@@ -759,7 +761,8 @@ impl K8sClient for HttpK8sClient {
             request.log_level,
         );
 
-        let node_selector = create_node_selector_json(&environment);
+        let node_selector = node_selector_json(&self.k8s_config.replicator_node_selectors);
+        let tolerations = tolerations_json(&self.k8s_config.replicator_tolerations);
         let init_containers =
             create_init_containers_json(prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(prefix, &environment);
@@ -773,6 +776,7 @@ impl K8sClient for HttpK8sClient {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -1399,14 +1403,39 @@ fn create_container_environment_json(
     container_environment
 }
 
+#[cfg(test)]
 fn create_node_selector_json(environment: &Environment) -> serde_json::Value {
-    // In staging and prod, pin pods to workload pods.
-    match environment {
-        Environment::Dev => json!({}),
-        Environment::Staging | Environment::Prod => json!({
-            "etl.supabase.com/node-role": "workloads"
-        }),
-    }
+    node_selector_json(&test_k8s_config(environment).replicator_node_selectors)
+}
+
+fn node_selector_json(selectors: &[crate::config::NodeSelectorConfig]) -> serde_json::Value {
+    json!(
+        selectors
+            .iter()
+            .map(|selector| (selector.key.clone(), selector.value.clone()))
+            .collect::<BTreeMap<_, _>>()
+    )
+}
+
+#[cfg(test)]
+fn create_tolerations_json(environment: &Environment) -> serde_json::Value {
+    tolerations_json(&test_k8s_config(environment).replicator_tolerations)
+}
+
+fn tolerations_json(tolerations: &[crate::config::TolerationConfig]) -> serde_json::Value {
+    serde_json::Value::Array(
+        tolerations
+            .iter()
+            .map(|toleration| {
+                json!({
+                    "key": toleration.key,
+                    "operator": "Equal",
+                    "value": toleration.value,
+                    "effect": toleration.effect,
+                })
+            })
+            .collect(),
+    )
 }
 
 fn create_init_containers_json(
@@ -1667,6 +1696,7 @@ fn create_replicator_stateful_set_json(
     replicator_image: &str,
     container_environment: Vec<serde_json::Value>,
     node_selector: serde_json::Value,
+    tolerations: serde_json::Value,
     init_containers: serde_json::Value,
     volumes: Vec<serde_json::Value>,
     volume_mounts: Vec<serde_json::Value>,
@@ -1716,15 +1746,7 @@ fn create_replicator_stateful_set_json(
               }
             },
             "volumes": volumes,
-            // Allow scheduling onto nodes tainted with the right node role.
-            "tolerations": [
-              {
-                "key": "etl.supabase.com/node-role",
-                "operator": "Equal",
-                "value": "workloads",
-                "effect": "NoSchedule"
-              }
-            ],
+            "tolerations": tolerations,
             "nodeSelector": node_selector,
             // We want to wait at most 5 minutes before K8S sends a `SIGKILL` to the containers,
             // this way we let the system finish any in-flight transaction, if there are any.
@@ -1989,6 +2011,8 @@ mod tests {
             memory_limit_mib: Some(-1),
         };
         let k8s_config = K8sConfig {
+            replicator_node_selectors: Default::default(),
+            replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: -10,
                 memory_request_mib: 0,
@@ -2047,6 +2071,8 @@ mod tests {
     #[test]
     fn test_replicator_resource_config_uses_api_vector_resources() {
         let k8s_config = K8sConfig {
+            replicator_node_selectors: Default::default(),
+            replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: 500,
                 memory_request_mib: 500,
@@ -2109,6 +2135,7 @@ mod tests {
             LogLevel::Info,
         );
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -2200,6 +2227,7 @@ mod tests {
                     replicator_image,
                     container_environment,
                     node_selector,
+                    tolerations,
                     init_containers,
                     volumes,
                     volume_mounts,
@@ -2249,6 +2277,8 @@ mod tests {
             },
         )]);
         let k8s_config = K8sConfig {
+            replicator_node_selectors: Default::default(),
+            replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: 300,
                 memory_request_mib: 400,
@@ -2772,6 +2802,74 @@ mod tests {
     }
 
     #[test]
+    fn replicator_stateful_set_applies_optional_scheduling_constraints() {
+        let resources =
+            ReplicatorStatefulSetResourcesConfig::for_environment(&Environment::Dev).unwrap();
+        let create_stateful_set = |node_selector, tolerations| {
+            create_replicator_stateful_set_json(
+                "tenant-1-42",
+                "tenant-1",
+                42,
+                "tenant-1-42-replicator",
+                "example.com/replicator:latest",
+                Vec::new(),
+                node_selector,
+                tolerations,
+                json!([]),
+                Vec::new(),
+                Vec::new(),
+                &resources,
+            )
+        };
+
+        let unpinned = create_stateful_set(json!({}), json!([]));
+        assert_eq!(unpinned.pointer("/spec/template/spec/nodeSelector"), Some(&json!({})));
+        assert_eq!(unpinned.pointer("/spec/template/spec/tolerations"), Some(&json!([])));
+
+        let configured = create_stateful_set(
+            node_selector_json(&[
+                crate::config::NodeSelectorConfig {
+                    key: "example.com/node-pool".to_owned(),
+                    value: "data".to_owned(),
+                },
+                crate::config::NodeSelectorConfig {
+                    key: "kubernetes.io/arch".to_owned(),
+                    value: "arm64".to_owned(),
+                },
+            ]),
+            tolerations_json(&[crate::config::TolerationConfig {
+                key: "example.com/dedicated".to_owned(),
+                value: "analytics".to_owned(),
+                effect: "CustomEffect".to_owned(),
+            }]),
+        );
+        assert_eq!(
+            configured.pointer("/spec/template/spec/nodeSelector/example.com~1node-pool"),
+            Some(&json!("data"))
+        );
+        assert_eq!(
+            configured.pointer("/spec/template/spec/nodeSelector/kubernetes.io~1arch"),
+            Some(&json!("arm64"))
+        );
+        assert_eq!(
+            configured.pointer("/spec/template/spec/tolerations/0/key"),
+            Some(&json!("example.com/dedicated"))
+        );
+        assert_eq!(
+            configured.pointer("/spec/template/spec/tolerations/0/operator"),
+            Some(&json!("Equal"))
+        );
+        assert_eq!(
+            configured.pointer("/spec/template/spec/tolerations/0/value"),
+            Some(&json!("analytics"))
+        );
+        assert_eq!(
+            configured.pointer("/spec/template/spec/tolerations/0/effect"),
+            Some(&json!("CustomEffect"))
+        );
+    }
+
+    #[test]
     fn test_create_init_containers() {
         let prefix = create_k8s_object_prefix(TENANT_ID, 42);
 
@@ -2850,6 +2948,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -2863,6 +2962,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -2892,6 +2992,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -2905,6 +3006,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -2934,6 +3036,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -2947,6 +3050,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -2983,6 +3087,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -2996,6 +3101,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -3025,6 +3131,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -3038,6 +3145,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -3067,6 +3175,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -3080,6 +3189,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -3116,6 +3226,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -3129,6 +3240,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -3158,6 +3270,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -3171,6 +3284,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,
@@ -3200,6 +3314,7 @@ mod tests {
         );
 
         let node_selector = create_node_selector_json(&environment);
+        let tolerations = create_tolerations_json(&environment);
         let init_containers =
             create_init_containers_json(&prefix, &environment, &stateful_set_resources);
         let volumes = create_volumes_json(&prefix, &environment);
@@ -3213,6 +3328,7 @@ mod tests {
             replicator_image,
             container_environment,
             node_selector,
+            tolerations,
             init_containers,
             volumes,
             volume_mounts,

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -1746,8 +1746,8 @@ fn create_replicator_stateful_set_json(
               }
             },
             "volumes": volumes,
-            "tolerations": tolerations,
             "nodeSelector": node_selector,
+            "tolerations": tolerations,
             // We want to wait at most 5 minutes before K8S sends a `SIGKILL` to the containers,
             // this way we let the system finish any in-flight transaction, if there are any.
             "terminationGracePeriodSeconds": 300,

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -86,12 +86,8 @@ const REPLICATOR_APP_SUFFIX: &str = "replicator-app";
 const REPLICATOR_CONTAINER_NAME_SUFFIX: &str = "replicator";
 /// Container name suffix for the Vector sidecar.
 const VECTOR_CONTAINER_NAME_SUFFIX: &str = "vector";
-/// Namespace where data-plane resources are created.
-const DATA_PLANE_NAMESPACE: &str = "etl-data-plane";
 /// Secret storing the Logflare API key.
 const LOGFLARE_SECRET_NAME: &str = "replicator-logflare-api-key";
-/// Docker image used for the Vector sidecar.
-const VECTOR_IMAGE_NAME: &str = "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc";
 /// Name of the replicator container port that serves Prometheus metrics.
 const REPLICATOR_METRICS_PORT_NAME: &str = "metrics";
 /// Port the replicator listens on for Prometheus metrics.
@@ -114,8 +110,6 @@ const LOGS_VOLUME_NAME: &str = "logs";
 const REPLICATOR_APP_LABEL: &str = "etl-replicator-app";
 /// Label used to identify DuckLake maintenance resources.
 const DUCKLAKE_MAINTENANCE_APP_LABEL: &str = "etl-ducklake-maintenance-app";
-/// ServiceAccount used by replicator pods for runtime coordination.
-const REPLICATOR_SERVICE_ACCOUNT_NAME: &str = "etl-replicator";
 /// DuckLake maintenance CRD group.
 const DUCKLAKE_MAINTENANCE_GROUP: &str = "etl.supabase.com";
 /// DuckLake maintenance CRD version.
@@ -249,6 +243,8 @@ fn test_k8s_config(environment: &Environment) -> K8sConfig {
         _ => (250, 125),
     };
     K8sConfig {
+        replicator_namespace: "etl-data-plane".to_owned(),
+        replicator_service_account_name: "etl-replicator".to_owned(),
         replicator_node_selectors: Default::default(),
         replicator_tolerations: Default::default(),
         replicator_resources: DefaultReplicatorResourcesConfig {
@@ -256,6 +252,7 @@ fn test_k8s_config(environment: &Environment) -> K8sConfig {
             cpu_request_millicores,
             destinations: Default::default(),
         },
+        vector_image: "timberio/vector:0.55.0-distroless-libc".to_owned(),
         vector_resources: DefaultVectorResourcesConfig {
             memory_request_mib: 192,
             cpu_request_millicores: 75,
@@ -265,8 +262,8 @@ fn test_k8s_config(environment: &Environment) -> K8sConfig {
 
 /// HTTP-based implementation of [`K8sClient`].
 ///
-/// The client is namespaced to the data-plane namespace and uses server-side
-/// apply to keep resources in sync.
+/// The client is scoped to the configured replicator namespace and uses
+/// server-side apply to keep resources in sync.
 #[derive(Debug)]
 pub struct HttpK8sClient {
     namespaces_api: Api<Namespace>,
@@ -285,17 +282,18 @@ impl HttpK8sClient {
     /// Prefers in-cluster configuration and falls back to the local kubeconfig
     /// when running outside the cluster.
     pub fn new(client: Client, k8s_config: K8sConfig) -> Result<HttpK8sClient, K8sError> {
+        let replicator_namespace = &k8s_config.replicator_namespace;
         let namespaces_api: Api<Namespace> = Api::all(client.clone());
         let service_accounts_api: Api<ServiceAccount> =
-            Api::namespaced(client.clone(), DATA_PLANE_NAMESPACE);
-        let secrets_api: Api<Secret> = Api::namespaced(client.clone(), DATA_PLANE_NAMESPACE);
-        let config_maps_api: Api<ConfigMap> = Api::namespaced(client.clone(), DATA_PLANE_NAMESPACE);
+            Api::namespaced(client.clone(), replicator_namespace);
+        let secrets_api: Api<Secret> = Api::namespaced(client.clone(), replicator_namespace);
+        let config_maps_api: Api<ConfigMap> = Api::namespaced(client.clone(), replicator_namespace);
         let stateful_sets_api: Api<StatefulSet> =
-            Api::namespaced(client.clone(), DATA_PLANE_NAMESPACE);
-        let pods_api: Api<Pod> = Api::namespaced(client.clone(), DATA_PLANE_NAMESPACE);
+            Api::namespaced(client.clone(), replicator_namespace);
+        let pods_api: Api<Pod> = Api::namespaced(client.clone(), replicator_namespace);
         let ducklake_maintenance_api: Api<DynamicObject> = Api::namespaced_with(
             client,
-            DATA_PLANE_NAMESPACE,
+            replicator_namespace,
             &ducklake_maintenance_api_resource(),
         );
 
@@ -316,31 +314,44 @@ impl HttpK8sClient {
     /// This only checks resources owned outside per-pipeline reconciliation. It
     /// does not create or mutate cluster resources.
     pub async fn preflight(&self) -> Result<(), K8sPreflightError> {
-        self.ensure_data_plane_namespace().await?;
+        self.ensure_replicator_namespace().await?;
         self.ensure_replicator_service_account().await?;
 
         Ok(())
     }
 
-    /// Ensures the data-plane namespace exists before namespaced APIs are used.
-    async fn ensure_data_plane_namespace(&self) -> Result<(), K8sPreflightError> {
-        match self.namespaces_api.get(DATA_PLANE_NAMESPACE).await {
+    /// Ensures the replicator namespace exists before namespaced APIs are used.
+    async fn ensure_replicator_namespace(&self) -> Result<(), K8sPreflightError> {
+        let namespace = &self.k8s_config.replicator_namespace;
+        match self.namespaces_api.get(namespace).await {
             Ok(_) => Ok(()),
             Err(kube::Error::Api(err)) if err.code == 404 => {
-                Err(K8sPreflightError::MissingDataPlaneNamespace)
+                Err(K8sPreflightError::MissingReplicatorNamespace { namespace: namespace.clone() })
             }
-            Err(source) => Err(K8sPreflightError::DataPlaneNamespaceCheck { source }),
+            Err(source) => Err(K8sPreflightError::ReplicatorNamespaceCheck {
+                namespace: namespace.clone(),
+                source,
+            }),
         }
     }
 
     /// Ensures replicator pods can be admitted with their configured identity.
     async fn ensure_replicator_service_account(&self) -> Result<(), K8sPreflightError> {
-        match self.service_accounts_api.get(REPLICATOR_SERVICE_ACCOUNT_NAME).await {
+        let namespace = &self.k8s_config.replicator_namespace;
+        let service_account_name = &self.k8s_config.replicator_service_account_name;
+        match self.service_accounts_api.get(service_account_name).await {
             Ok(_) => Ok(()),
             Err(kube::Error::Api(err)) if err.code == 404 => {
-                Err(K8sPreflightError::MissingReplicatorServiceAccount)
+                Err(K8sPreflightError::MissingReplicatorServiceAccount {
+                    namespace: namespace.clone(),
+                    service_account_name: service_account_name.clone(),
+                })
             }
-            Err(source) => Err(K8sPreflightError::ReplicatorServiceAccountCheck { source }),
+            Err(source) => Err(K8sPreflightError::ReplicatorServiceAccountCheck {
+                namespace: namespace.clone(),
+                service_account_name: service_account_name.clone(),
+                source,
+            }),
         }
     }
 
@@ -411,30 +422,45 @@ impl HttpK8sClient {
 /// Errors found while checking Kubernetes prerequisites at startup.
 #[derive(Debug, Error)]
 pub enum K8sPreflightError {
-    /// The namespace used for data-plane resources does not exist.
+    /// The namespace used for replicator resources does not exist.
     #[error(
-        "Kubernetes data-plane namespace `etl-data-plane` is missing. Create it before starting \
+        "Kubernetes replicator namespace `{namespace}` is missing. Create it before starting \
          etl-api."
     )]
-    MissingDataPlaneNamespace,
-    /// Checking the namespace failed.
-    #[error("Failed to check Kubernetes data-plane namespace `etl-data-plane`")]
-    DataPlaneNamespaceCheck {
+    MissingReplicatorNamespace {
+        /// Configured replicator namespace.
+        namespace: String,
+    },
+    /// Checking the replicator namespace failed.
+    #[error("Failed to check Kubernetes replicator namespace `{namespace}`")]
+    ReplicatorNamespaceCheck {
+        /// Configured replicator namespace.
+        namespace: String,
         /// Kubernetes API error.
         #[source]
         source: kube::Error,
     },
     /// The ServiceAccount used by replicator pods does not exist.
     #[error(
-        "Kubernetes ServiceAccount `etl-replicator` is missing in namespace `etl-data-plane`. \
-         Create it before starting etl-api so replicator pods can be admitted."
+        "Kubernetes ServiceAccount `{service_account_name}` is missing in namespace \
+         `{namespace}`. Create it before starting etl-api so replicator pods can be admitted."
     )]
-    MissingReplicatorServiceAccount,
+    MissingReplicatorServiceAccount {
+        /// Configured replicator namespace.
+        namespace: String,
+        /// Configured replicator ServiceAccount name.
+        service_account_name: String,
+    },
     /// Checking the ServiceAccount failed.
     #[error(
-        "Failed to check Kubernetes ServiceAccount `etl-replicator` in namespace `etl-data-plane`"
+        "Failed to check Kubernetes ServiceAccount `{service_account_name}` in namespace \
+         `{namespace}`"
     )]
     ReplicatorServiceAccountCheck {
+        /// Configured replicator namespace.
+        namespace: String,
+        /// Configured replicator ServiceAccount name.
+        service_account_name: String,
         /// Kubernetes API error.
         #[source]
         source: kube::Error,
@@ -454,6 +480,7 @@ impl K8sClient for HttpK8sClient {
         let postgres_secret_name = create_postgres_secret_name(prefix);
         let replicator_app_name = create_replicator_app_name(prefix);
         let postgres_secret_json = create_postgres_secret_json(
+            &self.k8s_config,
             &postgres_secret_name,
             &replicator_app_name,
             &encoded_postgres_password,
@@ -481,6 +508,7 @@ impl K8sClient for HttpK8sClient {
         let bq_secret_name = create_bq_secret_name(prefix);
         let replicator_app_name = create_replicator_app_name(prefix);
         let bq_secret_json = create_bq_service_account_key_secret_json(
+            &self.k8s_config,
             &bq_secret_name,
             &replicator_app_name,
             &encoded_bq_service_account_key,
@@ -508,6 +536,7 @@ impl K8sClient for HttpK8sClient {
             let clickhouse_secret_name = create_clickhouse_secret_name(prefix);
             let replicator_app_name = create_replicator_app_name(prefix);
             let secret = create_clickhouse_password_secret(
+                &self.k8s_config,
                 &clickhouse_secret_name,
                 &replicator_app_name,
                 password,
@@ -540,6 +569,7 @@ impl K8sClient for HttpK8sClient {
         let iceberg_secret_name = create_iceberg_secret_name(prefix);
         let replicator_app_name = create_replicator_app_name(prefix);
         let iceberg_secret_json = create_iceberg_secret_json(
+            &self.k8s_config,
             &iceberg_secret_name,
             &replicator_app_name,
             &encoded_catalog_token,
@@ -574,6 +604,7 @@ impl K8sClient for HttpK8sClient {
         let ducklake_secret_name = create_ducklake_secret_name(prefix);
         let replicator_app_name = create_replicator_app_name(prefix);
         let ducklake_secret_json = create_ducklake_secret_json(
+            &self.k8s_config,
             &ducklake_secret_name,
             &replicator_app_name,
             &encoded_catalog_url,
@@ -660,6 +691,7 @@ impl K8sClient for HttpK8sClient {
         let snowflake_secret_name = create_snowflake_secret_name(prefix);
         let replicator_app_name = create_replicator_app_name(prefix);
         let snowflake_secret_json = create_snowflake_secret_json(
+            &self.k8s_config,
             &snowflake_secret_name,
             &replicator_app_name,
             &encoded_private_key,
@@ -696,6 +728,7 @@ impl K8sClient for HttpK8sClient {
         let replicator_app_name = create_replicator_app_name(prefix);
 
         let config_map_json = create_replicator_config_map_json(
+            &self.k8s_config,
             &replicator_config_map_name,
             &replicator_app_name,
             files,
@@ -753,6 +786,7 @@ impl K8sClient for HttpK8sClient {
 
         let environment = Environment::load().map_err(K8sError::Config)?;
         let container_environment = create_container_environment_json(
+            &self.k8s_config,
             prefix,
             &environment,
             replicator_image,
@@ -763,12 +797,17 @@ impl K8sClient for HttpK8sClient {
 
         let node_selector = node_selector_json(&self.k8s_config.replicator_node_selectors);
         let tolerations = tolerations_json(&self.k8s_config.replicator_tolerations);
-        let init_containers =
-            create_init_containers_json(prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &self.k8s_config,
+            prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &self.k8s_config,
             prefix,
             &request.tenant_id,
             request.pipeline_id,
@@ -829,7 +868,8 @@ impl K8sClient for HttpK8sClient {
         debug!("patching ducklake maintenance");
 
         let name = create_ducklake_maintenance_name(prefix);
-        let ducklake_maintenance_json = create_ducklake_maintenance_json(prefix, &name, config);
+        let ducklake_maintenance_json =
+            create_ducklake_maintenance_json(&self.k8s_config, prefix, &name, config);
         let pp = PatchParams::apply(FIELD_MANAGER).force();
         self.ducklake_maintenance_api
             .patch(&name, &pp, &Patch::Apply(ducklake_maintenance_json))
@@ -980,6 +1020,7 @@ fn create_vector_container_name(prefix: &str) -> String {
 }
 
 fn create_postgres_secret_json(
+    k8s_config: &K8sConfig,
     secret_name: &str,
     replicator_app_name: &str,
     encoded_postgres_password: &str,
@@ -989,7 +1030,7 @@ fn create_postgres_secret_json(
       "kind": "Secret",
       "metadata": {
         "name": secret_name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
@@ -1003,6 +1044,7 @@ fn create_postgres_secret_json(
 }
 
 fn create_clickhouse_password_secret(
+    k8s_config: &K8sConfig,
     secret_name: &str,
     replicator_app_name: &str,
     clickhouse_password: &str,
@@ -1010,7 +1052,7 @@ fn create_clickhouse_password_secret(
     Secret {
         metadata: ObjectMeta {
             name: Some(secret_name.to_owned()),
-            namespace: Some(DATA_PLANE_NAMESPACE.to_owned()),
+            namespace: Some(k8s_config.replicator_namespace.clone()),
             labels: Some(BTreeMap::from([
                 ("etl.supabase.com/app-name".to_owned(), replicator_app_name.to_owned()),
                 ("etl.supabase.com/app-type".to_owned(), REPLICATOR_APP_LABEL.to_owned()),
@@ -1027,6 +1069,7 @@ fn create_clickhouse_password_secret(
 }
 
 fn create_snowflake_secret_json(
+    k8s_config: &K8sConfig,
     secret_name: &str,
     replicator_app_name: &str,
     encoded_private_key: &str,
@@ -1048,7 +1091,7 @@ fn create_snowflake_secret_json(
       "kind": "Secret",
       "metadata": {
         "name": secret_name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
@@ -1060,6 +1103,7 @@ fn create_snowflake_secret_json(
 }
 
 fn create_bq_service_account_key_secret_json(
+    k8s_config: &K8sConfig,
     secret_name: &str,
     replicator_app_name: &str,
     encoded_bq_service_account_key: &str,
@@ -1069,7 +1113,7 @@ fn create_bq_service_account_key_secret_json(
       "kind": "Secret",
       "metadata": {
         "name": secret_name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
@@ -1083,6 +1127,7 @@ fn create_bq_service_account_key_secret_json(
 }
 
 fn create_iceberg_secret_json(
+    k8s_config: &K8sConfig,
     secret_name: &str,
     replicator_app_name: &str,
     encoded_catalog_token: &str,
@@ -1094,7 +1139,7 @@ fn create_iceberg_secret_json(
       "kind": "Secret",
       "metadata": {
         "name": secret_name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
@@ -1110,6 +1155,7 @@ fn create_iceberg_secret_json(
 }
 
 fn create_ducklake_secret_json(
+    k8s_config: &K8sConfig,
     secret_name: &str,
     replicator_app_name: &str,
     encoded_catalog_url: &str,
@@ -1121,7 +1167,7 @@ fn create_ducklake_secret_json(
       "kind": "Secret",
       "metadata": {
         "name": secret_name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
@@ -1137,6 +1183,7 @@ fn create_ducklake_secret_json(
 }
 
 fn create_replicator_config_map_json(
+    k8s_config: &K8sConfig,
     config_map_name: &str,
     replicator_app_name: &str,
     files: Vec<ReplicatorConfigMapFile>,
@@ -1151,7 +1198,7 @@ fn create_replicator_config_map_json(
       "apiVersion": "v1",
       "metadata": {
         "name": config_map_name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
@@ -1162,6 +1209,7 @@ fn create_replicator_config_map_json(
 }
 
 fn create_ducklake_maintenance_json(
+    k8s_config: &K8sConfig,
     prefix: &str,
     name: &str,
     config: DuckLakeMaintenanceResourceConfig,
@@ -1175,7 +1223,7 @@ fn create_ducklake_maintenance_json(
       "kind": DUCKLAKE_MAINTENANCE_KIND,
       "metadata": {
         "name": name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": DUCKLAKE_MAINTENANCE_APP_LABEL,
@@ -1234,6 +1282,7 @@ fn create_ducklake_maintenance_json(
 }
 
 fn create_container_environment_json(
+    k8s_config: &K8sConfig,
     prefix: &str,
     environment: &Environment,
     replicator_image: &str,
@@ -1373,7 +1422,7 @@ fn create_container_environment_json(
                 }));
                 container_environment.push(json!({
                     "name": "ETL_DUCKLAKE_MAINTENANCE_CR_NAMESPACE",
-                    "value": DATA_PLANE_NAMESPACE
+                    "value": &k8s_config.replicator_namespace
                 }));
                 container_environment.push(json!({
                     "name": "ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_INLINE_FLUSH_MIN_INLINED_BYTES",
@@ -1439,6 +1488,7 @@ fn tolerations_json(tolerations: &[crate::config::TolerationConfig]) -> serde_js
 }
 
 fn create_init_containers_json(
+    k8s_config: &K8sConfig,
     prefix: &str,
     environment: &Environment,
     stateful_set_resources: &ReplicatorStatefulSetResourcesConfig,
@@ -1450,7 +1500,7 @@ fn create_init_containers_json(
         Environment::Staging | Environment::Prod => json!([
           {
             "name": vector_container_name,
-            "image": VECTOR_IMAGE_NAME,
+            "image": &k8s_config.vector_image,
             "restartPolicy": "Always",
             "securityContext": {
               "allowPrivilegeEscalation": false,
@@ -1689,6 +1739,7 @@ fn create_snowflake_passphrase_env_var_json(snowflake_secret_name: &str) -> serd
 
 #[expect(clippy::too_many_arguments)]
 fn create_replicator_stateful_set_json(
+    k8s_config: &K8sConfig,
     prefix: &str,
     tenant_id: &str,
     pipeline_id: i64,
@@ -1711,7 +1762,7 @@ fn create_replicator_stateful_set_json(
       "kind": "StatefulSet",
       "metadata": {
         "name": stateful_set_name,
-        "namespace": DATA_PLANE_NAMESPACE,
+        "namespace": &k8s_config.replicator_namespace,
         "labels": {
           "etl.supabase.com/app-name": replicator_app_name,
           "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
@@ -1739,7 +1790,7 @@ fn create_replicator_stateful_set_json(
             }
           },
           "spec": {
-            "serviceAccountName": REPLICATOR_SERVICE_ACCOUNT_NAME,
+            "serviceAccountName": &k8s_config.replicator_service_account_name,
             "securityContext": {
               "seccompProfile": {
                 "type": "RuntimeDefault"
@@ -1818,6 +1869,10 @@ mod tests {
     const MAX_BIGINT_ID: i64 = 9_223_372_036_854_775_807;
     const MAX_K8S_LABEL_VALUE_LEN: usize = 63;
     const CONTROLLER_REVISION_HASH_LEN: usize = 10;
+
+    fn default_k8s_config() -> K8sConfig {
+        test_k8s_config(&Environment::Staging)
+    }
 
     fn create_k8s_object_prefix(tenant_id: &str, replicator_id: i64) -> String {
         format!("{tenant_id}-{replicator_id}")
@@ -2011,8 +2066,6 @@ mod tests {
             memory_limit_mib: Some(-1),
         };
         let k8s_config = K8sConfig {
-            replicator_node_selectors: Default::default(),
-            replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: -10,
                 memory_request_mib: 0,
@@ -2022,6 +2075,7 @@ mod tests {
                 cpu_request_millicores: 0,
                 memory_request_mib: -20,
             },
+            ..default_k8s_config()
         };
         let default_replicator_resources =
             k8s_config.replicator_resources_for(DestinationKind::BigQuery);
@@ -2071,8 +2125,6 @@ mod tests {
     #[test]
     fn test_replicator_resource_config_uses_api_vector_resources() {
         let k8s_config = K8sConfig {
-            replicator_node_selectors: Default::default(),
-            replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: 500,
                 memory_request_mib: 500,
@@ -2082,6 +2134,7 @@ mod tests {
                 cpu_request_millicores: 80,
                 memory_request_mib: 192,
             },
+            ..default_k8s_config()
         };
         let default_replicator_resources =
             k8s_config.replicator_resources_for(DestinationKind::BigQuery);
@@ -2127,6 +2180,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
         let replicator_image = "supabase/replicator:1.2.3";
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -2136,19 +2190,29 @@ mod tests {
         );
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let resources = vec![
             (
                 "postgres secret",
-                create_postgres_secret_json(&postgres_secret_name, &replicator_app_name, "secret"),
+                create_postgres_secret_json(
+                    &default_k8s_config(),
+                    &postgres_secret_name,
+                    &replicator_app_name,
+                    "secret",
+                ),
             ),
             (
                 "clickhouse secret",
                 serde_json::to_value(create_clickhouse_password_secret(
+                    &default_k8s_config(),
                     &clickhouse_secret_name,
                     &replicator_app_name,
                     "secret",
@@ -2158,6 +2222,7 @@ mod tests {
             (
                 "bigquery secret",
                 create_bq_service_account_key_secret_json(
+                    &default_k8s_config(),
                     &bq_secret_name,
                     &replicator_app_name,
                     "secret",
@@ -2166,6 +2231,7 @@ mod tests {
             (
                 "iceberg secret",
                 create_iceberg_secret_json(
+                    &default_k8s_config(),
                     &iceberg_secret_name,
                     &replicator_app_name,
                     "secret",
@@ -2176,6 +2242,7 @@ mod tests {
             (
                 "ducklake secret",
                 create_ducklake_secret_json(
+                    &default_k8s_config(),
                     &ducklake_secret_name,
                     &replicator_app_name,
                     "secret",
@@ -2186,6 +2253,7 @@ mod tests {
             (
                 "snowflake secret",
                 create_snowflake_secret_json(
+                    &default_k8s_config(),
                     &snowflake_secret_name,
                     &replicator_app_name,
                     &BASE64_STANDARD.encode("secret"),
@@ -2195,6 +2263,7 @@ mod tests {
             (
                 "replicator config map",
                 create_replicator_config_map_json(
+                    &default_k8s_config(),
                     &config_map_name,
                     &replicator_app_name,
                     vec![ReplicatorConfigMapFile {
@@ -2206,6 +2275,7 @@ mod tests {
             (
                 "ducklake maintenance",
                 create_ducklake_maintenance_json(
+                    &default_k8s_config(),
                     &prefix,
                     &ducklake_maintenance_name,
                     DuckLakeMaintenanceResourceConfig {
@@ -2220,6 +2290,7 @@ mod tests {
             (
                 "replicator stateful set",
                 create_replicator_stateful_set_json(
+                    &default_k8s_config(),
                     &prefix,
                     MAX_TENANT_ID,
                     MAX_BIGINT_ID,
@@ -2239,6 +2310,125 @@ mod tests {
         for (resource_name, resource) in resources {
             assert_kubernetes_label_values_are_safe(resource_name, &resource);
         }
+    }
+
+    #[test]
+    fn configured_namespace_service_account_and_vector_image_are_propagated() {
+        let mut k8s_config = default_k8s_config();
+        k8s_config.replicator_namespace = "custom-data-plane".to_owned();
+        k8s_config.replicator_service_account_name = "custom-replicator".to_owned();
+        k8s_config.vector_image = "example.com/vector:custom".to_owned();
+
+        let prefix = create_k8s_object_prefix(TENANT_ID, PIPELINE_ID);
+        let app_name = create_replicator_app_name(&prefix);
+        let namespaced_resources = vec![
+            create_postgres_secret_json(&k8s_config, "postgres-secret", &app_name, "secret"),
+            serde_json::to_value(create_clickhouse_password_secret(
+                &k8s_config,
+                "clickhouse-secret",
+                &app_name,
+                "secret",
+            ))
+            .unwrap(),
+            create_snowflake_secret_json(
+                &k8s_config,
+                "snowflake-secret",
+                &app_name,
+                "secret",
+                None,
+            ),
+            create_bq_service_account_key_secret_json(
+                &k8s_config,
+                "bigquery-secret",
+                &app_name,
+                "secret",
+            ),
+            create_iceberg_secret_json(
+                &k8s_config,
+                "iceberg-secret",
+                &app_name,
+                "secret",
+                "secret",
+                "secret",
+            ),
+            create_ducklake_secret_json(
+                &k8s_config,
+                "ducklake-secret",
+                &app_name,
+                "secret",
+                "secret",
+                "secret",
+            ),
+            create_replicator_config_map_json(&k8s_config, "replicator-config", &app_name, vec![]),
+            create_ducklake_maintenance_json(
+                &k8s_config,
+                &prefix,
+                "ducklake-maintenance",
+                DuckLakeMaintenanceResourceConfig {
+                    tenant_id: TENANT_ID.to_owned(),
+                    pipeline_id: PIPELINE_ID,
+                    replicator_id: PIPELINE_ID,
+                    image: "example.com/replicator:custom".to_owned(),
+                    policy: DuckLakeMaintenancePolicy::default(),
+                },
+            ),
+        ];
+        for resource in namespaced_resources {
+            assert_eq!(resource.pointer("/metadata/namespace"), Some(&json!("custom-data-plane")));
+        }
+
+        let environment = Environment::Staging;
+        let stateful_set_resources =
+            ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
+        let container_environment = create_container_environment_json(
+            &k8s_config,
+            &prefix,
+            &environment,
+            "example.com/replicator:custom",
+            DestinationType::Ducklake,
+            Some(&DuckLakeMaintenanceConfig {
+                min_inlined_bytes: 10,
+                min_active_data_files: 20,
+                ..DuckLakeMaintenanceConfig::default()
+            }),
+            LogLevel::Info,
+        );
+        assert!(container_environment.iter().any(|entry| {
+            entry
+                == &json!({
+                    "name": "ETL_DUCKLAKE_MAINTENANCE_CR_NAMESPACE",
+                    "value": "custom-data-plane"
+                })
+        }));
+
+        let init_containers = create_init_containers_json(
+            &k8s_config,
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
+        assert_eq!(init_containers.pointer("/0/image"), Some(&json!("example.com/vector:custom")));
+
+        let stateful_set = create_replicator_stateful_set_json(
+            &k8s_config,
+            &prefix,
+            TENANT_ID,
+            PIPELINE_ID,
+            &create_stateful_set_name(&prefix),
+            "example.com/replicator:custom",
+            container_environment,
+            json!({}),
+            json!([]),
+            init_containers,
+            create_volumes_json(&prefix, &environment),
+            create_volume_mounts_json(&environment),
+            &stateful_set_resources,
+        );
+        assert_eq!(stateful_set.pointer("/metadata/namespace"), Some(&json!("custom-data-plane")));
+        assert_eq!(
+            stateful_set.pointer("/spec/template/spec/serviceAccountName"),
+            Some(&json!("custom-replicator"))
+        );
     }
 
     #[test]
@@ -2277,8 +2467,6 @@ mod tests {
             },
         )]);
         let k8s_config = K8sConfig {
-            replicator_node_selectors: Default::default(),
-            replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
                 cpu_request_millicores: 300,
                 memory_request_mib: 400,
@@ -2288,6 +2476,7 @@ mod tests {
                 cpu_request_millicores: 80,
                 memory_request_mib: 192,
             },
+            ..default_k8s_config()
         };
         let default_replicator_resources =
             k8s_config.replicator_resources_for(DestinationKind::Ducklake);
@@ -2311,6 +2500,7 @@ mod tests {
         let encoded_postgres_password = "dGVzdC1wYXNzd29yZA==";
 
         let secret_json = create_postgres_secret_json(
+            &default_k8s_config(),
             secret_name,
             &replicator_app_name,
             encoded_postgres_password,
@@ -2329,6 +2519,7 @@ mod tests {
         let encoded_bq_service_account_key = "ewogICJrZXkiOiAidmFsdWUiCn0=";
 
         let secret_json = create_bq_service_account_key_secret_json(
+            &default_k8s_config(),
             secret_name,
             &replicator_app_name,
             encoded_bq_service_account_key,
@@ -2349,6 +2540,7 @@ mod tests {
         let encoded_s3_secret_access_key = "NDUyOWE3ZmMwNzY2NDBjODRiZTgzZGJiNGMyNDI3MTNhOTk0MzE5OTBjYzJmMzIzMGM4MzVjOGJmZjAzYWE2ZQ==";
 
         let secret_json = create_iceberg_secret_json(
+            &default_k8s_config(),
             secret_name,
             &replicator_app_name,
             encoded_catalog_token,
@@ -2428,6 +2620,7 @@ mod tests {
         ];
 
         let config_map_json = create_replicator_config_map_json(
+            &default_k8s_config(),
             &replicator_config_map_name,
             &replicator_app_name,
             files,
@@ -2444,6 +2637,7 @@ mod tests {
         let name = create_ducklake_maintenance_name(&prefix);
 
         let ducklake_maintenance_json = create_ducklake_maintenance_json(
+            &default_k8s_config(),
             &prefix,
             &name,
             DuckLakeMaintenanceResourceConfig {
@@ -2534,6 +2728,7 @@ mod tests {
 
         let environment = Environment::Dev;
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -2545,6 +2740,7 @@ mod tests {
 
         let environment = Environment::Staging;
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -2556,6 +2752,7 @@ mod tests {
 
         let environment = Environment::Prod;
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -2572,6 +2769,7 @@ mod tests {
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Dev,
             replicator_image,
@@ -2582,6 +2780,7 @@ mod tests {
         assert_json_snapshot!(container_environment);
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Staging,
             replicator_image,
@@ -2592,6 +2791,7 @@ mod tests {
         assert_json_snapshot!(container_environment);
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Prod,
             replicator_image,
@@ -2608,6 +2808,7 @@ mod tests {
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Dev,
             replicator_image,
@@ -2618,6 +2819,7 @@ mod tests {
         assert_json_snapshot!(container_environment);
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Staging,
             replicator_image,
@@ -2628,6 +2830,7 @@ mod tests {
         assert_json_snapshot!(container_environment);
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Prod,
             replicator_image,
@@ -2644,6 +2847,7 @@ mod tests {
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Dev,
             replicator_image,
@@ -2668,6 +2872,7 @@ mod tests {
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Dev,
             replicator_image,
@@ -2692,6 +2897,7 @@ mod tests {
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Dev,
             replicator_image,
@@ -2720,6 +2926,7 @@ mod tests {
         let replicator_image = "ramsup/etl-replicator:2a41356af735f891de37d71c0e1a62864fe4630e";
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &Environment::Dev,
             replicator_image,
@@ -2747,6 +2954,7 @@ mod tests {
         let private_key = "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----";
         let encoded_private_key = BASE64_STANDARD.encode(private_key);
         let snowflake_secret_json = create_snowflake_secret_json(
+            &default_k8s_config(),
             "tenant-42-snowflake",
             "tenant-42-replicator-app",
             &encoded_private_key,
@@ -2755,7 +2963,10 @@ mod tests {
         let secret: Secret = serde_json::from_value(snowflake_secret_json).unwrap();
 
         assert_eq!(secret.metadata.name.as_deref(), Some("tenant-42-snowflake"));
-        assert_eq!(secret.metadata.namespace.as_deref(), Some(DATA_PLANE_NAMESPACE));
+        assert_eq!(
+            secret.metadata.namespace.as_deref(),
+            Some(default_k8s_config().replicator_namespace.as_str())
+        );
         assert_eq!(secret.type_.as_deref(), Some("Opaque"));
 
         let labels = secret.metadata.labels.as_ref().unwrap();
@@ -2775,6 +2986,7 @@ mod tests {
         let encoded_private_key = BASE64_STANDARD.encode(private_key);
         let encoded_passphrase = BASE64_STANDARD.encode(passphrase);
         let snowflake_secret_json = create_snowflake_secret_json(
+            &default_k8s_config(),
             "tenant-42-snowflake",
             "tenant-42-replicator-app",
             &encoded_private_key,
@@ -2807,6 +3019,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&Environment::Dev).unwrap();
         let create_stateful_set = |node_selector, tolerations| {
             create_replicator_stateful_set_json(
+                &default_k8s_config(),
                 "tenant-1-42",
                 "tenant-1",
                 42,
@@ -2876,22 +3089,34 @@ mod tests {
         let environment = Environment::Dev;
         let stateful_set_resources =
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
-        let node_selector =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let node_selector = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         assert_json_snapshot!(node_selector);
 
         let environment = Environment::Staging;
         let stateful_set_resources =
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
-        let node_selector =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let node_selector = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         assert_json_snapshot!(node_selector);
 
         let environment = Environment::Prod;
         let stateful_set_resources =
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
-        let node_selector =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let node_selector = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         assert_json_snapshot!(node_selector);
     }
 
@@ -2939,6 +3164,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -2949,12 +3175,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -2983,6 +3214,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -2993,12 +3225,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -3027,6 +3264,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -3037,12 +3275,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -3078,6 +3321,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -3088,12 +3332,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -3122,6 +3371,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -3132,12 +3382,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -3166,6 +3421,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -3176,12 +3432,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -3217,6 +3478,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -3227,12 +3489,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -3261,6 +3528,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -3271,12 +3539,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,
@@ -3305,6 +3578,7 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&environment).unwrap();
 
         let container_environment = create_container_environment_json(
+            &default_k8s_config(),
             &prefix,
             &environment,
             replicator_image,
@@ -3315,12 +3589,17 @@ mod tests {
 
         let node_selector = create_node_selector_json(&environment);
         let tolerations = create_tolerations_json(&environment);
-        let init_containers =
-            create_init_containers_json(&prefix, &environment, &stateful_set_resources);
+        let init_containers = create_init_containers_json(
+            &default_k8s_config(),
+            &prefix,
+            &environment,
+            &stateful_set_resources,
+        );
         let volumes = create_volumes_json(&prefix, &environment);
         let volume_mounts = create_volume_mounts_json(&environment);
 
         let stateful_set_json = create_replicator_stateful_set_json(
+            &default_k8s_config(),
             &prefix,
             TENANT_ID,
             PIPELINE_ID,

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -187,9 +187,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
             ]
           }
         ],
-        "nodeSelector": {
-          "etl.supabase.com/node-role": "workloads"
-        },
+        "nodeSelector": {},
         "securityContext": {
           "seccompProfile": {
             "type": "RuntimeDefault"
@@ -197,14 +195,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -154,7 +154,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 }
               }
             ],
-            "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "image": "timberio/vector:0.55.0-distroless-libc",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -150,7 +150,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 }
               }
             ],
-            "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "image": "timberio/vector:0.55.0-distroless-libc",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -183,9 +183,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
             ]
           }
         ],
-        "nodeSelector": {
-          "etl.supabase.com/node-role": "workloads"
-        },
+        "nodeSelector": {},
         "securityContext": {
           "seccompProfile": {
             "type": "RuntimeDefault"
@@ -193,14 +191,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
@@ -116,14 +116,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -172,7 +172,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 }
               }
             ],
-            "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "image": "timberio/vector:0.55.0-distroless-libc",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -205,9 +205,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
             ]
           }
         ],
-        "nodeSelector": {
-          "etl.supabase.com/node-role": "workloads"
-        },
+        "nodeSelector": {},
         "securityContext": {
           "seccompProfile": {
             "type": "RuntimeDefault"
@@ -215,14 +213,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -201,9 +201,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
             ]
           }
         ],
-        "nodeSelector": {
-          "etl.supabase.com/node-role": "workloads"
-        },
+        "nodeSelector": {},
         "securityContext": {
           "seccompProfile": {
             "type": "RuntimeDefault"
@@ -211,14 +209,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -168,7 +168,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 }
               }
             ],
-            "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "image": "timberio/vector:0.55.0-distroless-libc",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
@@ -134,14 +134,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -172,7 +172,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 }
               }
             ],
-            "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "image": "timberio/vector:0.55.0-distroless-libc",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -205,9 +205,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
             ]
           }
         ],
-        "nodeSelector": {
-          "etl.supabase.com/node-role": "workloads"
-        },
+        "nodeSelector": {},
         "securityContext": {
           "seccompProfile": {
             "type": "RuntimeDefault"
@@ -215,14 +213,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -201,9 +201,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
             ]
           }
         ],
-        "nodeSelector": {
-          "etl.supabase.com/node-role": "workloads"
-        },
+        "nodeSelector": {},
         "securityContext": {
           "seccompProfile": {
             "type": "RuntimeDefault"
@@ -211,14 +209,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -168,7 +168,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 }
               }
             ],
-            "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+            "image": "timberio/vector:0.55.0-distroless-libc",
             "name": "abcdefghijklmnopqrst-42-vector",
             "resources": {
               "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
@@ -134,14 +134,7 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
         },
         "serviceAccountName": "etl-replicator",
         "terminationGracePeriodSeconds": 300,
-        "tolerations": [
-          {
-            "effect": "NoSchedule",
-            "key": "etl.supabase.com/node-role",
-            "operator": "Equal",
-            "value": "workloads"
-          }
-        ],
+        "tolerations": [],
         "volumes": [
           {
             "configMap": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-2.snap
@@ -15,7 +15,7 @@ expression: node_selector
         }
       }
     ],
-    "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+    "image": "timberio/vector:0.55.0-distroless-libc",
     "name": "abcdefghijklmnopqrst-42-vector",
     "resources": {
       "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_init_containers-3.snap
@@ -15,7 +15,7 @@ expression: node_selector
         }
       }
     ],
-    "image": "public.ecr.aws/supabase/timberio/vector:0.55.0-distroless-libc",
+    "image": "timberio/vector:0.55.0-distroless-libc",
     "name": "abcdefghijklmnopqrst-42-vector",
     "resources": {
       "limits": {

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_node_selector-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_node_selector-2.snap
@@ -2,6 +2,4 @@
 source: crates/etl-api/src/k8s/http.rs
 expression: node_selector
 ---
-{
-  "etl.supabase.com/node-role": "workloads"
-}
+{}

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_node_selector-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_node_selector-3.snap
@@ -2,6 +2,4 @@
 source: crates/etl-api/src/k8s/http.rs
 expression: node_selector
 ---
-{
-  "etl.supabase.com/node-role": "workloads"
-}
+{}

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -32,16 +32,12 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     tenant_id: &str,
     pipeline_id: i64,
     encryption_key: &EncryptionKeyring,
-    k8s_client: Option<&dyn K8sClient>,
+    k8s_client: &dyn K8sClient,
     source_tls_config: &SourceTlsConfig,
     api_config: &ApiConfig,
 ) -> Result<bool, PipelineError> {
     let (pipeline, replicator, image, source, destination) =
         read_pipeline_components(connection, tenant_id, pipeline_id, encryption_key).await?;
-
-    let Some(k8s_client) = k8s_client else {
-        return Ok(false);
-    };
 
     if !should_reconcile_replicator_resources(k8s_client, tenant_id, replicator.id).await? {
         return Ok(false);

--- a/crates/etl-api/src/routes/destinations.rs
+++ b/crates/etl-api/src/routes/destinations.rs
@@ -309,7 +309,7 @@ pub(crate) async fn update_destination(
     Extension(pool): Extension<PgPool>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     destination_id: Path<i64>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     destination: Json<UpdateDestinationRequest>,
@@ -338,7 +338,7 @@ pub(crate) async fn update_destination(
             tenant_id,
             pipeline_id,
             &encryption_key,
-            k8s_client.as_deref(),
+            k8s_client.as_ref(),
             source_tls_config.as_ref(),
             api_config.as_ref(),
         )
@@ -372,7 +372,7 @@ pub(crate) async fn delete_destination(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     destination_id: Path<i64>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
 ) -> Result<impl IntoResponse, DestinationError> {
     let tenant_id = extract_tenant_id(&headers)?;
     let destination_id = destination_id.into_inner();
@@ -384,7 +384,7 @@ pub(crate) async fn delete_destination(
     let pipelines =
         read_pipelines_for_destination_for_deletion(&pool, tenant_id, destination_id).await?;
     if let Some(pipeline_id) =
-        first_active_pipeline_id(k8s_client.as_deref(), tenant_id, &pipelines).await?
+        first_active_pipeline_id(k8s_client.as_ref(), tenant_id, &pipelines).await?
     {
         return Err(DestinationError::ActivePipeline(pipeline_id));
     }

--- a/crates/etl-api/src/routes/destinations_pipelines.rs
+++ b/crates/etl-api/src/routes/destinations_pipelines.rs
@@ -361,7 +361,7 @@ pub(crate) async fn update_destination_and_pipeline(
     Extension(pool): Extension<PgPool>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     destination_and_pipeline_ids: Path<(i64, i64)>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     destination_and_pipeline: Json<UpdateDestinationPipelineRequest>,
@@ -425,7 +425,7 @@ pub(crate) async fn update_destination_and_pipeline(
         tenant_id,
         pipeline_id,
         &encryption_key,
-        k8s_client.as_deref(),
+        k8s_client.as_ref(),
         source_tls_config.as_ref(),
         api_config.as_ref(),
     )
@@ -462,7 +462,7 @@ pub(crate) async fn delete_destination_and_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     destination_and_pipeline_ids: Path<(i64, i64)>,
 ) -> Result<impl IntoResponse, DestinationPipelineError> {
@@ -480,7 +480,7 @@ pub(crate) async fn delete_destination_and_pipeline(
         ));
     }
 
-    if is_replicator_active(k8s_client.as_deref(), tenant_id, pipeline.replicator_id).await? {
+    if is_replicator_active(k8s_client.as_ref(), tenant_id, pipeline.replicator_id).await? {
         return Err(DestinationPipelineError::ActivePipeline(pipeline.id));
     }
 

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -801,7 +801,7 @@ pub(crate) async fn update_pipeline(
     Extension(pool): Extension<PgPool>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     pipeline_id: Path<i64>,
     pipeline: Json<UpdatePipelineRequest>,
@@ -838,7 +838,7 @@ pub(crate) async fn update_pipeline(
         tenant_id,
         pipeline_id,
         &encryption_key,
-        k8s_client.as_deref(),
+        k8s_client.as_ref(),
         source_tls_config.as_ref(),
         api_config.as_ref(),
     )
@@ -874,7 +874,7 @@ pub(crate) async fn delete_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     pipeline_id: Path<i64>,
 ) -> Result<impl IntoResponse, PipelineError> {
@@ -884,7 +884,7 @@ pub(crate) async fn delete_pipeline(
     let pipeline = read_pipeline_for_deletion(&pool, tenant_id, pipeline_id)
         .await?
         .ok_or(PipelineError::PipelineNotFound(pipeline_id))?;
-    if is_replicator_active(k8s_client.as_deref(), tenant_id, pipeline.replicator_id).await? {
+    if is_replicator_active(k8s_client.as_ref(), tenant_id, pipeline.replicator_id).await? {
         return Err(PipelineError::ActivePipeline(pipeline.id));
     }
 
@@ -998,7 +998,7 @@ pub(crate) async fn start_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     pipeline_id: Path<i64>,
@@ -1012,20 +1012,18 @@ pub(crate) async fn start_pipeline(
 
     let tls_config = source_tls_config.get_tls_config();
 
-    if let Some(k8s_client) = k8s_client.as_deref() {
-        create_or_update_pipeline_resources_in_k8s(
-            k8s_client,
-            tenant_id,
-            pipeline,
-            replicator,
-            image,
-            source,
-            destination,
-            api_config.supabase_api_url.as_deref(),
-            tls_config,
-        )
-        .await?;
-    }
+    create_or_update_pipeline_resources_in_k8s(
+        k8s_client.as_ref(),
+        tenant_id,
+        pipeline,
+        replicator,
+        image,
+        source,
+        destination,
+        api_config.supabase_api_url.as_deref(),
+        tls_config,
+    )
+    .await?;
     txn.commit().await?;
 
     Ok(StatusCode::OK)
@@ -1053,7 +1051,7 @@ pub(crate) async fn restart_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     pipeline_id: Path<i64>,
@@ -1067,7 +1065,7 @@ pub(crate) async fn restart_pipeline(
         tenant_id,
         pipeline_id,
         &encryption_key,
-        k8s_client.as_deref(),
+        k8s_client.as_ref(),
         &source_tls_config,
         &api_config,
     )
@@ -1100,7 +1098,7 @@ pub(crate) async fn restart_pipeline(
 pub(crate) async fn stop_pipeline(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     pipeline_id: Path<i64>,
 ) -> Result<impl IntoResponse, PipelineError> {
     let tenant_id = extract_tenant_id(&headers)?;
@@ -1115,9 +1113,7 @@ pub(crate) async fn stop_pipeline(
             .await?
             .ok_or(PipelineError::ReplicatorNotFound(pipeline_id))?;
 
-    if let Some(k8s_client) = k8s_client.as_deref() {
-        delete_pipeline_resources_in_k8s(k8s_client, tenant_id, replicator).await?;
-    }
+    delete_pipeline_resources_in_k8s(k8s_client.as_ref(), tenant_id, replicator).await?;
     txn.commit().await?;
 
     Ok(StatusCode::OK)
@@ -1141,16 +1137,14 @@ pub(crate) async fn stop_pipeline(
 pub(crate) async fn stop_all_pipelines(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
 ) -> Result<impl IntoResponse, PipelineError> {
     let tenant_id = extract_tenant_id(&headers)?;
 
     let mut txn = pool.begin().await?;
     let replicators = data::replicators::read_replicators(txn.deref_mut(), tenant_id).await?;
     for replicator in replicators {
-        if let Some(k8s_client) = k8s_client.as_deref() {
-            delete_pipeline_resources_in_k8s(k8s_client, tenant_id, replicator).await?;
-        }
+        delete_pipeline_resources_in_k8s(k8s_client.as_ref(), tenant_id, replicator).await?;
     }
     txn.commit().await?;
 
@@ -1238,7 +1232,7 @@ pub(crate) async fn get_pipeline_version(
 pub(crate) async fn get_pipeline_status(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     pipeline_id: Path<i64>,
 ) -> Result<impl IntoResponse, PipelineError> {
     let tenant_id = extract_tenant_id(&headers)?;
@@ -1252,12 +1246,8 @@ pub(crate) async fn get_pipeline_status(
             .await?
             .ok_or(PipelineError::ReplicatorNotFound(pipeline_id))?;
 
-    let status = if let Some(k8s_client) = k8s_client.as_deref() {
-        let prefix = create_k8s_object_prefix(tenant_id, replicator.id);
-        k8s_client.get_replicator_pod_status(&prefix).await?.into()
-    } else {
-        PipelineStatus::Stopped
-    };
+    let prefix = create_k8s_object_prefix(tenant_id, replicator.id);
+    let status = k8s_client.get_replicator_pod_status(&prefix).await?.into();
 
     let response = GetPipelineStatusResponse { pipeline_id, status };
 
@@ -1545,7 +1535,7 @@ pub(crate) async fn update_pipeline_version(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     pipeline_id: Path<i64>,
@@ -1602,7 +1592,7 @@ pub(crate) async fn update_pipeline_version(
         tenant_id,
         pipeline_id,
         &encryption_key,
-        k8s_client.as_deref(),
+        k8s_client.as_ref(),
         source_tls_config.as_ref(),
         api_config.as_ref(),
     )

--- a/crates/etl-api/src/routes/sources.rs
+++ b/crates/etl-api/src/routes/sources.rs
@@ -346,7 +346,7 @@ pub(crate) async fn update_source(
     Extension(pool): Extension<PgPool>,
     Extension(api_config): Extension<Arc<ApiConfig>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     source_id: Path<i64>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     source: Json<UpdateSourceRequest>,
@@ -382,7 +382,7 @@ pub(crate) async fn update_source(
             tenant_id,
             pipeline_id,
             &encryption_key,
-            k8s_client.as_deref(),
+            k8s_client.as_ref(),
             source_tls_config.as_ref(),
             api_config.as_ref(),
         )
@@ -415,7 +415,7 @@ pub(crate) async fn update_source(
 pub(crate) async fn delete_source(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     source_id: Path<i64>,
 ) -> Result<impl IntoResponse, SourceError> {
     let tenant_id = extract_tenant_id(&headers)?;
@@ -427,7 +427,7 @@ pub(crate) async fn delete_source(
 
     let pipelines = read_pipelines_for_source_for_deletion(&pool, tenant_id, source_id).await?;
     if let Some(pipeline_id) =
-        first_active_pipeline_id(k8s_client.as_deref(), tenant_id, &pipelines).await?
+        first_active_pipeline_id(k8s_client.as_ref(), tenant_id, &pipelines).await?
     {
         return Err(SourceError::ActivePipeline(pipeline_id));
     }

--- a/crates/etl-api/src/routes/tenants.rs
+++ b/crates/etl-api/src/routes/tenants.rs
@@ -324,7 +324,7 @@ pub(crate) async fn update_tenant(
 pub(crate) async fn delete_tenant(
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
-    Extension(k8s_client): Extension<Option<Arc<dyn K8sClient>>>,
+    Extension(k8s_client): Extension<Arc<dyn K8sClient>>,
     tenant_id: Path<String>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
 ) -> Result<impl IntoResponse, TenantError> {
@@ -335,7 +335,7 @@ pub(crate) async fn delete_tenant(
 
     let pipelines = read_all_pipelines_for_deletion(&pool, &tenant_id).await?;
     if let Some(pipeline_id) =
-        first_active_pipeline_id(k8s_client.as_deref(), &tenant_id, &pipelines).await?
+        first_active_pipeline_id(k8s_client.as_ref(), &tenant_id, &pipelines).await?
     {
         return Err(TenantError::ActivePipeline(pipeline_id));
     }

--- a/crates/etl-api/src/startup.rs
+++ b/crates/etl-api/src/startup.rs
@@ -16,7 +16,7 @@ use kube::config::KubeConfigOptions;
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -117,53 +117,16 @@ impl Application {
 
         let encryption_keyring = build_encryption_keyring(&config)?;
 
-        // Try to create Kubernetes client, but continue without it if unavailable
-        let kube_client_result = match Environment::load() {
-            Ok(Environment::Staging | Environment::Prod) => kube::Client::try_default().await.ok(),
-            Ok(Environment::Dev) => {
-                async {
-                    let options = KubeConfigOptions {
-                        context: Some("orbstack".to_owned()),
-                        cluster: Some("orbstack".to_owned()),
-                        user: Some("orbstack".to_owned()),
-                    };
-                    let kube_config = kube::config::Config::from_kubeconfig(&options).await.ok()?;
-                    let kube_client: kube::Client = kube_config.try_into().ok()?;
-                    test_orbstack_connection(&kube_client).await.ok()?;
-                    Some(kube_client)
-                }
-                .await
-            }
-            Err(_) => None,
-        };
-
         let feature_flags_client = init_feature_flags(config.configcat_sdk_key.as_deref())?;
 
-        let k8s_client = match kube_client_result {
-            Some(client) => match HttpK8sClient::new(client, config.k8s.clone()) {
-                Ok(client) => {
-                    client.preflight().await.context("Checking Kubernetes prerequisites")?;
-                    Some(Arc::new(client) as Arc<dyn K8sClient>)
-                }
-                Err(err) => {
-                    warn!(
-                        error = %err,
-                        "failed to create kubernetes client; etl-api is running in degraded mode \
-                        without full kubernetes capabilities and will skip kubernetes resource \
-                        creation, updates, deletion, status checks, and pod restarts"
-                    );
-                    None
-                }
-            },
-            None => {
-                warn!(
-                    "kubernetes client unavailable; etl-api is running in degraded mode without \
-                     full kubernetes capabilities and will skip kubernetes resource creation, \
-                     updates, deletion, status checks, and pod restarts"
-                );
-                None
-            }
-        };
+        let kube_client = create_kubernetes_client().await.context(
+            "Failed to initialize Kubernetes client. ETL API requires access to an active \
+             Kubernetes cluster",
+        )?;
+        let k8s_client = HttpK8sClient::new(kube_client, config.k8s.clone())
+            .context("Failed to configure Kubernetes resource client")?;
+        k8s_client.preflight().await.context("Kubernetes prerequisite validation failed")?;
+        let k8s_client = Arc::new(k8s_client) as Arc<dyn K8sClient>;
 
         let source_tls_config = SourceTlsConfig::new(config.source.tls.clone())
             .context("Resolving source TLS configuration")?;
@@ -200,6 +163,24 @@ impl Application {
     /// Runs the server until it receives a shutdown signal.
     pub async fn run_until_stopped(self) -> io::Result<()> {
         self.server.await.map_err(io::Error::other)?
+    }
+}
+
+async fn create_kubernetes_client() -> anyhow::Result<kube::Client> {
+    match Environment::load().context("Failed to load application environment")? {
+        Environment::Staging | Environment::Prod => Ok(kube::Client::try_default().await?),
+        Environment::Dev => {
+            let options = KubeConfigOptions {
+                context: Some("orbstack".to_owned()),
+                cluster: Some("orbstack".to_owned()),
+                user: Some("orbstack".to_owned()),
+            };
+            let kube_config = kube::config::Config::from_kubeconfig(&options).await?;
+            let kube_client = kube::Client::try_from(kube_config)?;
+            test_orbstack_connection(&kube_client).await?;
+
+            Ok(kube_client)
+        }
     }
 }
 
@@ -270,14 +251,14 @@ pub fn get_connection_pool(config: &PgConnectionConfig) -> PgPool {
 /// Creates and configures the HTTP server with all routes and middleware.
 ///
 /// Sets up authentication, tracing, Swagger UI, and all API endpoints. The
-/// Kubernetes client is optional to support testing scenarios; the source TLS
-/// configuration is always resolved (it does not depend on Kubernetes).
+/// The Kubernetes client and source TLS configuration are fully initialized
+/// before the server starts accepting requests.
 pub fn run(
     config: ApiConfig,
     listener: TcpListener,
     connection_pool: PgPool,
     encryption_keyring: encryption::EncryptionKeyring,
-    k8s_client: Option<Arc<dyn K8sClient>>,
+    k8s_client: Arc<dyn K8sClient>,
     source_tls_config: SourceTlsConfig,
     feature_flags_client: Option<FeatureFlagsClient>,
 ) -> Result<Server, anyhow::Error> {

--- a/crates/etl-api/tests/health_check.rs
+++ b/crates/etl-api/tests/health_check.rs
@@ -1,32 +1,12 @@
 use etl_telemetry::tracing::init_test_tracing;
 
-use crate::support::test_app::{spawn_test_app, spawn_test_app_without_k8s_client};
+use crate::support::test_app::spawn_test_app;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn health_check_returns_200() {
     init_test_tracing();
     // Arrange
     let app = spawn_test_app().await;
-
-    let client = reqwest::Client::new();
-
-    // Act
-    let response = client
-        .get(format!("{}/health_check", app.address))
-        .send()
-        .await
-        .expect("Failed to execute request.");
-
-    // Assert
-    assert!(response.status().is_success());
-    assert_eq!(Some(2), response.content_length());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn health_check_returns_200_without_k8s_client() {
-    init_test_tracing();
-    // Arrange
-    let app = spawn_test_app_without_k8s_client().await;
 
     let client = reqwest::Client::new();
 

--- a/crates/etl-api/tests/metrics.rs
+++ b/crates/etl-api/tests/metrics.rs
@@ -1,32 +1,13 @@
 use etl_telemetry::tracing::init_test_tracing;
 use reqwest::Url;
 
-use crate::support::test_app::{spawn_test_app, spawn_test_app_without_k8s_client};
+use crate::support::test_app::spawn_test_app;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn metrics_endpoint_returns_200() {
     init_test_tracing();
     // Arrange
     let app = spawn_test_app().await;
-
-    let client = reqwest::Client::new();
-
-    // Act
-    let response = client
-        .get(local_test_url(&app.address, "/metrics"))
-        .send()
-        .await
-        .expect("Failed to execute request.");
-
-    // Assert
-    assert!(response.status().is_success());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn metrics_endpoint_returns_200_without_k8s_client() {
-    init_test_tracing();
-    // Arrange
-    let app = spawn_test_app_without_k8s_client().await;
 
     let client = reqwest::Client::new();
 

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -39,9 +39,7 @@ use crate::support::{
         sources::create_source,
         tenants::{create_tenant, create_tenant_with_id_and_name},
     },
-    test_app::{
-        TestApp, spawn_test_app, spawn_test_app_with_k8s_state, spawn_test_app_without_k8s_client,
-    },
+    test_app::{TestApp, spawn_test_app, spawn_test_app_with_k8s_state},
 };
 
 /// Finds a named property in a possibly composed OpenAPI schema.
@@ -109,46 +107,6 @@ async fn setup_basic_pipeline() -> (TestApp, String, i64, i64, i64) {
     )
     .await;
     (app, tenant_id, source_id, destination_id, pipeline_id)
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn pipeline_k8s_endpoints_are_noops_without_k8s_client() {
-    init_test_tracing();
-    let app = spawn_test_app_without_k8s_client().await;
-    create_default_image(&app).await;
-    let tenant_id = create_tenant(&app).await;
-    let source_id = create_source(&app, &tenant_id).await;
-    let destination_id = create_destination(&app, &tenant_id).await;
-    let pipeline_id = create_pipeline_with_config(
-        &app,
-        &tenant_id,
-        source_id,
-        destination_id,
-        new_pipeline_config(),
-    )
-    .await;
-
-    let response = app.start_pipeline(&tenant_id, pipeline_id).await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let response = app
-        .api_client
-        .get(format!("{}/v1/pipelines/{pipeline_id}/status", app.address))
-        .bearer_auth(app.api_key.clone())
-        .header("tenant_id", &tenant_id)
-        .send()
-        .await
-        .expect("failed to execute request");
-    assert_eq!(response.status(), StatusCode::OK);
-    let response: serde_json::Value =
-        response.json().await.expect("failed to deserialize response");
-    assert_eq!(response["status"]["name"], "stopped");
-
-    let response = app.stop_pipeline(&tenant_id, pipeline_id).await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let response = app.stop_all_pipelines(&tenant_id).await;
-    assert_eq!(response.status(), StatusCode::OK);
 }
 
 /// Creates a pipeline setup with a real source database for table state

--- a/crates/etl-api/tests/sources.rs
+++ b/crates/etl-api/tests/sources.rs
@@ -33,10 +33,7 @@ use crate::support::{
         },
         tenants::create_tenant,
     },
-    test_app::{
-        TestApp, spawn_test_app, spawn_test_app_with_trusted_username,
-        spawn_test_app_without_k8s_client,
-    },
+    test_app::{TestApp, spawn_test_app, spawn_test_app_with_trusted_username},
 };
 
 fn source_config_from_db_config(source_db_config: &PgConnectionConfig) -> FullApiSourceConfig {
@@ -406,32 +403,6 @@ async fn updating_source_with_running_pipeline_restarts_replicator() {
 
     assert_eq!(response.status(), StatusCode::OK);
     assert!(app.k8s_state.create_calls() > create_calls_before);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn updating_source_with_pipeline_succeeds_without_k8s_client() {
-    init_test_tracing();
-    let app = spawn_test_app_without_k8s_client().await;
-    let tenant_id = &create_tenant(&app).await;
-
-    let source = CreateSourceRequest { name: new_name(), config: new_source_config() };
-    let response = app.create_source(tenant_id, &source).await;
-    let response: CreateSourceResponse =
-        response.json().await.expect("failed to deserialize response");
-    let source_id = response.id;
-
-    create_default_image(&app).await;
-    create_pipeline_for_source(&app, tenant_id, source_id).await;
-
-    let updated_config =
-        UpdateSourceRequest { name: updated_name(), config: updated_source_config() };
-    let response = app.update_source(tenant_id, source_id, &updated_config).await;
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let response = app.read_source(tenant_id, source_id).await;
-    let response: ReadSourceResponse =
-        response.json().await.expect("failed to deserialize response");
-    assert_eq!(response.name, updated_config.name);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -633,6 +633,8 @@ async fn spawn_test_app_with_services(
         database: database_config,
         application: ApplicationSettings { host: base_address.to_owned(), port },
         k8s: K8sConfig {
+            replicator_node_selectors: Default::default(),
+            replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
                 memory_request_mib: 250,
                 cpu_request_millicores: 125,

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -595,16 +595,12 @@ pub(crate) async fn spawn_test_app_with_k8s_state(
 ) -> TestApp {
     let k8s_client: Arc<dyn K8sClient> = Arc::new(MockK8sClient::new(k8s_state.clone()));
 
-    spawn_test_app_with_services(trusted_source_username, Some(k8s_client), k8s_state).await
-}
-
-pub(crate) async fn spawn_test_app_without_k8s_client() -> TestApp {
-    spawn_test_app_with_services(None, None, MockK8sState::default()).await
+    spawn_test_app_with_services(trusted_source_username, k8s_client, k8s_state).await
 }
 
 async fn spawn_test_app_with_services(
     trusted_source_username: Option<String>,
-    k8s_client: Option<Arc<dyn K8sClient>>,
+    k8s_client: Arc<dyn K8sClient>,
     k8s_state: MockK8sState,
 ) -> TestApp {
     Environment::Dev.set();
@@ -633,6 +629,8 @@ async fn spawn_test_app_with_services(
         database: database_config,
         application: ApplicationSettings { host: base_address.to_owned(), port },
         k8s: K8sConfig {
+            replicator_namespace: "etl-data-plane".to_owned(),
+            replicator_service_account_name: "etl-replicator".to_owned(),
             replicator_node_selectors: Default::default(),
             replicator_tolerations: Default::default(),
             replicator_resources: DefaultReplicatorResourcesConfig {
@@ -640,6 +638,7 @@ async fn spawn_test_app_with_services(
                 cpu_request_millicores: 125,
                 destinations: Default::default(),
             },
+            vector_image: "timberio/vector:0.55.0-distroless-libc".to_owned(),
             vector_resources: DefaultVectorResourcesConfig {
                 memory_request_mib: 192,
                 cpu_request_millicores: 75,


### PR DESCRIPTION
This PR adds new config params to the ETL API that allow more k8s things to be configured, making it completely independent of hardcoded values. In addition, it removes the unnecessary k8s-less mode, which is not needed and just increases the complexity of the code.