### PR TITLE
ref(core): Rework how schemas are cleaned up

### DIFF
--- a/crates/etl-destinations/tests/clickhouse/pipeline.rs
+++ b/crates/etl-destinations/tests/clickhouse/pipeline.rs
@@ -2353,6 +2353,15 @@ async fn stale_relation_replay_rejected_inner(engine: ClickHouseEngine) {
         .unwrap()
         .expect("metadata should exist after table creation");
     let initial_snapshot_id = initial_metadata.snapshot_id;
+    let stale_table_schema = store
+        .get_table_schema(&table_id, initial_snapshot_id)
+        .await
+        .unwrap()
+        .expect("initial schema snapshot should exist before schema change");
+    let stale_schema = ReplicatedTableSchema::from_mask(
+        stale_table_schema,
+        initial_metadata.replication_mask.clone(),
+    );
 
     // Add a column and stream one row that carries data in it.
     let event_notify = destination
@@ -2392,16 +2401,6 @@ async fn stale_relation_replay_rejected_inner(engine: ClickHouseEngine) {
     let clickhouse_table_name = applied_metadata.destination_table_id.clone();
 
     // --- WHEN: a fresh destination on the same store replays the old relation ---
-    let stale_table_schema = store
-        .get_table_schema(&table_id, initial_snapshot_id)
-        .await
-        .unwrap()
-        .expect("pre-change schema snapshot should still be retained");
-    let stale_schema = ReplicatedTableSchema::from_mask(
-        stale_table_schema,
-        initial_metadata.replication_mask.clone(),
-    );
-
     let restarted_destination =
         clickhouse_db.build_destination_with_engine(store.clone(), engine).await;
     let result = restarted_destination

--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -14,6 +15,7 @@ use crate::{
     error::{ErrorKind, EtlResult},
     etl_error,
     runtime::concurrency::{ShutdownResult, ShutdownRx},
+    schema::TableId,
     source_payload_metadata::StreamingPayloadMetadata,
 };
 
@@ -115,7 +117,7 @@ pub(crate) type CompletedWriteEventsResult<T = DestinationWriteStatus> =
     CompletedAsyncResult<T, ApplyLoopAsyncResultMetadata>;
 
 /// Metadata carried by apply-loop event write completions.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct ApplyLoopAsyncResultMetadata {
     /// Commit end LSN associated with the dispatched batch, if any.
     ///
@@ -129,6 +131,13 @@ pub(crate) struct ApplyLoopAsyncResultMetadata {
     pub durability: WriteEventsDurability,
     /// Number of events in the dispatched batch.
     pub event_count: usize,
+    /// Tables whose schemas were communicated through relation events.
+    ///
+    /// A durable result confirms that the destination processed these
+    /// relations, making their tables likely candidates for obsolete schema
+    /// cleanup. Treating every relation as a candidate also reconstructs
+    /// cleanup work after restart without a separate persisted pending marker.
+    pub relation_table_ids: HashSet<TableId>,
     /// PostgreSQL tuple bytes accumulated for the dispatched event batch.
     pub streaming_payload_metadata: StreamingPayloadMetadata,
     /// Instant at which the event batch was handed off to the destination.
@@ -259,6 +268,7 @@ mod tests {
             commit_end_lsn: Some(PgLsn::from(42)),
             durability: WriteEventsDurability::MayDefer,
             event_count: 1,
+            relation_table_ids: HashSet::from([TableId::new(7)]),
             streaming_payload_metadata: StreamingPayloadMetadata::insert(7),
             dispatched_at: Instant::now(),
         };
@@ -272,6 +282,7 @@ mod tests {
         let metadata = metadata.expect("metadata should be present");
         assert_eq!(metadata.commit_end_lsn, Some(PgLsn::from(42)));
         assert_eq!(metadata.durability, WriteEventsDurability::MayDefer);
+        assert_eq!(metadata.relation_table_ids, HashSet::from([TableId::new(7)]));
         assert_eq!(result.unwrap(), 7);
     }
 

--- a/crates/etl/src/failpoints.rs
+++ b/crates/etl/src/failpoints.rs
@@ -18,7 +18,6 @@ pub const START_TABLE_SYNC_AFTER_FINISHED_COPY_FP: &str = "start_table_sync.afte
 pub const TABLE_SYNC_WORKER_BEFORE_STREAMING_FP: &str = "table_sync_worker.before_streaming_fp";
 pub const SEND_STATUS_UPDATE_FP: &str = "send_status_update_fp";
 pub const STORE_REPLICATION_PROGRESS_FP: &str = "store_replication_progress_fp";
-pub const FORCE_SCHEMA_CLEANUP_FP: &str = "force_schema_cleanup_fp";
 
 /// Executes a configurable failpoint for testing error scenarios.
 ///

--- a/crates/etl/src/observability.rs
+++ b/crates/etl/src/observability.rs
@@ -228,27 +228,29 @@ pub(crate) fn register_metrics() {
         describe_counter!(
             ETL_SCHEMA_CLEANUPS_TOTAL,
             Unit::Count,
-            "Total number of asynchronous schema cleanup tasks completed, labeled by worker_type."
+            "Total number of schema cleanup requests successfully completed, labeled by \
+             worker_type."
         );
 
         describe_counter!(
             ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
             Unit::Count,
-            "Total number of asynchronous schema cleanup errors, labeled by worker_type."
+            "Total number of schema cleanup request failures and cleanup worker failures, labeled \
+             by worker_type."
         );
 
         describe_counter!(
             ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
             Unit::Count,
-            "Total number of tables considered by asynchronous schema cleanup tasks, labeled by \
-             worker_type."
+            "Total number of tables included in successfully completed schema cleanup requests, \
+             labeled by worker_type."
         );
 
         describe_counter!(
             ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL,
             Unit::Count,
-            "Total number of obsolete schema versions pruned by asynchronous schema cleanup \
-             tasks, labeled by worker_type."
+            "Total number of obsolete schema versions pruned by successfully completed schema \
+             cleanup requests, labeled by worker_type."
         );
 
         describe_counter!(

--- a/crates/etl/src/observability.rs
+++ b/crates/etl/src/observability.rs
@@ -228,21 +228,21 @@ pub(crate) fn register_metrics() {
         describe_counter!(
             ETL_SCHEMA_CLEANUPS_TOTAL,
             Unit::Count,
-            "Total number of schema cleanup requests successfully completed, labeled by \
+            "Total number of batched schema cleanup operations successfully completed, labeled by \
              worker_type."
         );
 
         describe_counter!(
             ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
             Unit::Count,
-            "Total number of schema cleanup request failures and cleanup worker failures, labeled \
-             by worker_type."
+            "Total number of batched schema cleanup operation failures and cleanup worker \
+             failures, labeled by worker_type."
         );
 
         describe_counter!(
             ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
             Unit::Count,
-            "Total number of tables included in successfully completed schema cleanup requests, \
+            "Total number of tables included in successfully completed schema cleanup operations, \
              labeled by worker_type."
         );
 
@@ -250,7 +250,7 @@ pub(crate) fn register_metrics() {
             ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL,
             Unit::Count,
             "Total number of obsolete schema versions pruned by successfully completed schema \
-             cleanup requests, labeled by worker_type."
+             cleanup operations, labeled by worker_type."
         );
 
         describe_counter!(

--- a/crates/etl/src/postgres/mod.rs
+++ b/crates/etl/src/postgres/mod.rs
@@ -13,5 +13,5 @@ pub mod migrations;
 
 pub(crate) use source_pool::OutOfBandSourcePool;
 pub(crate) use stream::{
-    ReplicationMessageStream, StatusUpdateResult, StatusUpdateType, TableCopyRow, TableCopyStream,
+    ReplicationMessageStream, StatusUpdateType, TableCopyRow, TableCopyStream,
 };

--- a/crates/etl/src/postgres/stream/mod.rs
+++ b/crates/etl/src/postgres/stream/mod.rs
@@ -3,7 +3,5 @@
 mod replication_message;
 mod table_copy;
 
-pub(crate) use replication_message::{
-    ReplicationMessageStream, StatusUpdateResult, StatusUpdateType,
-};
+pub(crate) use replication_message::{ReplicationMessageStream, StatusUpdateType};
 pub(crate) use table_copy::{TableCopyRow, TableCopyStream};

--- a/crates/etl/src/postgres/stream/replication_message.rs
+++ b/crates/etl/src/postgres/stream/replication_message.rs
@@ -47,15 +47,6 @@ pub(crate) enum StatusUpdateType {
     ShutdownFlush,
 }
 
-/// Outcome of a status update attempt.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum StatusUpdateResult {
-    /// A status update was accepted by the local replication stream wrapper.
-    Sent,
-    /// No status update was sent because throttling suppressed it.
-    Skipped,
-}
-
 impl StatusUpdateType {
     /// Returns `true` whether this status update type requires a reply from
     /// Postgres, `false` otherwise.
@@ -114,7 +105,7 @@ impl ReplicationMessageStream {
         mut flush_lsn: PgLsn,
         force: bool,
         status_update_type: StatusUpdateType,
-    ) -> EtlResult<StatusUpdateResult> {
+    ) -> EtlResult<()> {
         // If the failpoint is active, we do not send any status update. This is useful
         // for testing the system when we want to check what happens when no
         // status updates are sent.
@@ -122,7 +113,7 @@ impl ReplicationMessageStream {
         if etl_fail_point_active(SEND_STATUS_UPDATE_FP) {
             warn!("not sending status update due to active failpoint");
 
-            return Ok(StatusUpdateResult::Skipped);
+            return Ok(());
         }
 
         let this = self.project();
@@ -178,7 +169,7 @@ impl ReplicationMessageStream {
                     "skipping status update"
                 );
 
-                return Ok(StatusUpdateResult::Skipped);
+                return Ok(());
             }
         }
 
@@ -222,7 +213,7 @@ impl ReplicationMessageStream {
         *this.last_write_lsn = Some(write_lsn);
         *this.last_flush_lsn = Some(flush_lsn);
 
-        Ok(StatusUpdateResult::Sent)
+        Ok(())
     }
 }
 

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -116,6 +116,14 @@ const KEEP_ALIVE_DEADLINE_FRACTION: f64 = 0.6;
 const MIN_KEEP_ALIVE_DEADLINE_DURATION: Duration = Duration::from_millis(100);
 /// Maximum accepted-but-not-durable streaming writes tracked per apply loop.
 const MAX_PENDING_DURABLE_DISPATCHES: usize = 1024;
+/// Maximum number of table schema cleanups buffered per apply loop.
+///
+/// Each queue entry contains one table identifier and one frozen retention
+/// boundary. A capacity of 1024 accommodates large bursts of relation messages
+/// while keeping queue memory bounded. Queueing is non-blocking, so additional
+/// candidates remain pending in the apply loop and are retried after a later
+/// durable flush result.
+const SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY: usize = 1024;
 
 /// Result type for the apply loop execution.
 ///
@@ -394,11 +402,11 @@ impl HandleMessageResult {
     }
 }
 
-/// Immutable retention boundaries for one asynchronous schema cleanup.
+/// Immutable retention boundary for one asynchronous table schema cleanup.
 ///
 /// The apply loop builds this request immediately after persisting
 /// commit-boundary progress and reading destination metadata. The background
-/// worker must use these frozen boundaries rather than reloading newer state:
+/// worker must use this frozen boundary rather than reloading newer state:
 /// arbitrary queue delay can then only make the request conservative.
 ///
 /// Concurrent schema insertion is also safe: ordered replication cannot later
@@ -411,15 +419,17 @@ impl HandleMessageResult {
 /// newer one—cannot remove a schema retained by the newer boundary.
 #[derive(Debug)]
 struct SchemaCleanupRequest {
-    /// Per-table boundaries captured at the durable flush result.
-    table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
+    /// Table whose obsolete schema versions may be pruned.
+    table_id: TableId,
+    /// Retention boundary captured at the durable flush result.
+    retention: TableSchemaRetention,
 }
 
 /// Background tasks owned by an apply loop invocation.
 #[derive(Debug)]
 struct ApplyLoopTasks {
     /// Sender for serialized background schema cleanup requests.
-    schema_cleanup_tx: Option<mpsc::UnboundedSender<SchemaCleanupRequest>>,
+    schema_cleanup_tx: Option<mpsc::Sender<SchemaCleanupRequest>>,
     /// Background worker that serially processes schema cleanup requests.
     schema_cleanup_worker_task: JoinHandle<()>,
     /// Background replication lag sampler task owned by this apply loop.
@@ -438,7 +448,8 @@ impl ApplyLoopTasks {
     where
         S: SchemaStore + Send + Sync + 'static,
     {
-        let (schema_cleanup_tx, schema_cleanup_rx) = mpsc::unbounded_channel();
+        let (schema_cleanup_tx, schema_cleanup_rx) =
+            mpsc::channel(SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY);
         let schema_cleanup_worker_task =
             Self::spawn_schema_cleanup_worker(schema_store, schema_cleanup_rx, worker_type);
 
@@ -456,33 +467,31 @@ impl ApplyLoopTasks {
         }
     }
 
-    /// Tries to queue a schema cleanup request for the provided retention
-    /// boundaries.
+    /// Tries to queue a schema cleanup request for one table.
     ///
-    /// Returns `false` only when the background worker cannot accept the
-    /// request.
-    fn try_queue_schema_cleanup(
-        &self,
-        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
-    ) -> bool {
+    /// Returns `false` when the bounded queue is full or the background worker
+    /// has stopped. This method never waits for queue capacity.
+    fn try_queue_schema_cleanup(&self, table_id: TableId, retention: TableSchemaRetention) -> bool {
         let Some(schema_cleanup_tx) = &self.schema_cleanup_tx else {
             return false;
         };
 
-        let request = SchemaCleanupRequest { table_schema_retentions };
-        if schema_cleanup_tx.send(request).is_err() {
-            error!("schema cleanup worker stopped before accepting cleanup request");
+        let request = SchemaCleanupRequest { table_id, retention };
+        match schema_cleanup_tx.try_send(request) {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Full(_)) => false,
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                error!("schema cleanup worker stopped before accepting cleanup request");
 
-            return false;
+                false
+            }
         }
-
-        true
     }
 
     /// Starts the worker that serially prunes requested table schema versions.
     fn spawn_schema_cleanup_worker<S>(
         schema_store: S,
-        mut schema_cleanup_rx: mpsc::UnboundedReceiver<SchemaCleanupRequest>,
+        mut schema_cleanup_rx: mpsc::Receiver<SchemaCleanupRequest>,
         worker_type: WorkerType,
     ) -> JoinHandle<()>
     where
@@ -490,7 +499,21 @@ impl ApplyLoopTasks {
     {
         tokio::spawn(async move {
             while let Some(request) = schema_cleanup_rx.recv().await {
-                let table_schema_retentions = request.table_schema_retentions;
+                // Coalesce up to one bounded batch of available requests to
+                // retain batched store cleanup without making the apply loop
+                // wait for it.
+                let mut table_schema_retentions =
+                    HashMap::with_capacity(schema_cleanup_rx.len().saturating_add(1));
+                table_schema_retentions.insert(request.table_id, request.retention);
+
+                for _ in 1..SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY {
+                    let Ok(request) = schema_cleanup_rx.try_recv() else {
+                        break;
+                    };
+
+                    table_schema_retentions.insert(request.table_id, request.retention);
+                }
+
                 let table_count = table_schema_retentions.len() as u64;
                 match schema_store.prune_table_schemas(table_schema_retentions).await {
                     Ok(deleted_count) => {
@@ -1669,12 +1692,24 @@ where
             return;
         }
 
-        // With the retention boundaries fixed, queue the database deletion
-        // without stalling the apply loop. The cleanup worker serializes
-        // requests from this apply loop.
-        if self.tasks.try_queue_schema_cleanup(table_schema_retentions) {
-            self.state.pending_relation_table_ids.clear();
+        // Queue each frozen table boundary without waiting for capacity. The
+        // cleanup worker coalesces available entries into batched store calls.
+        // Candidates that do not fit remain pending for the next durable result.
+        let mut deferred_table_ids = HashSet::new();
+        let mut table_schema_retentions = table_schema_retentions.into_iter();
+
+        while let Some((table_id, retention)) = table_schema_retentions.next() {
+            if !self.tasks.try_queue_schema_cleanup(table_id, retention) {
+                deferred_table_ids.insert(table_id);
+                deferred_table_ids.extend(table_schema_retentions.map(|(table_id, _)| table_id));
+
+                break;
+            }
         }
+
+        self.state
+            .pending_relation_table_ids
+            .retain(|table_id| deferred_table_ids.contains(table_id));
     }
 
     /// Returns schema retention boundaries for tables this worker may clean up.
@@ -3813,5 +3848,39 @@ async fn get_replicated_table_schema(
                 )
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn schema_cleanup_queue_is_bounded_by_table_count() {
+        let (schema_cleanup_tx, mut schema_cleanup_rx) =
+            mpsc::channel(SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY);
+        let tasks = ApplyLoopTasks {
+            schema_cleanup_tx: Some(schema_cleanup_tx),
+            schema_cleanup_worker_task: tokio::spawn(future::pending()),
+            replication_lag_sampler_task: tokio::spawn(future::pending()),
+        };
+        let retention = TableSchemaRetention::SnapshotId(SnapshotId::from(1));
+
+        for table_id in 1..=SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY {
+            let table_id = TableId::from(u32::try_from(table_id).unwrap());
+            assert!(tasks.try_queue_schema_cleanup(table_id, retention));
+        }
+
+        let overflow_table_id =
+            TableId::from(u32::try_from(SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY + 1).unwrap());
+        assert!(!tasks.try_queue_schema_cleanup(overflow_table_id, retention));
+
+        schema_cleanup_rx.recv().await.unwrap();
+        assert!(tasks.try_queue_schema_cleanup(overflow_table_id, retention));
+
+        tasks.schema_cleanup_worker_task.abort();
+        tasks.replication_lag_sampler_task.abort();
     }
 }

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -546,7 +546,8 @@ impl ApplyLoopTasks {
     async fn handle_replication_lag_sampler_task_result(&mut self) {
         // We abort the task, so that awaiting on the handle is as quick as possible.
         //
-        // It's fine to abort this task midway, since it's not going to affect consistency.
+        // It's fine to abort this task midway, since it's not going to affect
+        // consistency.
         self.replication_lag_sampler_task.abort();
 
         if let Err(err) = (&mut self.replication_lag_sampler_task).await
@@ -564,9 +565,9 @@ impl ApplyLoopTasks {
         // request before the apply loop returns.
         //
         // We don't want to call abort on the task, just to prevent possible errors from
-        // partial completion around await points. In practice, it could be suspendable midway,
-        // but it's safer to avoid it, also since the pruning of schemas should be relatively
-        // quick.
+        // partial completion around await points. In practice, it could be suspendable
+        // midway, but it's safer to avoid it, also since the pruning of schemas
+        // should be relatively quick.
         self.schema_cleanup_tx.take();
 
         if let Err(err) = (&mut self.schema_cleanup_worker_task).await {
@@ -574,7 +575,7 @@ impl ApplyLoopTasks {
                 ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
                 WORKER_TYPE_LABEL => worker_type.as_str(),
             )
-                .increment(1);
+            .increment(1);
 
             error!(
                 %worker_type,

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -3850,37 +3850,3 @@ async fn get_replicated_table_schema(
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::future;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn schema_cleanup_queue_is_bounded_by_table_count() {
-        let (schema_cleanup_tx, mut schema_cleanup_rx) =
-            mpsc::channel(SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY);
-        let tasks = ApplyLoopTasks {
-            schema_cleanup_tx: Some(schema_cleanup_tx),
-            schema_cleanup_worker_task: tokio::spawn(future::pending()),
-            replication_lag_sampler_task: tokio::spawn(future::pending()),
-        };
-        let retention = TableSchemaRetention::SnapshotId(SnapshotId::from(1));
-
-        for table_id in 1..=SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY {
-            let table_id = TableId::from(u32::try_from(table_id).unwrap());
-            assert!(tasks.try_queue_schema_cleanup(table_id, retention));
-        }
-
-        let overflow_table_id =
-            TableId::from(u32::try_from(SCHEMA_CLEANUP_QUEUE_TABLE_CAPACITY + 1).unwrap());
-        assert!(!tasks.try_queue_schema_cleanup(overflow_table_id, retention));
-
-        schema_cleanup_rx.recv().await.unwrap();
-        assert!(tasks.try_queue_schema_cleanup(overflow_table_id, retention));
-
-        tasks.schema_cleanup_worker_task.abort();
-        tasks.replication_lag_sampler_task.abort();
-    }
-}

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -28,7 +28,7 @@ use postgres_replication::{
 };
 use tokio::{
     pin,
-    sync::{Mutex, Semaphore, watch},
+    sync::{Semaphore, mpsc, watch},
     task::JoinHandle,
     time::MissedTickBehavior,
 };
@@ -36,9 +36,7 @@ use tokio_postgres::types::PgLsn;
 use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "failpoints")]
-use crate::failpoints::{
-    FORCE_SCHEMA_CLEANUP_FP, STORE_REPLICATION_PROGRESS_FP, etl_fail_point_active,
-};
+use crate::failpoints::{STORE_REPLICATION_PROGRESS_FP, etl_fail_point_active};
 use crate::{
     bail,
     data::SizeHint,
@@ -63,7 +61,7 @@ use crate::{
     },
     pipeline::PipelineId,
     postgres::{
-        OutOfBandSourcePool, ReplicationMessageStream, StatusUpdateResult, StatusUpdateType,
+        OutOfBandSourcePool, ReplicationMessageStream, StatusUpdateType,
         client::{PgReplicationClient, PostgresConnectionUpdate},
         codec::{
             DDL_MESSAGE_PREFIX, SchemaChangeMessage, delete_message_payload_bytes,
@@ -116,13 +114,6 @@ const KEEP_ALIVE_DEADLINE_FRACTION: f64 = 0.6;
 /// deadline at that scale would make the apply loop spin sending forced keep
 /// alives, which is not operationally useful. We clamp to `100ms`.
 const MIN_KEEP_ALIVE_DEADLINE_DURATION: Duration = Duration::from_millis(100);
-/// Minimum interval between best-effort schema cleanup tasks during normal
-/// replication.
-///
-/// Cleanup is considered only after status updates, because those are natural
-/// progress points where durable ETL progress may have advanced. The next
-/// deadline is scheduled when the previous cleanup task finishes.
-const SCHEMA_CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
 /// Maximum accepted-but-not-durable streaming writes tracked per apply loop.
 const MAX_PENDING_DURABLE_DISPATCHES: usize = 1024;
 
@@ -403,42 +394,54 @@ impl HandleMessageResult {
     }
 }
 
-/// Running schema cleanup marker.
+/// Immutable retention boundaries for one asynchronous schema cleanup.
 ///
-/// Finishing the marker schedules the next cleanup deadline. This keeps the
-/// deadline mutex private while allowing a cleanup run to reset it after it
-/// either finishes or decides not to spawn background work.
+/// The apply loop builds this request immediately after persisting
+/// commit-boundary progress and reading destination metadata. The background
+/// worker must use these frozen boundaries rather than reloading newer state:
+/// arbitrary queue delay can then only make the request conservative.
+///
+/// Concurrent schema insertion is also safe: ordered replication cannot later
+/// introduce a schema at or below persisted progress, and pruning always
+/// preserves every snapshot newer than the frozen boundary.
+///
+/// Pruning is idempotent and does not rely on request order. Each boundary
+/// preserves the greatest schema snapshot at or below it and every newer
+/// snapshot, so replaying a request—or processing an older request after a
+/// newer one—cannot remove a schema retained by the newer boundary.
 #[derive(Debug)]
-struct SchemaCleanupRun {
-    /// Shared cleanup deadline owned by [`ApplyLoopState`].
-    deadline: Arc<Mutex<Option<Instant>>>,
-}
-
-impl SchemaCleanupRun {
-    /// Schedules the next cleanup after the current run finishes.
-    async fn finish(self) {
-        let mut deadline = self.deadline.lock().await;
-        *deadline = Some(Instant::now() + SCHEMA_CLEANUP_INTERVAL);
-    }
+struct SchemaCleanupRequest {
+    /// Per-table boundaries captured at the durable flush result.
+    table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
 }
 
 /// Background tasks owned by an apply loop invocation.
 #[derive(Debug)]
 struct ApplyLoopTasks {
-    /// Background schema cleanup task owned by this apply loop.
-    schema_cleanup_task: Option<JoinHandle<()>>,
+    /// Sender for serialized background schema cleanup requests.
+    schema_cleanup_tx: Option<mpsc::UnboundedSender<SchemaCleanupRequest>>,
+    /// Background worker that serially processes schema cleanup requests.
+    schema_cleanup_worker_task: JoinHandle<()>,
     /// Background replication lag sampler task owned by this apply loop.
     replication_lag_sampler_task: JoinHandle<()>,
 }
 
 impl ApplyLoopTasks {
-    /// Creates task ownership and starts the required replication lag sampler.
-    fn new(
+    /// Creates task ownership and starts background workers.
+    fn start<S>(
+        schema_store: S,
         out_of_band_source_pool: OutOfBandSourcePool,
         replication_lag_metrics: ReplicationLagMetrics,
         worker_type: WorkerType,
         replication_lag_refresh_interval: Duration,
-    ) -> Self {
+    ) -> Self
+    where
+        S: SchemaStore + Send + Sync + 'static,
+    {
+        let (schema_cleanup_tx, schema_cleanup_rx) = mpsc::unbounded_channel();
+        let schema_cleanup_worker_task =
+            Self::spawn_schema_cleanup_worker(schema_store, schema_cleanup_rx, worker_type);
+
         let replication_lag_sampler_task = Self::spawn_replication_lag_sampler(
             out_of_band_source_pool,
             replication_lag_metrics,
@@ -446,117 +449,104 @@ impl ApplyLoopTasks {
             replication_lag_refresh_interval,
         );
 
-        Self { schema_cleanup_task: None, replication_lag_sampler_task }
-    }
-
-    /// Returns `true` if a schema cleanup task is still running.
-    fn has_running_schema_cleanup_task(&self) -> bool {
-        self.schema_cleanup_task.is_some()
-    }
-
-    /// Starts a schema cleanup task for the provided retention boundaries.
-    fn spawn_schema_cleanup<S>(
-        &mut self,
-        schema_store: S,
-        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
-        schema_cleanup_run: SchemaCleanupRun,
-        worker_type: WorkerType,
-    ) where
-        S: SchemaStore + Send + Sync + 'static,
-    {
-        let table_count = table_schema_retentions.len() as u64;
-        let cleanup_task = tokio::spawn(async move {
-            match schema_store.prune_table_schemas(table_schema_retentions).await {
-                Ok(deleted_count) => {
-                    counter!(
-                        ETL_SCHEMA_CLEANUPS_TOTAL,
-                        WORKER_TYPE_LABEL => worker_type.as_str(),
-                    )
-                    .increment(1);
-
-                    counter!(
-                        ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
-                        WORKER_TYPE_LABEL => worker_type.as_str(),
-                    )
-                    .increment(table_count);
-
-                    counter!(
-                        ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL,
-                        WORKER_TYPE_LABEL => worker_type.as_str(),
-                    )
-                    .increment(deleted_count);
-
-                    if deleted_count > 0 {
-                        info!(
-                            %worker_type,
-                            deleted_count,
-                            "completed obsolete table schema cleanup"
-                        );
-                    }
-                }
-                Err(err) => {
-                    counter!(
-                        ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
-                        WORKER_TYPE_LABEL => worker_type.as_str(),
-                    )
-                    .increment(1);
-
-                    error!(
-                        %worker_type,
-                        error = %err,
-                        "failed to clean up obsolete table schemas"
-                    );
-                }
-            };
-
-            schema_cleanup_run.finish().await;
-        });
-
-        self.schema_cleanup_task = Some(cleanup_task);
-    }
-
-    /// Collects a completed schema cleanup task.
-    async fn collect_finished_schema_cleanup_task(
-        &mut self,
-        worker_type: WorkerType,
-        schema_cleanup_deadline: &Arc<Mutex<Option<Instant>>>,
-    ) {
-        if self.schema_cleanup_task.as_ref().is_some_and(JoinHandle::is_finished) {
-            self.handle_schema_cleanup_task_result(worker_type, schema_cleanup_deadline).await;
+        Self {
+            schema_cleanup_tx: Some(schema_cleanup_tx),
+            schema_cleanup_worker_task,
+            replication_lag_sampler_task,
         }
     }
 
-    /// Joins the recorded schema cleanup task and handles its result.
-    async fn handle_schema_cleanup_task_result(
-        &mut self,
+    /// Tries to queue a schema cleanup request for the provided retention
+    /// boundaries.
+    ///
+    /// Returns `false` only when the background worker cannot accept the
+    /// request.
+    fn try_queue_schema_cleanup(
+        &self,
+        table_schema_retentions: HashMap<TableId, TableSchemaRetention>,
+    ) -> bool {
+        let Some(schema_cleanup_tx) = &self.schema_cleanup_tx else {
+            return false;
+        };
+
+        let request = SchemaCleanupRequest { table_schema_retentions };
+        if schema_cleanup_tx.send(request).is_err() {
+            error!("schema cleanup worker stopped before accepting cleanup request");
+
+            return false;
+        }
+
+        true
+    }
+
+    /// Starts the worker that serially prunes requested table schema versions.
+    fn spawn_schema_cleanup_worker<S>(
+        schema_store: S,
+        mut schema_cleanup_rx: mpsc::UnboundedReceiver<SchemaCleanupRequest>,
         worker_type: WorkerType,
-        schema_cleanup_deadline: &Arc<Mutex<Option<Instant>>>,
-    ) {
-        let Some(cleanup_task) = self.schema_cleanup_task.take() else {
-            return;
-        };
+    ) -> JoinHandle<()>
+    where
+        S: SchemaStore + Send + Sync + 'static,
+    {
+        tokio::spawn(async move {
+            while let Some(request) = schema_cleanup_rx.recv().await {
+                let table_schema_retentions = request.table_schema_retentions;
+                let table_count = table_schema_retentions.len() as u64;
+                match schema_store.prune_table_schemas(table_schema_retentions).await {
+                    Ok(deleted_count) => {
+                        counter!(
+                            ETL_SCHEMA_CLEANUPS_TOTAL,
+                            WORKER_TYPE_LABEL => worker_type.as_str(),
+                        )
+                        .increment(1);
 
-        let Err(cleanup_task_error) = cleanup_task.await else {
-            return;
-        };
+                        counter!(
+                            ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
+                            WORKER_TYPE_LABEL => worker_type.as_str(),
+                        )
+                        .increment(table_count);
 
-        Self::reset_schema_cleanup_deadline(schema_cleanup_deadline).await;
+                        counter!(
+                            ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL,
+                            WORKER_TYPE_LABEL => worker_type.as_str(),
+                        )
+                        .increment(deleted_count);
 
-        counter!(
-            ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
-            WORKER_TYPE_LABEL => worker_type.as_str(),
-        )
-        .increment(1);
+                        if deleted_count > 0 {
+                            info!(
+                                %worker_type,
+                                deleted_count,
+                                "completed obsolete table schema cleanup"
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        // Cleanup is best-effort. Do not block later requests behind a
+                        // permanently failing one: a later relation for the table,
+                        // including its first relation after restart, will enqueue a
+                        // fresh cleanup attempt.
+                        counter!(
+                            ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
+                            WORKER_TYPE_LABEL => worker_type.as_str(),
+                        )
+                        .increment(1);
 
-        error!(
-            %worker_type,
-            error = %cleanup_task_error,
-            "schema cleanup task failed before completing"
-        );
+                        error!(
+                            %worker_type,
+                            error = %err,
+                            "failed to clean up obsolete table schemas"
+                        );
+                    }
+                };
+            }
+        })
     }
 
     /// Aborts and joins the replication lag sampler task.
     async fn handle_replication_lag_sampler_task_result(&mut self) {
+        // We abort the task, so that awaiting on the handle is as quick as possible.
+        //
+        // It's fine to abort this task midway, since it's not going to affect consistency.
         self.replication_lag_sampler_task.abort();
 
         if let Err(err) = (&mut self.replication_lag_sampler_task).await
@@ -569,14 +559,35 @@ impl ApplyLoopTasks {
         }
     }
 
-    /// Aborts interruptible tasks and joins all owned background tasks.
-    async fn teardown(
-        &mut self,
-        worker_type: WorkerType,
-        schema_cleanup_deadline: &Arc<Mutex<Option<Instant>>>,
-    ) {
+    async fn handle_schema_cleanup_task_result(&mut self, worker_type: WorkerType) {
+        // Closing the sender lets the cleanup worker finish every accepted
+        // request before the apply loop returns.
+        //
+        // We don't want to call abort on the task, just to prevent possible errors from
+        // partial completion around await points. In practice, it could be suspendable midway,
+        // but it's safer to avoid it, also since the pruning of schemas should be relatively
+        // quick.
+        self.schema_cleanup_tx.take();
+
+        if let Err(err) = (&mut self.schema_cleanup_worker_task).await {
+            counter!(
+                ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
+                WORKER_TYPE_LABEL => worker_type.as_str(),
+            )
+                .increment(1);
+
+            error!(
+                %worker_type,
+                error = %err,
+                "schema cleanup worker task failed before completing"
+            );
+        }
+    }
+
+    /// Stops and joins all owned background tasks.
+    async fn teardown(&mut self, worker_type: WorkerType) {
         self.handle_replication_lag_sampler_task_result().await;
-        self.handle_schema_cleanup_task_result(worker_type, schema_cleanup_deadline).await;
+        self.handle_schema_cleanup_task_result(worker_type).await;
     }
 
     /// Starts the replication lag sampler for an apply loop.
@@ -624,12 +635,6 @@ impl ApplyLoopTasks {
             }
         }
     }
-
-    /// Schedules schema cleanup again after the configured interval.
-    async fn reset_schema_cleanup_deadline(schema_cleanup_deadline: &Arc<Mutex<Option<Instant>>>) {
-        let mut schema_cleanup_deadline = schema_cleanup_deadline.lock().await;
-        *schema_cleanup_deadline = Some(Instant::now() + SCHEMA_CLEANUP_INTERVAL);
-    }
 }
 
 /// A buffered batch of events waiting to be sent to the destination.
@@ -637,6 +642,8 @@ impl ApplyLoopTasks {
 struct EventBatch {
     /// Events accumulated in the batch.
     events: Vec<Event>,
+    /// Tables whose schemas are communicated by relation events in the batch.
+    relation_table_ids: HashSet<TableId>,
     /// Decoded in-memory size estimate used only to decide when to flush.
     size_hint_bytes: usize,
     /// PostgreSQL tuple bytes used for source metrics and usage accounting.
@@ -651,6 +658,7 @@ impl EventBatch {
     fn with_capacity(capacity: usize) -> Self {
         Self {
             events: Vec::with_capacity(capacity),
+            relation_table_ids: HashSet::new(),
             size_hint_bytes: 0,
             streaming_payload_metadata: StreamingPayloadMetadata::default(),
         }
@@ -658,6 +666,10 @@ impl EventBatch {
 
     /// Adds an event and its source payload metadata to the batch.
     fn push(&mut self, event: Event, streaming_payload_metadata: StreamingPayloadMetadata) {
+        if let Event::Relation(relation) = &event {
+            self.relation_table_ids.insert(relation.replicated_table_schema.id());
+        }
+
         self.size_hint_bytes = self.size_hint_bytes.saturating_add(event.size_hint());
         self.streaming_payload_metadata.merge(streaming_payload_metadata);
         self.events.push(event);
@@ -688,12 +700,11 @@ impl EventBatch {
         std::mem::replace(self, Self::with_capacity(replacement_capacity))
     }
 
-    /// Splits the batch into its events, event count, and source payload
-    /// metadata.
-    fn into_parts(self) -> (Vec<Event>, usize, StreamingPayloadMetadata) {
+    /// Splits the batch into its events and dispatch metadata.
+    fn into_parts(self) -> (Vec<Event>, usize, HashSet<TableId>, StreamingPayloadMetadata) {
         let event_count = self.events.len();
 
-        (self.events, event_count, self.streaming_payload_metadata)
+        (self.events, event_count, self.relation_table_ids, self.streaming_payload_metadata)
     }
 }
 
@@ -725,6 +736,13 @@ struct ApplyLoopState {
     /// [`MAX_PENDING_DURABLE_DISPATCHES`]. Timing entries are metric-only
     /// state, so overflow skips new entries instead of affecting replication.
     pending_durable_dispatches: VecDeque<PendingDurableDispatch>,
+    /// Relation tables not yet covered by persisted commit-boundary progress.
+    ///
+    /// This includes relations from `Accepted` writes and from durable
+    /// mid-transaction writes that carry no commit end LSN. A later durable
+    /// commit-bearing result covers them cumulatively and makes their tables
+    /// candidates for obsolete schema cleanup.
+    pending_relation_table_ids: HashSet<TableId>,
     /// The LSN of the commit WAL entry of the transaction that is currently
     /// being processed.
     remote_final_lsn: Option<PgLsn>,
@@ -773,11 +791,6 @@ struct ApplyLoopState {
     bootstrap_snapshot_id: SnapshotId,
     /// Replication slot name used by this loop.
     slot_name: String,
-    /// Shared schema cleanup deadline.
-    ///
-    /// `None` means a cleanup run has claimed the deadline. The run resets this
-    /// after it either finishes or decides not to spawn background work.
-    schema_cleanup_deadline: Arc<Mutex<Option<Instant>>>,
 }
 
 impl ApplyLoopState {
@@ -792,6 +805,7 @@ impl ApplyLoopState {
         Self {
             last_commit_end_lsn: None,
             pending_durable_dispatches: VecDeque::new(),
+            pending_relation_table_ids: HashSet::new(),
             remote_final_lsn: None,
             replication_progress,
             replication_lag_metrics,
@@ -807,9 +821,6 @@ impl ApplyLoopState {
             processing_paused: false,
             bootstrap_snapshot_id,
             slot_name,
-            schema_cleanup_deadline: Arc::new(Mutex::new(Some(
-                Instant::now() + SCHEMA_CLEANUP_INTERVAL,
-            ))),
         }
     }
 
@@ -931,27 +942,6 @@ impl ApplyLoopState {
         } else {
             self.replication_progress.last_flush_lsn()
         }
-    }
-
-    /// Tries to mark schema cleanup as running if the deadline has elapsed.
-    async fn try_start_schema_cleanup(&self) -> Option<SchemaCleanupRun> {
-        let mut schema_cleanup_deadline = self.schema_cleanup_deadline.lock().await;
-        let deadline = (*schema_cleanup_deadline)?;
-
-        #[cfg(feature = "failpoints")]
-        if etl_fail_point_active(FORCE_SCHEMA_CLEANUP_FP) {
-            *schema_cleanup_deadline = None;
-
-            return Some(SchemaCleanupRun { deadline: Arc::clone(&self.schema_cleanup_deadline) });
-        }
-
-        if Instant::now() < deadline {
-            return None;
-        }
-
-        *schema_cleanup_deadline = None;
-
-        Some(SchemaCleanupRun { deadline: Arc::clone(&self.schema_cleanup_deadline) })
     }
 
     /// Returns true if the apply loop is in the middle of processing a
@@ -1158,7 +1148,8 @@ where
 
         let replication_lag_refresh_interval =
             Duration::from_millis(config.replication_lag_refresh_interval_ms);
-        let tasks = ApplyLoopTasks::new(
+        let tasks = ApplyLoopTasks::start(
+            schema_store.clone(),
             out_of_band_source_pool,
             replication_lag_metrics.clone(),
             worker_type,
@@ -1199,9 +1190,7 @@ where
     ) -> EtlResult<ApplyLoopResult> {
         let result = self.run(replication_client, start_lsn).await;
 
-        self.tasks
-            .teardown(self.worker_context.worker_type(), &self.state.schema_cleanup_deadline)
-            .await;
+        self.tasks.teardown(self.worker_context.worker_type()).await;
 
         result
     }
@@ -1600,7 +1589,7 @@ where
         force: bool,
         status_update_type: StatusUpdateType,
     ) -> EtlResult<()> {
-        let status_update_result = replication_message_stream
+        replication_message_stream
             .as_mut()
             .stream_mut()
             .send_status_update(
@@ -1611,39 +1600,27 @@ where
             )
             .await?;
 
-        // If we sent a status update, we check if we can perform schema cleanup for old
-        // table schema snapshots.
-        if let StatusUpdateResult::Sent = status_update_result {
-            self.maybe_spawn_schema_cleanup().await?;
-        }
-
         Ok(())
     }
 
-    /// Attempts to spawn a best-effort task that prunes obsolete schema
-    /// versions.
+    /// Tries to queue best-effort cleanup for relation tables covered by
+    /// durable progress.
     ///
-    /// Cleanup uses ETL-owned durable replication progress. If no progress row
-    /// exists yet, pruning is skipped instead of relying on PostgreSQL slot
-    /// state.
-    async fn maybe_spawn_schema_cleanup(&mut self) -> EtlResult<()> {
-        self.tasks
-            .collect_finished_schema_cleanup_task(
-                self.worker_context.worker_type(),
-                &self.state.schema_cleanup_deadline,
-            )
-            .await;
-
-        if self.tasks.has_running_schema_cleanup_task() {
-            return Ok(());
+    /// The persisted progress row is deliberately reloaded here instead of
+    /// using the apply loop's in-memory flush position. Cleanup removes replay
+    /// state, so its boundary must survive a crash independently of this
+    /// process.
+    ///
+    /// Pending candidates remain in [`ApplyLoopState`] when a transient failure
+    /// prevents evaluation or queueing, so the next durable result retries
+    /// them. They are cleared only after successful evaluation and, when
+    /// needed, successful queueing.
+    async fn try_queue_schema_cleanup(&mut self) {
+        if self.state.pending_relation_table_ids.is_empty() {
+            return;
         }
 
-        let Some(schema_cleanup_run) = self.state.try_start_schema_cleanup().await else {
-            return Ok(());
-        };
-
         let worker_type = self.worker_context.worker_type();
-
         let durable_flush_lsn = match self.schema_store.get_replication_progress(worker_type).await
         {
             Ok(Some(durable_flush_lsn)) => durable_flush_lsn,
@@ -1653,9 +1630,7 @@ where
                     "skipping schema cleanup because durable replication progress is not available"
                 );
 
-                schema_cleanup_run.finish().await;
-
-                return Ok(());
+                return;
             }
             Err(err) => {
                 warn!(
@@ -1664,15 +1639,13 @@ where
                     "skipping schema cleanup because durable replication progress could not be loaded"
                 );
 
-                schema_cleanup_run.finish().await;
-
-                return Ok(());
+                return;
             }
         };
 
         // We get the table retention boundaries that this apply loop instance
-        // can safely prune up to. The map is frozen before the background task
-        // is spawned, so any concurrent progress can only make this cleanup
+        // can safely prune up to. The map is frozen before the request is
+        // queued, so any concurrent progress can only make this cleanup
         // conservative.
         let table_schema_retentions =
             match self.get_table_schema_retentions(durable_flush_lsn).await {
@@ -1684,50 +1657,50 @@ where
                         "failed to determine schema cleanup ownership"
                     );
 
-                    schema_cleanup_run.finish().await;
-
-                    return Ok(());
+                    return;
                 }
             };
 
         // If there are no tables to try to prune, we don't want to attempt it.
         if table_schema_retentions.is_empty() {
-            schema_cleanup_run.finish().await;
+            self.state.pending_relation_table_ids.clear();
 
-            return Ok(());
+            return;
         }
 
-        // At this point we know the retention boundaries to check for pruning,
-        // so we can offload this to a background task to not stall the worker.
-        // This is fine since those boundaries are frozen, so this task can take
-        // its time to do the job without interfering with the apply loop. Also,
-        // no more than one pruning task can occur at the same time within an
-        // apply loop instance, so this makes this even safer.
-        self.tasks.spawn_schema_cleanup(
-            self.schema_store.clone(),
-            table_schema_retentions,
-            schema_cleanup_run,
-            worker_type,
-        );
-
-        Ok(())
+        // With the retention boundaries fixed, queue the database deletion
+        // without stalling the apply loop. The cleanup worker serializes
+        // requests from this apply loop.
+        if self.tasks.try_queue_schema_cleanup(table_schema_retentions) {
+            self.state.pending_relation_table_ids.clear();
+        }
     }
 
     /// Returns schema retention boundaries for tables this worker may clean up.
     ///
-    /// The shared cache is used only to find active tables, and the worker's
-    /// normal ownership check decides which of those tables can be considered.
-    /// A table's cleanup boundary is capped by durable ETL replication progress
-    /// and by the earliest destination metadata snapshot that may still be
-    /// needed.
+    /// The candidates come from relation events covered by a durable
+    /// destination result. The worker's normal ownership check decides which
+    /// of those tables can be considered.
+    ///
+    /// The cleanup LSN is the minimum of persisted commit-boundary progress and
+    /// the earliest snapshot still referenced by destination metadata.
+    /// Persisted progress is an arbitrary LSN and need not identify a schema
+    /// version. The schema store resolves it to the greatest snapshot at or
+    /// below that LSN, preserving that snapshot and every newer version.
+    ///
+    /// Progress and metadata do not need to be read in one transaction. During
+    /// normal replication both safe boundaries move forward, so taking their
+    /// minimum from a mixed observation is conservative. Table lifecycle resets
+    /// remove the prior schemas before rebuilding them, and rebuilt nonzero
+    /// snapshots occur after the frozen progress boundary.
     async fn get_table_schema_retentions(
         &self,
         durable_flush_lsn: PgLsn,
     ) -> EtlResult<HashMap<TableId, TableSchemaRetention>> {
-        let active_table_ids = self.shared_table_cache.active_table_ids().await;
-        let mut table_schema_retentions = HashMap::with_capacity(active_table_ids.len());
+        let mut table_schema_retentions =
+            HashMap::with_capacity(self.state.pending_relation_table_ids.len());
 
-        for table_id in active_table_ids {
+        for &table_id in &self.state.pending_relation_table_ids {
             // Only prune snapshots for tables this worker would apply at this
             // flush position. This keeps table sync workers limited to their
             // assigned table while preserving apply worker ownership rules.
@@ -1754,16 +1727,16 @@ where
                 continue;
             };
 
-            // We take the earliest snapshot id that is still needed by the destination
-            // table metadata.
+            // An applying schema change may still need both endpoints for recovery, so
+            // retain from the earlier destination snapshot.
             let destination_retention_snapshot_id = destination_table_metadata
                 .previous_snapshot_id
                 .unwrap_or(destination_table_metadata.snapshot_id)
                 .min(destination_table_metadata.snapshot_id);
 
-            // We determine whether the durable flush lsn or the snapshot id is the new
-            // retention limit. We could use a normal PgLsn type for handling
-            // this, but to make the implementation more explicit we use an enum.
+            // Choose the smaller LSN while retaining why it bounded cleanup. Unlike the
+            // destination value, durable progress need not coincide with a schema
+            // snapshot.
             let retention = if durable_flush_lsn <= destination_retention_snapshot_id.into_inner() {
                 TableSchemaRetention::DurableFlushLsn(durable_flush_lsn)
             } else {
@@ -1801,6 +1774,18 @@ where
         let status = result?;
 
         if let Some(metadata) = metadata.as_ref() {
+            // Relation events are optimistic cleanup signals: the first relation after
+            // startup need not represent a schema change, while a real DDL is
+            // communicated downstream through one. Accumulate them until a durable
+            // result also carries a commit end LSN, because only then can persisted
+            // progress cover every preceding relation in this ordered apply-loop
+            // stream. This also makes cleanup self-healing across restarts: the first
+            // later relation rebuilds the candidate even though this in-memory set was
+            // lost.
+            self.state
+                .pending_relation_table_ids
+                .extend(metadata.relation_table_ids.iter().copied());
+
             if metadata.durability == WriteEventsDurability::RequireDurable
                 && status == DestinationWriteStatus::Accepted
             {
@@ -1904,10 +1889,15 @@ where
                     // Note that it could be that there is no end lsn for a specific batch, which
                     // could happen if we process a huge transaction, and we don't reach the
                     // commit before flushing. In that case, we don't process syncing
-                    // tables, meaning that progress it not tracked, since it's not going to
+                    // tables, meaning that progress is not tracked, since it's not going to
                     // do anything because we can only track progress at commit boundaries.
                     if let Some(commit_end_lsn) = metadata.commit_end_lsn {
                         self.process_syncing_tables_after_flush(commit_end_lsn).await?;
+
+                        // Progress and table-sync state are now durable. Freeze cleanup
+                        // boundaries for all cumulatively covered relations before
+                        // allowing their database deletion to run asynchronously.
+                        self.try_queue_schema_cleanup().await;
                     }
                 }
             }
@@ -2069,7 +2059,8 @@ where
     ) -> EtlResult<()> {
         debug_assert!(!self.state.has_pending_flush_result());
 
-        let (events, event_count, streaming_payload_metadata) = event_batch.into_parts();
+        let (events, event_count, relation_table_ids, streaming_payload_metadata) =
+            event_batch.into_parts();
         // `Complete` is terminal, so no later write is guaranteed to settle an
         // `Accepted` result. Its final batch must confirm cumulative durability
         // before the apply loop can complete.
@@ -2090,6 +2081,7 @@ where
             commit_end_lsn: self.state.last_commit_end_lsn.take(),
             durability,
             event_count,
+            relation_table_ids,
             streaming_payload_metadata,
             dispatched_at: Instant::now(),
         };

--- a/crates/etl/src/replication/table_cache.rs
+++ b/crates/etl/src/replication/table_cache.rs
@@ -103,6 +103,7 @@ impl SharedTableCache {
 
     /// Returns the current active table ids in the cache, which represent the
     /// active tables being replicated.
+    #[cfg(test)]
     pub(crate) async fn active_table_ids(&self) -> Vec<TableId> {
         let guard = self.inner.read().await;
         guard.keys().copied().collect()

--- a/crates/etl/src/store/schema/table.rs
+++ b/crates/etl/src/store/schema/table.rs
@@ -282,4 +282,35 @@ mod tests {
         assert_eq!(removed, 0);
         assert_eq!(snapshots.snapshots_count(table_id), 1);
     }
+
+    #[test]
+    fn prune_is_idempotent_for_repeated_and_out_of_order_boundaries() {
+        let table_id = TableId::new(10);
+        let mut snapshots = TableSchemaSnapshots::default();
+
+        for snapshot_id in [100, 200, 300] {
+            snapshots.insert(test_schema(table_id, snapshot_id));
+        }
+
+        let newer_retention = HashMap::from([(
+            table_id,
+            TableSchemaRetention::DurableFlushLsn(SnapshotId::from(350).into()),
+        )]);
+        assert_eq!(snapshots.prune(&newer_retention), 2);
+        assert_eq!(snapshots.prune(&newer_retention), 0);
+
+        let older_retention = HashMap::from([(
+            table_id,
+            TableSchemaRetention::DurableFlushLsn(SnapshotId::from(250).into()),
+        )]);
+        assert_eq!(snapshots.prune(&older_retention), 0);
+        assert_eq!(snapshots.snapshots_count(table_id), 1);
+        assert_eq!(
+            snapshots
+                .get_at_or_before(table_id, SnapshotId::max())
+                .expect("newest schema should remain")
+                .snapshot_id,
+            SnapshotId::from(300)
+        );
+    }
 }

--- a/crates/etl/src/test_utils/test_destination_wrapper.rs
+++ b/crates/etl/src/test_utils/test_destination_wrapper.rs
@@ -379,6 +379,7 @@ where
                 commit_end_lsn: None,
                 durability,
                 event_count: events.len(),
+                relation_table_ids: Default::default(),
                 streaming_payload_metadata: Default::default(),
                 dispatched_at: Instant::now(),
             });

--- a/crates/etl/tests/pipeline_with_failpoints.rs
+++ b/crates/etl/tests/pipeline_with_failpoints.rs
@@ -11,7 +11,7 @@ use etl::{
     error::EtlResult,
     event::{Event, EventType, InsertEvent},
     failpoints::{
-        FORCE_SCHEMA_CLEANUP_FP, SEND_STATUS_UPDATE_FP, START_TABLE_SYNC_AFTER_FINISHED_COPY_FP,
+        SEND_STATUS_UPDATE_FP, START_TABLE_SYNC_AFTER_FINISHED_COPY_FP,
         START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP, START_TABLE_SYNC_DURING_DATA_SYNC_FP,
         STORE_REPLICATION_PROGRESS_FP, TABLE_SYNC_WORKER_BEFORE_STREAMING_FP,
     },
@@ -1578,7 +1578,7 @@ async fn table_schema_snapshots_are_consistent_after_missing_status_update_with_
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn schema_snapshots_are_pruned_after_confirmed_progress() {
+async fn schema_snapshots_are_pruned_after_durable_relation_batch() {
     let _scenario = FailScenario::setup();
 
     init_test_tracing();
@@ -1590,6 +1590,7 @@ async fn schema_snapshots_are_pruned_after_confirmed_progress() {
         )
         .await;
 
+    let prune_notify = store.notify_on_table_schema_prune().await;
     let events_notify = destination
         .wait_for_events(vec![
             EventCondition::TableCount(EventType::Relation, table_id, 2),
@@ -1628,32 +1629,113 @@ async fn schema_snapshots_are_pruned_after_confirmed_progress() {
         .unwrap();
 
     events_notify.notified().await;
-
-    let table_schemas = store.get_table_schemas().await;
-    let before_snapshots = table_schemas.get(&table_id).unwrap();
-    assert_table_schema_snapshots(
-        before_snapshots,
-        &[
-            &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
-            &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
-            &[("id", Type::INT8), ("name", Type::TEXT), ("email", Type::TEXT)],
-        ],
-    );
-
-    let prune_notify = store.notify_on_table_schema_prune().await;
-
-    fail::cfg(FORCE_SCHEMA_CLEANUP_FP, "return").unwrap();
-
     prune_notify.notified().await;
-
-    fail::remove(FORCE_SCHEMA_CLEANUP_FP);
 
     pipeline.shutdown_and_wait().await.unwrap();
 
     let table_schemas = store.get_table_schemas().await;
     let after_snapshots = table_schemas.get(&table_id).unwrap();
     assert_eq!(after_snapshots.len(), 1);
-    assert_eq!(after_snapshots[0], before_snapshots[2]);
+    assert_table_schema_column_names_types(
+        &after_snapshots[0].1,
+        &[("id", Type::INT8), ("name", Type::TEXT), ("email", Type::TEXT)],
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn first_relation_after_restart_retries_schema_cleanup() {
+    let _scenario = FailScenario::setup();
+    fail::cfg(STORE_REPLICATION_PROGRESS_FP, "return").unwrap();
+
+    init_test_tracing();
+
+    let (database, table_name, table_id, store, destination, pipeline, pipeline_id, publication) =
+        create_database_and_ready_pipeline_with_table(
+            "schema_cleanup_restart",
+            &[("name", "text not null"), ("age", "integer not null")],
+        )
+        .await;
+
+    let events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
+        .await;
+
+    database
+        .alter_table(
+            table_name.clone(),
+            &[TableModification::AddColumn {
+                name: "email",
+                data_type: "text not null default 'unknown@example.com'",
+            }],
+        )
+        .await
+        .unwrap();
+    database
+        .insert_values(
+            table_name.clone(),
+            &["name", "age", "email"],
+            &[&"Alice", &25, &"alice@example.com"],
+        )
+        .await
+        .unwrap();
+
+    database
+        .alter_table(table_name.clone(), &[TableModification::DropColumn { name: "age" }])
+        .await
+        .unwrap();
+    database
+        .insert_values(table_name.clone(), &["name", "email"], &[&"Bob", &"bob@example.com"])
+        .await
+        .unwrap();
+
+    events_notify.notified().await;
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_schemas = store.get_table_schemas().await;
+    assert_eq!(table_schemas.get(&table_id).unwrap().len(), 3);
+
+    fail::remove(STORE_REPLICATION_PROGRESS_FP);
+
+    let mut pipeline =
+        create_pipeline(&database.config, pipeline_id, publication, store.clone(), destination);
+    let mut prune_notify = store.notify_on_table_schema_prune().await;
+
+    pipeline.start().await.unwrap();
+
+    // The first post-restart DML emits a relation even without another DDL.
+    // That relation reconstructs the in-memory cleanup candidate lost at
+    // shutdown.
+    database
+        .insert_values(table_name, &["name", "email"], &[&"Charlie", &"charlie@example.com"])
+        .await
+        .unwrap();
+
+    loop {
+        prune_notify.notified().await;
+
+        // Register the next notification before checking so a cleanup between
+        // the check and the next wait cannot be missed.
+        let next_prune_notify = store.notify_on_table_schema_prune().await;
+        let table_schemas = store.get_table_schemas().await;
+        if table_schemas.get(&table_id).unwrap().len() == 1 {
+            break;
+        }
+
+        prune_notify = next_prune_notify;
+    }
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let table_schemas = store.get_table_schemas().await;
+    let after_snapshots = table_schemas.get(&table_id).unwrap();
+    assert_eq!(after_snapshots.len(), 1);
+    assert_table_schema_column_names_types(
+        &after_snapshots[0].1,
+        &[("id", Type::INT8), ("name", Type::TEXT), ("email", Type::TEXT)],
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/pipeline_with_failpoints.rs
+++ b/crates/etl/tests/pipeline_with_failpoints.rs
@@ -1694,8 +1694,17 @@ async fn first_relation_after_restart_retries_schema_cleanup() {
     events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
+    // Without durable progress, cleanup cannot determine a crash-safe
+    // retention boundary. All schema versions therefore remain available.
     let table_schemas = store.get_table_schemas().await;
-    assert_eq!(table_schemas.get(&table_id).unwrap().len(), 3);
+    assert_table_schema_snapshots(
+        table_schemas.get(&table_id).unwrap(),
+        &[
+            &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
+            &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
+            &[("id", Type::INT8), ("name", Type::TEXT), ("email", Type::TEXT)],
+        ],
+    );
 
     fail::remove(STORE_REPLICATION_PROGRESS_FP);
 

--- a/crates/etl/tests/pipelines_with_schema_changes.rs
+++ b/crates/etl/tests/pipelines_with_schema_changes.rs
@@ -4,7 +4,7 @@ use etl::{
     data::{ArrayCell, Cell},
     event::{Event, EventType},
     pipeline::PipelineId,
-    schema::{ColumnSchema, TableId},
+    schema::{ColumnSchema, SnapshotId, TableId, TableSchema},
     store::TableStateType,
     test_utils::{
         database::{spawn_source_database, test_table_name},
@@ -41,10 +41,6 @@ fn get_last_insert_event(events: &[Event], table_id: TableId) -> &Event {
         .expect("no insert events for table")
 }
 
-fn schema_columns(schema: &etl::schema::TableSchema) -> Vec<(String, Type)> {
-    schema.column_schemas.iter().map(|column| (column.name.clone(), column.typ.clone())).collect()
-}
-
 fn assert_column_default_contains<'a>(
     columns: impl IntoIterator<Item = &'a ColumnSchema>,
     column_name: &str,
@@ -69,20 +65,18 @@ fn assert_column_default_contains<'a>(
     }
 }
 
-fn find_snapshot_index_after(
-    snapshots: &[(etl::schema::SnapshotId, etl::schema::TableSchema)],
-    start_index: usize,
+/// Asserts that cleanup retained only the expected current schema.
+fn assert_only_schema_snapshot<'a>(
+    snapshots: &'a [(SnapshotId, TableSchema)],
     expected: &[(&str, Type)],
-) -> usize {
-    let expected =
-        expected.iter().map(|(name, typ)| ((*name).to_owned(), typ.clone())).collect::<Vec<_>>();
+) -> &'a TableSchema {
+    assert_eq!(snapshots.len(), 1);
+    assert_schema_snapshots_ordering(snapshots, false);
 
-    snapshots
-        .iter()
-        .enumerate()
-        .skip(start_index)
-        .find_map(|(index, (_, schema))| (schema_columns(schema) == expected).then_some(index))
-        .expect("expected schema snapshot in order")
+    let (_, schema) = &snapshots[0];
+    assert_table_schema_column_names_types(schema, expected);
+
+    schema
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -141,21 +135,11 @@ async fn relation_message_updates_when_column_added() {
     };
     assert_eq!(i.table_row.values().len(), 4);
 
-    // Verify schema snapshots are stored in order.
+    // Verify cleanup retained the current schema.
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
-    assert_eq!(snapshots.len(), 2);
-    assert_schema_snapshots_ordering(snapshots, true);
-
-    let (_, first_schema) = &snapshots[0];
-    assert_table_schema_column_names_types(
-        first_schema,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
-    );
-
-    let (_, second_schema) = &snapshots[1];
-    assert_table_schema_column_names_types(
-        second_schema,
+    assert_only_schema_snapshot(
+        snapshots,
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
     );
 }
@@ -206,23 +190,10 @@ async fn relation_message_updates_when_column_removed() {
     };
     assert_eq!(i.table_row.values().len(), 2);
 
-    // Verify schema snapshots are stored in order.
+    // Verify cleanup retained the current schema.
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
-    assert_eq!(snapshots.len(), 2);
-    assert_schema_snapshots_ordering(snapshots, true);
-
-    let (_, first_schema) = &snapshots[0];
-    assert_table_schema_column_names_types(
-        first_schema,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
-    );
-
-    let (_, second_schema) = &snapshots[1];
-    assert_table_schema_column_names_types(
-        second_schema,
-        &[("id", Type::INT8), ("name", Type::TEXT)],
-    );
+    assert_only_schema_snapshot(snapshots, &[("id", Type::INT8), ("name", Type::TEXT)]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -277,21 +248,11 @@ async fn relation_message_updates_when_column_renamed() {
     };
     assert_eq!(i.table_row.values().len(), 3);
 
-    // Verify schema snapshots are stored in order.
+    // Verify cleanup retained the current schema.
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
-    assert_eq!(snapshots.len(), 2);
-    assert_schema_snapshots_ordering(snapshots, true);
-
-    let (_, first_schema) = &snapshots[0];
-    assert_table_schema_column_names_types(
-        first_schema,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
-    );
-
-    let (_, second_schema) = &snapshots[1];
-    assert_table_schema_column_names_types(
-        second_schema,
+    assert_only_schema_snapshot(
+        snapshots,
         &[("id", Type::INT8), ("full_name", Type::TEXT), ("age", Type::INT4)],
     );
 }
@@ -348,21 +309,11 @@ async fn relation_message_updates_when_column_type_changes() {
     };
     assert_eq!(i.table_row.values().len(), 3);
 
-    // Verify schema snapshots are stored in order.
+    // Verify cleanup retained the current schema.
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
-    assert_eq!(snapshots.len(), 2);
-    assert_schema_snapshots_ordering(snapshots, true);
-
-    let (_, first_schema) = &snapshots[0];
-    assert_table_schema_column_names_types(
-        first_schema,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
-    );
-
-    let (_, second_schema) = &snapshots[1];
-    assert_table_schema_column_names_types(
-        second_schema,
+    assert_only_schema_snapshot(
+        snapshots,
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT8)],
     );
 }
@@ -485,16 +436,8 @@ async fn alter_table_without_dml_stores_schema_snapshot() {
 
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
-    assert_eq!(snapshots.len(), 2);
-    assert_schema_snapshots_ordering(snapshots, true);
-    let (_, first_schema) = &snapshots[0];
-    assert_table_schema_column_names_types(
-        first_schema,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4)],
-    );
-    let (_, second_schema) = &snapshots[1];
-    assert_table_schema_column_names_types(
-        second_schema,
+    assert_only_schema_snapshot(
+        snapshots,
         &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("email", Type::TEXT)],
     );
 }
@@ -672,12 +615,8 @@ async fn default_expressions_round_trip_through_schema_changes_and_defaulted_ins
 
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
-    assert_eq!(snapshots.len(), 2);
-    assert_schema_snapshots_ordering(snapshots, true);
-
-    let (_, second_schema) = &snapshots[1];
-    assert_table_schema_column_names_types(
-        second_schema,
+    let schema = assert_only_schema_snapshot(
+        snapshots,
         &[
             ("id", Type::INT8),
             ("name", Type::TEXT),
@@ -694,37 +633,25 @@ async fn default_expressions_round_trip_through_schema_changes_and_defaulted_ins
             ("expires_at", Type::TIMESTAMPTZ),
         ],
     );
-    assert_column_default_contains(&second_schema.column_schemas, "status_text", &["pending"]);
-    assert_column_default_contains(&second_schema.column_schemas, "score", &["10", "5"]);
-    assert_column_default_contains(&second_schema.column_schemas, "active", &["true"]);
-    assert_column_default_contains(&second_schema.column_schemas, "created_at", &["now"]);
-    assert_column_default_contains(&second_schema.column_schemas, "created_on", &["2026-01-01"]);
+    assert_column_default_contains(&schema.column_schemas, "status_text", &["pending"]);
+    assert_column_default_contains(&schema.column_schemas, "score", &["10", "5"]);
+    assert_column_default_contains(&schema.column_schemas, "active", &["true"]);
+    assert_column_default_contains(&schema.column_schemas, "created_at", &["now"]);
+    assert_column_default_contains(&schema.column_schemas, "created_on", &["2026-01-01"]);
     assert_column_default_contains(
-        &second_schema.column_schemas,
+        &schema.column_schemas,
         "payload",
         &["jsonb_build_object", "source", "api"],
     );
-    assert_column_default_contains(&second_schema.column_schemas, "lower_name", &["lower", "user"]);
+    assert_column_default_contains(&schema.column_schemas, "lower_name", &["lower", "user"]);
+    assert_column_default_contains(&schema.column_schemas, "label", &["coalesce", "fallback"]);
+    assert_column_default_contains(&schema.column_schemas, "tags", &["array", "alpha", "beta"]);
     assert_column_default_contains(
-        &second_schema.column_schemas,
-        "label",
-        &["coalesce", "fallback"],
-    );
-    assert_column_default_contains(
-        &second_schema.column_schemas,
-        "tags",
-        &["array", "alpha", "beta"],
-    );
-    assert_column_default_contains(
-        &second_schema.column_schemas,
+        &schema.column_schemas,
         "fixed_uuid",
         &["00000000-0000-0000-0000-000000000001"],
     );
-    assert_column_default_contains(
-        &second_schema.column_schemas,
-        "expires_at",
-        &["now", "30 days"],
-    );
+    assert_column_default_contains(&schema.column_schemas, "expires_at", &["now", "30 days"]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -739,6 +666,13 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await;
 
     // Add column + insert, then restart.
+    let events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 1),
+            EventCondition::TableCount(EventType::Insert, table_id, 1),
+        ])
+        .await;
+
     database
         .alter_table(
             table_name.clone(),
@@ -756,14 +690,7 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    destination
-        .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 1),
-            EventCondition::TableCount(EventType::Insert, table_id, 1),
-        ])
-        .await
-        .notified()
-        .await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Rename column + change type + insert, then restart.
@@ -776,6 +703,13 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     );
 
     pipeline.start().await.unwrap();
+
+    let events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 2),
+            EventCondition::TableCount(EventType::Insert, table_id, 2),
+        ])
+        .await;
 
     database
         .alter_table(
@@ -802,14 +736,7 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    destination
-        .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 2),
-            EventCondition::TableCount(EventType::Insert, table_id, 2),
-        ])
-        .await
-        .notified()
-        .await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Drop column + insert, then restart.
@@ -822,6 +749,13 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     );
 
     pipeline.start().await.unwrap();
+
+    let events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 3),
+            EventCondition::TableCount(EventType::Insert, table_id, 3),
+        ])
+        .await;
 
     database
         .alter_table(table_name.clone(), &[TableModification::DropColumn { name: "status" }])
@@ -837,14 +771,7 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    destination
-        .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 3),
-            EventCondition::TableCount(EventType::Insert, table_id, 3),
-        ])
-        .await
-        .notified()
-        .await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     // Add another column + rename existing + insert, then verify.
@@ -857,6 +784,13 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     );
 
     pipeline.start().await.unwrap();
+
+    let events_notify = destination
+        .wait_for_events(vec![
+            EventCondition::TableCount(EventType::Relation, table_id, 4),
+            EventCondition::TableCount(EventType::Insert, table_id, 4),
+        ])
+        .await;
 
     database
         .alter_table(
@@ -886,14 +820,7 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
         .await
         .unwrap();
 
-    destination
-        .wait_for_events(vec![
-            EventCondition::TableCount(EventType::Relation, table_id, 4),
-            EventCondition::TableCount(EventType::Insert, table_id, 4),
-        ])
-        .await
-        .notified()
-        .await;
+    events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
@@ -916,135 +843,11 @@ async fn pipeline_recovers_after_multiple_schema_changes_and_restart() {
     };
     assert_eq!(i.table_row.values().len(), 5);
 
-    // Verify the expected schema versions are stored in order.
-    //
-    // Around restarts we may re-observe equivalent schema state, so this test
-    // checks that the important versions appear in order instead of pinning the
-    // total snapshot count exactly.
+    // Verify cleanup across restarts retained only the current schema.
     let table_schemas = store.get_table_schemas().await;
     let snapshots = table_schemas.get(&table_id).unwrap();
-    assert_schema_snapshots_ordering(snapshots, true);
-    let mut index = find_snapshot_index_after(
+    assert_only_schema_snapshot(
         snapshots,
-        0,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("status", Type::TEXT)],
-    );
-    assert_table_schema_column_names_types(
-        &snapshots[index].1,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("age", Type::INT4), ("status", Type::TEXT)],
-    );
-
-    index = find_snapshot_index_after(
-        snapshots,
-        index + 1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("age", Type::INT4),
-            ("status", Type::TEXT),
-            ("email", Type::TEXT),
-        ],
-    );
-    assert_table_schema_column_names_types(
-        &snapshots[index].1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("age", Type::INT4),
-            ("status", Type::TEXT),
-            ("email", Type::TEXT),
-        ],
-    );
-
-    index = find_snapshot_index_after(
-        snapshots,
-        index + 1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("years", Type::INT4),
-            ("status", Type::TEXT),
-            ("email", Type::TEXT),
-        ],
-    );
-    assert_table_schema_column_names_types(
-        &snapshots[index].1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("years", Type::INT4),
-            ("status", Type::TEXT),
-            ("email", Type::TEXT),
-        ],
-    );
-
-    index = find_snapshot_index_after(
-        snapshots,
-        index + 1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("years", Type::INT8),
-            ("status", Type::TEXT),
-            ("email", Type::TEXT),
-        ],
-    );
-    assert_table_schema_column_names_types(
-        &snapshots[index].1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("years", Type::INT8),
-            ("status", Type::TEXT),
-            ("email", Type::TEXT),
-        ],
-    );
-
-    index = find_snapshot_index_after(
-        snapshots,
-        index + 1,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("years", Type::INT8), ("email", Type::TEXT)],
-    );
-    assert_table_schema_column_names_types(
-        &snapshots[index].1,
-        &[("id", Type::INT8), ("name", Type::TEXT), ("years", Type::INT8), ("email", Type::TEXT)],
-    );
-
-    index = find_snapshot_index_after(
-        snapshots,
-        index + 1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("years", Type::INT8),
-            ("email", Type::TEXT),
-            ("created_at", Type::TIMESTAMP),
-        ],
-    );
-    assert_table_schema_column_names_types(
-        &snapshots[index].1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("years", Type::INT8),
-            ("email", Type::TEXT),
-            ("created_at", Type::TIMESTAMP),
-        ],
-    );
-
-    index = find_snapshot_index_after(
-        snapshots,
-        index + 1,
-        &[
-            ("id", Type::INT8),
-            ("name", Type::TEXT),
-            ("years", Type::INT8),
-            ("contact_email", Type::TEXT),
-            ("created_at", Type::TIMESTAMP),
-        ],
-    );
-    assert_table_schema_column_names_types(
-        &snapshots[index].1,
         &[
             ("id", Type::INT8),
             ("name", Type::TEXT),
@@ -1159,21 +962,11 @@ async fn partitioned_table_schema_change_updates_relation_message() {
     };
     assert_eq!(i.table_row.values().len(), 4);
 
-    // Verify schema snapshots are stored in order.
+    // Verify cleanup retained the current schema.
     let table_schemas = state_store.get_table_schemas().await;
     let snapshots = table_schemas.get(&parent_table_id).unwrap();
-    assert_eq!(snapshots.len(), 2);
-    assert_schema_snapshots_ordering(snapshots, true);
-
-    let (_, first_schema) = &snapshots[0];
-    assert_table_schema_column_names_types(
-        first_schema,
-        &[("id", Type::INT8), ("data", Type::TEXT), ("partition_key", Type::INT4)],
-    );
-
-    let (_, second_schema) = &snapshots[1];
-    assert_table_schema_column_names_types(
-        second_schema,
+    assert_only_schema_snapshot(
+        snapshots,
         &[
             ("id", Type::INT8),
             ("data", Type::TEXT),


### PR DESCRIPTION
This PR improves schema cleanup by triggering it only when obsolete table schemas are likely to exist. It replaces the previous time-based mechanism, which performed unnecessary work and added avoidable complexity.

The new algorithm uses `Relation` messages as an optimistic cleanup signal. After a batch containing one or more `Relation` messages is durably flushed, the system attempts to clean up obsolete schema versions for the affected tables.

This design also recovers naturally across restarts. PostgreSQL emits `Relation` messages again on a new replication connection, allowing the system to reconstruct cleanup candidates without persisting additional state. The first durably flushed `Relation` message therefore triggers another cleanup attempt, even when it represents the existing schema rather than a new DDL change.