### PR TITLE
deps: make the sqlx TLS backend selectable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,55 @@ jobs:
         if: matrix.check == 'sort'
         run: cargo sort --workspace --grouped --check
 
+  check-tls-aws-lc:
+    name: TLS Backend (AWS-LC only)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      # Library crates with default features off and only the AWS-LC backend selected.
+      TLS_FEATURES: etl/tls-rustls-aws-lc-rs,etl-postgres/tls-rustls-aws-lc-rs,etl-postgres/store,etl-maintenance/tls-rustls-aws-lc-rs,etl-destinations/tls-rustls-aws-lc-rs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: tls-aws-lc
+
+      - name: Verify SQLx Ring Feature Is Absent
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ducklake makes sqlx a dependency of etl-destinations and etl-maintenance;
+          # resolving the feature graph does not compile DuckDB.
+          sqlx_features="$(cargo tree \
+            -p etl -p etl-postgres -p etl-maintenance -p etl-destinations \
+            --no-default-features \
+            --features "${TLS_FEATURES},etl-destinations/ducklake" \
+            -e features -i sqlx)"
+
+          if ! grep -q 'sqlx feature "tls-rustls-aws-lc-rs"' <<< "${sqlx_features}"; then
+            echo "sqlx feature tls-rustls-aws-lc-rs is not enabled" >&2
+            exit 1
+          fi
+
+          if grep -q 'sqlx feature "tls-rustls-ring"' <<< "${sqlx_features}"; then
+            echo "sqlx feature tls-rustls-ring is enabled by:" >&2
+            grep -A5 'sqlx feature "tls-rustls-ring"' <<< "${sqlx_features}" >&2
+            exit 1
+          fi
+
+      - name: Check AWS-LC Build
+        run: |
+          cargo check \
+            -p etl -p etl-postgres -p etl-maintenance -p etl-destinations \
+            --no-default-features \
+            --features "${TLS_FEATURES}"
+
   check-actions:
     name: Actions Lint
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/crates/etl-api/Cargo.toml
+++ b/crates/etl-api/Cargo.toml
@@ -35,11 +35,11 @@ base64 = { workspace = true, features = ["std"] }
 chrono = { workspace = true }
 configcat = { workspace = true }
 constant_time_eq = { workspace = true }
-etl = { workspace = true }
+etl = { workspace = true, features = ["tls-rustls-ring"] }
 etl-config = { workspace = true, features = ["utoipa", "supabase"] }
-etl-destinations = { workspace = true }
-etl-maintenance = { workspace = true }
-etl-postgres = { workspace = true, features = ["store"] }
+etl-destinations = { workspace = true, features = ["tls-rustls-ring"] }
+etl-maintenance = { workspace = true, features = ["tls-rustls-ring"] }
+etl-postgres = { workspace = true, features = ["store", "tls-rustls-ring"] }
 etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 kube = { workspace = true, features = ["runtime", "derive", "client", "rustls-tls"] }

--- a/crates/etl-api/Cargo.toml
+++ b/crates/etl-api/Cargo.toml
@@ -52,7 +52,7 @@ secrecy = { workspace = true }
 sentry = { workspace = true, features = ["tower-http", "tower-axum-matched-path"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "macros", "postgres", "json", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-ring", "macros", "postgres", "json", "migrate"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tokio-rustls = { workspace = true, features = ["aws-lc-rs", "logging", "tls12"] }

--- a/crates/etl-benchmarks/Cargo.toml
+++ b/crates/etl-benchmarks/Cargo.toml
@@ -31,7 +31,7 @@ k8s-openapi = { workspace = true, features = ["latest"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "migrate"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal"] }
 tracing = { workspace = true, default-features = true }
 url = { workspace = true }

--- a/crates/etl-benchmarks/Cargo.toml
+++ b/crates/etl-benchmarks/Cargo.toml
@@ -22,10 +22,10 @@ snowflake = ["dep:etl-destinations", "etl-destinations/snowflake"]
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, default-features = true, features = ["std", "derive"] }
-etl = { workspace = true, features = ["test-utils"] }
+etl = { workspace = true, features = ["test-utils", "tls-rustls-ring"] }
 etl-config = { workspace = true }
-etl-destinations = { workspace = true, optional = true }
-etl-postgres = { workspace = true, features = ["sqlx"] }
+etl-destinations = { workspace = true, optional = true, features = ["tls-rustls-ring"] }
+etl-postgres = { workspace = true, features = ["sqlx", "tls-rustls-ring"] }
 etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -13,6 +13,9 @@ homepage.workspace = true
 doctest = false
 
 [features]
+default = ["tls-rustls-ring"]
+tls-rustls-ring = ["sqlx?/tls-rustls-ring"]
+tls-rustls-aws-lc-rs = ["sqlx?/tls-rustls-aws-lc-rs"]
 ducklake = [
     "dep:duckdb",
     "dep:etl-maintenance",
@@ -128,7 +131,7 @@ secrecy = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true, features = ["arbitrary_precision", "std"] }
 sha2 = { workspace = true, optional = true }
-sqlx = { workspace = true, optional = true, features = ["runtime-tokio", "tls-rustls", "postgres"] }
+sqlx = { workspace = true, optional = true, features = ["runtime-tokio", "postgres"] }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt", "sync", "time"] }
 tokio-postgres = { workspace = true, optional = true }

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -14,8 +14,16 @@ doctest = false
 
 [features]
 default = ["tls-rustls-ring"]
-tls-rustls-ring = ["sqlx?/tls-rustls-ring"]
-tls-rustls-aws-lc-rs = ["sqlx?/tls-rustls-aws-lc-rs"]
+tls-rustls-ring = [
+    "etl/tls-rustls-ring",
+    "etl-maintenance?/tls-rustls-ring",
+    "sqlx?/tls-rustls-ring",
+]
+tls-rustls-aws-lc-rs = [
+    "etl/tls-rustls-aws-lc-rs",
+    "etl-maintenance?/tls-rustls-aws-lc-rs",
+    "sqlx?/tls-rustls-aws-lc-rs",
+]
 ducklake = [
     "dep:duckdb",
     "dep:etl-maintenance",

--- a/crates/etl-destinations/src/snowflake/README.md
+++ b/crates/etl-destinations/src/snowflake/README.md
@@ -21,7 +21,7 @@ To run a specific destination test directly:
 
 ```bash
 source .env
-cargo test -p etl-destinations --no-default-features --features snowflake,test-utils -- --ignored authenticate_against_snowflake
+cargo test -p etl-destinations --no-default-features --features snowflake,test-utils,tls-rustls-ring -- --ignored authenticate_against_snowflake
 ```
 
 ### Connection String

--- a/crates/etl-examples/Cargo.toml
+++ b/crates/etl-examples/Cargo.toml
@@ -42,9 +42,9 @@ snowflake = ["etl-destinations/snowflake"]
 [dependencies]
 
 clap = { workspace = true, default-features = true, features = ["std", "derive", "env"] }
-etl = { workspace = true }
+etl = { workspace = true, features = ["tls-rustls-ring"] }
 etl-config = { workspace = true }
-etl-destinations = { workspace = true }
+etl-destinations = { workspace = true, features = ["tls-rustls-ring"] }
 k8s-openapi = { workspace = true, features = ["latest"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 tokio = { workspace = true, features = ["macros", "signal", "time"] }

--- a/crates/etl-maintenance/Cargo.toml
+++ b/crates/etl-maintenance/Cargo.toml
@@ -11,7 +11,9 @@ homepage.workspace = true
 doctest = false
 
 [features]
-default = []
+default = ["tls-rustls-ring"]
+tls-rustls-ring = ["sqlx/tls-rustls-ring", "etl/tls-rustls-ring"]
+tls-rustls-aws-lc-rs = ["sqlx/tls-rustls-aws-lc-rs", "etl/tls-rustls-aws-lc-rs"]
 ducklake = [
     "dep:duckdb",
     "dep:kube",
@@ -40,7 +42,7 @@ r2d2 = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true, features = ["arbitrary_precision", "std"] }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "migrate", "chrono"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "migrate", "chrono"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tokio-postgres = { workspace = true, optional = true }

--- a/crates/etl-maintenance/Cargo.toml
+++ b/crates/etl-maintenance/Cargo.toml
@@ -40,7 +40,7 @@ r2d2 = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true, features = ["arbitrary_precision", "std"] }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate", "chrono"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "migrate", "chrono"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tokio-postgres = { workspace = true, optional = true }

--- a/crates/etl-postgres/Cargo.toml
+++ b/crates/etl-postgres/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 doctest = false
 
 [features]
+default = ["tls-rustls-ring"]
+tls-rustls-ring = ["sqlx/tls-rustls-ring"]
+tls-rustls-aws-lc-rs = ["sqlx/tls-rustls-aws-lc-rs"]
 test-utils = []
 tokio = []
 sqlx = []
@@ -30,7 +33,7 @@ futures = { workspace = true }
 pg_escape = { workspace = true }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "macros", "postgres", "json", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "macros", "postgres", "json", "migrate"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { workspace = true, features = ["runtime", "with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }

--- a/crates/etl-postgres/src/lib.rs
+++ b/crates/etl-postgres/src/lib.rs
@@ -3,6 +3,16 @@
 //! This crate owns Postgres-specific helpers that need to be shared across
 //! crates: source database access, replication slot naming, ETL metadata-store
 //! queries, schema primitives, value wrappers, and type conversion helpers.
+//!
+//! Select the rustls cryptography backend with the `tls-rustls-ring` (default)
+//! or `tls-rustls-aws-lc-rs` feature; the build fails when neither is enabled.
+
+// SQLx is a required dependency used by the source, slot, lag, and store
+// modules, so fail loudly instead of silently building it without TLS.
+#[cfg(not(any(feature = "tls-rustls-ring", feature = "tls-rustls-aws-lc-rs")))]
+compile_error!(
+    "Either the `tls-rustls-ring` or the `tls-rustls-aws-lc-rs` feature must be enabled."
+);
 
 pub mod application_name;
 pub mod default_expression;

--- a/crates/etl-replicator/Cargo.toml
+++ b/crates/etl-replicator/Cargo.toml
@@ -39,7 +39,7 @@ secrecy = { workspace = true }
 sentry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "migrate"] }
 
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tracing = { workspace = true, default-features = true }

--- a/crates/etl-replicator/Cargo.toml
+++ b/crates/etl-replicator/Cargo.toml
@@ -26,10 +26,10 @@ egress = ["etl/egress"]
 [dependencies]
 
 configcat = { workspace = true }
-etl = { workspace = true }
+etl = { workspace = true, features = ["tls-rustls-ring"] }
 etl-config = { workspace = true, features = ["supabase"] }
-etl-destinations = { workspace = true }
-etl-maintenance = { workspace = true }
+etl-destinations = { workspace = true, features = ["tls-rustls-ring"] }
+etl-maintenance = { workspace = true, features = ["tls-rustls-ring"] }
 etl-telemetry = { workspace = true }
 k8s-openapi = { workspace = true, features = ["latest"] }
 metrics = { workspace = true }

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -11,13 +11,13 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
-tls-rustls-ring = ["sqlx/tls-rustls-ring"]
-tls-rustls-aws-lc-rs = ["sqlx/tls-rustls-aws-lc-rs"]
+default = ["tls-rustls-ring"]
+tls-rustls-ring = ["sqlx/tls-rustls-ring", "etl-postgres/tls-rustls-ring"]
+tls-rustls-aws-lc-rs = ["sqlx/tls-rustls-aws-lc-rs", "etl-postgres/tls-rustls-aws-lc-rs"]
 test-utils = ["etl-postgres/test-utils", "dep:proptest"]
 failpoints = ["fail/failpoints"]
 egress = []
 fuzzing = []
-default = ["tls-rustls-ring"]
 
 [dependencies]
 

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -11,11 +11,13 @@ repository.workspace = true
 homepage.workspace = true
 
 [features]
+tls-rustls-ring = ["sqlx/tls-rustls-ring"]
+tls-rustls-aws-lc-rs = ["sqlx/tls-rustls-aws-lc-rs"]
 test-utils = ["etl-postgres/test-utils", "dep:proptest"]
 failpoints = ["fail/failpoints"]
 egress = []
 fuzzing = []
-default = []
+default = ["tls-rustls-ring"]
 
 [dependencies]
 
@@ -36,7 +38,7 @@ rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 serde_json = { workspace = true, features = ["arbitrary_precision", "std"] }
 simdutf8 = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "migrate"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "migrate"] }
 sysinfo = { workspace = true, features = ["system"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 tokio-postgres = { workspace = true, features = ["runtime", "with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -173,9 +173,23 @@
 //!
 //! # Feature Flags
 //!
+//! - `tls-rustls-ring` (default): Use `ring` as the rustls cryptography backend
+//!   for SQLx connections
+//! - `tls-rustls-aws-lc-rs`: Use `aws-lc-rs` as the rustls cryptography backend
+//!   for SQLx connections
 //! - `egress`: Enable structured billing usage logs
 //! - `test-utils`: Enable testing utilities and mock implementations
 //! - `failpoints`: Enable fault injection for testing error scenarios
+//!
+//! At least one TLS backend must be enabled; the build fails when neither is.
+//! To link only `aws-lc-rs`, disable default features and enable
+//! `tls-rustls-aws-lc-rs`. When both backends are enabled, SQLx uses `ring`.
+
+// Fail loudly instead of silently building SQLx without TLS.
+#[cfg(not(any(feature = "tls-rustls-ring", feature = "tls-rustls-aws-lc-rs")))]
+compile_error!(
+    "Either the `tls-rustls-ring` or the `tls-rustls-aws-lc-rs` feature must be enabled."
+);
 
 pub mod config;
 pub mod data;

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -19,7 +19,7 @@ schemars = "0.8"
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "json"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "json"] }
 tokio = { workspace = true, features = ["full"] }
 toml = "1.1"
 xshell = "0.2"

--- a/crates/xtask/src/commands/test_snowflake.rs
+++ b/crates/xtask/src/commands/test_snowflake.rs
@@ -91,7 +91,7 @@ impl TestSnowflakeArgs {
         eprintln!("{GREEN}❄️  running Snowflake destination integration tests.{RESET}");
         let tests = CargoFeatureSelection::new(
             true,
-            vec!["snowflake".to_owned(), "test-utils".to_owned()],
+            vec!["snowflake".to_owned(), "test-utils".to_owned(), "tls-rustls-ring".to_owned()],
             vec!["etl-destinations".to_owned()],
         )
         .apply_to(

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 cargo-fuzz = true
 
 [dependencies]
-etl = { path = "../crates/etl", default-features = false, features = ["fuzzing"] }
+etl = { path = "../crates/etl", default-features = false, features = ["fuzzing", "tls-rustls-ring"] }
 libfuzzer-sys = "0.4"
 
 [[bin]]


### PR DESCRIPTION
sqlx's tls-rustls feature is an alias for tls-rustls-ring, so every crate here links ring with no way for a consumer to choose otherwise. sqlx also prefers ring when both backends are enabled, so a consumer cannot override it by adding a feature: the choice has to be made where the dependency is declared.

The library crates now expose tls-rustls-ring and tls-rustls-aws-lc-rs, defaulting to ring so nothing changes for existing users. Binaries keep ring explicitly. This lets a consumer that already uses aws-lc-rs elsewhere avoid linking two cryptographic implementations; etl-postgres is itself such a case, since it declares rustls with the aws-lc-rs feature while its sqlx pulls ring.

## What kind of change does this PR introduce?

Build feature

## What is the current behavior?

Two crypto implementations being pulled in as opposed to one

## What is the new behavior?

Configurable build to use aws-lc-rs everywhere