### PR TITLE
fix(snowflake): deduplicate outcome-unknown truncates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6022,6 +6022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7285,6 +7291,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -81,6 +81,7 @@ snowflake = [
     "dep:thiserror",
     "dep:tokio",
     "dep:tracing",
+    "uuid/v5",
     "dep:zstd",
 ]
 # We assume that `test-utils` is always used in conjunction with `bigquery` or `iceberg` thus we only

--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -10,6 +10,7 @@ use tokio::{
     time::{Instant, sleep},
 };
 use tracing::warn;
+use uuid::Uuid;
 
 use crate::snowflake::{
     Config, Error, Result, SnowpipeError,
@@ -57,6 +58,62 @@ const STREAMING_PENDING_MAX_ROW_BATCHES: usize = 64;
 
 /// Maximum accepted compressed bytes before forcing a durability wait.
 const STREAMING_PENDING_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// Namespace for deterministic Snowflake truncate-attempt request IDs.
+///
+/// The namespace and encoded identity are a durable protocol: changing either
+/// would prevent a restarted process from recovering an outcome-unknown SQL
+/// request under its original ID.
+const TRUNCATE_ATTEMPT_NAMESPACE: Uuid = Uuid::from_u128(0x4b929faf_9687_4544_a34f_f934369a37f7);
+
+/// Version tag for the truncate-attempt identity encoding.
+const TRUNCATE_ATTEMPT_IDENTITY_VERSION: &[u8] = b"supabase-etl/snowflake/truncate-attempt/v1";
+
+/// Stable identity for one physical Snowflake truncate attempt.
+#[derive(Clone, Copy)]
+struct TruncateAttemptIdentity<'a> {
+    /// ETL pipeline that owns the target channel.
+    pipeline_id: PipelineId,
+    /// Source Postgres table identifier.
+    table_id: TableId,
+    /// Exact Snowflake database identifier used by SQL.
+    database: &'a str,
+    /// Exact Snowflake schema identifier used by SQL.
+    schema: &'a str,
+    /// Exact Snowflake table identifier used by SQL.
+    table: &'a str,
+    /// Source truncate boundary assigned to the channel before SQL.
+    truncate_offset: &'a OffsetToken,
+    /// Snowflake channel creation timestamp observed before SQL.
+    channel_created_on_ms: u64,
+    /// Cumulative inserted rows observed before SQL.
+    rows_inserted: u64,
+}
+
+impl TruncateAttemptIdentity<'_> {
+    /// Derives the Snowflake SQL request ID for this physical attempt.
+    fn request_id(self) -> Uuid {
+        fn append_identity_component(identity: &mut Vec<u8>, component: &[u8]) {
+            let component_len = u64::try_from(component.len())
+                .expect("identity component length should fit into u64");
+            identity.extend_from_slice(&component_len.to_be_bytes());
+            identity.extend_from_slice(component);
+        }
+
+        let mut identity = Vec::new();
+        append_identity_component(&mut identity, TRUNCATE_ATTEMPT_IDENTITY_VERSION);
+        identity.extend_from_slice(&self.pipeline_id.to_be_bytes());
+        identity.extend_from_slice(&self.table_id.into_inner().to_be_bytes());
+        append_identity_component(&mut identity, self.database.as_bytes());
+        append_identity_component(&mut identity, self.schema.as_bytes());
+        append_identity_component(&mut identity, self.table.as_bytes());
+        append_identity_component(&mut identity, self.truncate_offset.as_ref().as_bytes());
+        identity.extend_from_slice(&self.channel_created_on_ms.to_be_bytes());
+        identity.extend_from_slice(&self.rows_inserted.to_be_bytes());
+
+        Uuid::new_v5(&TRUNCATE_ATTEMPT_NAMESPACE, &identity)
+    }
+}
 
 /// Global accepted-but-not-durable Snowflake streaming state.
 #[derive(Debug, Default)]
@@ -429,7 +486,10 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
     /// then held while the channel is opened at the truncate boundary, the
     /// table is cleared, and the channel is reopened after DDL. This makes a
     /// failed attempt safe to replay: earlier DML is covered by the channel
-    /// offset, while later DML remains eligible for replay.
+    /// offset, while later DML remains eligible for replay. The first open's
+    /// channel lineage and row progress identify the physical SQL attempt so a
+    /// restart can reconcile an outcome-unknown request without suppressing a
+    /// later required truncate.
     pub async fn truncate_table(
         &self,
         table_id: TableId,
@@ -451,8 +511,24 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
             // Open at the truncate offset before clearing the table. This waits for
             // any in-flight rowset to commit and invalidates the previous owner's
             // continuation token.
-            guard.open_at(truncate_offset).await?;
-            self.sql_client.truncate_table(table_name).await?;
+            let status = guard.open_at(truncate_offset).await?;
+            let channel_created_on_ms = status.created_on_ms.ok_or_else(|| {
+                Error::Channel(
+                    "Snowflake open response omitted the channel creation timestamp.".into(),
+                )
+            })?;
+            let request_id = TruncateAttemptIdentity {
+                pipeline_id: self.pipeline_id,
+                table_id,
+                database: &self.database,
+                schema: &self.schema,
+                table: table_name,
+                truncate_offset,
+                channel_created_on_ms,
+                rows_inserted: status.rows_inserted,
+            }
+            .request_id();
+            self.sql_client.truncate_table(table_name, request_id).await?;
 
             // TRUNCATE may invalidate that token, so reopen at the same offset before
             // allowing another sender to acquire the channel lock.
@@ -759,6 +835,72 @@ mod tests {
 
         assert!(state.limits_reached());
         assert!(state.would_exceed_limits(1));
+    }
+
+    #[test]
+    fn truncate_attempt_request_id_has_stable_encoding() {
+        let truncate_offset = OffsetToken::new(0x1234_5678_9abc_def0_u64.into(), 42);
+        let identity = TruncateAttemptIdentity {
+            pipeline_id: 17,
+            table_id: TableId::new(23),
+            database: "TEST_DB",
+            schema: "PUBLIC",
+            table: "USERS",
+            truncate_offset: &truncate_offset,
+            channel_created_on_ms: 1_754_321_098_765,
+            rows_inserted: 987_654,
+        };
+
+        assert_eq!(identity.request_id().to_string(), "f57cbf52-002a-5509-a5e7-670dd1ec603b");
+    }
+
+    #[test]
+    fn truncate_attempt_request_id_changes_with_each_identity_component() {
+        let truncate_offset = OffsetToken::new(100_u64.into(), 3);
+        let other_truncate_offset = OffsetToken::new(100_u64.into(), 4);
+        let identity = TruncateAttemptIdentity {
+            pipeline_id: 17,
+            table_id: TableId::new(23),
+            database: "TEST_DB",
+            schema: "PUBLIC",
+            table: "USERS",
+            truncate_offset: &truncate_offset,
+            channel_created_on_ms: 1_754_321_098_765,
+            rows_inserted: 987_654,
+        };
+        let expected = identity.request_id();
+        let variants = [
+            TruncateAttemptIdentity { pipeline_id: 18, ..identity },
+            TruncateAttemptIdentity { table_id: TableId::new(24), ..identity },
+            TruncateAttemptIdentity { database: "OTHER_DB", ..identity },
+            TruncateAttemptIdentity { schema: "PRIVATE", ..identity },
+            TruncateAttemptIdentity { table: "users", ..identity },
+            TruncateAttemptIdentity { truncate_offset: &other_truncate_offset, ..identity },
+            TruncateAttemptIdentity { channel_created_on_ms: 1_754_321_098_766, ..identity },
+            TruncateAttemptIdentity { rows_inserted: 987_655, ..identity },
+        ];
+
+        for variant in variants {
+            assert_ne!(variant.request_id(), expected);
+        }
+    }
+
+    #[test]
+    fn truncate_attempt_target_components_are_length_delimited() {
+        let truncate_offset = OffsetToken::new(100_u64.into(), 3);
+        let first = TruncateAttemptIdentity {
+            pipeline_id: 17,
+            table_id: TableId::new(23),
+            database: "AB",
+            schema: "C",
+            table: "USERS",
+            truncate_offset: &truncate_offset,
+            channel_created_on_ms: 1_754_321_098_765,
+            rows_inserted: 987_654,
+        };
+        let second = TruncateAttemptIdentity { database: "A", schema: "BC", ..first };
+
+        assert_ne!(first.request_id(), second.request_id());
     }
 
     #[tokio::test]

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use etl::{
     bail,
@@ -38,6 +42,27 @@ type EventIter = std::iter::Peekable<std::vec::IntoIter<Event>>;
 /// Maximum time allowed to drain Snowflake event tasks and retire local table
 /// state before a reset.
 const RESET_PREPARATION_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Takes consecutive truncate operations without collapsing distinct source
+/// boundaries. An outcome-unknown earlier truncate must be reconciled before a
+/// later boundary; otherwise it could finish late and erase rows restored after
+/// the later truncate. Duplicate tables are collapsed only within one event.
+fn take_truncate_operations(iter: &mut EventIter) -> Vec<(ReplicatedTableSchema, OffsetToken)> {
+    let mut operations = Vec::new();
+    while matches!(iter.peek(), Some(Event::Truncate(_))) {
+        if let Some(Event::Truncate(truncate)) = iter.next() {
+            let offset = OffsetToken::new(truncate.commit_lsn, truncate.tx_ordinal);
+            let mut table_ids = HashSet::new();
+            for schema in truncate.truncated_tables {
+                if table_ids.insert(schema.id()) {
+                    operations.push((schema, offset.clone()));
+                }
+            }
+        }
+    }
+
+    operations
+}
 
 /// Coordinates the initial Snowflake setup of each table.
 ///
@@ -323,22 +348,10 @@ where
     }
 
     async fn apply_truncate_events(&self, iter: &mut EventIter) -> EtlResult<bool> {
-        // Collect consecutive truncate events by table.
-        // Keep the latest offset, for each table.
-        let mut truncated: HashMap<TableId, (ReplicatedTableSchema, OffsetToken)> = HashMap::new();
-        while matches!(iter.peek(), Some(Event::Truncate(_))) {
-            if let Some(Event::Truncate(truncate)) = iter.next() {
-                let offset = OffsetToken::new(truncate.commit_lsn, truncate.tx_ordinal);
-                for schema in truncate.truncated_tables {
-                    // Keep each table's latest consecutive truncate boundary.
-                    truncated.insert(schema.id(), (schema, offset.clone()));
-                }
-            }
-        }
-        let had_truncates = !truncated.is_empty();
+        let operations = take_truncate_operations(iter);
+        let had_truncates = !operations.is_empty();
 
-        // Truncate tables.
-        for (_, (schema, offset)) in truncated {
+        for (schema, offset) in operations {
             self.prepare_table_for_streaming(&schema).await?;
             let table_name = try_stringify_table_name(schema.name())?.to_uppercase();
             self.client
@@ -758,7 +771,7 @@ mod tests {
 
     use etl::{
         data::{Cell, PartialTableRow},
-        event::RelationEvent,
+        event::{RelationEvent, TruncateEvent},
         pipeline::PipelineId,
         schema::{IdentityMask, PgLsn, ReplicationMask, SnapshotId, TableName, TableSchema, Type},
         store::StateStore,
@@ -822,6 +835,39 @@ mod tests {
         let identity_mask = IdentityMask::from_bytes(vec![1, 0]);
 
         ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask)
+    }
+
+    #[test]
+    fn truncate_operations_preserve_distinct_source_boundaries() {
+        let schema = replicated_schema();
+        let first_offset = OffsetToken::new(PgLsn::from(10_u64), 1);
+        let second_offset = OffsetToken::new(PgLsn::from(20_u64), 2);
+        let mut iter = vec![
+            Event::Truncate(TruncateEvent {
+                commit_lsn: PgLsn::from(10_u64),
+                tx_ordinal: 1,
+                options: 0,
+                truncated_tables: vec![schema.clone(), schema.clone()],
+            }),
+            Event::Truncate(TruncateEvent {
+                commit_lsn: PgLsn::from(20_u64),
+                tx_ordinal: 2,
+                options: 0,
+                truncated_tables: vec![schema.clone()],
+            }),
+            Event::Unsupported,
+        ]
+        .into_iter()
+        .peekable();
+
+        let operations = take_truncate_operations(&mut iter);
+
+        assert_eq!(operations.len(), 2);
+        assert_eq!(operations[0].0.id(), schema.id());
+        assert_eq!(operations[0].1, first_offset);
+        assert_eq!(operations[1].0.id(), schema.id());
+        assert_eq!(operations[1].1, second_offset);
+        assert!(matches!(iter.next(), Some(Event::Unsupported)));
     }
 
     #[tokio::test]

--- a/crates/etl-destinations/src/snowflake/sql_client.rs
+++ b/crates/etl-destinations/src/snowflake/sql_client.rs
@@ -3,6 +3,7 @@ use std::{sync::Arc, time::Duration};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
+use uuid::Uuid;
 
 use crate::{
     retry::{RetryDecision, RetryPolicy, retry_with_backoff},
@@ -69,8 +70,13 @@ impl<T: TokenProvider> SqlClient<T> {
     }
 
     /// Execute a DDL statement (runs on Cloud Services, no warehouse required).
+    ///
+    /// Generates one request ID for this invocation so Snowflake can reconcile
+    /// transport retries. A later invocation gets a new ID: recovery across
+    /// invocations requires an operation-specific caller-owned identity.
     pub async fn execute_ddl(&self, sql: &str) -> Result<()> {
-        self.execute_statement(sql).await?;
+        let request_id = Uuid::new_v4();
+        self.execute_statement_with_request_id(sql, request_id).await?;
         Ok(())
     }
 
@@ -88,9 +94,14 @@ impl<T: TokenProvider> SqlClient<T> {
     }
 
     /// Remove all rows from a table without dropping it.
-    pub async fn truncate_table(&self, table_name: &str) -> Result<()> {
+    ///
+    /// `request_id` must remain stable while one execution has an unknown
+    /// outcome and must change for each later physical truncate attempt.
+    pub async fn truncate_table(&self, table_name: &str, request_id: Uuid) -> Result<()> {
         let fqn = self.fully_qualified_name(table_name);
-        self.execute_ddl(&format!("TRUNCATE TABLE {fqn}")).await
+        self.execute_statement_with_request_id(&format!("TRUNCATE TABLE {fqn}"), request_id)
+            .await?;
+        Ok(())
     }
 
     /// Drop a table if it exists.
@@ -172,7 +183,26 @@ impl<T: TokenProvider> SqlClient<T> {
     /// - Other 4xx: non-retriable `Error::HttpStatus`.
     pub(crate) async fn execute_statement(&self, sql: &str) -> Result<StatementResponse> {
         let url = format!("{}/api/v2/statements", self.config.account_url());
+        self.execute_statement_at_url(sql, &url).await
+    }
 
+    /// Submit a retry-safe SQL statement with a caller-owned request ID.
+    async fn execute_statement_with_request_id(
+        &self,
+        sql: &str,
+        request_id: Uuid,
+    ) -> Result<StatementResponse> {
+        let url = self.statement_url_with_request_id(request_id);
+        self.execute_statement_at_url(sql, &url).await
+    }
+
+    /// Build the retry-safe SQL statement URL for one logical request.
+    fn statement_url_with_request_id(&self, request_id: Uuid) -> String {
+        format!("{}/api/v2/statements?requestId={request_id}&retry=true", self.config.account_url())
+    }
+
+    /// Submit a SQL statement to a prebuilt URL and reuse it across retries.
+    async fn execute_statement_at_url(&self, sql: &str, url: &str) -> Result<StatementResponse> {
         let body = StatementRequest {
             statement: sql,
             database: &self.config.database,
@@ -193,7 +223,7 @@ impl<T: TokenProvider> SqlClient<T> {
                     "retrying sql rest api request"
                 );
             },
-            || self.attempt_statement(&url, &body),
+            || self.attempt_statement(url, &body),
         )
         .await
         .map_err(|f| f.last_error)
@@ -350,6 +380,24 @@ fn classify_for_retry(error: &Error) -> RetryDecision {
 mod tests {
     use super::*;
 
+    /// Token provider used by hermetic SQL client tests.
+    struct TestTokenProvider;
+
+    impl TokenProvider for TestTokenProvider {
+        async fn get_token(&self) -> Result<String> {
+            Ok("test-token".to_owned())
+        }
+
+        async fn invalidate_token(&self) {}
+    }
+
+    /// Build a SQL client with deterministic, non-secret configuration.
+    fn test_client() -> SqlClient<TestTokenProvider> {
+        let config = Config::new("example-account", "test-user", "test-db", "test-schema")
+            .expect("test configuration should be valid");
+        SqlClient::new(config, Arc::new(TestTokenProvider), Client::new())
+    }
+
     #[test]
     fn classify_for_retry_cases() {
         let cases = [
@@ -377,5 +425,29 @@ mod tests {
         for (error, expected) in cases {
             assert_eq!(classify_for_retry(&error), expected, "error: {error:?}");
         }
+    }
+
+    /// Request-aware statement URLs carry Snowflake's retry parameters.
+    #[test]
+    fn statement_url_with_request_id_includes_retry_parameters() {
+        let client = test_client();
+        let request_id = Uuid::parse_str("67e55044-10b1-426f-9247-bb680e5fe0c8")
+            .expect("request ID should be valid");
+
+        let url = reqwest::Url::parse(&client.statement_url_with_request_id(request_id))
+            .expect("statement URL should be valid");
+        let query_pairs = url
+            .query_pairs()
+            .map(|(name, value)| (name.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(url.path(), "/api/v2/statements");
+        assert_eq!(
+            query_pairs,
+            vec![
+                ("requestId".to_owned(), request_id.to_string()),
+                ("retry".to_owned(), "true".to_owned()),
+            ]
+        );
     }
 }

--- a/crates/etl-destinations/tests/snowflake/destination.rs
+++ b/crates/etl-destinations/tests/snowflake/destination.rs
@@ -493,10 +493,10 @@ async fn whole_transaction_replay_restores_post_truncate_rows() {
         // before its source checkpoint advanced. The fresh destination must
         // therefore replay the whole transaction, including the first insert.
         let pipeline_id: PipelineId = 1;
-        let restarted_destination =
+        let first_restarted_destination =
             Destination::new(Client::new(build_auth(), pipeline_id), harness.store.clone());
         let replay_status = invoke_write_events(
-            &restarted_destination,
+            &first_restarted_destination,
             WriteEventsDurability::RequireDurable,
             truncate_replay_events(&schema),
         )
@@ -506,7 +506,37 @@ async fn whole_transaction_replay_restores_post_truncate_rows() {
 
         let post_truncate_offset = OffsetToken::new(PgLsn::from(20_u64), 3);
         let rows = poll_and_query_rows(
-            &restarted_destination,
+            &first_restarted_destination,
+            &harness,
+            table_id,
+            &sf_table,
+            &post_truncate_offset,
+        )
+        .await;
+        // The first replay must restore the later row exactly once before the
+        // next replay has a chance to repair it.
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], serde_json::json!("2"));
+        assert_eq!(rows[0][1], serde_json::json!("after"));
+        assert_eq!(rows[0][3], serde_json::json!(post_truncate_offset.to_string()));
+
+        // Replay the same source range through another fresh process. The
+        // channel has advanced since the previous physical truncate, so this
+        // cycle must derive a new request ID and clear the previously restored
+        // row before inserting it again.
+        let second_restarted_destination =
+            Destination::new(Client::new(build_auth(), pipeline_id), harness.store.clone());
+        let second_replay_status = invoke_write_events(
+            &second_restarted_destination,
+            WriteEventsDurability::RequireDurable,
+            truncate_replay_events(&schema).into_iter().skip(1).collect(),
+        )
+        .await
+        .expect("second replayed truncate sequence failed");
+        assert_eq!(second_replay_status, DestinationWriteStatus::Durable);
+
+        let rows = poll_and_query_rows(
+            &second_restarted_destination,
             &harness,
             table_id,
             &sf_table,

--- a/crates/etl-destinations/tests/snowflake/sql_client.rs
+++ b/crates/etl-destinations/tests/snowflake/sql_client.rs
@@ -1,6 +1,8 @@
 use etl_destinations::snowflake::{
-    AuthManager, HttpExchanger, SqlClient, test_utils::load_test_config,
+    AuthManager, HttpExchanger, SqlClient,
+    test_utils::{load_test_config, query_rows},
 };
+use uuid::Uuid;
 
 use super::common::{build_auth, with_table_cleanup};
 
@@ -27,7 +29,7 @@ async fn ddl_lifecycle() {
             "table should exist after creation"
         );
 
-        client.truncate_table(&table).await.expect("truncate failed");
+        client.truncate_table(&table, Uuid::new_v4()).await.expect("truncate failed");
 
         assert!(
             client.table_exists(&table).await.expect("table_exists failed"),
@@ -40,6 +42,53 @@ async fn ddl_lifecycle() {
             !client.table_exists(&table).await.expect("table_exists failed"),
             "table should not exist after drop"
         );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Snowflake credentials — see etl-destinations/src/snowflake/README.md"]
+async fn truncate_request_id_is_idempotent_across_clients() {
+    let client = build_sql_client();
+    let config = load_test_config();
+    let table = format!("etl_test_{}", Uuid::new_v4().simple());
+    let fqn = format!("\"{}\".\"{}\".\"{table}\"", config.database(), config.schema());
+
+    with_table_cleanup(&client, &[&table], || async {
+        client
+            .create_table_if_not_exists(&table, r#""id" NUMBER(10,0)"#)
+            .await
+            .expect("create table failed");
+        client
+            .execute_ddl(&format!("insert into {fqn} values (1)"))
+            .await
+            .expect("initial insert failed");
+
+        let request_id = Uuid::new_v4();
+        client.truncate_table(&table, request_id).await.expect("initial truncate failed");
+        client
+            .execute_ddl(&format!("insert into {fqn} values (2)"))
+            .await
+            .expect("post-truncate insert failed");
+
+        let restarted_client = build_sql_client();
+        restarted_client
+            .truncate_table(&table, request_id)
+            .await
+            .expect("same-ID truncate retry failed");
+        let rows = query_rows(&restarted_client, &format!("select \"id\" from {fqn}"))
+            .await
+            .expect("query after same-ID retry failed");
+        assert_eq!(rows, vec![vec![serde_json::json!("2")]]);
+
+        restarted_client
+            .truncate_table(&table, Uuid::new_v4())
+            .await
+            .expect("fresh-ID truncate failed");
+        let rows = query_rows(&restarted_client, &format!("select \"id\" from {fqn}"))
+            .await
+            .expect("query after fresh-ID truncate failed");
+        assert!(rows.is_empty());
     })
     .await;
 }


### PR DESCRIPTION
## Context

The truncate replay recovery from #957 can resubmit a Snowflake `TRUNCATE` after losing its SQL API outcome. Without a stable request ID, an earlier request could finish after replay restored later rows and erase them.

A concrete failing sequence is:

1. A source transaction contains `INSERT (1, 'before')`, `TRUNCATE`, then `INSERT (2, 'after')`.
2. ETL submits the truncate as request R1. Snowflake accepts it, but ETL loses the response while R1 may still be executing, so the source checkpoint does not advance.
3. On restart, the recovery from [#957](https://github.com/supabase/etl/pull/957) replays the transaction. Without a stable `requestId`, ETL submits the same truncate as a separate request R2.
4. R2 completes first. Replay inserts `(2, 'after')` and advances the channel offset past that insert.
5. R1 then completes late and clears the table again.

The destination is now empty even though its channel offset records `(2, 'after')` as applied, so normal recovery will not restore the missing row.

This PR gives retries of the same fenced truncate attempt the same Snowflake `requestId`, causing the retry to reconcile R1 instead of scheduling R2. A genuinely new truncate attempt still receives a new ID.

## Changes

- Derive a deterministic UUIDv5 from the fenced physical truncate attempt.
- Reuse its `requestId` for the same unknown attempt, while deriving a new ID after channel progress. This follows Snowflake’s [documented SQL API resubmission protocol](https://docs.snowflake.com/en/developer-guide/sql-api/submitting-requests#resubmitting-a-request-to-execute-sql-statements): resubmit the same outcome-unknown truncate with its original `requestId` and `retry=true`, while deriving a new `requestId` after channel progress proves that a genuinely new truncate attempt is required.
- Process each source `TRUNCATE` separately, resolving an earlier request with an unknown outcome before moving to a later one.
- Give ordinary DDL invocations UUIDv4 IDs reused by their internal HTTP retries. I will explore the possibility of some corner-cases failure modes for those other DDLs and add follow-up PR, if anything is discovered

## Validation

Added identity and boundary unit tests, a credentialed cross-client idempotency test, and multi-cycle replay coverage proving post-truncate rows are restored exactly once.