### PR TITLE
feat(ducklake): add support for table ordering configuration

### DIFF
--- a/crates/etl-api/src/configs/destination.rs
+++ b/crates/etl-api/src/configs/destination.rs
@@ -1,6 +1,9 @@
 use etl_config::{
     SerializableSecretString,
-    shared::{ClickHouseEngine, DestinationConfig, DuckLakeMaintenanceMode, IcebergConfig},
+    shared::{
+        ClickHouseEngine, DestinationConfig, DuckLakeMaintenanceMode, DuckLakeTableSortingConfig,
+        IcebergConfig,
+    },
 };
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
@@ -145,6 +148,10 @@ pub enum ApiDestinationConfig {
         #[schema(example = "kubernetes")]
         #[serde(default)]
         maintenance_mode: DuckLakeMaintenanceMode,
+        /// Per-table DuckLake sort orders. Omit to preserve today's unsorted
+        /// behavior.
+        #[serde(default, skip_serializing_if = "DuckLakeTableSortingConfig::is_empty")]
+        table_sorting: DuckLakeTableSortingConfig,
     },
     Snowflake {
         #[schema(example = "ORGNAME-ACCOUNTNAME")]
@@ -422,6 +429,9 @@ pub enum UpdateApiDestinationConfig {
         #[schema(example = "kubernetes")]
         #[serde(default, skip_serializing_if = "UpdateField::is_preserve")]
         maintenance_mode: UpdateField<DuckLakeMaintenanceMode>,
+        /// Replaces all per-table sort orders. `null` resets them.
+        #[serde(default, skip_serializing_if = "UpdateField::is_preserve")]
+        table_sorting: UpdateField<DuckLakeTableSortingConfig>,
     },
     Snowflake {
         #[schema(example = "ORGNAME-ACCOUNTNAME")]
@@ -518,6 +528,7 @@ impl UpdateApiDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => Self::Ducklake {
                 catalog_url: UpdateField::Set(catalog_url),
                 data_path: UpdateField::Set(data_path),
@@ -534,6 +545,7 @@ impl UpdateApiDestinationConfig {
                 ),
                 expire_snapshots_older_than: UpdateField::from_option(expire_snapshots_older_than),
                 maintenance_mode: UpdateField::Set(maintenance_mode),
+                table_sorting: UpdateField::Set(table_sorting),
             },
             ApiDestinationConfig::Snowflake {
                 account_id,
@@ -635,6 +647,7 @@ impl UpdateApiDestinationConfig {
                     maintenance_target_file_size,
                     expire_snapshots_older_than,
                     maintenance_mode,
+                    table_sorting,
                 },
                 StoredDestinationConfig::Ducklake {
                     catalog_url: stored_catalog_url,
@@ -650,6 +663,7 @@ impl UpdateApiDestinationConfig {
                     maintenance_target_file_size: stored_maintenance_target_file_size,
                     expire_snapshots_older_than: stored_expire_snapshots_older_than,
                     maintenance_mode: stored_maintenance_mode,
+                    table_sorting: stored_table_sorting,
                 },
             ) => Ok(StoredDestinationConfig::Ducklake {
                 catalog_url: catalog_url.apply_to_required(
@@ -675,6 +689,8 @@ impl UpdateApiDestinationConfig {
                     .apply_to_option(stored_expire_snapshots_older_than),
                 maintenance_mode: maintenance_mode
                     .apply_to_value(stored_maintenance_mode, DuckLakeMaintenanceMode::default),
+                table_sorting: table_sorting
+                    .apply_to_value(stored_table_sorting, DuckLakeTableSortingConfig::default),
             }),
             (
                 Self::Snowflake {
@@ -787,6 +803,7 @@ impl UpdateApiDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => Ok(StoredDestinationConfig::Ducklake {
                 catalog_url: catalog_url.into_required(
                     missing_required_secret("DuckLake", "catalog_url"),
@@ -810,6 +827,10 @@ impl UpdateApiDestinationConfig {
                 maintenance_mode: maintenance_mode.apply_to_value(
                     DuckLakeMaintenanceMode::default(),
                     DuckLakeMaintenanceMode::default,
+                ),
+                table_sorting: table_sorting.apply_to_value(
+                    DuckLakeTableSortingConfig::default(),
+                    DuckLakeTableSortingConfig::default,
                 ),
             }),
             Self::Snowflake {
@@ -943,6 +964,7 @@ impl From<StoredDestinationConfig> for ApiDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => Self::Ducklake {
                 catalog_url,
                 data_path,
@@ -957,6 +979,7 @@ impl From<StoredDestinationConfig> for ApiDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             },
             StoredDestinationConfig::Snowflake {
                 account_id,
@@ -1012,6 +1035,7 @@ pub enum StoredDestinationConfig {
         maintenance_target_file_size: Option<String>,
         expire_snapshots_older_than: Option<String>,
         maintenance_mode: DuckLakeMaintenanceMode,
+        table_sorting: DuckLakeTableSortingConfig,
     },
     Snowflake {
         account_id: String,
@@ -1101,6 +1125,7 @@ impl StoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => DestinationConfig::Ducklake {
                 catalog_url: catalog_url.into(),
                 data_path,
@@ -1115,6 +1140,7 @@ impl StoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             },
             Self::Snowflake {
                 account_id,
@@ -1209,6 +1235,7 @@ impl From<ApiDestinationConfig> for StoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => Self::Ducklake {
                 catalog_url,
                 data_path,
@@ -1223,6 +1250,7 @@ impl From<ApiDestinationConfig> for StoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             },
             ApiDestinationConfig::Snowflake {
                 account_id,
@@ -1352,6 +1380,7 @@ impl Encrypt<EncryptedStoredDestinationConfig> for StoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => {
                 let encrypted_catalog_url =
                     encrypt_text(catalog_url.expose_secret().to_owned(), encryption_key)?;
@@ -1376,6 +1405,7 @@ impl Encrypt<EncryptedStoredDestinationConfig> for StoredDestinationConfig {
                     maintenance_target_file_size,
                     expire_snapshots_older_than,
                     maintenance_mode,
+                    table_sorting,
                 })
             }
             Self::Snowflake {
@@ -1457,6 +1487,8 @@ pub enum EncryptedStoredDestinationConfig {
         expire_snapshots_older_than: Option<String>,
         #[serde(default)]
         maintenance_mode: DuckLakeMaintenanceMode,
+        #[serde(default, skip_serializing_if = "DuckLakeTableSortingConfig::is_empty")]
+        table_sorting: DuckLakeTableSortingConfig,
     },
     Snowflake {
         account_id: String,
@@ -1594,6 +1626,7 @@ impl Decrypt<StoredDestinationConfig> for EncryptedStoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => Ok(StoredDestinationConfig::Ducklake {
                 catalog_url: SerializableSecretString::from(decrypt_text(
                     catalog_url,
@@ -1619,6 +1652,7 @@ impl Decrypt<StoredDestinationConfig> for EncryptedStoredDestinationConfig {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             }),
             Self::Snowflake {
                 account_id,
@@ -2073,6 +2107,45 @@ mod tests {
     use crate::configs::encryption::{
         EncryptionKey, EncryptionKeyring, encrypt_text, generate_random_key,
     };
+
+    fn ducklake_table_sorting() -> DuckLakeTableSortingConfig {
+        serde_json::from_value(serde_json::json!({
+            "tables": [{
+                "schema": "public",
+                "table": "events",
+                "sort_by": {
+                    "kind": "columns",
+                    "columns": [{
+                        "name": "created_at",
+                        "direction": "desc",
+                        "nulls": "last"
+                    }]
+                }
+            }]
+        }))
+        .unwrap()
+    }
+
+    fn ducklake_api_config(table_sorting: DuckLakeTableSortingConfig) -> ApiDestinationConfig {
+        ApiDestinationConfig::Ducklake {
+            catalog_url: SerializableSecretString::from(
+                "postgres://user:pass@localhost:5432/ducklake_catalog".to_owned(),
+            ),
+            data_path: "s3://bucket/path".to_owned(),
+            pool_size: Some(4),
+            s3_access_key_id: None,
+            s3_secret_access_key: None,
+            s3_region: None,
+            s3_endpoint: None,
+            s3_url_style: None,
+            s3_use_ssl: None,
+            metadata_schema: None,
+            maintenance_target_file_size: None,
+            expire_snapshots_older_than: None,
+            maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting,
+        }
+    }
 
     #[test]
     fn stored_destination_config_encryption_decryption_bigquery() {
@@ -2572,6 +2645,47 @@ mod tests {
     }
 
     #[test]
+    fn update_api_destination_config_preserves_clears_and_replaces_table_sorting() {
+        let stored_config: StoredDestinationConfig =
+            ducklake_api_config(ducklake_table_sorting()).into();
+        let preserve: UpdateApiDestinationConfig =
+            serde_json::from_value(serde_json::json!({"ducklake": {}})).unwrap();
+        let preserved = preserve.merge_into_stored(stored_config.clone()).unwrap();
+        let StoredDestinationConfig::Ducklake { table_sorting, .. } = preserved else {
+            panic!("Config type doesn't match");
+        };
+        assert_eq!(table_sorting, ducklake_table_sorting());
+
+        let clear: UpdateApiDestinationConfig = serde_json::from_value(serde_json::json!({
+            "ducklake": {"table_sorting": null}
+        }))
+        .unwrap();
+        let cleared = clear.merge_into_stored(stored_config.clone()).unwrap();
+        let StoredDestinationConfig::Ducklake { table_sorting, .. } = cleared else {
+            panic!("Config type doesn't match");
+        };
+        assert!(table_sorting.is_empty());
+
+        let replacement: DuckLakeTableSortingConfig = serde_json::from_value(serde_json::json!({
+            "tables": [{
+                "schema": "public",
+                "table": "accounts",
+                "sort_by": {"kind": "primary_key"}
+            }]
+        }))
+        .unwrap();
+        let replace: UpdateApiDestinationConfig = serde_json::from_value(serde_json::json!({
+            "ducklake": {"table_sorting": replacement}
+        }))
+        .unwrap();
+        let replaced = replace.merge_into_stored(stored_config).unwrap();
+        let StoredDestinationConfig::Ducklake { table_sorting, .. } = replaced else {
+            panic!("Config type doesn't match");
+        };
+        assert_eq!(table_sorting, replacement);
+    }
+
+    #[test]
     fn update_api_destination_config_replaces_provided_bigquery_secret() {
         let stored_config = StoredDestinationConfig::BigQuery {
             project_id: "test-project".to_owned(),
@@ -2916,6 +3030,7 @@ mod tests {
             maintenance_target_file_size: Some("10MB".to_owned()),
             expire_snapshots_older_than: Some("7 days".to_owned()),
             maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting: ducklake_table_sorting(),
         };
 
         let key = EncryptionKeyring::from(EncryptionKey {
@@ -2942,6 +3057,7 @@ mod tests {
                     maintenance_target_file_size: target1,
                     expire_snapshots_older_than: expire1,
                     maintenance_mode: mode1,
+                    table_sorting: sorting1,
                 },
                 StoredDestinationConfig::Ducklake {
                     catalog_url: c2,
@@ -2957,6 +3073,7 @@ mod tests {
                     maintenance_target_file_size: target2,
                     expire_snapshots_older_than: expire2,
                     maintenance_mode: mode2,
+                    table_sorting: sorting2,
                 },
             ) => {
                 assert_eq!(c1.expose_secret(), c2.expose_secret());
@@ -2978,6 +3095,7 @@ mod tests {
                 assert_eq!(target1, target2);
                 assert_eq!(expire1, expire2);
                 assert_eq!(mode1, mode2);
+                assert_eq!(sorting1, sorting2);
             }
             _ => panic!("Config types don't match"),
         }
@@ -3002,8 +3120,11 @@ mod tests {
         .unwrap();
 
         match config {
-            EncryptedStoredDestinationConfig::Ducklake { maintenance_mode, .. } => {
+            EncryptedStoredDestinationConfig::Ducklake {
+                maintenance_mode, table_sorting, ..
+            } => {
                 assert_eq!(maintenance_mode, DuckLakeMaintenanceMode::Disabled);
+                assert!(table_sorting.is_empty());
             }
             _ => panic!("Config type doesn't match"),
         }
@@ -3034,8 +3155,9 @@ mod tests {
         .unwrap();
 
         match config {
-            ApiDestinationConfig::Ducklake { maintenance_mode, .. } => {
+            ApiDestinationConfig::Ducklake { maintenance_mode, table_sorting, .. } => {
                 assert_eq!(maintenance_mode, DuckLakeMaintenanceMode::Disabled);
+                assert!(table_sorting.is_empty());
             }
             _ => panic!("Config type doesn't match"),
         }
@@ -3059,6 +3181,7 @@ mod tests {
             maintenance_target_file_size: None,
             expire_snapshots_older_than: None,
             maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting: ducklake_table_sorting(),
         };
 
         let stored: StoredDestinationConfig = api_config.clone().into();
@@ -3115,6 +3238,7 @@ mod tests {
             maintenance_target_file_size: Some("10MB".to_owned()),
             expire_snapshots_older_than: Some("7 days".to_owned()),
             maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting: ducklake_table_sorting(),
         };
 
         assert_json_snapshot!(api_config);
@@ -3137,6 +3261,7 @@ mod tests {
                     maintenance_target_file_size: target1,
                     expire_snapshots_older_than: expire1,
                     maintenance_mode: mode1,
+                    table_sorting: sorting1,
                 },
                 ApiDestinationConfig::Ducklake {
                     catalog_url: c2,
@@ -3152,6 +3277,7 @@ mod tests {
                     maintenance_target_file_size: target2,
                     expire_snapshots_older_than: expire2,
                     maintenance_mode: mode2,
+                    table_sorting: sorting2,
                 },
             ) => {
                 assert_eq!(c1.expose_secret(), c2.expose_secret());
@@ -3173,6 +3299,7 @@ mod tests {
                 assert_eq!(target1, &target2);
                 assert_eq!(expire1, &expire2);
                 assert_eq!(mode1, &mode2);
+                assert_eq!(sorting1, &sorting2);
             }
             _ => panic!("Deserialization failed or variant mismatch"),
         }

--- a/crates/etl-api/src/configs/snapshots/etl_api__configs__destination__tests__api_destination_config_serialization_ducklake.snap
+++ b/crates/etl-api/src/configs/snapshots/etl_api__configs__destination__tests__api_destination_config_serialization_ducklake.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/etl-api/src/configs/destination.rs
-assertion_line: 1303
+assertion_line: 3254
 expression: api_config
 ---
 {
@@ -17,6 +17,24 @@ expression: api_config
     "metadata_schema": "ducklake",
     "maintenance_target_file_size": "10MB",
     "expire_snapshots_older_than": "7 days",
-    "maintenance_mode": "kubernetes"
+    "maintenance_mode": "kubernetes",
+    "table_sorting": {
+      "tables": [
+        {
+          "schema": "public",
+          "table": "events",
+          "sort_by": {
+            "kind": "columns",
+            "columns": [
+              {
+                "name": "created_at",
+                "direction": "desc",
+                "nulls": "last"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 }

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -962,6 +962,7 @@ mod tests {
             maintenance_target_file_size: None,
             expire_snapshots_older_than: None,
             maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting: Default::default(),
         };
 
         let secrets = build_secrets_from_configs(&source_config, &destination_config).unwrap();
@@ -1002,6 +1003,7 @@ mod tests {
             maintenance_target_file_size: None,
             expire_snapshots_older_than: None,
             maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting: Default::default(),
         };
 
         let error = build_secrets_from_configs(&source_config, &destination_config).unwrap_err();

--- a/crates/etl-api/src/validation/validators/destination.rs
+++ b/crates/etl-api/src/validation/validators/destination.rs
@@ -238,11 +238,22 @@ mod ducklake {
             metadata_schema,
             maintenance_target_file_size,
             expire_snapshots_older_than,
-            maintenance_mode: _,
+            maintenance_mode,
+            table_sorting,
         } = config
         else {
             unreachable!("Destination config should match DuckLake.");
         };
+
+        if !table_sorting.is_empty()
+            && *maintenance_mode == etl_config::shared::DuckLakeMaintenanceMode::Disabled
+        {
+            return Ok(vec![ValidationFailure::critical(
+                "DuckLake Table Sorting Invalid",
+                "DuckLake table sorting requires `maintenance_mode` to be `kubernetes` or \
+                 `postgres` so flush and compaction can materialize the configured order.",
+            )]);
+        }
 
         DucklakeValidator::new(
             catalog_url.expose_secret().to_owned(),
@@ -325,3 +336,37 @@ mod snowflake {
 }
 
 disabled_destination!(snowflake, "snowflake", "Snowflake");
+
+#[cfg(all(test, feature = "ducklake"))]
+mod tests {
+    use etl_config::Environment;
+
+    use super::*;
+    use crate::validation::FailureType;
+
+    #[tokio::test]
+    async fn ducklake_table_sorting_requires_maintenance_mode() {
+        let config: ApiDestinationConfig = serde_json::from_value(serde_json::json!({
+            "ducklake": {
+                "catalog_url": "postgres://localhost/ducklake",
+                "data_path": "s3://bucket/path",
+                "maintenance_mode": "disabled",
+                "table_sorting": {
+                    "tables": [{
+                        "schema": "public",
+                        "table": "events",
+                        "sort_by": {"kind": "primary_key"}
+                    }]
+                }
+            }
+        }))
+        .unwrap();
+        let ctx = ValidationContext::builder(Environment::Dev).build();
+
+        let failures = ducklake::validate(&config, &ctx).await.unwrap();
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].failure_type, FailureType::Critical);
+        assert_eq!(failures[0].name, "DuckLake Table Sorting Invalid");
+    }
+}

--- a/crates/etl-api/tests/destinations.rs
+++ b/crates/etl-api/tests/destinations.rs
@@ -487,6 +487,7 @@ async fn ducklake_destination_update_preserves_and_clears_encrypted_fields() {
             maintenance_target_file_size: UpdateField::Preserve,
             expire_snapshots_older_than: UpdateField::Preserve,
             maintenance_mode: UpdateField::Preserve,
+            table_sorting: UpdateField::Preserve,
         },
     };
     let response = app.update_destination(tenant_id, destination_id, &update_request).await;

--- a/crates/etl-api/tests/support/mocks.rs
+++ b/crates/etl-api/tests/support/mocks.rs
@@ -88,6 +88,7 @@ pub(crate) mod destinations {
             maintenance_target_file_size: Some("10MB".to_owned()),
             expire_snapshots_older_than: Some("7 days".to_owned()),
             maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting: Default::default(),
         }
     }
 

--- a/crates/etl-api/tests/validators/ducklake.rs
+++ b/crates/etl-api/tests/validators/ducklake.rs
@@ -43,6 +43,7 @@ fn create_ducklake_config(
         maintenance_target_file_size: None,
         expire_snapshots_older_than: None,
         maintenance_mode: DuckLakeMaintenanceMode::Disabled,
+        table_sorting: Default::default(),
     }
 }
 

--- a/crates/etl-config/src/shared/destination.rs
+++ b/crates/etl-config/src/shared/destination.rs
@@ -62,6 +62,85 @@ pub enum DuckLakeMaintenanceMode {
     Postgres,
 }
 
+/// Per-table sort-order configuration for DuckLake destinations.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+pub struct DuckLakeTableSortingConfig {
+    /// Source tables whose DuckLake counterparts should have a sort order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tables: Vec<DuckLakeTableSortConfig>,
+}
+
+impl DuckLakeTableSortingConfig {
+    /// Returns whether no table sort orders are configured.
+    pub fn is_empty(&self) -> bool {
+        self.tables.is_empty()
+    }
+}
+
+/// Sort-order configuration for one source table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+pub struct DuckLakeTableSortConfig {
+    /// Source PostgreSQL schema name.
+    pub schema: String,
+    /// Source PostgreSQL table name.
+    pub table: String,
+    /// Columns used by the DuckLake sort order.
+    pub sort_by: DuckLakeSortBy,
+}
+
+/// Selector used to resolve a DuckLake table's sort columns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DuckLakeSortBy {
+    /// Use the explicitly configured columns in their listed order.
+    Columns {
+        /// Ordered sort columns.
+        columns: Vec<DuckLakeSortColumn>,
+    },
+    /// Use the source PostgreSQL primary-key columns in key-definition order.
+    PrimaryKey,
+}
+
+/// One column in an explicit DuckLake sort order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+pub struct DuckLakeSortColumn {
+    /// Source column name.
+    pub name: String,
+    /// Sort direction.
+    #[serde(default)]
+    pub direction: DuckLakeSortDirection,
+    /// Optional null placement. DuckLake's default is used when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nulls: Option<DuckLakeSortNulls>,
+}
+
+/// Direction of a DuckLake sort column.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum DuckLakeSortDirection {
+    /// Sort values in ascending order.
+    #[default]
+    Asc,
+    /// Sort values in descending order.
+    Desc,
+}
+
+/// Null placement for a DuckLake sort column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum DuckLakeSortNulls {
+    /// Place null values before non-null values.
+    First,
+    /// Place null values after non-null values.
+    Last,
+}
+
 /// Supported product destination kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -178,6 +257,9 @@ pub enum DestinationConfig {
         /// External maintenance coordination backend.
         #[serde(default)]
         maintenance_mode: DuckLakeMaintenanceMode,
+        /// Optional per-table sort orders applied during DuckLake maintenance.
+        #[serde(default, skip_serializing_if = "DuckLakeTableSortingConfig::is_empty")]
+        table_sorting: DuckLakeTableSortingConfig,
     },
     Snowflake {
         /// Snowflake account identifier in "ORGNAME-ACCOUNTNAME" format.
@@ -399,6 +481,9 @@ pub enum DestinationConfigWithoutSecrets {
         /// External maintenance coordination backend.
         #[serde(default)]
         maintenance_mode: DuckLakeMaintenanceMode,
+        /// Optional per-table sort orders applied during DuckLake maintenance.
+        #[serde(default, skip_serializing_if = "DuckLakeTableSortingConfig::is_empty")]
+        table_sorting: DuckLakeTableSortingConfig,
     },
     Snowflake {
         /// Snowflake account identifier in "ORGNAME-ACCOUNTNAME" format.
@@ -450,6 +535,7 @@ impl From<DestinationConfig> for DestinationConfigWithoutSecrets {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             } => DestinationConfigWithoutSecrets::Ducklake {
                 data_path,
                 pool_size,
@@ -461,6 +547,7 @@ impl From<DestinationConfig> for DestinationConfigWithoutSecrets {
                 maintenance_target_file_size,
                 expire_snapshots_older_than,
                 maintenance_mode,
+                table_sorting,
             },
             DestinationConfig::Snowflake {
                 account_id,
@@ -501,6 +588,13 @@ mod tests {
             maintenance_target_file_size: None,
             expire_snapshots_older_than: None,
             maintenance_mode: DuckLakeMaintenanceMode::Kubernetes,
+            table_sorting: DuckLakeTableSortingConfig {
+                tables: vec![DuckLakeTableSortConfig {
+                    schema: "public".to_owned(),
+                    table: "events".to_owned(),
+                    sort_by: DuckLakeSortBy::PrimaryKey,
+                }],
+            },
         };
 
         let without_secrets = DestinationConfigWithoutSecrets::from(config);
@@ -509,6 +603,53 @@ mod tests {
 
         assert!(!serialized.contains("catalog_url"));
         assert!(!serialized.contains("user:pass"));
+        assert_eq!(
+            json["ducklake"]["table_sorting"]["tables"][0]["sort_by"]["kind"],
+            "primary_key"
+        );
+    }
+
+    #[test]
+    fn ducklake_table_sorting_deserializes_column_and_primary_key_modes() {
+        let config: DuckLakeTableSortingConfig = serde_json::from_value(serde_json::json!({
+            "tables": [
+                {
+                    "schema": "public",
+                    "table": "events",
+                    "sort_by": {
+                        "kind": "columns",
+                        "columns": [
+                            {
+                                "name": "tenant_id"
+                            },
+                            {
+                                "name": "created_at",
+                                "direction": "desc",
+                                "nulls": "first"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "schema": "public",
+                    "table": "accounts",
+                    "sort_by": {
+                        "kind": "primary_key"
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(config.tables.len(), 2);
+        let DuckLakeSortBy::Columns { columns } = &config.tables[0].sort_by else {
+            panic!("Expected explicit columns");
+        };
+        assert_eq!(columns[0].direction, DuckLakeSortDirection::Asc);
+        assert_eq!(columns[0].nulls, None);
+        assert_eq!(columns[1].direction, DuckLakeSortDirection::Desc);
+        assert_eq!(columns[1].nulls, Some(DuckLakeSortNulls::First));
+        assert_eq!(config.tables[1].sort_by, DuckLakeSortBy::PrimaryKey);
     }
 
     #[test]

--- a/crates/etl-config/src/shared/mod.rs
+++ b/crates/etl-config/src/shared/mod.rs
@@ -14,7 +14,9 @@ pub use connection::{
 };
 pub use destination::{
     ClickHouseEngine, DestinationConfig, DestinationConfigWithoutSecrets, DestinationKind,
-    DuckLakeMaintenanceMode, IcebergConfig, IcebergConfigWithoutSecrets,
+    DuckLakeMaintenanceMode, DuckLakeSortBy, DuckLakeSortColumn, DuckLakeSortDirection,
+    DuckLakeSortNulls, DuckLakeTableSortConfig, DuckLakeTableSortingConfig, IcebergConfig,
+    IcebergConfigWithoutSecrets,
 };
 pub use pipeline::{
     BatchConfig, InvalidatedSlotBehavior, MemoryBackpressureConfig, PipelineConfig,

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -22,7 +22,13 @@ use etl::{
     },
     store::{DestinationStore, TableStateType},
 };
-use etl_config::ducklake_catalog_metadata_connect_options;
+use etl_config::{
+    ducklake_catalog_metadata_connect_options,
+    shared::{
+        DuckLakeSortBy, DuckLakeSortColumn, DuckLakeSortDirection, DuckLakeSortNulls,
+        DuckLakeTableSortingConfig,
+    },
+};
 use metrics::gauge;
 use parking_lot::Mutex;
 use pg_escape::{quote_identifier as quote_postgres_identifier, quote_literal};
@@ -76,11 +82,12 @@ use crate::{
         },
         schema::{
             build_add_column_sql_ducklake, build_create_table_sql_ducklake,
-            build_drop_column_sql_ducklake, build_drop_default_sql_ducklake,
-            build_rename_column_sql_ducklake, build_set_default_sql_ducklake,
-            supports_column_default_ducklake,
+            build_disable_sort_on_insert_sql_ducklake, build_drop_column_sql_ducklake,
+            build_drop_default_sql_ducklake, build_rename_column_sql_ducklake,
+            build_reset_sorted_by_sql_ducklake, build_set_default_sql_ducklake,
+            build_set_sorted_by_sql_ducklake, supports_column_default_ducklake,
         },
-        sql::qualified_lake_table_name,
+        sql::{qualified_lake_table_name, quote_identifier},
     },
     recovery::previous_replication_mask_for_recovery,
 };
@@ -142,6 +149,180 @@ fn should_request_file_maintenance(
     !copy_phase_active && active_data_files > rewrite_data_files_min_active_data_files
 }
 
+/// One active sort key read from the DuckLake metadata catalog.
+#[derive(Debug, PartialEq, Eq)]
+struct ActiveDuckLakeSortColumn {
+    expression: String,
+    direction: String,
+    null_order: String,
+}
+
+/// Validates and indexes configured DuckLake table sort orders.
+fn index_table_sorting_config(
+    config: DuckLakeTableSortingConfig,
+) -> EtlResult<HashMap<DuckLakeTableName, DuckLakeSortBy>> {
+    let mut table_sorting = HashMap::with_capacity(config.tables.len());
+
+    for table in config.tables {
+        if table.schema.is_empty() {
+            return Err(etl_error!(
+                ErrorKind::ConfigError,
+                "DuckLake table sorting configuration is invalid",
+                "A table sorting schema name must not be empty"
+            ));
+        }
+        if table.table.is_empty() {
+            return Err(etl_error!(
+                ErrorKind::ConfigError,
+                "DuckLake table sorting configuration is invalid",
+                format!("Table name must not be empty for schema `{}`", table.schema)
+            ));
+        }
+
+        if let DuckLakeSortBy::Columns { columns } = &table.sort_by {
+            if columns.is_empty() {
+                return Err(etl_error!(
+                    ErrorKind::ConfigError,
+                    "DuckLake table sorting configuration is invalid",
+                    format!(
+                        "Explicit sort columns must not be empty for `{}.{}`",
+                        table.schema, table.table
+                    )
+                ));
+            }
+
+            let mut column_names = HashSet::with_capacity(columns.len());
+            for column in columns {
+                if column.name.is_empty() {
+                    return Err(etl_error!(
+                        ErrorKind::ConfigError,
+                        "DuckLake table sorting configuration is invalid",
+                        format!(
+                            "Sort column names must not be empty for `{}.{}`",
+                            table.schema, table.table
+                        )
+                    ));
+                }
+                if !column_names.insert(column.name.as_str()) {
+                    return Err(etl_error!(
+                        ErrorKind::ConfigError,
+                        "DuckLake table sorting configuration is invalid",
+                        format!(
+                            "Sort column `{}` is configured more than once for `{}.{}`",
+                            column.name, table.schema, table.table
+                        )
+                    ));
+                }
+            }
+        }
+
+        let table_name = DuckLakeTableName::new(table.schema, table.table);
+        if table_sorting.insert(table_name.clone(), table.sort_by).is_some() {
+            return Err(etl_error!(
+                ErrorKind::ConfigError,
+                "DuckLake table sorting configuration is invalid",
+                format!("Table `{table_name}` is configured more than once")
+            ));
+        }
+    }
+
+    Ok(table_sorting)
+}
+
+/// Resolves a configured selector against the current replicated table schema.
+fn resolve_table_sort_columns(
+    table_sorting: &HashMap<DuckLakeTableName, DuckLakeSortBy>,
+    table_name: &DuckLakeTableName,
+    table_schema: &ReplicatedTableSchema,
+) -> EtlResult<Option<Vec<DuckLakeSortColumn>>> {
+    let Some(sort_by) = table_sorting.get(table_name) else {
+        return Ok(None);
+    };
+
+    match sort_by {
+        DuckLakeSortBy::Columns { columns } => {
+            let replicated_columns: HashSet<_> =
+                table_schema.column_schemas().map(|column| column.name.as_str()).collect();
+            for column in columns {
+                if !replicated_columns.contains(column.name.as_str()) {
+                    return Err(etl_error!(
+                        ErrorKind::ConfigError,
+                        "DuckLake table sorting column is not replicated",
+                        format!("Table `{table_name}` does not replicate column `{}`", column.name)
+                    ));
+                }
+            }
+            Ok(Some(columns.clone()))
+        }
+        DuckLakeSortBy::PrimaryKey => {
+            if !table_schema.all_primary_key_columns_replicated() {
+                let columns = table_schema
+                    .unreplicated_primary_key_column_schemas()
+                    .map(|column| column.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(etl_error!(
+                    ErrorKind::ConfigError,
+                    "DuckLake primary-key sorting requires every primary-key column",
+                    format!(
+                        "Table `{table_name}` does not replicate primary-key columns: {columns}"
+                    )
+                ));
+            }
+
+            let mut columns = table_schema
+                .primary_key_column_schemas()
+                .filter_map(|column| {
+                    column.primary_key_ordinal_position.map(|ordinal| {
+                        (
+                            ordinal,
+                            DuckLakeSortColumn {
+                                name: column.name.clone(),
+                                direction: DuckLakeSortDirection::Asc,
+                                nulls: None,
+                            },
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            if columns.is_empty() {
+                return Err(etl_error!(
+                    ErrorKind::ConfigError,
+                    "DuckLake primary-key sorting requires a primary key",
+                    format!("Table `{table_name}` has no primary key")
+                ));
+            }
+            columns.sort_unstable_by_key(|(ordinal, _)| *ordinal);
+
+            Ok(Some(columns.into_iter().map(|(_, column)| column).collect()))
+        }
+    }
+}
+
+/// Returns whether catalog metadata matches the desired column sort order.
+fn active_sort_order_matches(
+    active: &[ActiveDuckLakeSortColumn],
+    desired: &[DuckLakeSortColumn],
+) -> bool {
+    active.len() == desired.len()
+        && active.iter().zip(desired).all(|(active, desired)| {
+            let expression_matches = active.expression == desired.name
+                || active.expression == quote_identifier(&desired.name);
+            let direction = match desired.direction {
+                DuckLakeSortDirection::Asc => "ASC",
+                DuckLakeSortDirection::Desc => "DESC",
+            };
+            let null_order = match desired.nulls.unwrap_or(DuckLakeSortNulls::Last) {
+                DuckLakeSortNulls::First => "NULLS_FIRST",
+                DuckLakeSortNulls::Last => "NULLS_LAST",
+            };
+
+            expression_matches
+                && active.direction.eq_ignore_ascii_case(direction)
+                && active.null_order.eq_ignore_ascii_case(null_order)
+        })
+}
+
 // ── destination
 // ───────────────────────────────────────────────────────────────
 
@@ -175,6 +356,8 @@ pub struct DuckLakeDestination<S> {
     metadata_schema: Arc<str>,
     expire_snapshots_older_than: Arc<str>,
     metadata_pg_pool: PgPool,
+    /// Desired per-table sort orders indexed by source schema and table.
+    table_sorting: Arc<HashMap<DuckLakeTableName, DuckLakeSortBy>>,
     table_creation_slots: Arc<Semaphore>,
     table_write_slots: Arc<Mutex<HashMap<DuckLakeTableName, Arc<Semaphore>>>>,
     store: S,
@@ -1039,6 +1222,36 @@ where
         external_maintenance: DuckLakeExternalMaintenanceConfig,
         store: S,
     ) -> EtlResult<Self> {
+        Self::new_with_table_sorting_and_external_maintenance(
+            catalog_url,
+            data_path,
+            pool_size,
+            s3,
+            metadata_schema,
+            maintenance_target_file_size,
+            expire_snapshots_older_than,
+            DuckLakeTableSortingConfig::default(),
+            external_maintenance,
+            store,
+        )
+        .await
+    }
+
+    /// Creates a new DuckLake destination with table sorting and external
+    /// maintenance configuration.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_with_table_sorting_and_external_maintenance(
+        catalog_url: Url,
+        data_path: Url,
+        pool_size: u32,
+        s3: Option<S3Config>,
+        metadata_schema: Option<String>,
+        maintenance_target_file_size: Option<String>,
+        expire_snapshots_older_than: Option<String>,
+        table_sorting: DuckLakeTableSortingConfig,
+        external_maintenance: DuckLakeExternalMaintenanceConfig,
+        store: S,
+    ) -> EtlResult<Self> {
         register_metrics();
 
         if !matches!(catalog_url.scheme(), "postgres" | "postgresql") {
@@ -1056,6 +1269,16 @@ where
                 "Pool size must be at least 1"
             ));
         }
+        if !table_sorting.is_empty()
+            && external_maintenance.mode == DuckLakeMaintenanceMode::Disabled
+        {
+            return Err(etl_error!(
+                ErrorKind::ConfigError,
+                "DuckLake table sorting requires external maintenance",
+                "Set DuckLake maintenance_mode to `kubernetes` or `postgres`"
+            ));
+        }
+        let table_sorting = Arc::new(index_table_sorting_config(table_sorting)?);
 
         let extension_strategy = current_duckdb_extension_strategy()?;
         let disable_extension_autoload = extension_strategy.disables_autoload();
@@ -1217,6 +1440,7 @@ where
             metadata_schema: Arc::clone(&metadata_schema),
             expire_snapshots_older_than: Arc::clone(&expire_snapshots_older_than),
             metadata_pg_pool: metadata_pg_pool.clone(),
+            table_sorting,
             table_creation_slots,
             table_write_slots: Arc::default(),
             store,
@@ -1503,6 +1727,7 @@ where
         {
             self.reconcile_missing_replicated_columns(&table_name, new_replicated_table_schema)
                 .await?;
+            self.reconcile_table_sorting(&table_name, new_replicated_table_schema).await?;
             self.cleanup_tombstone_columns_after_applied(&table_name, new_replicated_table_schema)
                 .await;
             info!(
@@ -1559,6 +1784,7 @@ where
             return Err(error);
         }
         self.reconcile_missing_replicated_columns(&table_name, new_replicated_table_schema).await?;
+        self.reconcile_table_sorting(&table_name, new_replicated_table_schema).await?;
 
         let applied_metadata = updated_metadata.to_applied();
         self.store.store_destination_table_metadata(table_id, applied_metadata).await?;
@@ -1643,6 +1869,85 @@ where
             }
 
             execute_ddl("commit", "DuckLake DDL transaction commit failed")
+        })
+        .await
+    }
+
+    /// Reconciles the configured sort order and maintenance-only insert policy.
+    async fn reconcile_table_sorting(
+        &self,
+        table_name: &DuckLakeTableName,
+        table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()> {
+        let desired =
+            resolve_table_sort_columns(self.table_sorting.as_ref(), table_name, table_schema)?;
+        let _table_write_permit = self.acquire_table_write_slot(table_name).await?;
+        let _checkpoint_guard = self.acquire_mutation_guard().await;
+
+        let sql = format!(
+            "select e.expression, e.sort_direction, e.null_order from {}.{} as e join {}.{} as i \
+             on i.sort_id = e.sort_id and i.table_id = e.table_id join {}.{} as t on t.table_id = \
+             i.table_id join {}.{} as s on s.schema_id = t.schema_id where s.schema_name = $1 and \
+             t.table_name = $2 and s.end_snapshot is null and t.end_snapshot is null and \
+             i.end_snapshot is null order by e.sort_key_index",
+            quote_postgres_identifier(self.metadata_schema.as_ref()),
+            quote_postgres_identifier("ducklake_sort_expression"),
+            quote_postgres_identifier(self.metadata_schema.as_ref()),
+            quote_postgres_identifier("ducklake_sort_info"),
+            quote_postgres_identifier(self.metadata_schema.as_ref()),
+            quote_postgres_identifier("ducklake_table"),
+            quote_postgres_identifier(self.metadata_schema.as_ref()),
+            quote_postgres_identifier("ducklake_schema")
+        );
+        let active: Vec<(String, String, String)> = sqlx::query_as(AssertSqlSafe(sql))
+            .bind(table_name.schema())
+            .bind(table_name.table())
+            .fetch_all(&self.metadata_pg_pool)
+            .await
+            .map_err(|source| {
+                etl_error!(
+                    ErrorKind::DestinationQueryFailed,
+                    "DuckLake table sort order query failed",
+                    format!("table={table_name}"),
+                    source: source
+                )
+            })?;
+        let active = active
+            .into_iter()
+            .map(|(expression, direction, null_order)| ActiveDuckLakeSortColumn {
+                expression,
+                direction,
+                null_order,
+            })
+            .collect::<Vec<_>>();
+
+        let ddl = match desired {
+            Some(columns) => {
+                let mut statements = Vec::with_capacity(2);
+                if !active_sort_order_matches(&active, &columns) {
+                    statements.push(build_set_sorted_by_sql_ducklake(table_name, &columns));
+                }
+                // Keep foreground insert latency unchanged. Flush and compaction
+                // still use the table's active sort order.
+                statements.push(build_disable_sort_on_insert_sql_ducklake(table_name));
+                statements.join(";\n")
+            }
+            None if !active.is_empty() => build_reset_sorted_by_sql_ducklake(table_name),
+            None => return Ok(()),
+        };
+        let table_name = table_name.clone();
+
+        run_duckdb_blocking(Arc::clone(&self.pool), Arc::clone(&self.blocking_slots), move |conn| {
+            conn.execute_batch(&ddl).map_err(|source| {
+                etl_error!(
+                    ErrorKind::DestinationQueryFailed,
+                    "DuckLake table sorting reconciliation failed",
+                    format_query_error_detail(&ddl),
+                    source: source
+                )
+            })?;
+            debug!(table = %table_name, "ducklake table sorting reconciled");
+            Ok(())
         })
         .await
     }
@@ -1796,6 +2101,7 @@ where
 
             self.issue_create_table_stmt(&table_name, &target_schema).await?;
             self.reconcile_missing_replicated_columns(&table_name, &target_schema).await?;
+            self.reconcile_table_sorting(&table_name, &target_schema).await?;
             self.cleanup_tombstone_columns_after_applied(&table_name, &target_schema).await;
             self.created_tables.lock().insert(table_name);
         }
@@ -2136,6 +2442,7 @@ where
 
         self.issue_create_table_stmt(table_name, replicated_table_schema).await?;
         self.reconcile_missing_replicated_columns(table_name, replicated_table_schema).await?;
+        self.reconcile_table_sorting(table_name, replicated_table_schema).await?;
 
         self.store.store_destination_table_metadata(table_id, metadata.to_applied()).await
     }
@@ -2312,6 +2619,7 @@ where
             }
         }
         self.reconcile_missing_replicated_columns(table_name, &target_schema).await?;
+        self.reconcile_table_sorting(table_name, &target_schema).await?;
 
         let metadata = metadata.to_applied();
         self.store.store_destination_table_metadata(table_id, metadata.clone()).await?;
@@ -2380,6 +2688,7 @@ where
                 self.issue_create_table_stmt(&table_name, replicated_table_schema).await?;
                 self.reconcile_missing_replicated_columns(&table_name, replicated_table_schema)
                     .await?;
+                self.reconcile_table_sorting(&table_name, replicated_table_schema).await?;
             }
         }
 
@@ -2821,6 +3130,114 @@ mod tests {
 
     fn ducklake_table_name() -> DuckLakeTableName {
         DuckLakeTableName::new("public", "users")
+    }
+
+    #[test]
+    fn primary_key_sorting_uses_key_definition_order() {
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(1),
+            TableName::new("public".to_owned(), "users".to_owned()),
+            vec![
+                ColumnSchema::new("tenant_id".to_owned(), PgType::INT4, -1, 1, false)
+                    .with_primary_key(2),
+                ColumnSchema::new("id".to_owned(), PgType::INT4, -1, 2, false).with_primary_key(1),
+            ],
+        ));
+        let replicated_table_schema = ReplicatedTableSchema::all(table_schema);
+        let table_name = ducklake_table_name();
+        let sorting = index_table_sorting_config(DuckLakeTableSortingConfig {
+            tables: vec![etl_config::shared::DuckLakeTableSortConfig {
+                schema: "public".to_owned(),
+                table: "users".to_owned(),
+                sort_by: DuckLakeSortBy::PrimaryKey,
+            }],
+        })
+        .unwrap();
+
+        let columns = resolve_table_sort_columns(&sorting, &table_name, &replicated_table_schema)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            columns.iter().map(|column| column.name.as_str()).collect::<Vec<_>>(),
+            vec!["id", "tenant_id"]
+        );
+        assert!(columns.iter().all(|column| {
+            column.direction == DuckLakeSortDirection::Asc && column.nulls.is_none()
+        }));
+    }
+
+    #[test]
+    fn explicit_sorting_rejects_unreplicated_columns() {
+        let table_schema = Arc::new(make_schema(1, "public", "users"));
+        let replicated_table_schema =
+            ReplicatedTableSchema::from_mask(table_schema, ReplicationMask::from_bytes(vec![1, 0]));
+        let table_name = ducklake_table_name();
+        let sorting = index_table_sorting_config(DuckLakeTableSortingConfig {
+            tables: vec![etl_config::shared::DuckLakeTableSortConfig {
+                schema: "public".to_owned(),
+                table: "users".to_owned(),
+                sort_by: DuckLakeSortBy::Columns {
+                    columns: vec![DuckLakeSortColumn {
+                        name: "name".to_owned(),
+                        direction: DuckLakeSortDirection::Desc,
+                        nulls: Some(DuckLakeSortNulls::First),
+                    }],
+                },
+            }],
+        })
+        .unwrap();
+
+        let error = resolve_table_sort_columns(&sorting, &table_name, &replicated_table_schema)
+            .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ConfigError);
+        assert!(error.to_string().contains("not replicated"));
+    }
+
+    #[test]
+    fn active_sort_order_comparison_uses_ducklake_defaults() {
+        let active = vec![ActiveDuckLakeSortColumn {
+            expression: r#""id""#.to_owned(),
+            direction: "ASC".to_owned(),
+            null_order: "NULLS_LAST".to_owned(),
+        }];
+        let desired = vec![DuckLakeSortColumn {
+            name: "id".to_owned(),
+            direction: DuckLakeSortDirection::Asc,
+            nulls: None,
+        }];
+
+        assert!(active_sort_order_matches(&active, &desired));
+    }
+
+    #[tokio::test]
+    async fn table_sorting_requires_external_maintenance() {
+        let sorting = DuckLakeTableSortingConfig {
+            tables: vec![etl_config::shared::DuckLakeTableSortConfig {
+                schema: "public".to_owned(),
+                table: "users".to_owned(),
+                sort_by: DuckLakeSortBy::PrimaryKey,
+            }],
+        };
+
+        let error = DuckLakeDestination::new_with_table_sorting_and_external_maintenance(
+            Url::parse("postgres://localhost/ducklake").unwrap(),
+            Url::parse("file:///tmp/ducklake").unwrap(),
+            1,
+            None,
+            None,
+            None,
+            None,
+            sorting,
+            DuckLakeExternalMaintenanceConfig::disabled(),
+            MemoryStore::new(),
+        )
+        .await
+        .err()
+        .expect("Sorting without maintenance should fail");
+
+        assert_eq!(error.kind(), ErrorKind::ConfigError);
     }
 
     fn make_alternative_identity_schema() -> ReplicatedTableSchema {

--- a/crates/etl-destinations/src/ducklake/schema.rs
+++ b/crates/etl-destinations/src/ducklake/schema.rs
@@ -4,10 +4,12 @@ use etl::schema::{
     ColumnSchema, DefaultExpression, NumericModifiers, Type, is_array_type, numeric_modifiers,
     parse_default_expression,
 };
+use etl_config::shared::{DuckLakeSortColumn, DuckLakeSortDirection, DuckLakeSortNulls};
+use pg_escape::quote_literal;
 use tracing::warn;
 
 use crate::ducklake::{
-    DuckLakeTableName,
+    DuckLakeTableName, LAKE_CATALOG,
     sql::{qualified_lake_schema_name, qualified_lake_table_name, quote_identifier},
 };
 
@@ -230,6 +232,47 @@ pub(super) fn build_create_table_sql_ducklake(
     )
 }
 
+/// Builds a DuckLake `alter table set sorted by` statement.
+pub(super) fn build_set_sorted_by_sql_ducklake(
+    table_name: &DuckLakeTableName,
+    columns: &[DuckLakeSortColumn],
+) -> String {
+    let table_name = qualified_lake_table_name(table_name);
+    let columns = columns
+        .iter()
+        .map(|column| {
+            let direction = match column.direction {
+                DuckLakeSortDirection::Asc => "asc",
+                DuckLakeSortDirection::Desc => "desc",
+            };
+            let nulls = match column.nulls {
+                Some(DuckLakeSortNulls::First) => " nulls first",
+                Some(DuckLakeSortNulls::Last) => " nulls last",
+                None => "",
+            };
+            format!("{} {direction}{nulls}", quote_identifier(&column.name))
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!("alter table {table_name} set sorted by ({columns})")
+}
+
+/// Builds a DuckLake `alter table reset sorted by` statement.
+pub(super) fn build_reset_sorted_by_sql_ducklake(table_name: &DuckLakeTableName) -> String {
+    format!("alter table {} reset sorted by", qualified_lake_table_name(table_name))
+}
+
+/// Builds the table-scoped option that keeps foreground inserts unsorted.
+pub(super) fn build_disable_sort_on_insert_sql_ducklake(table_name: &DuckLakeTableName) -> String {
+    format!(
+        "call {}.set_option('sort_on_insert', false, schema => {}, table_name => {})",
+        quote_identifier(LAKE_CATALOG),
+        quote_literal(table_name.schema()),
+        quote_literal(table_name.table())
+    )
+}
+
 /// Builds a DuckLake `alter table add column` statement.
 ///
 /// DuckLake stores add-time defaults as metadata and does not rewrite data
@@ -325,6 +368,36 @@ mod tests {
         assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::JSONB, -1), "json");
         assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::OID, -1), "ubigint");
         assert_eq!(postgres_scalar_type_to_ducklake_sql(&Type::BYTEA, -1), "blob");
+    }
+
+    #[test]
+    fn builds_sorted_table_statements() {
+        let table_name = table_name(r#"events"2026"#);
+        let columns = vec![
+            DuckLakeSortColumn {
+                name: "tenant_id".to_owned(),
+                direction: DuckLakeSortDirection::Asc,
+                nulls: None,
+            },
+            DuckLakeSortColumn {
+                name: r#"created"at"#.to_owned(),
+                direction: DuckLakeSortDirection::Desc,
+                nulls: Some(DuckLakeSortNulls::First),
+            },
+        ];
+
+        assert_eq!(
+            build_set_sorted_by_sql_ducklake(&table_name, &columns),
+            r#"alter table "lake"."public"."events""2026" set sorted by ("tenant_id" asc, "created""at" desc nulls first)"#
+        );
+        assert_eq!(
+            build_reset_sorted_by_sql_ducklake(&table_name),
+            r#"alter table "lake"."public"."events""2026" reset sorted by"#
+        );
+        assert_eq!(
+            build_disable_sort_on_insert_sql_ducklake(&table_name),
+            r#"call "lake".set_option('sort_on_insert', false, schema => 'public', table_name => 'events"2026')"#
+        );
     }
 
     #[test]

--- a/crates/etl-replicator/src/core/destinations.rs
+++ b/crates/etl-replicator/src/core/destinations.rs
@@ -213,6 +213,7 @@ mod ducklake {
             maintenance_target_file_size,
             expire_snapshots_older_than,
             maintenance_mode,
+            table_sorting,
         } = &replicator_config.destination
         else {
             unreachable!("Destination kind should match DuckLake config");
@@ -245,7 +246,7 @@ mod ducklake {
         let external_maintenance =
             DuckLakeExternalMaintenanceConfig { mode: maintenance_mode, pipeline_id };
 
-        let destination = DuckLakeDestination::new_with_external_maintenance(
+        let destination = DuckLakeDestination::new_with_table_sorting_and_external_maintenance(
             parse_ducklake_url(catalog_url.expose_secret()).map_err(ReplicatorError::config)?,
             parse_ducklake_s3_data_path(data_path).map_err(ReplicatorError::config)?,
             *pool_size,
@@ -253,6 +254,7 @@ mod ducklake {
             metadata_schema.clone(),
             maintenance_target_file_size.clone(),
             expire_snapshots_older_than.clone(),
+            table_sorting.clone(),
             external_maintenance,
             store.clone(),
         )

--- a/crates/xtask/src/commands/set_ducklake_maintenance_mode.rs
+++ b/crates/xtask/src/commands/set_ducklake_maintenance_mode.rs
@@ -128,6 +128,7 @@ async fn set_ducklake_maintenance_mode(
             maintenance_target_file_size,
             expire_snapshots_older_than,
             maintenance_mode: _,
+            table_sorting,
         } => StoredDestinationConfig::Ducklake {
             catalog_url,
             data_path,
@@ -142,6 +143,7 @@ async fn set_ducklake_maintenance_mode(
             maintenance_target_file_size,
             expire_snapshots_older_than,
             maintenance_mode: mode,
+            table_sorting,
         },
         _ => unreachable!(),
     };


### PR DESCRIPTION
Example of request payload to configure sorted table in ducklake:

```json
"table_sorting": {
  "tables": [
    {
      "schema": "public",
      "table": "events",
      "sort_by": {
        "kind": "columns",
        "columns": [
          {
            "name": "tenant_id"
          },
          {
            "name": "created_at",
            "direction": "desc",
            "nulls": "last"
          }
        ]
      }
    },
    {
      "schema": "public",
      "table": "accounts",
      "sort_by": {
        "kind": "primary_key"
      }
    }
  ]
}
```