### PR TITLE
Generalize walsender reconnect helpers

### DIFF
--- a/crates/etl/src/test_utils/database.rs
+++ b/crates/etl/src/test_utils/database.rs
@@ -142,17 +142,78 @@ pub async fn spawn_source_database() -> PgDatabase<Client> {
     database
 }
 
-/// Returns the replication slot's confirmed flush LSN and active walsender PID.
-pub async fn replication_slot_state(client: &Client, slot_name: &str) -> (PgLsn, Option<i32>) {
+/// Queries the replication slot's confirmed flush LSN and active walsender PID.
+async fn query_replication_slot_state(
+    client: &Client,
+    slot_name: &str,
+) -> Result<(PgLsn, Option<i32>), tokio_postgres::Error> {
     let row = client
         .query_one(
             "select confirmed_flush_lsn, active_pid from pg_replication_slots where slot_name = $1",
             &[&slot_name],
         )
-        .await
-        .unwrap();
+        .await?;
 
-    (row.get(0), row.get(1))
+    Ok((row.get(0), row.get(1)))
+}
+
+/// Returns the replication slot's confirmed flush LSN and active walsender PID.
+pub async fn replication_slot_state(client: &Client, slot_name: &str) -> (PgLsn, Option<i32>) {
+    query_replication_slot_state(client, slot_name)
+        .await
+        .expect("Failed to query replication slot state")
+}
+
+/// Result of trying to terminate the active walsender for a replication slot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WalsenderTermination {
+    /// The replication slot has no active walsender.
+    Inactive,
+    /// Postgres did not terminate the active walsender.
+    NotTerminated {
+        /// PID of the walsender that Postgres did not terminate.
+        pid: i32,
+    },
+    /// Postgres terminated the active walsender.
+    Terminated {
+        /// PID of the terminated walsender.
+        pid: i32,
+    },
+}
+
+/// Requests termination of the walsender with `pid`.
+///
+/// Returns whether Postgres terminated the backend.
+///
+/// # Errors
+///
+/// Returns an error if Postgres cannot run the termination query.
+pub async fn terminate_walsender(client: &Client, pid: i32) -> Result<bool, tokio_postgres::Error> {
+    let row = client.query_one("select pg_terminate_backend($1)", &[&pid]).await?;
+
+    Ok(row.get(0))
+}
+
+/// Tries to terminate the active walsender for `slot_name`.
+///
+/// # Errors
+///
+/// Returns an error if Postgres cannot query the replication slot or run the
+/// termination query.
+pub async fn terminate_active_walsender(
+    client: &Client,
+    slot_name: &str,
+) -> Result<WalsenderTermination, tokio_postgres::Error> {
+    let (_, active_pid) = query_replication_slot_state(client, slot_name).await?;
+    let Some(pid) = active_pid else {
+        return Ok(WalsenderTermination::Inactive);
+    };
+
+    if terminate_walsender(client, pid).await? {
+        Ok(WalsenderTermination::Terminated { pid })
+    } else {
+        Ok(WalsenderTermination::NotTerminated { pid })
+    }
 }
 
 /// Waits until a replication slot has confirmed at least `expected_lsn`.
@@ -183,23 +244,34 @@ pub async fn wait_for_replication_slot_flush_lsn(
 /// Waits until the replication slot is served by a walsender other than
 /// `old_pid`.
 ///
-/// # Panics
+/// Returns the new walsender PID, or [`None`] if no new walsender becomes
+/// active within `timeout`.
 ///
-/// Panics after [`DEFAULT_NOTIFY_TIMEOUT`] if no new walsender becomes active,
-/// mirroring [`crate::test_utils::notify::TimedNotify`].
-pub async fn wait_for_new_walsender(client: &Client, slot_name: &str, old_pid: i32) {
-    tokio::time::timeout(DEFAULT_NOTIFY_TIMEOUT, async {
+/// # Errors
+///
+/// Returns an error if Postgres cannot query the replication slot state.
+pub async fn wait_for_new_walsender(
+    client: &Client,
+    slot_name: &str,
+    old_pid: i32,
+    timeout: Duration,
+) -> Result<Option<i32>, tokio_postgres::Error> {
+    let result = tokio::time::timeout(timeout, async {
         loop {
-            let (_, active_pid) = replication_slot_state(client, slot_name).await;
+            let (_, active_pid) = query_replication_slot_state(client, slot_name).await?;
             if let Some(pid) = active_pid
                 && pid != old_pid
             {
-                return;
+                return Ok::<i32, tokio_postgres::Error>(pid);
             }
 
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
     })
-    .await
-    .expect("timed out waiting for a new walsender to serve the replication slot");
+    .await;
+
+    match result {
+        Ok(result) => result.map(Some),
+        Err(_) => Ok(None),
+    }
 }

--- a/crates/etl/src/test_utils/database.rs
+++ b/crates/etl/src/test_utils/database.rs
@@ -169,11 +169,13 @@ pub async fn replication_slot_state(client: &Client, slot_name: &str) -> (PgLsn,
 pub enum WalsenderTermination {
     /// The replication slot has no active walsender.
     Inactive,
+
     /// Postgres did not terminate the active walsender.
     NotTerminated {
         /// PID of the walsender that Postgres did not terminate.
         pid: i32,
     },
+
     /// Postgres terminated the active walsender.
     Terminated {
         /// PID of the terminated walsender.

--- a/crates/etl/tests/pipeline.rs
+++ b/crates/etl/tests/pipeline.rs
@@ -14,13 +14,13 @@ use etl::{
     store::{SchemaStore, StateStore, TableRetryPolicy, TableState, TableStateType, WorkerType},
     test_utils::{
         database::{
-            replication_slot_state, spawn_source_database, test_table_name, wait_for_new_walsender,
-            wait_for_replication_slot_flush_lsn,
+            replication_slot_state, spawn_source_database, terminate_walsender, test_table_name,
+            wait_for_new_walsender, wait_for_replication_slot_flush_lsn,
         },
         event::{EventCondition, group_events_by_type_and_table_id},
         faults::{FaultAction, FaultyOp},
         memory_destination::MemoryDestination,
-        notify::TimedNotify,
+        notify::{DEFAULT_NOTIFY_TIMEOUT, TimedNotify},
         notifying_store::NotifyingStore,
         pipeline::{
             PipelineBuilder, create_pipeline, create_pipeline_with_batch_config,
@@ -1498,9 +1498,14 @@ async fn streaming_reconnect_does_not_replay_already_flushed_events() {
     .await
     .expect("timed out waiting for confirmed_flush_lsn to advance after flush");
 
-    client.query_one("select pg_terminate_backend($1)", &[&terminated_pid]).await.unwrap();
+    assert!(terminate_walsender(client, terminated_pid).await.unwrap());
 
-    wait_for_new_walsender(client, &apply_slot_name, terminated_pid).await;
+    assert!(
+        wait_for_new_walsender(client, &apply_slot_name, terminated_pid, DEFAULT_NOTIFY_TIMEOUT,)
+            .await
+            .unwrap()
+            .is_some()
+    );
 
     let second_insert_notify = destination
         .wait_for_events(vec![EventCondition::TableCount(

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -214,8 +214,7 @@ impl<'a> WalsenderRouletteWorkload<'a> {
         }
     }
 
-    /// Terminates the active apply walsender and maps failures to the property
-    /// case.
+    /// Terminates the active apply walsender and maps failures.
     async fn terminate_apply_walsender(&self) -> Result<i32, TestCaseError> {
         let client = self.database.client.as_ref().unwrap();
         let termination =
@@ -234,7 +233,7 @@ impl<'a> WalsenderRouletteWorkload<'a> {
         }
     }
 
-    /// Waits for a new apply walsender within the roulette timeout.
+    /// Waits for a new apply walsender and maps failures.
     async fn wait_for_reconnect(&self, old_pid: i32) -> Result<(), TestCaseError> {
         let client = self.database.client.as_ref().unwrap();
         let reconnect =

--- a/crates/etl/tests/pipeline_with_faulty_destination.rs
+++ b/crates/etl/tests/pipeline_with_faulty_destination.rs
@@ -8,12 +8,15 @@ use etl::{
     schema::{TableId, TableName},
     store::{StateStore, TableRetryPolicy, TableState, TableStateType},
     test_utils::{
-        database::{replication_slot_state, spawn_source_database, wait_for_new_walsender},
+        database::{
+            WalsenderTermination, replication_slot_state, spawn_source_database,
+            terminate_active_walsender, terminate_walsender, wait_for_new_walsender,
+        },
         event::{EventCondition, group_events_by_type_and_table_id},
         faults::{FaultAction, FaultyOp},
         materialize::{FromTableRow, materialize_events},
         memory_destination::MemoryDestination,
-        notify::TimedNotify,
+        notify::{DEFAULT_NOTIFY_TIMEOUT, TimedNotify},
         notifying_store::NotifyingStore,
         pipeline::create_pipeline,
         property::{block_on, run_expensive_property},
@@ -149,36 +152,6 @@ async fn wait_for_notification(
         .map_err(|_| TestCaseError::fail(format!("timed out waiting for {description}")))
 }
 
-/// Terminates the active apply walsender and returns its PID.
-async fn terminate_apply_walsender(
-    client: &Client,
-    apply_slot_name: &str,
-) -> Result<i32, TestCaseError> {
-    let (_, active_pid) = replication_slot_state(client, apply_slot_name).await;
-    let old_pid = active_pid
-        .ok_or_else(|| TestCaseError::fail("apply walsender was not active at disconnect"))?;
-    let row = client
-        .query_one("select pg_terminate_backend($1)", &[&old_pid])
-        .await
-        .map_err(|error| TestCaseError::fail(format!("failed to terminate walsender: {error}")))?;
-    let terminated: bool = row.get(0);
-
-    prop_assert!(terminated, "Postgres did not terminate apply walsender {old_pid}");
-
-    Ok(old_pid)
-}
-
-/// Waits for a new apply walsender within the roulette timeout.
-async fn wait_for_apply_reconnect(
-    client: &Client,
-    apply_slot_name: &str,
-    old_pid: i32,
-) -> Result<(), TestCaseError> {
-    tokio::time::timeout(ROULETTE_TIMEOUT, wait_for_new_walsender(client, apply_slot_name, old_pid))
-        .await
-        .map_err(|_| TestCaseError::fail("timed out waiting for the apply walsender to reconnect"))
-}
-
 /// Mutable state used to execute one walsender roulette workload.
 struct WalsenderRouletteWorkload<'a> {
     /// Source database receiving generated transactions.
@@ -241,6 +214,42 @@ impl<'a> WalsenderRouletteWorkload<'a> {
         }
     }
 
+    /// Terminates the active apply walsender and maps failures to the property
+    /// case.
+    async fn terminate_apply_walsender(&self) -> Result<i32, TestCaseError> {
+        let client = self.database.client.as_ref().unwrap();
+        let termination =
+            terminate_active_walsender(client, self.apply_slot_name).await.map_err(|error| {
+                TestCaseError::fail(format!("Failed to terminate active walsender: {error}"))
+            })?;
+
+        match termination {
+            WalsenderTermination::Inactive => {
+                Err(TestCaseError::fail("Apply walsender was not active at disconnect"))
+            }
+            WalsenderTermination::NotTerminated { pid } => Err(TestCaseError::fail(format!(
+                "Postgres did not terminate apply walsender {pid}"
+            ))),
+            WalsenderTermination::Terminated { pid } => Ok(pid),
+        }
+    }
+
+    /// Waits for a new apply walsender within the roulette timeout.
+    async fn wait_for_reconnect(&self, old_pid: i32) -> Result<(), TestCaseError> {
+        let client = self.database.client.as_ref().unwrap();
+        let reconnect =
+            wait_for_new_walsender(client, self.apply_slot_name, old_pid, ROULETTE_TIMEOUT).await;
+        let new_pid = reconnect.map_err(|error| {
+            TestCaseError::fail(format!(
+                "Failed to query the apply walsender while waiting for reconnect: {error}"
+            ))
+        })?;
+
+        prop_assert!(new_pid.is_some(), "Timed out waiting for the apply walsender to reconnect");
+
+        Ok(())
+    }
+
     /// Disconnects after the scheduled write reaches the destination.
     async fn disconnect_after_delivered_write(
         &mut self,
@@ -248,10 +257,9 @@ impl<'a> WalsenderRouletteWorkload<'a> {
     ) -> Result<(), TestCaseError> {
         self.insert_user(user_number).await?;
 
-        let client = self.database.client.as_ref().unwrap();
-        let old_pid = terminate_apply_walsender(client, self.apply_slot_name).await?;
+        let old_pid = self.terminate_apply_walsender().await?;
 
-        wait_for_apply_reconnect(client, self.apply_slot_name, old_pid).await
+        self.wait_for_reconnect(old_pid).await
     }
 
     /// Disconnects while the scheduled write response is held.
@@ -269,18 +277,17 @@ impl<'a> WalsenderRouletteWorkload<'a> {
             .await
             .map_err(|_| TestCaseError::fail("timed out waiting for held write response"))?;
 
-        let client = self.database.client.as_ref().unwrap();
-        let old_pid = terminate_apply_walsender(client, self.apply_slot_name).await?;
+        let old_pid = self.terminate_apply_walsender().await?;
 
         match response_timing {
             WriteResponseTiming::ReleaseThenWaitForReconnect => {
                 hold.release_ok();
                 wait_for_notification(&delivered, format!("delivery of held user {user_id}"))
                     .await?;
-                wait_for_apply_reconnect(client, self.apply_slot_name, old_pid).await
+                self.wait_for_reconnect(old_pid).await
             }
             WriteResponseTiming::WaitForReconnectThenRelease => {
-                wait_for_apply_reconnect(client, self.apply_slot_name, old_pid).await?;
+                self.wait_for_reconnect(old_pid).await?;
                 hold.release_ok();
                 wait_for_notification(&delivered, format!("delivery of held user {user_id}")).await
             }
@@ -575,7 +582,17 @@ async fn apply_retry_reselects_relation_snapshots_after_ambiguous_write() {
     transaction.commit_transaction().await;
 
     users_ready_notify.notified().await;
-    wait_for_new_walsender(database.client.as_ref().unwrap(), &apply_slot_name, old_pid).await;
+    assert!(
+        wait_for_new_walsender(
+            database.client.as_ref().unwrap(),
+            &apply_slot_name,
+            old_pid,
+            DEFAULT_NOTIFY_TIMEOUT,
+        )
+        .await
+        .unwrap()
+        .is_some()
+    );
     replayed_events_notify.notified().await;
     pipeline.shutdown_and_wait().await.unwrap();
 
@@ -886,10 +903,13 @@ async fn apply_disconnect_with_write_held_until_after_reconnect_replays_without_
     let client = database.client.as_ref().unwrap();
     let (flush_lsn_at_kill, active_pid) = replication_slot_state(client, &apply_slot_name).await;
     let old_pid = active_pid.expect("apply walsender should be active");
-
-    client.query_one("select pg_terminate_backend($1)", &[&old_pid]).await.unwrap();
-
-    wait_for_new_walsender(client, &apply_slot_name, old_pid).await;
+    assert!(terminate_walsender(client, old_pid).await.unwrap());
+    assert!(
+        wait_for_new_walsender(client, &apply_slot_name, old_pid, DEFAULT_NOTIFY_TIMEOUT)
+            .await
+            .unwrap()
+            .is_some()
+    );
 
     // WHEN: the held response is released only after the reconnect
     let replay_recorded_notify = destination
@@ -975,7 +995,7 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
         .wait_for_all_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
         .await;
 
-    client.query_one("select pg_terminate_backend($1)", &[&old_pid]).await.unwrap();
+    assert!(terminate_walsender(client, old_pid).await.unwrap());
 
     hold.release_ok();
 
@@ -984,7 +1004,12 @@ async fn apply_disconnect_with_write_released_before_reconnect_recovers_without_
         .first()
         .expect("released insert should be recorded");
 
-    wait_for_new_walsender(client, &apply_slot_name, old_pid).await;
+    assert!(
+        wait_for_new_walsender(client, &apply_slot_name, old_pid, DEFAULT_NOTIFY_TIMEOUT)
+            .await
+            .unwrap()
+            .is_some()
+    );
 
     // THEN: streaming continues without loss, replaying the insert at most once
     let second_insert_notify = destination


### PR DESCRIPTION
- Generalizes the walsender termination and reconnect test helpers.
- Adds fallible utilities for PID and active-slot termination.
- Makes reconnect timeouts explicit and reports the replacement walsender PID.
- Migrates existing pipeline tests, preserving roulette-specific failure handling and timeout behavior.
- Removes duplicated termination queries and reconnect polling logic.