### PR TITLE
Add randomized walsender disconnect test

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -467,10 +467,10 @@ Property tests built on the shared runner in `etl::test_utils::property`
 `crates/etl-destinations/tests/clickhouse/value_roundtrip.rs`) run
 randomly generated cases until a wall-clock budget elapses:
 
-| Variable                    | Description                                                                                   |
-|-----------------------------|-----------------------------------------------------------------------------------------------|
-| `PROPERTY_TEST_BUDGET_SECS` | Wall-clock budget per property in seconds (default `2`); raise it for deeper local or CI runs |
-| `PROPERTY_TEST_SEED`        | Pin the chunk RNG seed to replay a failing chunk; the failure panic prints the seed to use    |
+| Variable                    | Description                                                                                                                |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `PROPERTY_TEST_BUDGET_SECS` | Override the wall-clock budget per property; cheap properties default to `2` seconds and expensive properties default to `32` seconds |
+| `PROPERTY_TEST_SEED`        | Pin the chunk RNG seed to replay a failing chunk; the failure panic prints the seed to use                                 |
 
 #### Test Output and Logging
 

--- a/crates/etl/src/test_utils/property.rs
+++ b/crates/etl/src/test_utils/property.rs
@@ -1,14 +1,12 @@
 //! Budget-based property test runner and shared roundtrip-test helpers.
 //!
-//! [`run_property`] runs freshly generated cases until a wall-clock budget
-//! elapses instead of a fixed case count. The budget comes from the
-//! `PROPERTY_TEST_BUDGET_SECS` environment variable (default 2), so a
-//! regular suite pays a few seconds per property while CI or local deep runs
-//! can raise it to minutes.
+//! [`run_property`] runs cheap cases with a default two-second budget.
+//! [`run_expensive_property`] checks the budget after every case and defaults
+//! to 32 seconds. `PROPERTY_TEST_BUDGET_SECS` overrides either budget, so CI
+//! or local deep runs can raise it to minutes.
 //!
-//! On failure the panic names the failing chunk's RNG seed; set
-//! `PROPERTY_TEST_SEED` to that value to replay the chunk
-//! deterministically.
+//! On failure the panic names the failing chunk's RNG seed. Set
+//! `PROPERTY_TEST_SEED` to that value to replay the chunk deterministically.
 //!
 //! The module also hosts the small helpers the value roundtrip properties
 //! share across crates: the sync-to-async bridge, bit-level float matchers,
@@ -27,13 +25,21 @@ use proptest::{
 /// Number of generated cases between deadline checks.
 const CASES_PER_CHUNK: u32 = 64;
 
+/// Number of expensive cases between deadline checks.
+const EXPENSIVE_CASES_PER_CHUNK: u32 = 1;
+
+/// Default wall-clock budget for cheap properties.
+const DEFAULT_PROPERTY_BUDGET_SECS: u64 = 2;
+
+/// Default wall-clock budget for expensive properties.
+const DEFAULT_EXPENSIVE_PROPERTY_BUDGET_SECS: u64 = 32;
+
 /// Returns the wall-clock budget for one property.
 ///
-/// Panics on a malformed value instead of falling back to the default, so a
-/// deep run with a typoed budget fails loudly rather than silently running
-/// the shallow default.
-fn property_budget() -> Duration {
-    let secs = std::env::var("PROPERTY_TEST_BUDGET_SECS").map_or(2, |value| {
+/// Panics on a malformed value instead of falling back to `default_secs`, so
+/// a deep run with a typoed budget fails loudly.
+fn property_budget(default_secs: u64) -> Duration {
+    let secs = std::env::var("PROPERTY_TEST_BUDGET_SECS").map_or(default_secs, |value| {
         value.parse().expect("PROPERTY_TEST_BUDGET_SECS must be an integer number of seconds")
     });
 
@@ -53,30 +59,31 @@ fn chunk_rng(seed: u64) -> TestRng {
     TestRng::from_seed(RngAlgorithm::ChaCha, &bytes)
 }
 
-/// Runs `check` on freshly generated values until the property budget elapses.
-///
-/// Each chunk runs a fixed number of cases (`CASES_PER_CHUNK`) from a fresh
-/// random seed. On failure the value is shrunk by proptest and reported
-/// through a panic that also names the chunk seed, so the minimal failing
-/// input shows up in the test output and the chunk can be replayed with
-/// `PROPERTY_TEST_SEED`.
-pub fn run_property<S: Strategy>(
+/// Runs generated chunks until the property budget elapses.
+fn run_property_with_config<S: Strategy>(
     name: &str,
     strategy: &S,
+    cases_per_chunk: u32,
+    default_budget_secs: u64,
+    max_shrink_iters: u32,
     check: impl Fn(&S::Value) -> Result<(), TestCaseError>,
 ) {
-    let deadline = Instant::now() + property_budget();
+    let deadline = Instant::now() + property_budget(default_budget_secs);
     let replay_seed = replay_seed();
     let mut total_cases = 0u64;
 
     loop {
         let seed = replay_seed.unwrap_or_else(rand::random);
-        let config =
-            Config { cases: CASES_PER_CHUNK, failure_persistence: None, ..Default::default() };
+        let config = Config {
+            cases: cases_per_chunk,
+            max_shrink_iters,
+            failure_persistence: None,
+            ..Default::default()
+        };
         let mut runner = TestRunner::new_with_rng(config, chunk_rng(seed));
 
         match runner.run(strategy, |value| check(&value)) {
-            Ok(()) => total_cases += u64::from(CASES_PER_CHUNK),
+            Ok(()) => total_cases += u64::from(cases_per_chunk),
             Err(err) => panic!(
                 "property '{name}' failed after ~{total_cases} passing cases; rerun with \
                  PROPERTY_TEST_SEED={seed} to replay the failing chunk:\n{err}"
@@ -91,6 +98,48 @@ pub fn run_property<S: Strategy>(
     }
 
     println!("property '{name}': {total_cases} cases passed");
+}
+
+/// Runs `check` on cheap generated values until the property budget elapses.
+///
+/// Each chunk runs a fixed number of cases (`CASES_PER_CHUNK`) from a fresh
+/// random seed. On failure the value is shrunk by proptest and reported
+/// through a panic that also names the chunk seed, so the minimal failing
+/// input shows up in the test output and the chunk can be replayed with
+/// `PROPERTY_TEST_SEED`.
+pub fn run_property<S: Strategy>(
+    name: &str,
+    strategy: &S,
+    check: impl Fn(&S::Value) -> Result<(), TestCaseError>,
+) {
+    run_property_with_config(
+        name,
+        strategy,
+        CASES_PER_CHUNK,
+        DEFAULT_PROPERTY_BUDGET_SECS,
+        Config::default().max_shrink_iters,
+        check,
+    );
+}
+
+/// Runs `check` once between property-budget checks.
+///
+/// Use this runner when each case has expensive setup or I/O. It uses a
+/// 32-second default budget and does not shrink because each shrink attempt
+/// would run the full case again. The reported seed replays the exact case.
+pub fn run_expensive_property<S: Strategy>(
+    name: &str,
+    strategy: &S,
+    check: impl Fn(&S::Value) -> Result<(), TestCaseError>,
+) {
+    run_property_with_config(
+        name,
+        strategy,
+        EXPENSIVE_CASES_PER_CHUNK,
+        DEFAULT_EXPENSIVE_PROPERTY_BUDGET_SECS,
+        0,
+        check,
+    );
 }
 
 /// Runs an async future to completion from inside a synchronous proptest

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -337,82 +337,93 @@ async fn run_walsender_roulette_case(case: WalsenderRouletteCase) -> Result<(), 
         .start()
         .await
         .map_err(|error| TestCaseError::fail(format!("pipeline failed to start: {error}")))?;
-    wait_for_notification(&users_ready, "users table to become ready").await?;
+    let case_result: Result<(), TestCaseError> = async {
+        wait_for_notification(&users_ready, "users table to become ready").await?;
 
-    for user_number in 1..case.disconnect_after {
-        insert_user_and_wait(
-            &mut database,
-            &users_schema.name,
-            &destination,
-            table_id,
-            user_number,
-        )
-        .await?;
-    }
-
-    match case.response_timing {
-        WriteResponseTiming::Unheld => {
+        for user_number in 1..case.disconnect_after {
             insert_user_and_wait(
                 &mut database,
                 &users_schema.name,
                 &destination,
                 table_id,
-                case.disconnect_after,
+                user_number,
             )
             .await?;
-
-            let client = database.client.as_ref().unwrap();
-            let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
-            wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
         }
-        timing => {
-            let user_id = i64::try_from(case.disconnect_after)
-                .expect("roulette user number should fit in i64");
-            let delivered = notify_on_user_insert(&destination, table_id, user_id).await;
-            let hold = destination.hold_next(FaultyOp::WriteEvents).await;
 
-            insert_users_data(
-                &mut database,
-                &users_schema.name,
-                case.disconnect_after..=case.disconnect_after,
-            )
-            .await;
-            tokio::time::timeout(ROULETTE_TIMEOUT, hold.wait_reached())
-                .await
-                .map_err(|_| TestCaseError::fail("timed out waiting for held write response"))?;
+        match case.response_timing {
+            WriteResponseTiming::Unheld => {
+                insert_user_and_wait(
+                    &mut database,
+                    &users_schema.name,
+                    &destination,
+                    table_id,
+                    case.disconnect_after,
+                )
+                .await?;
 
-            let client = database.client.as_ref().unwrap();
-            let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
-
-            if matches!(timing, WriteResponseTiming::ReleaseThenWaitForReconnect) {
-                hold.release_ok();
-                wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
-                    .await?;
+                let client = database.client.as_ref().unwrap();
+                let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
                 wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
-            } else {
-                wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
-                hold.release_ok();
-                wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
-                    .await?;
+            }
+            timing => {
+                let user_id = i64::try_from(case.disconnect_after)
+                    .expect("roulette user number should fit in i64");
+                let delivered = notify_on_user_insert(&destination, table_id, user_id).await;
+                let hold = destination.hold_next(FaultyOp::WriteEvents).await;
+
+                insert_users_data(
+                    &mut database,
+                    &users_schema.name,
+                    case.disconnect_after..=case.disconnect_after,
+                )
+                .await;
+                tokio::time::timeout(ROULETTE_TIMEOUT, hold.wait_reached()).await.map_err(
+                    |_| TestCaseError::fail("timed out waiting for held write response"),
+                )?;
+
+                let client = database.client.as_ref().unwrap();
+                let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
+
+                if matches!(timing, WriteResponseTiming::ReleaseThenWaitForReconnect) {
+                    hold.release_ok();
+                    wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
+                        .await?;
+                    wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
+                } else {
+                    wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
+                    hold.release_ok();
+                    wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
+                        .await?;
+                }
             }
         }
-    }
 
-    for user_number in (case.disconnect_after + 1)..=case.transaction_count {
-        insert_user_and_wait(
-            &mut database,
-            &users_schema.name,
-            &destination,
-            table_id,
-            user_number,
-        )
-        .await?;
-    }
+        for user_number in (case.disconnect_after + 1)..=case.transaction_count {
+            insert_user_and_wait(
+                &mut database,
+                &users_schema.name,
+                &destination,
+                table_id,
+                user_number,
+            )
+            .await?;
+        }
 
-    tokio::time::timeout(ROULETTE_TIMEOUT, pipeline.shutdown_and_wait())
+        Ok(())
+    }
+    .await;
+
+    let shutdown_result = tokio::time::timeout(ROULETTE_TIMEOUT, pipeline.shutdown_and_wait())
         .await
-        .map_err(|_| TestCaseError::fail("timed out waiting for pipeline shutdown"))?
-        .map_err(|error| TestCaseError::fail(format!("pipeline shutdown failed: {error}")))?;
+        .map_err(|_| TestCaseError::fail("timed out waiting for pipeline shutdown"))
+        .and_then(|result| {
+            result
+                .map_err(|error| TestCaseError::fail(format!("pipeline shutdown failed: {error}")))
+        });
+
+    case_result?;
+    shutdown_result?;
 
     let source_users =
         read_source_users(database.client.as_ref().unwrap(), &users_schema.name).await?;

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -149,22 +149,6 @@ async fn wait_for_notification(
         .map_err(|_| TestCaseError::fail(format!("timed out waiting for {description}")))
 }
 
-/// Inserts one autocommit user transaction and waits for its delivery.
-async fn insert_user_and_wait(
-    database: &mut PgDatabase<Client>,
-    users_table_name: &TableName,
-    destination: &RouletteDestination,
-    table_id: TableId,
-    user_number: usize,
-) -> Result<(), TestCaseError> {
-    let user_id = i64::try_from(user_number).expect("roulette user number should fit in i64");
-    let delivered = notify_on_user_insert(destination, table_id, user_id).await;
-
-    insert_users_data(database, users_table_name, user_number..=user_number).await;
-
-    wait_for_notification(&delivered, format!("delivery of user {user_id}")).await
-}
-
 /// Terminates the active apply walsender and returns its PID.
 async fn terminate_apply_walsender(
     client: &Client,
@@ -193,6 +177,117 @@ async fn wait_for_apply_reconnect(
     tokio::time::timeout(ROULETTE_TIMEOUT, wait_for_new_walsender(client, apply_slot_name, old_pid))
         .await
         .map_err(|_| TestCaseError::fail("timed out waiting for the apply walsender to reconnect"))
+}
+
+/// Mutable state used to execute one walsender roulette workload.
+struct WalsenderRouletteWorkload<'a> {
+    /// Source database receiving generated transactions.
+    database: &'a mut PgDatabase<Client>,
+    /// Qualified users table name.
+    users_table_name: &'a TableName,
+    /// Destination recording replicated events.
+    destination: &'a RouletteDestination,
+    /// Users table identifier.
+    table_id: TableId,
+    /// Apply replication slot name.
+    apply_slot_name: &'a str,
+}
+
+impl<'a> WalsenderRouletteWorkload<'a> {
+    /// Executes the generated transactions and disconnect schedule.
+    async fn run(
+        &mut self,
+        case: WalsenderRouletteCase,
+        users_ready: &TimedNotify,
+    ) -> Result<(), TestCaseError> {
+        wait_for_notification(users_ready, "users table to become ready").await?;
+
+        for user_number in 1..case.disconnect_after {
+            self.insert_user(user_number).await?;
+        }
+
+        self.disconnect(case.disconnect_after, case.response_timing).await?;
+
+        for user_number in (case.disconnect_after + 1)..=case.transaction_count {
+            self.insert_user(user_number).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Inserts one autocommit user transaction and waits for its delivery.
+    async fn insert_user(&mut self, user_number: usize) -> Result<(), TestCaseError> {
+        let user_id = i64::try_from(user_number).expect("roulette user number should fit in i64");
+        let delivered = notify_on_user_insert(self.destination, self.table_id, user_id).await;
+
+        insert_users_data(self.database, self.users_table_name, user_number..=user_number).await;
+
+        wait_for_notification(&delivered, format!("delivery of user {user_id}")).await
+    }
+
+    /// Executes the generated disconnect schedule.
+    async fn disconnect(
+        &mut self,
+        user_number: usize,
+        response_timing: WriteResponseTiming,
+    ) -> Result<(), TestCaseError> {
+        match response_timing {
+            WriteResponseTiming::Unheld => self.disconnect_after_delivered_write(user_number).await,
+            WriteResponseTiming::ReleaseThenWaitForReconnect
+            | WriteResponseTiming::WaitForReconnectThenRelease => {
+                self.disconnect_with_held_write(user_number, response_timing).await
+            }
+        }
+    }
+
+    /// Disconnects after the scheduled write reaches the destination.
+    async fn disconnect_after_delivered_write(
+        &mut self,
+        user_number: usize,
+    ) -> Result<(), TestCaseError> {
+        self.insert_user(user_number).await?;
+
+        let client = self.database.client.as_ref().unwrap();
+        let old_pid = terminate_apply_walsender(client, self.apply_slot_name).await?;
+
+        wait_for_apply_reconnect(client, self.apply_slot_name, old_pid).await
+    }
+
+    /// Disconnects while the scheduled write response is held.
+    async fn disconnect_with_held_write(
+        &mut self,
+        user_number: usize,
+        response_timing: WriteResponseTiming,
+    ) -> Result<(), TestCaseError> {
+        let user_id = i64::try_from(user_number).expect("roulette user number should fit in i64");
+        let delivered = notify_on_user_insert(self.destination, self.table_id, user_id).await;
+        let hold = self.destination.hold_next(FaultyOp::WriteEvents).await;
+
+        insert_users_data(self.database, self.users_table_name, user_number..=user_number).await;
+        tokio::time::timeout(ROULETTE_TIMEOUT, hold.wait_reached())
+            .await
+            .map_err(|_| TestCaseError::fail("timed out waiting for held write response"))?;
+
+        let client = self.database.client.as_ref().unwrap();
+        let old_pid = terminate_apply_walsender(client, self.apply_slot_name).await?;
+
+        match response_timing {
+            WriteResponseTiming::ReleaseThenWaitForReconnect => {
+                hold.release_ok();
+                wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
+                    .await?;
+                wait_for_apply_reconnect(client, self.apply_slot_name, old_pid).await
+            }
+            WriteResponseTiming::WaitForReconnectThenRelease => {
+                wait_for_apply_reconnect(client, self.apply_slot_name, old_pid).await?;
+                hold.release_ok();
+                wait_for_notification(&delivered, format!("delivery of held user {user_id}")).await
+            }
+            WriteResponseTiming::Unheld => {
+                unreachable!("held write disconnect requires a held response timing")
+            }
+        }
+    }
 }
 
 /// Reads the committed users from the source table.
@@ -337,82 +432,16 @@ async fn run_walsender_roulette_case(case: WalsenderRouletteCase) -> Result<(), 
         .start()
         .await
         .map_err(|error| TestCaseError::fail(format!("pipeline failed to start: {error}")))?;
-    let case_result: Result<(), TestCaseError> = async {
-        wait_for_notification(&users_ready, "users table to become ready").await?;
-
-        for user_number in 1..case.disconnect_after {
-            insert_user_and_wait(
-                &mut database,
-                &users_schema.name,
-                &destination,
-                table_id,
-                user_number,
-            )
-            .await?;
-        }
-
-        match case.response_timing {
-            WriteResponseTiming::Unheld => {
-                insert_user_and_wait(
-                    &mut database,
-                    &users_schema.name,
-                    &destination,
-                    table_id,
-                    case.disconnect_after,
-                )
-                .await?;
-
-                let client = database.client.as_ref().unwrap();
-                let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
-                wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
-            }
-            timing => {
-                let user_id = i64::try_from(case.disconnect_after)
-                    .expect("roulette user number should fit in i64");
-                let delivered = notify_on_user_insert(&destination, table_id, user_id).await;
-                let hold = destination.hold_next(FaultyOp::WriteEvents).await;
-
-                insert_users_data(
-                    &mut database,
-                    &users_schema.name,
-                    case.disconnect_after..=case.disconnect_after,
-                )
-                .await;
-                tokio::time::timeout(ROULETTE_TIMEOUT, hold.wait_reached()).await.map_err(
-                    |_| TestCaseError::fail("timed out waiting for held write response"),
-                )?;
-
-                let client = database.client.as_ref().unwrap();
-                let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
-
-                if matches!(timing, WriteResponseTiming::ReleaseThenWaitForReconnect) {
-                    hold.release_ok();
-                    wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
-                        .await?;
-                    wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
-                } else {
-                    wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
-                    hold.release_ok();
-                    wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
-                        .await?;
-                }
-            }
-        }
-
-        for user_number in (case.disconnect_after + 1)..=case.transaction_count {
-            insert_user_and_wait(
-                &mut database,
-                &users_schema.name,
-                &destination,
-                table_id,
-                user_number,
-            )
-            .await?;
-        }
-
-        Ok(())
-    }
-    .await;
+    let workload_result = {
+        let mut workload = WalsenderRouletteWorkload {
+            database: &mut database,
+            users_table_name: &users_schema.name,
+            destination: &destination,
+            table_id,
+            apply_slot_name: &apply_slot_name,
+        };
+        workload.run(case, &users_ready).await
+    };
 
     let shutdown_result = tokio::time::timeout(ROULETTE_TIMEOUT, pipeline.shutdown_and_wait())
         .await
@@ -422,7 +451,7 @@ async fn run_walsender_roulette_case(case: WalsenderRouletteCase) -> Result<(), 
                 .map_err(|error| TestCaseError::fail(format!("pipeline shutdown failed: {error}")))
         });
 
-    case_result?;
+    workload_result?;
     shutdown_result?;
 
     let source_users =

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -46,15 +46,15 @@ const ROULETTE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Destination wrapper used by the walsender roulette.
 type RouletteDestination = TestDestinationWrapper<MemoryDestination<NotifyingStore>>;
 
-/// Controls the write response state when the walsender disconnects.
+/// Controls write-response handling around the walsender disconnect.
 #[derive(Clone, Copy, Debug)]
 enum WriteResponseTiming {
     /// Disconnect after the prefix is acknowledged.
     Unheld,
-    /// Release the in-flight response before observing the reconnect.
-    ReleasedBeforeReconnect,
-    /// Release the in-flight response after observing the reconnect.
-    ReleasedAfterReconnect,
+    /// Release the in-flight response, then wait for the reconnect.
+    ReleaseThenWaitForReconnect,
+    /// Wait for the reconnect, then release the in-flight response.
+    WaitForReconnectThenRelease,
 }
 
 /// One generated walsender roulette schedule.
@@ -64,7 +64,7 @@ struct WalsenderRouletteCase {
     transaction_count: usize,
     /// Non-empty proper prefix after which the walsender disconnects.
     disconnect_after: usize,
-    /// Write response state at disconnect time.
+    /// Write-response schedule around the disconnect.
     response_timing: WriteResponseTiming,
 }
 
@@ -72,8 +72,8 @@ struct WalsenderRouletteCase {
 fn walsender_roulette_cases() -> impl Strategy<Value = WalsenderRouletteCase> {
     let response_timing = prop_oneof![
         Just(WriteResponseTiming::Unheld),
-        Just(WriteResponseTiming::ReleasedBeforeReconnect),
-        Just(WriteResponseTiming::ReleasedAfterReconnect),
+        Just(WriteResponseTiming::ReleaseThenWaitForReconnect),
+        Just(WriteResponseTiming::WaitForReconnectThenRelease),
     ];
 
     (2usize..=8, response_timing)
@@ -384,7 +384,7 @@ async fn run_walsender_roulette_case(case: WalsenderRouletteCase) -> Result<(), 
             let client = database.client.as_ref().unwrap();
             let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
 
-            if matches!(timing, WriteResponseTiming::ReleasedBeforeReconnect) {
+            if matches!(timing, WriteResponseTiming::ReleaseThenWaitForReconnect) {
                 hold.release_ok();
                 wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
                     .await?;

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -1,26 +1,31 @@
-use std::time::Duration;
+use std::{collections::BTreeMap, time::Duration};
 
 use etl::{
+    data::{Cell, TableRow},
     error::ErrorKind,
     event::{Event, EventType},
     pipeline::PipelineId,
-    schema::TableId,
+    schema::{TableId, TableName},
     store::{StateStore, TableRetryPolicy, TableState, TableStateType},
     test_utils::{
         database::{replication_slot_state, spawn_source_database, wait_for_new_walsender},
         event::{EventCondition, group_events_by_type_and_table_id},
         faults::{FaultAction, FaultyOp},
+        materialize::{FromTableRow, materialize_events},
         memory_destination::MemoryDestination,
+        notify::TimedNotify,
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
+        property::{block_on, run_expensive_property},
         test_destination_wrapper::TestDestinationWrapper,
         test_schema::{TableSelection, insert_users_data, setup_test_database_schema},
     },
 };
-use etl_postgres::slots::EtlReplicationSlot;
+use etl_postgres::{slots::EtlReplicationSlot, tokio::test_utils::PgDatabase};
 use etl_telemetry::tracing::init_test_tracing;
+use proptest::prelude::*;
 use rand::random;
-use tokio_postgres::types::PgLsn;
+use tokio_postgres::{Client, types::PgLsn};
 
 /// Returns the commit LSNs of recorded insert events for the table, in order.
 fn table_insert_commit_lsns(events: &[Event], table_id: TableId) -> Vec<PgLsn> {
@@ -33,6 +38,387 @@ fn table_insert_commit_lsns(events: &[Event], table_id: TableId) -> Vec<PgLsn> {
             _ => None,
         })
         .collect()
+}
+
+/// Maximum time for one roulette synchronization point.
+const ROULETTE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Destination wrapper used by the walsender roulette.
+type RouletteDestination = TestDestinationWrapper<MemoryDestination<NotifyingStore>>;
+
+/// Controls the write response state when the walsender disconnects.
+#[derive(Clone, Copy, Debug)]
+enum WriteResponseTiming {
+    /// Disconnect after the prefix is acknowledged.
+    Unheld,
+    /// Release the in-flight response before observing the reconnect.
+    ReleasedBeforeReconnect,
+    /// Release the in-flight response after observing the reconnect.
+    ReleasedAfterReconnect,
+}
+
+/// One generated walsender roulette schedule.
+#[derive(Clone, Copy, Debug)]
+struct WalsenderRouletteCase {
+    /// Number of committed single-row transactions.
+    transaction_count: usize,
+    /// Non-empty proper prefix after which the walsender disconnects.
+    disconnect_after: usize,
+    /// Write response state at disconnect time.
+    response_timing: WriteResponseTiming,
+}
+
+/// Generates bounded workloads and disconnect schedules.
+fn walsender_roulette_cases() -> impl Strategy<Value = WalsenderRouletteCase> {
+    let response_timing = prop_oneof![
+        Just(WriteResponseTiming::Unheld),
+        Just(WriteResponseTiming::ReleasedBeforeReconnect),
+        Just(WriteResponseTiming::ReleasedAfterReconnect),
+    ];
+
+    (2usize..=8, response_timing)
+        .prop_flat_map(|(transaction_count, response_timing)| {
+            (Just(transaction_count), 1usize..transaction_count, Just(response_timing))
+        })
+        .prop_map(|(transaction_count, disconnect_after, response_timing)| WalsenderRouletteCase {
+            transaction_count,
+            disconnect_after,
+            response_timing,
+        })
+}
+
+/// Typed state for one row in the users table.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct UserRecord {
+    /// Source primary key.
+    id: i64,
+    /// Source user name.
+    name: String,
+    /// Source user age.
+    age: i32,
+}
+
+impl FromTableRow for UserRecord {
+    type Id = i64;
+
+    fn from_table_row(table_row: &TableRow) -> Option<Self> {
+        let [Cell::I64(id), Cell::String(name), Cell::I32(age)] = table_row.values() else {
+            return None;
+        };
+
+        Some(Self { id: *id, name: name.clone(), age: *age })
+    }
+
+    fn id(&self) -> Self::Id {
+        self.id
+    }
+}
+
+/// Returns whether the event history contains an insert for `user_id`.
+fn has_user_insert(events: &[Event], table_id: TableId, user_id: i64) -> bool {
+    events.iter().any(|event| {
+        let Event::Insert(insert) = event else {
+            return false;
+        };
+
+        insert.replicated_table_schema.id() == table_id
+            && matches!(
+                insert.table_row.values().first(),
+                Some(Cell::I64(recorded_id)) if *recorded_id == user_id
+            )
+    })
+}
+
+/// Registers a notification for one user insert.
+async fn notify_on_user_insert(
+    destination: &RouletteDestination,
+    table_id: TableId,
+    user_id: i64,
+) -> TimedNotify {
+    destination.notify_on_events(move |events| has_user_insert(events, table_id, user_id)).await
+}
+
+/// Waits for one bounded roulette synchronization point.
+async fn wait_for_notification(
+    notification: &TimedNotify,
+    description: impl Into<String>,
+) -> Result<(), TestCaseError> {
+    let description = description.into();
+    tokio::time::timeout(ROULETTE_TIMEOUT, notification.inner().notified())
+        .await
+        .map_err(|_| TestCaseError::fail(format!("timed out waiting for {description}")))
+}
+
+/// Inserts one autocommit user transaction and waits for its delivery.
+async fn insert_user_and_wait(
+    database: &mut PgDatabase<Client>,
+    users_table_name: &TableName,
+    destination: &RouletteDestination,
+    table_id: TableId,
+    user_number: usize,
+) -> Result<(), TestCaseError> {
+    let user_id = i64::try_from(user_number).expect("roulette user number should fit in i64");
+    let delivered = notify_on_user_insert(destination, table_id, user_id).await;
+
+    insert_users_data(database, users_table_name, user_number..=user_number).await;
+
+    wait_for_notification(&delivered, format!("delivery of user {user_id}")).await
+}
+
+/// Terminates the active apply walsender and returns its PID.
+async fn terminate_apply_walsender(
+    client: &Client,
+    apply_slot_name: &str,
+) -> Result<i32, TestCaseError> {
+    let (_, active_pid) = replication_slot_state(client, apply_slot_name).await;
+    let old_pid = active_pid
+        .ok_or_else(|| TestCaseError::fail("apply walsender was not active at disconnect"))?;
+    let row = client
+        .query_one("select pg_terminate_backend($1)", &[&old_pid])
+        .await
+        .map_err(|error| TestCaseError::fail(format!("failed to terminate walsender: {error}")))?;
+    let terminated: bool = row.get(0);
+
+    prop_assert!(terminated, "Postgres did not terminate apply walsender {old_pid}");
+
+    Ok(old_pid)
+}
+
+/// Waits for a new apply walsender within the roulette timeout.
+async fn wait_for_apply_reconnect(
+    client: &Client,
+    apply_slot_name: &str,
+    old_pid: i32,
+) -> Result<(), TestCaseError> {
+    tokio::time::timeout(ROULETTE_TIMEOUT, wait_for_new_walsender(client, apply_slot_name, old_pid))
+        .await
+        .map_err(|_| TestCaseError::fail("timed out waiting for the apply walsender to reconnect"))
+}
+
+/// Reads the committed users from the source table.
+async fn read_source_users(
+    client: &Client,
+    users_table_name: &TableName,
+) -> Result<BTreeMap<i64, UserRecord>, TestCaseError> {
+    let query = format!(
+        "select id, name, age from {} order by id",
+        users_table_name.as_quoted_identifier()
+    );
+    let rows = client
+        .query(&query, &[])
+        .await
+        .map_err(|error| TestCaseError::fail(format!("failed to read source users: {error}")))?;
+    let mut users = BTreeMap::new();
+
+    for row in rows {
+        let user = UserRecord { id: row.get(0), name: row.get(1), age: row.get(2) };
+        let previous = users.insert(user.id, user);
+        prop_assert!(previous.is_none(), "source returned a duplicate user ID");
+    }
+
+    Ok(users)
+}
+
+/// Compares acknowledged destination history with committed source state.
+fn assert_users_converged(
+    events: &[Event],
+    table_id: TableId,
+    source_users: &BTreeMap<i64, UserRecord>,
+    transaction_count: usize,
+) -> Result<(), TestCaseError> {
+    let materialized_users = materialize_events::<UserRecord>(events, Some(table_id));
+    let table_insert_count = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                Event::Insert(insert) if insert.replicated_table_schema.id() == table_id
+            )
+        })
+        .count();
+
+    prop_assert_eq!(
+        materialized_users.len(),
+        table_insert_count,
+        "every recorded insert must contain a complete users row"
+    );
+
+    let mut destination_users = BTreeMap::new();
+    let mut delivery_metadata = BTreeMap::<i64, (PgLsn, usize)>::new();
+
+    for event in events {
+        let Event::Insert(insert) = event else {
+            continue;
+        };
+        if insert.replicated_table_schema.id() != table_id {
+            continue;
+        }
+
+        let Some(Cell::I64(user_id)) = insert.table_row.values().first() else {
+            return Err(TestCaseError::fail("recorded users insert did not contain an int8 ID"));
+        };
+
+        if let Some((first_commit_lsn, delivery_count)) = delivery_metadata.get_mut(user_id) {
+            prop_assert_eq!(
+                *first_commit_lsn,
+                insert.commit_lsn,
+                "replayed insert for user {} changed its commit LSN",
+                user_id
+            );
+            *delivery_count += 1;
+        } else {
+            delivery_metadata.insert(*user_id, (insert.commit_lsn, 1));
+        }
+    }
+
+    for user in materialized_users {
+        if let Some(previous) = destination_users.get(&user.id) {
+            prop_assert_eq!(
+                previous,
+                &user,
+                "replayed insert for user {} changed its payload",
+                user.id
+            );
+        } else {
+            destination_users.insert(user.id, user);
+        }
+    }
+
+    prop_assert_eq!(
+        source_users.len(),
+        transaction_count,
+        "source did not contain every committed transaction"
+    );
+    prop_assert_eq!(
+        &destination_users,
+        source_users,
+        "materialized destination state did not converge to source state"
+    );
+    prop_assert_eq!(
+        delivery_metadata.len(),
+        source_users.len(),
+        "event history contained missing or unexpected user IDs"
+    );
+
+    for user_id in source_users.keys() {
+        let delivery_count =
+            delivery_metadata.get(user_id).map_or(0, |(_, delivery_count)| *delivery_count);
+        prop_assert!(
+            (1..=2).contains(&delivery_count),
+            "user {user_id} had {delivery_count} deliveries; expected one delivery or one replay"
+        );
+    }
+
+    Ok(())
+}
+
+/// Runs one generated workload and fault schedule to convergence.
+async fn run_walsender_roulette_case(case: WalsenderRouletteCase) -> Result<(), TestCaseError> {
+    let mut database = spawn_source_database().await;
+    let database_schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let users_schema = database_schema.users_schema();
+    let table_id = users_schema.id;
+
+    let store = NotifyingStore::new();
+    let destination = TestDestinationWrapper::wrap(MemoryDestination::new(store.clone()));
+    let pipeline_id: PipelineId = random();
+    let apply_slot_name: String =
+        EtlReplicationSlot::for_apply_worker(pipeline_id).try_into().unwrap();
+    let mut pipeline = create_pipeline(
+        &database.config,
+        pipeline_id,
+        database_schema.publication_name(),
+        store.clone(),
+        destination.clone(),
+    );
+    let users_ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    pipeline
+        .start()
+        .await
+        .map_err(|error| TestCaseError::fail(format!("pipeline failed to start: {error}")))?;
+    wait_for_notification(&users_ready, "users table to become ready").await?;
+
+    for user_number in 1..case.disconnect_after {
+        insert_user_and_wait(
+            &mut database,
+            &users_schema.name,
+            &destination,
+            table_id,
+            user_number,
+        )
+        .await?;
+    }
+
+    match case.response_timing {
+        WriteResponseTiming::Unheld => {
+            insert_user_and_wait(
+                &mut database,
+                &users_schema.name,
+                &destination,
+                table_id,
+                case.disconnect_after,
+            )
+            .await?;
+
+            let client = database.client.as_ref().unwrap();
+            let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
+            wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
+        }
+        timing => {
+            let user_id = i64::try_from(case.disconnect_after)
+                .expect("roulette user number should fit in i64");
+            let delivered = notify_on_user_insert(&destination, table_id, user_id).await;
+            let hold = destination.hold_next(FaultyOp::WriteEvents).await;
+
+            insert_users_data(
+                &mut database,
+                &users_schema.name,
+                case.disconnect_after..=case.disconnect_after,
+            )
+            .await;
+            tokio::time::timeout(ROULETTE_TIMEOUT, hold.wait_reached())
+                .await
+                .map_err(|_| TestCaseError::fail("timed out waiting for held write response"))?;
+
+            let client = database.client.as_ref().unwrap();
+            let old_pid = terminate_apply_walsender(client, &apply_slot_name).await?;
+
+            if matches!(timing, WriteResponseTiming::ReleasedBeforeReconnect) {
+                hold.release_ok();
+                wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
+                    .await?;
+                wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
+            } else {
+                wait_for_apply_reconnect(client, &apply_slot_name, old_pid).await?;
+                hold.release_ok();
+                wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
+                    .await?;
+            }
+        }
+    }
+
+    for user_number in (case.disconnect_after + 1)..=case.transaction_count {
+        insert_user_and_wait(
+            &mut database,
+            &users_schema.name,
+            &destination,
+            table_id,
+            user_number,
+        )
+        .await?;
+    }
+
+    tokio::time::timeout(ROULETTE_TIMEOUT, pipeline.shutdown_and_wait())
+        .await
+        .map_err(|_| TestCaseError::fail("timed out waiting for pipeline shutdown"))?
+        .map_err(|error| TestCaseError::fail(format!("pipeline shutdown failed: {error}")))?;
+
+    let source_users =
+        read_source_users(database.client.as_ref().unwrap(), &users_schema.name).await?;
+    let events = destination.get_events().await;
+
+    assert_users_converged(&events, table_id, &source_users, case.transaction_count)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -445,4 +831,14 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
         "insert must survive with at most one replay, got {first_count} copies"
     );
     assert_eq!(final_lsns.iter().filter(|lsn| **lsn > first_commit_lsn).count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn apply_disconnect_at_randomized_positions_converges_without_loss() {
+    init_test_tracing();
+
+    let strategy = walsender_roulette_cases();
+    run_expensive_property("walsender roulette", &strategy, |case| {
+        block_on(run_walsender_roulette_case(*case))
+    });
 }


### PR DESCRIPTION
Randomizes our walsender disconnect test that we get more coverage of disconnects, rather than always killing the walsender at a handpicked moment.