### PR TITLE
ref(core): remove impossible state

### DIFF
--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -143,7 +143,7 @@ pub(crate) struct ApplyLoopAsyncResultMetadata {
 /// side immediately or later, depending on the method.
 #[derive(Debug)]
 pub struct AsyncResult<T> {
-    tx: Option<oneshot::Sender<(Instant, EtlResult<T>)>>,
+    tx: oneshot::Sender<(Instant, EtlResult<T>)>,
 }
 
 impl<T> AsyncResult<T> {
@@ -155,18 +155,14 @@ impl<T> AsyncResult<T> {
     pub(crate) fn new<M>(metadata: M) -> (Self, PendingAsyncResult<T, M>) {
         let (tx, rx) = oneshot::channel();
 
-        (Self { tx: Some(tx) }, PendingAsyncResult { metadata: Some(metadata), rx })
+        (Self { tx }, PendingAsyncResult { metadata: Some(metadata), rx })
     }
 
     /// Sends the final result to the waiting receiver and records its
     /// completion instant.
-    pub fn send(mut self, result: EtlResult<T>) {
-        let Some(tx) = self.tx.take() else {
-            return;
-        };
-
+    pub fn send(self, result: EtlResult<T>) {
         let completed_at = Instant::now();
-        if tx.send((completed_at, result)).is_err() {
+        if self.tx.send((completed_at, result)).is_err() {
             debug!("async result receiver was already closed");
         }
     }

--- a/crates/etl/src/pipeline.rs
+++ b/crates/etl/src/pipeline.rs
@@ -226,7 +226,7 @@ where
             table_sync_worker_permits,
             memory_monitor.clone(),
         )
-        .spawn()?;
+        .spawn();
 
         self.state = PipelineState::Started { apply_worker, pool, memory_monitor };
 

--- a/crates/etl/src/runtime/apply/worker.rs
+++ b/crates/etl/src/runtime/apply/worker.rs
@@ -208,7 +208,7 @@ where
     /// LSN, creating coordination signals, and launching the main apply
     /// loop. The worker runs asynchronously and can be monitored through
     /// the returned handle.
-    pub(crate) fn spawn(self) -> EtlResult<ApplyWorkerHandle> {
+    pub(crate) fn spawn(self) -> ApplyWorkerHandle {
         info!("starting apply worker");
 
         let apply_worker_span = tracing::info_span!(
@@ -221,7 +221,7 @@ where
 
         let handle = tokio::spawn(apply_worker);
 
-        Ok(ApplyWorkerHandle { handle })
+        ApplyWorkerHandle { handle }
     }
 
     /// Runs the apply worker with retry handling for timed-retriable errors.

--- a/crates/etl/src/runtime/apply/worker.rs
+++ b/crates/etl/src/runtime/apply/worker.rs
@@ -38,7 +38,7 @@ use crate::{
 /// handle enables waiting for worker completion and checking final results.
 #[derive(Debug)]
 pub(crate) struct ApplyWorkerHandle {
-    handle: Option<JoinHandle<EtlResult<()>>>,
+    handle: JoinHandle<EtlResult<()>>,
 }
 
 impl ApplyWorkerHandle {
@@ -47,12 +47,8 @@ impl ApplyWorkerHandle {
     /// This method blocks until the apply worker finishes processing, either
     /// due to successful completion, shutdown signal, or error. It properly
     /// handles panics that might occur within the worker task.
-    pub(crate) async fn wait(mut self) -> EtlResult<()> {
-        let Some(handle) = self.handle.take() else {
-            return Ok(());
-        };
-
-        handle.await.map_err(|err| {
+    pub(crate) async fn wait(self) -> EtlResult<()> {
+        self.handle.await.map_err(|err| {
             if err.is_cancelled() {
                 etl_error!(ErrorKind::ApplyWorkerCancelled, "Apply worker was cancelled", source: err)
             } else {
@@ -225,7 +221,7 @@ where
 
         let handle = tokio::spawn(apply_worker);
 
-        Ok(ApplyWorkerHandle { handle: Some(handle) })
+        Ok(ApplyWorkerHandle { handle })
     }
 
     /// Runs the apply worker with retry handling for timed-retriable errors.


### PR DESCRIPTION
## Why

- Both handles were wrapped in `Option`, even though `send` and `wait` consume them and can only be called once. 
- `ApplyWorker::spawn` also returned a `Result`, even though it cannot return an error.

These are remnants of previous design.

## What changed

- Store both handles directly.
- Return `ApplyWorkerHandle` directly from `spawn`.
- Remove the unreachable branches and unnecessary error propagation.

No behavior changed. 