### PR TITLE
docs: clarify assertion message guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,8 +291,11 @@
 - Doctests use `cargo test --doc` (nextest does not support them).
 - If test output shows `0 passed; 0 failed; 0 ignored; n filtered out`, treat that as a failure to run tests.
 - Verify that expected tests actually ran, not just that Cargo exited successfully.
-- Do not add custom messages to assertions. Use a preceding comment when an
-  assertion's purpose is not evident from its expression.
+- Avoid custom assertion messages that merely restate the assertion. Use a
+  preceding comment to explain why a non-obvious invariant matters. In
+  table-driven tests, loops, and shared assertion helpers, include a concise,
+  non-sensitive case identifier when the default failure output would not
+  identify the failing case.
 - Prefer running `cargo nextest list` before using filters or crate-specific commands if there is any doubt.
 - When fixing a specific crate, run the narrowest relevant tests first, then broaden if needed.
 - When a test failure needs deeper debugging, rerun the targeted test with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,11 +291,12 @@
 - Doctests use `cargo test --doc` (nextest does not support them).
 - If test output shows `0 passed; 0 failed; 0 ignored; n filtered out`, treat that as a failure to run tests.
 - Verify that expected tests actually ran, not just that Cargo exited successfully.
-- Avoid custom assertion messages that merely restate the assertion. Use a
-  preceding comment to explain why a non-obvious invariant matters. In
-  table-driven tests, loops, and shared assertion helpers, include a concise,
-  non-sensitive case identifier when the default failure output would not
-  identify the failing case.
+- Avoid custom assertion messages that merely restate the condition or duplicate
+  values already reported by the assertion macro. Use a preceding comment to
+  explain why a non-obvious invariant matters. Add a concise custom message when
+  it supplies non-sensitive runtime context that the default failure output
+  cannot provide, such as a case identifier in table-driven tests, loops, or
+  shared assertion helpers.
 - Prefer running `cargo nextest list` before using filters or crate-specific commands if there is any doubt.
 - When fixing a specific crate, run the narrowest relevant tests first, then broaden if needed.
 - When a test failure needs deeper debugging, rerun the targeted test with


### PR DESCRIPTION
## Summary

Clarify that redundant assertion messages should be avoided while preserving concise, non-sensitive case context for table-driven tests, loops, and shared assertion helpers.