### PR TITLE
feat(core): Add vertical pod autoscaling support

### DIFF
--- a/crates/etl-api/README.md
+++ b/crates/etl-api/README.md
@@ -162,10 +162,20 @@ fall back to a disruption-aware Pod recreation. `minReplicas: 1` permits that
 fallback for the single-replica StatefulSet. The global defaults should normally
 match the autoscaling maximum, so a new replicator begins with the full copy
 allocation. Explicit destination and pipeline overrides remain authoritative.
-Before deliberately restarting a running replicator, the API resets its VPA
-recommendation. The replacement Pod therefore starts from the max-sized
-StatefulSet template for a possible new table-copy phase, after which a fresh
-recommendation converges it back toward observed usage.
+
+This max-first behavior is intentional for the current design. A fresh pipeline
+starts oversized to absorb the initial burst of data without an early OOM and
+to give table copy as much throughput as the configured operating envelope
+allows. After a short observation period, VPA converges CPU and memory toward
+the measured workload so long-running streaming remains efficient. This is the
+interim phase model until the replicator can explicitly signal copy and
+streaming transitions to autoscaling.
+
+Restarting a running replicator deliberately preserves its VPA recommendation:
+a restart refreshes the process and configuration but is not an autoscaling
+phase transition. To discard the recommendation and return to the max-sized
+initial allocation, stop the pipeline and then start it again. Stop deletes the
+StatefulSet and VPA; start recreates both with fresh recommendation history.
 
 ### Encryption Keys
 

--- a/crates/etl-api/README.md
+++ b/crates/etl-api/README.md
@@ -40,6 +40,8 @@ Before running the API, you must have:
   context.
 - The configured replicator namespace and ServiceAccount already created in
   that cluster.
+- The `autoscaling.k8s.io/v1` Vertical Pod Autoscaler CRDs installed. The API
+  checks this prerequisite at startup before it can create pipeline workloads.
 
 ETL API validates its Kubernetes connection and shared prerequisites during
 startup. It exits instead of serving requests when Kubernetes initialization or
@@ -104,12 +106,13 @@ k8s:
       value: data
       effect: NoSchedule
   replicator_resources:
-    cpu_request_millicores: 500
-    memory_request_mib: 2000
-    destinations:
-      ducklake:
-        cpu_request_millicores: 1000
-        memory_request_mib: 4000
+    cpu_request_millicores: 2000
+    memory_request_mib: 8192
+  replicator_autoscaling:
+    min_cpu_millicores: 250
+    max_cpu_millicores: 2000
+    min_memory_mib: 768
+    max_memory_mib: 8192
   vector_image: timberio/vector:0.55.0-distroless-libc
   vector_resources:
     cpu_request_millicores: 75
@@ -148,9 +151,21 @@ replicator_resources:
 
 All pipeline resource fields are optional. Request precedence is pipeline
 override, destination-kind default, then global default. If a limit is omitted,
-it matches the final request. Before Kubernetes resources are applied, final
-requests are clamped to at least `1m` CPU and `1Mi` memory, and final limits are
-clamped so they are never below their paired requests.
+it matches the final request. If a limit is supplied, the larger of the request
+and limit becomes the allocation emitted as both request and limit. The
+allocation is clamped to `replicator_autoscaling` bounds. The same bounds are
+written to the VPA resource policy. CPU/memory requests always equal limits so
+every generated replicator Pod has Kubernetes Guaranteed QoS. VPA controls both
+requests and limits, preserving their initial 1:1 ratio while applying
+recommendations with `InPlaceOrRecreate`; blocked in-place updates may therefore
+fall back to a disruption-aware Pod recreation. `minReplicas: 1` permits that
+fallback for the single-replica StatefulSet. The global defaults should normally
+match the autoscaling maximum, so a new replicator begins with the full copy
+allocation. Explicit destination and pipeline overrides remain authoritative.
+Before deliberately restarting a running replicator, the API resets its VPA
+recommendation. The replacement Pod therefore starts from the max-sized
+StatefulSet template for a possible new table-copy phase, after which a fresh
+recommendation converges it back toward observed usage.
 
 ### Encryption Keys
 

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -85,7 +85,10 @@ pub struct K8sConfig {
 ///
 /// The API applies these bounds both to the initial StatefulSet allocation and
 /// to the per-pipeline VPA policy, keeping the VPA object as the source of
-/// truth for the workload's operating envelope.
+/// truth for the workload's operating envelope. Global replicator resources
+/// should normally match the maximum bounds: fresh pipelines intentionally
+/// start oversized for initial-copy throughput and burst safety, then VPA
+/// converges them toward their steady-state usage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub struct ReplicatorAutoscalingConfig {
     /// Minimum replicator memory allocation, in Mi.

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -71,11 +71,42 @@ pub struct K8sConfig {
     /// replicator pod unless a destination-kind default or pipeline-level
     /// override supplies one of those request values.
     pub replicator_resources: DefaultReplicatorResourcesConfig,
+    /// CPU and memory bounds shared by generated VPAs and StatefulSets.
+    #[serde(default)]
+    pub replicator_autoscaling: ReplicatorAutoscalingConfig,
     /// Vector image used by the logging sidecar.
     #[serde(default = "default_vector_image")]
     pub vector_image: String,
     /// Default request sizing for the Vector sidecar.
     pub vector_resources: DefaultVectorResourcesConfig,
+}
+
+/// Resource bounds enforced for autoscaled replicator containers.
+///
+/// The API applies these bounds both to the initial StatefulSet allocation and
+/// to the per-pipeline VPA policy, keeping the VPA object as the source of
+/// truth for the workload's operating envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub struct ReplicatorAutoscalingConfig {
+    /// Minimum replicator memory allocation, in Mi.
+    pub min_memory_mib: i32,
+    /// Maximum replicator memory allocation, in Mi.
+    pub max_memory_mib: i32,
+    /// Minimum replicator CPU allocation, in millicores.
+    pub min_cpu_millicores: i32,
+    /// Maximum replicator CPU allocation, in millicores.
+    pub max_cpu_millicores: i32,
+}
+
+impl Default for ReplicatorAutoscalingConfig {
+    fn default() -> Self {
+        Self {
+            min_memory_mib: 768,
+            max_memory_mib: 8 * 1024,
+            min_cpu_millicores: 250,
+            max_cpu_millicores: 2_000,
+        }
+    }
 }
 
 fn default_replicator_namespace() -> String {
@@ -167,7 +198,27 @@ impl ApiConfig {
     /// Validates API service configuration.
     pub fn validate(&self) -> Result<(), String> {
         self.k8s.replicator_resources.validate()?;
+        self.k8s.replicator_autoscaling.validate()?;
         self.k8s.vector_resources.validate()?;
+
+        Ok(())
+    }
+}
+
+impl ReplicatorAutoscalingConfig {
+    /// Validates that autoscaling bounds are positive and ordered.
+    pub fn validate(&self) -> Result<(), String> {
+        validate_positive_request("K8s autoscaling minimum memory", self.min_memory_mib)?;
+        validate_positive_request("K8s autoscaling maximum memory", self.max_memory_mib)?;
+        validate_positive_request("K8s autoscaling minimum cpu", self.min_cpu_millicores)?;
+        validate_positive_request("K8s autoscaling maximum cpu", self.max_cpu_millicores)?;
+
+        if self.min_memory_mib > self.max_memory_mib {
+            return Err("K8s autoscaling minimum memory must not exceed maximum memory".to_owned());
+        }
+        if self.min_cpu_millicores > self.max_cpu_millicores {
+            return Err("K8s autoscaling minimum cpu must not exceed maximum cpu".to_owned());
+        }
 
         Ok(())
     }
@@ -461,6 +512,22 @@ mod tests {
                 cpu_request_millicores: 500,
             }
         );
+        assert_eq!(config.replicator_autoscaling, ReplicatorAutoscalingConfig::default());
+    }
+
+    #[test]
+    fn replicator_autoscaling_bounds_must_be_positive_and_ordered() {
+        let invalid = ReplicatorAutoscalingConfig {
+            min_memory_mib: 1024,
+            max_memory_mib: 512,
+            min_cpu_millicores: 300,
+            max_cpu_millicores: 200,
+        };
+
+        assert!(invalid.validate().unwrap_err().contains("minimum memory"));
+
+        let invalid = ReplicatorAutoscalingConfig { min_memory_mib: 0, ..Default::default() };
+        assert!(invalid.validate().unwrap_err().contains("must be greater than 0"));
     }
 
     #[test]

--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -76,6 +76,17 @@ pub struct ReplicatorStatefulSetConfig {
     pub log_level: LogLevel,
 }
 
+/// Replicator Vertical Pod Autoscaler materialization input.
+#[derive(Debug, Clone)]
+pub struct ReplicatorVerticalPodAutoscalerConfig {
+    /// Existing Kubernetes resource prefix.
+    pub prefix: String,
+    /// Tenant id that owns the replicator.
+    pub tenant_id: String,
+    /// Pipeline id that owns the replicator.
+    pub pipeline_id: i64,
+}
+
 /// The type of destination storage system for replication.
 ///
 /// Determines which destination-specific resources and configurations are
@@ -315,10 +326,23 @@ pub trait K8sClient: Send + Sync {
         config: ReplicatorStatefulSetConfig,
     ) -> Result<(), K8sError>;
 
+    /// Creates or updates the Vertical Pod Autoscaler for the replicator
+    /// `StatefulSet`.
+    async fn create_or_update_replicator_vertical_pod_autoscaler(
+        &self,
+        config: ReplicatorVerticalPodAutoscalerConfig,
+    ) -> Result<(), K8sError>;
+
     /// Deletes the replicator `StatefulSet`.
     ///
     /// Does nothing if the stateful set does not exist.
     async fn delete_replicator_stateful_set(&self, prefix: &str) -> Result<(), K8sError>;
+
+    /// Deletes the replicator Vertical Pod Autoscaler.
+    ///
+    /// Does nothing if the autoscaler does not exist.
+    async fn delete_replicator_vertical_pod_autoscaler(&self, prefix: &str)
+    -> Result<(), K8sError>;
 
     /// Returns whether the replicator `StatefulSet` exists.
     async fn replicator_stateful_set_exists(&self, prefix: &str) -> Result<bool, K8sError>;

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -194,11 +194,6 @@ pub async fn create_or_update_pipeline_resources_in_k8s(
         },
     )
     .await?;
-    // Keep the VPA after the StatefulSet in this sequence. On initial creation,
-    // and after an intentional restart resets the VPA, this lets the new Pod
-    // start from the max-sized resources in the StatefulSet template before a
-    // fresh recommendation can converge it down. A future explicit copy-phase
-    // signal can use the same reset-to-maximum transition.
     k8s_client
         .create_or_update_replicator_vertical_pod_autoscaler(
             ReplicatorVerticalPodAutoscalerConfig {
@@ -229,25 +224,6 @@ pub async fn delete_pipeline_resources_in_k8s(
     delete_dynamic_replicator_secrets(k8s_client, &prefix).await?;
     delete_replicator_config(k8s_client, &prefix).await?;
     delete_replicator_stateful_set(k8s_client, &prefix).await?;
-
-    Ok(())
-}
-
-/// Deletes the per-pipeline VPA before intentionally restarting a running
-/// replicator.
-///
-/// VPA recommendations survive ordinary StatefulSet rollouts and are applied
-/// by the admission controller to replacement Pods. Resetting the VPA gives
-/// the replacement Pod the max-sized resources persisted in the StatefulSet
-/// template, providing headroom for a new table-copy phase. Reconciliation
-/// recreates the VPA immediately afterwards so usage-based sizing resumes.
-pub async fn reset_replicator_vertical_pod_autoscaler(
-    k8s_client: &dyn K8sClient,
-    tenant_id: &str,
-    replicator_id: i64,
-) -> Result<(), K8sCoreError> {
-    let prefix = create_k8s_object_prefix(tenant_id, replicator_id);
-    k8s_client.delete_replicator_vertical_pod_autoscaler(&prefix).await?;
 
     Ok(())
 }
@@ -931,15 +907,6 @@ mod tests {
             should_reconcile_replicator_resources(&client, "tenant-42", 4).await.unwrap();
 
         assert!(!should_reconcile);
-    }
-
-    #[tokio::test]
-    async fn restart_resets_the_existing_vpa_recommendation() {
-        let client = RecordingK8sClient::default();
-
-        reset_replicator_vertical_pod_autoscaler(&client, "tenant-42", 4).await.unwrap();
-
-        assert_eq!(client.calls(), vec!["delete-vpa:tenant-42-4"]);
     }
 
     #[tokio::test]

--- a/crates/etl-api/src/k8s/core.rs
+++ b/crates/etl-api/src/k8s/core.rs
@@ -28,7 +28,7 @@ use crate::{
     k8s::{
         DestinationType, K8sClient, K8sError, KubernetesMaintenanceMaterializer, PodStatus,
         ReplicatorConfigMapFile, ReplicatorStatefulSetConfig,
-        ducklake_maintenance_policy_from_config,
+        ReplicatorVerticalPodAutoscalerConfig, ducklake_maintenance_policy_from_config,
     },
 };
 
@@ -183,7 +183,7 @@ pub async fn create_or_update_pipeline_resources_in_k8s(
     create_or_update_replicator_stateful_set(
         k8s_client,
         ReplicatorStatefulSetConfig {
-            prefix,
+            prefix: prefix.clone(),
             tenant_id: tenant_id.to_owned(),
             pipeline_id: pipeline.id,
             replicator_image,
@@ -194,6 +194,20 @@ pub async fn create_or_update_pipeline_resources_in_k8s(
         },
     )
     .await?;
+    // Keep the VPA after the StatefulSet in this sequence. On initial creation,
+    // and after an intentional restart resets the VPA, this lets the new Pod
+    // start from the max-sized resources in the StatefulSet template before a
+    // fresh recommendation can converge it down. A future explicit copy-phase
+    // signal can use the same reset-to-maximum transition.
+    k8s_client
+        .create_or_update_replicator_vertical_pod_autoscaler(
+            ReplicatorVerticalPodAutoscalerConfig {
+                prefix: prefix.clone(),
+                tenant_id: tenant_id.to_owned(),
+                pipeline_id: pipeline.id,
+            },
+        )
+        .await?;
 
     Ok(())
 }
@@ -210,10 +224,30 @@ pub async fn delete_pipeline_resources_in_k8s(
 ) -> Result<(), K8sCoreError> {
     let prefix = create_k8s_object_prefix(tenant_id, replicator.id);
 
+    k8s_client.delete_replicator_vertical_pod_autoscaler(&prefix).await?;
     k8s_client.delete_ducklake_maintenance(&prefix).await?;
     delete_dynamic_replicator_secrets(k8s_client, &prefix).await?;
     delete_replicator_config(k8s_client, &prefix).await?;
     delete_replicator_stateful_set(k8s_client, &prefix).await?;
+
+    Ok(())
+}
+
+/// Deletes the per-pipeline VPA before intentionally restarting a running
+/// replicator.
+///
+/// VPA recommendations survive ordinary StatefulSet rollouts and are applied
+/// by the admission controller to replacement Pods. Resetting the VPA gives
+/// the replacement Pod the max-sized resources persisted in the StatefulSet
+/// template, providing headroom for a new table-copy phase. Reconciliation
+/// recreates the VPA immediately afterwards so usage-based sizing resumes.
+pub async fn reset_replicator_vertical_pod_autoscaler(
+    k8s_client: &dyn K8sClient,
+    tenant_id: &str,
+    replicator_id: i64,
+) -> Result<(), K8sCoreError> {
+    let prefix = create_k8s_object_prefix(tenant_id, replicator_id);
+    k8s_client.delete_replicator_vertical_pod_autoscaler(&prefix).await?;
 
     Ok(())
 }
@@ -771,7 +805,22 @@ mod tests {
             Ok(())
         }
 
+        async fn create_or_update_replicator_vertical_pod_autoscaler(
+            &self,
+            _config: ReplicatorVerticalPodAutoscalerConfig,
+        ) -> Result<(), K8sError> {
+            Ok(())
+        }
+
         async fn delete_replicator_stateful_set(&self, _prefix: &str) -> Result<(), K8sError> {
+            Ok(())
+        }
+
+        async fn delete_replicator_vertical_pod_autoscaler(
+            &self,
+            prefix: &str,
+        ) -> Result<(), K8sError> {
+            self.calls.lock().unwrap().push(format!("delete-vpa:{prefix}"));
             Ok(())
         }
 
@@ -882,6 +931,15 @@ mod tests {
             should_reconcile_replicator_resources(&client, "tenant-42", 4).await.unwrap();
 
         assert!(!should_reconcile);
+    }
+
+    #[tokio::test]
+    async fn restart_resets_the_existing_vpa_recommendation() {
+        let client = RecordingK8sClient::default();
+
+        reset_replicator_vertical_pod_autoscaler(&client, "tenant-42", 4).await.unwrap();
+
+        assert_eq!(client.calls(), vec!["delete-vpa:tenant-42-4"]);
     }
 
     #[tokio::test]

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -17,7 +17,7 @@ use k8s_openapi::{
 };
 use kube::{
     Client,
-    api::{Api, DeleteParams, Patch, PatchParams},
+    api::{Api, DeleteParams, ListParams, Patch, PatchParams},
     core::{ApiResource, DynamicObject, GroupVersionKind},
 };
 use serde_json::json;
@@ -27,7 +27,10 @@ use tracing::debug;
 #[cfg(test)]
 use crate::config::DefaultReplicatorResourcesConfig;
 use crate::{
-    config::{DefaultVectorResourcesConfig, K8sConfig, ResolvedReplicatorResourcesConfig},
+    config::{
+        DefaultVectorResourcesConfig, K8sConfig, ReplicatorAutoscalingConfig,
+        ResolvedReplicatorResourcesConfig,
+    },
     configs::{
         log::LogLevel,
         pipeline::{DuckLakeMaintenanceConfig, ReplicatorResourcesConfig},
@@ -35,6 +38,7 @@ use crate::{
     k8s::{
         DestinationType, DuckLakeMaintenanceResourceConfig, K8sClient, K8sError, PodPhase,
         PodStatus, ReplicatorConfigMapFile, ReplicatorStatefulSetConfig,
+        ReplicatorVerticalPodAutoscalerConfig,
     },
 };
 
@@ -116,6 +120,12 @@ const DUCKLAKE_MAINTENANCE_GROUP: &str = "etl.supabase.com";
 const DUCKLAKE_MAINTENANCE_VERSION: &str = "v1alpha1";
 /// DuckLake maintenance CRD kind.
 const DUCKLAKE_MAINTENANCE_KIND: &str = "DuckLakeMaintenance";
+/// Vertical Pod Autoscaler CRD group.
+const VERTICAL_POD_AUTOSCALER_GROUP: &str = "autoscaling.k8s.io";
+/// Vertical Pod Autoscaler CRD version.
+const VERTICAL_POD_AUTOSCALER_VERSION: &str = "v1";
+/// Vertical Pod Autoscaler CRD kind.
+const VERTICAL_POD_AUTOSCALER_KIND: &str = "VerticalPodAutoscaler";
 
 /// Minimum Kubernetes CPU quantity emitted by the API, in millicores.
 const MIN_K8S_CPU_MILLICORES: i32 = 1;
@@ -144,6 +154,7 @@ impl ReplicatorStatefulSetResourcesConfig {
             k8s_config.replicator_resources_for(DestinationKind::BigQuery);
         Self::from_default_resources(
             &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
             &k8s_config.vector_resources,
             None,
         )
@@ -153,29 +164,22 @@ impl ReplicatorStatefulSetResourcesConfig {
     /// pipeline-level replicator resource overrides.
     ///
     /// Request precedence is pipeline override first, then the mandatory API
-    /// default from `k8s.replicator_resources`. Limit precedence is explicit
-    /// pipeline limit first, then the final request. Vector requests come from
-    /// `k8s.vector_resources`, and Vector limits match those requests. Keeping
-    /// both CPU and memory limits equal to requests for every container lets
-    /// the pod qualify for Kubernetes Guaranteed QoS unless the pipeline opts
-    /// into different replicator limits.
+    /// default from `k8s.replicator_resources`. An explicit pipeline limit is
+    /// treated as another allocation floor. The larger value is emitted as
+    /// both request and limit, just as Vector limits match Vector requests, so
+    /// every generated Pod qualifies for Kubernetes Guaranteed QoS.
     fn from_default_resources(
         default_replicator_resources: &ResolvedReplicatorResourcesConfig,
+        autoscaling: &ReplicatorAutoscalingConfig,
         default_vector_resources: &DefaultVectorResourcesConfig,
         pipeline_replicator_resources: Option<&ReplicatorResourcesConfig>,
     ) -> Result<Self, K8sError> {
-        let replicator_memory_request = clamp_k8s_resource_quantity(
-            pipeline_replicator_resources
-                .and_then(|config| config.memory_request_mib)
-                .unwrap_or(default_replicator_resources.memory_request_mib),
-            MIN_K8S_MEMORY_MIB,
-        );
-        let replicator_cpu_request = clamp_k8s_resource_quantity(
-            pipeline_replicator_resources
-                .and_then(|config| config.cpu_request_millicores)
-                .unwrap_or(default_replicator_resources.cpu_request_millicores),
-            MIN_K8S_CPU_MILLICORES,
-        );
+        let replicator_memory_request = pipeline_replicator_resources
+            .and_then(|config| config.memory_request_mib)
+            .unwrap_or(default_replicator_resources.memory_request_mib);
+        let replicator_cpu_request = pipeline_replicator_resources
+            .and_then(|config| config.cpu_request_millicores)
+            .unwrap_or(default_replicator_resources.cpu_request_millicores);
         let vector_memory_request = clamp_k8s_resource_quantity(
             default_vector_resources.memory_request_mib,
             MIN_K8S_MEMORY_MIB,
@@ -185,28 +189,22 @@ impl ReplicatorStatefulSetResourcesConfig {
             MIN_K8S_CPU_MILLICORES,
         );
 
-        // Keep default limits equal to requests so long-running pipelines get
-        // Guaranteed QoS. A pipeline-level limit override is an intentional
-        // opt-out for workloads that need extra replicator headroom. The
-        // replicator memory monitor reads the container cgroup limit through
-        // sysinfo, so batch budgets and memory backpressure scale with this
-        // default limit.
+        // Keep requests and limits equal even when a pipeline supplies a
+        // larger historical limit. The replicator memory monitor reads the
+        // container cgroup limit through sysinfo, so batch budgets and memory
+        // backpressure scale with this single allocation value.
         let replicator_memory_limit = pipeline_replicator_resources
             .and_then(|config| config.memory_limit_mib)
             .unwrap_or(replicator_memory_request);
-        let replicator_memory_limit = clamp_k8s_resource_limit(
-            replicator_memory_limit,
-            replicator_memory_request,
-            MIN_K8S_MEMORY_MIB,
-        );
+        let replicator_memory_allocation = replicator_memory_request
+            .max(replicator_memory_limit)
+            .clamp(autoscaling.min_memory_mib, autoscaling.max_memory_mib);
         let replicator_cpu_limit = pipeline_replicator_resources
             .and_then(|config| config.cpu_limit_millicores)
             .unwrap_or(replicator_cpu_request);
-        let replicator_cpu_limit = clamp_k8s_resource_limit(
-            replicator_cpu_limit,
-            replicator_cpu_request,
-            MIN_K8S_CPU_MILLICORES,
-        );
+        let replicator_cpu_allocation = replicator_cpu_request
+            .max(replicator_cpu_limit)
+            .clamp(autoscaling.min_cpu_millicores, autoscaling.max_cpu_millicores);
 
         // Sidecars participate in pod QoS too, so Vector must also keep
         // limits equal to requests for the pod to stay Guaranteed.
@@ -214,10 +212,10 @@ impl ReplicatorStatefulSetResourcesConfig {
         let vector_cpu_limit = vector_cpu_request;
 
         Ok(Self {
-            replicator_memory_limit: format!("{replicator_memory_limit}Mi"),
-            replicator_memory_request: format!("{replicator_memory_request}Mi"),
-            replicator_cpu_limit: format!("{replicator_cpu_limit}m"),
-            replicator_cpu_request: format!("{replicator_cpu_request}m"),
+            replicator_memory_limit: format!("{replicator_memory_allocation}Mi"),
+            replicator_memory_request: format!("{replicator_memory_allocation}Mi"),
+            replicator_cpu_limit: format!("{replicator_cpu_allocation}m"),
+            replicator_cpu_request: format!("{replicator_cpu_allocation}m"),
             vector_memory_limit: format!("{vector_memory_limit}Mi"),
             vector_memory_request: format!("{vector_memory_request}Mi"),
             vector_cpu_limit: format!("{vector_cpu_limit}m"),
@@ -229,11 +227,6 @@ impl ReplicatorStatefulSetResourcesConfig {
 /// Clamps a Kubernetes resource quantity to the smallest value this API emits.
 fn clamp_k8s_resource_quantity(value: i32, minimum: i32) -> i32 {
     value.max(minimum)
-}
-
-/// Clamps a Kubernetes resource limit so it can satisfy its paired request.
-fn clamp_k8s_resource_limit(limit: i32, request: i32, minimum: i32) -> i32 {
-    limit.max(request).max(minimum)
 }
 
 #[cfg(test)]
@@ -252,6 +245,7 @@ fn test_k8s_config(environment: &Environment) -> K8sConfig {
             cpu_request_millicores,
             destinations: Default::default(),
         },
+        replicator_autoscaling: ReplicatorAutoscalingConfig::default(),
         vector_image: "timberio/vector:0.55.0-distroless-libc".to_owned(),
         vector_resources: DefaultVectorResourcesConfig {
             memory_request_mib: 192,
@@ -273,6 +267,7 @@ pub struct HttpK8sClient {
     stateful_sets_api: Api<StatefulSet>,
     pods_api: Api<Pod>,
     ducklake_maintenance_api: Api<DynamicObject>,
+    vertical_pod_autoscalers_api: Api<DynamicObject>,
     k8s_config: K8sConfig,
 }
 
@@ -292,9 +287,14 @@ impl HttpK8sClient {
             Api::namespaced(client.clone(), replicator_namespace);
         let pods_api: Api<Pod> = Api::namespaced(client.clone(), replicator_namespace);
         let ducklake_maintenance_api: Api<DynamicObject> = Api::namespaced_with(
-            client,
+            client.clone(),
             replicator_namespace,
             &ducklake_maintenance_api_resource(),
+        );
+        let vertical_pod_autoscalers_api: Api<DynamicObject> = Api::namespaced_with(
+            client,
+            replicator_namespace,
+            &vertical_pod_autoscaler_api_resource(),
         );
 
         Ok(HttpK8sClient {
@@ -305,6 +305,7 @@ impl HttpK8sClient {
             stateful_sets_api,
             pods_api,
             ducklake_maintenance_api,
+            vertical_pod_autoscalers_api,
             k8s_config,
         })
     }
@@ -316,6 +317,7 @@ impl HttpK8sClient {
     pub async fn preflight(&self) -> Result<(), K8sPreflightError> {
         self.ensure_replicator_namespace().await?;
         self.ensure_replicator_service_account().await?;
+        self.ensure_vertical_pod_autoscaler_api().await?;
 
         Ok(())
     }
@@ -350,6 +352,21 @@ impl HttpK8sClient {
             Err(source) => Err(K8sPreflightError::ReplicatorServiceAccountCheck {
                 namespace: namespace.clone(),
                 service_account_name: service_account_name.clone(),
+                source,
+            }),
+        }
+    }
+
+    /// Ensures VPAs can be materialized before serving requests.
+    async fn ensure_vertical_pod_autoscaler_api(&self) -> Result<(), K8sPreflightError> {
+        let namespace = &self.k8s_config.replicator_namespace;
+        match self.vertical_pod_autoscalers_api.list(&ListParams::default().limit(1)).await {
+            Ok(_) => Ok(()),
+            Err(kube::Error::Api(err)) if err.code == 404 => {
+                Err(K8sPreflightError::MissingVerticalPodAutoscalerApi)
+            }
+            Err(source) => Err(K8sPreflightError::VerticalPodAutoscalerApiCheck {
+                namespace: namespace.clone(),
                 source,
             }),
         }
@@ -461,6 +478,23 @@ pub enum K8sPreflightError {
         namespace: String,
         /// Configured replicator ServiceAccount name.
         service_account_name: String,
+        /// Kubernetes API error.
+        #[source]
+        source: kube::Error,
+    },
+    /// The VPA CustomResourceDefinition is not registered in the cluster.
+    #[error(
+        "Kubernetes VerticalPodAutoscaler v1 API is missing. Install the VPA CRDs before starting \
+         etl-api."
+    )]
+    MissingVerticalPodAutoscalerApi,
+    /// Checking the namespaced VPA API failed.
+    #[error(
+        "Failed to check the Kubernetes VerticalPodAutoscaler v1 API in namespace `{namespace}`"
+    )]
+    VerticalPodAutoscalerApiCheck {
+        /// Configured replicator namespace.
+        namespace: String,
         /// Kubernetes API error.
         #[source]
         source: kube::Error,
@@ -771,6 +805,7 @@ impl K8sClient for HttpK8sClient {
             self.k8s_config.replicator_resources_for(request.destination_type.kind());
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
             &default_replicator_resources,
+            &self.k8s_config.replicator_autoscaling,
             &self.k8s_config.vector_resources,
             request.replicator_resources.as_ref(),
         )?;
@@ -833,6 +868,28 @@ impl K8sClient for HttpK8sClient {
         Ok(())
     }
 
+    async fn create_or_update_replicator_vertical_pod_autoscaler(
+        &self,
+        request: ReplicatorVerticalPodAutoscalerConfig,
+    ) -> Result<(), K8sError> {
+        debug!("patching vertical pod autoscaler");
+
+        let name = create_stateful_set_name(&request.prefix);
+        let vertical_pod_autoscaler = create_replicator_vertical_pod_autoscaler_json(
+            &self.k8s_config,
+            &request.prefix,
+            &request.tenant_id,
+            request.pipeline_id,
+            &name,
+        )?;
+        let pp = PatchParams::apply(FIELD_MANAGER).force();
+        self.vertical_pod_autoscalers_api
+            .patch(&name, &pp, &Patch::Apply(vertical_pod_autoscaler))
+            .await?;
+
+        Ok(())
+    }
+
     async fn delete_replicator_stateful_set(&self, prefix: &str) -> Result<(), K8sError> {
         debug!("deleting stateful set");
 
@@ -842,6 +899,21 @@ impl K8sClient for HttpK8sClient {
                 self.stateful_sets_api.delete(&stateful_set_name, &dp).await,
             )?;
         }
+
+        Ok(())
+    }
+
+    async fn delete_replicator_vertical_pod_autoscaler(
+        &self,
+        prefix: &str,
+    ) -> Result<(), K8sError> {
+        debug!("deleting vertical pod autoscaler");
+
+        let name = create_stateful_set_name(prefix);
+        let dp = DeleteParams::default();
+        Self::handle_delete_with_404_ignore(
+            self.vertical_pod_autoscalers_api.delete(&name, &dp).await,
+        )?;
 
         Ok(())
     }
@@ -1008,6 +1080,14 @@ fn ducklake_maintenance_api_resource() -> ApiResource {
         DUCKLAKE_MAINTENANCE_GROUP,
         DUCKLAKE_MAINTENANCE_VERSION,
         DUCKLAKE_MAINTENANCE_KIND,
+    ))
+}
+
+fn vertical_pod_autoscaler_api_resource() -> ApiResource {
+    ApiResource::from_gvk(&GroupVersionKind::gvk(
+        VERTICAL_POD_AUTOSCALER_GROUP,
+        VERTICAL_POD_AUTOSCALER_VERSION,
+        VERTICAL_POD_AUTOSCALER_KIND,
     ))
 }
 
@@ -1772,6 +1852,11 @@ fn create_replicator_stateful_set_json(
       },
       "spec": {
         "replicas": 1,
+        // The VPA controller's blocked-resize fallback updates this Pod template and relies on the
+        // StatefulSet controller to terminate and recreate the Pod gracefully.
+        "updateStrategy": {
+          "type": "RollingUpdate"
+        },
         "selector": {
           "matchLabels": {
             "etl.supabase.com/app-name": replicator_app_name,
@@ -1807,6 +1892,16 @@ fn create_replicator_stateful_set_json(
               {
                 "name": replicator_container_name,
                 "image": replicator_image,
+                "resizePolicy": [
+                  {
+                    "resourceName": "cpu",
+                    "restartPolicy": "NotRequired"
+                  },
+                  {
+                    "resourceName": "memory",
+                    "restartPolicy": "NotRequired"
+                  }
+                ],
                 "securityContext": {
                   "allowPrivilegeEscalation": false,
                   "capabilities": {
@@ -1838,6 +1933,65 @@ fn create_replicator_stateful_set_json(
         }
       }
     })
+}
+
+fn create_replicator_vertical_pod_autoscaler_json(
+    k8s_config: &K8sConfig,
+    prefix: &str,
+    tenant_id: &str,
+    pipeline_id: i64,
+    stateful_set_name: &str,
+) -> Result<DynamicObject, serde_json::Error> {
+    let replicator_app_name = create_replicator_app_name(prefix);
+    let replicator_container_name = create_replicator_container_name(prefix);
+
+    serde_json::from_value(json!({
+      "apiVersion": format!("{VERTICAL_POD_AUTOSCALER_GROUP}/{VERTICAL_POD_AUTOSCALER_VERSION}"),
+      "kind": VERTICAL_POD_AUTOSCALER_KIND,
+      "metadata": {
+        "name": stateful_set_name,
+        "namespace": &k8s_config.replicator_namespace,
+        "labels": {
+          "etl.supabase.com/app-name": replicator_app_name,
+          "etl.supabase.com/app-type": REPLICATOR_APP_LABEL,
+          "etl.supabase.com/pipeline-id": pipeline_id.to_string(),
+          "etl.supabase.com/tenant-id": tenant_id
+        }
+      },
+      "spec": {
+        "targetRef": {
+          "apiVersion": "apps/v1",
+          "kind": "StatefulSet",
+          "name": stateful_set_name
+        },
+        "updatePolicy": {
+          "updateMode": "InPlaceOrRecreate",
+          "minReplicas": 1
+        },
+        "resourcePolicy": {
+          "containerPolicies": [
+            {
+              "containerName": replicator_container_name,
+              "mode": "Auto",
+              "controlledResources": ["cpu", "memory"],
+              "controlledValues": "RequestsAndLimits",
+              "minAllowed": {
+                "cpu": format!("{}m", k8s_config.replicator_autoscaling.min_cpu_millicores),
+                "memory": format!("{}Mi", k8s_config.replicator_autoscaling.min_memory_mib)
+              },
+              "maxAllowed": {
+                "cpu": format!("{}m", k8s_config.replicator_autoscaling.max_cpu_millicores),
+                "memory": format!("{}Mi", k8s_config.replicator_autoscaling.max_memory_mib)
+              }
+            },
+            {
+              "containerName": "*",
+              "mode": "Off"
+            }
+          ]
+        }
+      }
+    }))
 }
 
 fn get_restarted_at_annotation_value() -> String {
@@ -1999,9 +2153,9 @@ mod tests {
             ReplicatorStatefulSetResourcesConfig::for_environment(&Environment::Staging).unwrap();
 
         assert_eq!(prod.replicator_cpu_request, "500m");
-        assert_eq!(prod.replicator_memory_request, "500Mi");
-        assert_eq!(staging.replicator_cpu_request, "125m");
-        assert_eq!(staging.replicator_memory_request, "250Mi");
+        assert_eq!(prod.replicator_memory_request, "768Mi");
+        assert_eq!(staging.replicator_cpu_request, "250m");
+        assert_eq!(staging.replicator_memory_request, "768Mi");
         assert_eq!(prod.vector_cpu_request, "75m");
         assert_eq!(prod.vector_memory_request, "192Mi");
         assert_eq!(prod.vector_cpu_limit, "75m");
@@ -2021,6 +2175,7 @@ mod tests {
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
             &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
@@ -2046,19 +2201,20 @@ mod tests {
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
             &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
         .unwrap();
 
-        assert_eq!(stateful_set_resources.replicator_cpu_request, "750m");
-        assert_eq!(stateful_set_resources.replicator_memory_request, "1536Mi");
+        assert_eq!(stateful_set_resources.replicator_cpu_request, "1000m");
+        assert_eq!(stateful_set_resources.replicator_memory_request, "2048Mi");
         assert_eq!(stateful_set_resources.replicator_cpu_limit, "1000m");
         assert_eq!(stateful_set_resources.replicator_memory_limit, "2048Mi");
     }
 
     #[test]
-    fn test_replicator_stateful_set_resources_clamps_to_kubernetes_minimums() {
+    fn test_replicator_stateful_set_resources_clamps_to_autoscaling_minimums() {
         let overrides = ReplicatorResourcesConfig {
             cpu_request_millicores: Some(0),
             memory_request_mib: Some(-20),
@@ -2082,15 +2238,16 @@ mod tests {
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
             &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
         .unwrap();
 
-        assert_eq!(stateful_set_resources.replicator_cpu_request, "1m");
-        assert_eq!(stateful_set_resources.replicator_memory_request, "1Mi");
-        assert_eq!(stateful_set_resources.replicator_cpu_limit, "1m");
-        assert_eq!(stateful_set_resources.replicator_memory_limit, "1Mi");
+        assert_eq!(stateful_set_resources.replicator_cpu_request, "250m");
+        assert_eq!(stateful_set_resources.replicator_memory_request, "768Mi");
+        assert_eq!(stateful_set_resources.replicator_cpu_limit, "250m");
+        assert_eq!(stateful_set_resources.replicator_memory_limit, "768Mi");
         assert_eq!(stateful_set_resources.vector_cpu_request, "1m");
         assert_eq!(stateful_set_resources.vector_memory_request, "1Mi");
         assert_eq!(stateful_set_resources.vector_cpu_limit, "1m");
@@ -2111,6 +2268,7 @@ mod tests {
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
             &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
@@ -2141,6 +2299,7 @@ mod tests {
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
             &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
             &k8s_config.vector_resources,
             None,
         )
@@ -2150,6 +2309,33 @@ mod tests {
         assert_eq!(stateful_set_resources.vector_memory_request, "192Mi");
         assert_eq!(stateful_set_resources.vector_cpu_limit, "80m");
         assert_eq!(stateful_set_resources.vector_memory_limit, "192Mi");
+    }
+
+    #[test]
+    fn default_replicator_allocation_can_start_at_the_autoscaling_maximum() {
+        let k8s_config = K8sConfig {
+            replicator_resources: DefaultReplicatorResourcesConfig {
+                cpu_request_millicores: 2_000,
+                memory_request_mib: 8_192,
+                destinations: Default::default(),
+            },
+            ..default_k8s_config()
+        };
+        let default_replicator_resources =
+            k8s_config.replicator_resources_for(DestinationKind::BigQuery);
+
+        let resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
+            &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
+            &k8s_config.vector_resources,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(resources.replicator_cpu_request, "2000m");
+        assert_eq!(resources.replicator_memory_request, "8192Mi");
+        assert_eq!(resources.replicator_cpu_limit, resources.replicator_cpu_request);
+        assert_eq!(resources.replicator_memory_limit, resources.replicator_memory_request);
     }
 
     #[test]
@@ -2483,6 +2669,7 @@ mod tests {
 
         let stateful_set_resources = ReplicatorStatefulSetResourcesConfig::from_default_resources(
             &default_replicator_resources,
+            &k8s_config.replicator_autoscaling,
             &k8s_config.vector_resources,
             Some(&overrides),
         )
@@ -3079,6 +3266,86 @@ mod tests {
         assert_eq!(
             configured.pointer("/spec/template/spec/tolerations/0/effect"),
             Some(&json!("CustomEffect"))
+        );
+    }
+
+    #[test]
+    fn replicator_stateful_set_allows_in_place_cpu_and_memory_resize() {
+        let resources =
+            ReplicatorStatefulSetResourcesConfig::for_environment(&Environment::Dev).unwrap();
+        let stateful_set = create_replicator_stateful_set_json(
+            &default_k8s_config(),
+            "tenant-1-42",
+            "tenant-1",
+            42,
+            "tenant-1-42-replicator",
+            "example.com/replicator:latest",
+            Vec::new(),
+            json!({}),
+            json!([]),
+            json!([]),
+            Vec::new(),
+            Vec::new(),
+            &resources,
+        );
+
+        assert_eq!(
+            stateful_set.pointer("/spec/template/spec/containers/0/resizePolicy"),
+            Some(&json!([
+                {"resourceName": "cpu", "restartPolicy": "NotRequired"},
+                {"resourceName": "memory", "restartPolicy": "NotRequired"}
+            ]))
+        );
+        assert_eq!(
+            stateful_set.pointer("/spec/updateStrategy/type"),
+            Some(&json!("RollingUpdate"))
+        );
+    }
+
+    #[test]
+    fn replicator_vertical_pod_autoscaler_applies_requests_and_limits_in_place() {
+        let autoscaler = create_replicator_vertical_pod_autoscaler_json(
+            &default_k8s_config(),
+            "tenant-1-42",
+            "tenant-1",
+            42,
+            "tenant-1-42-replicator",
+        )
+        .unwrap();
+        let autoscaler = serde_json::to_value(autoscaler).unwrap();
+
+        assert_eq!(
+            autoscaler.pointer("/spec/updatePolicy/updateMode"),
+            Some(&json!("InPlaceOrRecreate"))
+        );
+        assert_eq!(autoscaler.pointer("/spec/updatePolicy/minReplicas"), Some(&json!(1)));
+        assert_eq!(
+            autoscaler.pointer("/spec/targetRef"),
+            Some(&json!({
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "name": "tenant-1-42-replicator"
+            }))
+        );
+        assert_eq!(
+            autoscaler.pointer("/spec/resourcePolicy/containerPolicies/0/containerName"),
+            Some(&json!("tenant-1-42-replicator"))
+        );
+        assert_eq!(
+            autoscaler.pointer("/spec/resourcePolicy/containerPolicies/0/minAllowed"),
+            Some(&json!({"cpu": "250m", "memory": "768Mi"}))
+        );
+        assert_eq!(
+            autoscaler.pointer("/spec/resourcePolicy/containerPolicies/0/maxAllowed"),
+            Some(&json!({"cpu": "2000m", "memory": "8192Mi"}))
+        );
+        assert_eq!(
+            autoscaler.pointer("/spec/resourcePolicy/containerPolicies/0/controlledValues"),
+            Some(&json!("RequestsAndLimits"))
+        );
+        assert_eq!(
+            autoscaler.pointer("/spec/resourcePolicy/containerPolicies/1/mode"),
+            Some(&json!("Off"))
         );
     }
 

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-2.snap
@@ -111,14 +111,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               },
               "requests": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -215,6 +225,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json-3.snap
@@ -107,14 +107,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
                 "cpu": "500m",
-                "memory": "500Mi"
+                "memory": "768Mi"
               },
               "requests": {
                 "cpu": "500m",
-                "memory": "500Mi"
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -211,6 +221,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_bq_replicator_stateful_set_json.snap
@@ -81,14 +81,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               },
               "requests": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -126,6 +136,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-2.snap
@@ -129,14 +129,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               },
               "requests": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -233,6 +243,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json-3.snap
@@ -125,14 +125,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
                 "cpu": "500m",
-                "memory": "500Mi"
+                "memory": "768Mi"
               },
               "requests": {
                 "cpu": "500m",
-                "memory": "500Mi"
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -229,6 +239,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_ducklake_replicator_stateful_set_json.snap
@@ -99,14 +99,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               },
               "requests": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -144,6 +154,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-2.snap
@@ -129,14 +129,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               },
               "requests": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -233,6 +243,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json-3.snap
@@ -125,14 +125,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
                 "cpu": "500m",
-                "memory": "500Mi"
+                "memory": "768Mi"
               },
               "requests": {
                 "cpu": "500m",
-                "memory": "500Mi"
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -229,6 +239,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
+++ b/crates/etl-api/src/k8s/snapshots/etl_api__k8s__http__tests__create_iceberg_replicator_stateful_set_json.snap
@@ -99,14 +99,24 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
                 "protocol": "TCP"
               }
             ],
+            "resizePolicy": [
+              {
+                "resourceName": "cpu",
+                "restartPolicy": "NotRequired"
+              },
+              {
+                "resourceName": "memory",
+                "restartPolicy": "NotRequired"
+              }
+            ],
             "resources": {
               "limits": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               },
               "requests": {
-                "cpu": "125m",
-                "memory": "250Mi"
+                "cpu": "250m",
+                "memory": "768Mi"
               }
             },
             "securityContext": {
@@ -144,6 +154,9 @@ expression: "serde_json :: to_string_pretty(& stateful_set_json).unwrap()"
           }
         ]
       }
+    },
+    "updateStrategy": {
+      "type": "RollingUpdate"
     }
   }
 }

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -4,7 +4,10 @@ use crate::{
     data::pipelines::read_pipeline_components,
     k8s::{
         K8sClient, SourceTlsConfig,
-        core::{create_or_update_pipeline_resources_in_k8s, should_reconcile_replicator_resources},
+        core::{
+            create_or_update_pipeline_resources_in_k8s, reset_replicator_vertical_pod_autoscaler,
+            should_reconcile_replicator_resources,
+        },
     },
     routes::pipelines::PipelineError,
     validation::{self, ValidationContext, ValidationError, ValidationFailure},
@@ -14,10 +17,11 @@ use crate::{
 ///
 /// Update endpoints that can change source, destination, pipeline, image, or
 /// runtime resource configuration should call this after persisting the new API
-/// state. The helper first materializes the latest Kubernetes Secrets,
-/// ConfigMap, maintenance resources, and StatefulSet from that state. It then
-/// relies on the StatefulSet materialization to change the pod template restart
-/// annotation, which intentionally kicks off pod recreation.
+/// state. The helper resets the old VPA recommendation, materializes the latest
+/// Kubernetes resources, and relies on the StatefulSet materialization to
+/// change the pod template restart annotation. The replacement Pod therefore
+/// starts from the max-sized template allocation before fresh VPA
+/// recommendations converge it toward observed usage.
 ///
 /// This forced recreation is part of the contract. The replicator loads its
 /// mounted config and secret-backed environment when the process starts, so a
@@ -42,6 +46,12 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     if !should_reconcile_replicator_resources(k8s_client, tenant_id, replicator.id).await? {
         return Ok(false);
     }
+
+    // An existing VPA recommendation would otherwise mutate the replacement
+    // Pod back to its streaming allocation during admission. A deliberate
+    // restart may begin another table copy, so reset recommendation history and
+    // let the StatefulSet template provide the initial max-sized allocation.
+    reset_replicator_vertical_pod_autoscaler(k8s_client, tenant_id, replicator.id).await?;
 
     create_or_update_pipeline_resources_in_k8s(
         k8s_client,

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -4,10 +4,7 @@ use crate::{
     data::pipelines::read_pipeline_components,
     k8s::{
         K8sClient, SourceTlsConfig,
-        core::{
-            create_or_update_pipeline_resources_in_k8s, reset_replicator_vertical_pod_autoscaler,
-            should_reconcile_replicator_resources,
-        },
+        core::{create_or_update_pipeline_resources_in_k8s, should_reconcile_replicator_resources},
     },
     routes::pipelines::PipelineError,
     validation::{self, ValidationContext, ValidationError, ValidationFailure},
@@ -17,11 +14,9 @@ use crate::{
 ///
 /// Update endpoints that can change source, destination, pipeline, image, or
 /// runtime resource configuration should call this after persisting the new API
-/// state. The helper resets the old VPA recommendation, materializes the latest
-/// Kubernetes resources, and relies on the StatefulSet materialization to
-/// change the pod template restart annotation. The replacement Pod therefore
-/// starts from the max-sized template allocation before fresh VPA
-/// recommendations converge it toward observed usage.
+/// state. The helper materializes the latest Kubernetes resources and relies on
+/// the StatefulSet materialization to change the pod template restart
+/// annotation.
 ///
 /// This forced recreation is part of the contract. The replicator loads its
 /// mounted config and secret-backed environment when the process starts, so a
@@ -46,12 +41,6 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     if !should_reconcile_replicator_resources(k8s_client, tenant_id, replicator.id).await? {
         return Ok(false);
     }
-
-    // An existing VPA recommendation would otherwise mutate the replacement
-    // Pod back to its streaming allocation during admission. A deliberate
-    // restart may begin another table copy, so reset recommendation history and
-    // let the StatefulSet template provide the initial max-sized allocation.
-    reset_replicator_vertical_pod_autoscaler(k8s_client, tenant_id, replicator.id).await?;
 
     create_or_update_pipeline_resources_in_k8s(
         k8s_client,

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -1033,7 +1033,7 @@ pub(crate) async fn start_pipeline(
     post,
     path = "/pipelines/{pipeline_id}/restart",
     summary = "Restart a pipeline",
-    description = "Reconciles the pipeline's Kubernetes resources and restarts its replicator.",
+    description = "Reconciles the pipeline's Kubernetes resources and restarts its replicator while preserving its current VPA recommendation. Stop and start the pipeline to reset autoscaling and return to the initial allocation.",
     params(
         ("pipeline_id" = i64, Path, description = "Unique ID of the pipeline"),
         ("tenant_id" = String, Header, description = "Tenant ID used to scope the request")

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -1437,6 +1437,7 @@ async fn a_running_pipeline_can_be_restarted() {
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     assert!(k8s_state.create_calls() > create_calls_before);
+    assert_eq!(k8s_state.vpa_delete_calls(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1468,7 +1469,8 @@ async fn a_stopped_pipeline_cannot_be_restarted() {
 async fn an_existing_pipeline_can_be_stopped() {
     init_test_tracing();
     // Arrange
-    let app = spawn_test_app().await;
+    let k8s_state = MockK8sState::default();
+    let app = spawn_test_app_with_k8s_state(None, k8s_state.clone()).await;
     create_default_image(&app).await;
     let tenant_id = &create_tenant(&app).await;
     let source_id = create_source(&app, tenant_id).await;
@@ -1486,6 +1488,7 @@ async fn an_existing_pipeline_can_be_stopped() {
 
     // Assert
     assert!(response.status().is_success());
+    assert_eq!(k8s_state.vpa_delete_calls(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/support/k8s_client.rs
+++ b/crates/etl-api/tests/support/k8s_client.rs
@@ -10,7 +10,7 @@ use etl_api::{
     configs::pipeline::ReplicatorResourcesConfig,
     k8s::{
         DuckLakeMaintenanceResourceConfig, K8sClient, K8sError, PodStatus, ReplicatorConfigMapFile,
-        ReplicatorStatefulSetConfig,
+        ReplicatorStatefulSetConfig, ReplicatorVerticalPodAutoscalerConfig,
     },
 };
 use tokio::sync::RwLock;
@@ -178,7 +178,22 @@ impl K8sClient for MockK8sClient {
         Ok(())
     }
 
+    async fn create_or_update_replicator_vertical_pod_autoscaler(
+        &self,
+        _config: ReplicatorVerticalPodAutoscalerConfig,
+    ) -> Result<(), K8sError> {
+        self.record_create_call();
+        Ok(())
+    }
+
     async fn delete_replicator_stateful_set(&self, _prefix: &str) -> Result<(), K8sError> {
+        Ok(())
+    }
+
+    async fn delete_replicator_vertical_pod_autoscaler(
+        &self,
+        _prefix: &str,
+    ) -> Result<(), K8sError> {
         Ok(())
     }
 

--- a/crates/etl-api/tests/support/k8s_client.rs
+++ b/crates/etl-api/tests/support/k8s_client.rs
@@ -19,6 +19,7 @@ use tokio::sync::RwLock;
 pub(crate) struct MockK8sState {
     pod_status: Arc<RwLock<PodStatus>>,
     create_calls: Arc<AtomicUsize>,
+    vpa_delete_calls: Arc<AtomicUsize>,
     ducklake_maintenance_create_calls: Arc<AtomicUsize>,
     last_replicator_resources: Arc<RwLock<Option<ReplicatorResourcesConfig>>>,
 }
@@ -28,6 +29,7 @@ impl Default for MockK8sState {
         Self {
             pod_status: Arc::new(RwLock::new(PodStatus::Started)),
             create_calls: Arc::new(AtomicUsize::new(0)),
+            vpa_delete_calls: Arc::new(AtomicUsize::new(0)),
             ducklake_maintenance_create_calls: Arc::new(AtomicUsize::new(0)),
             last_replicator_resources: Arc::new(RwLock::new(None)),
         }
@@ -41,6 +43,10 @@ impl MockK8sState {
 
     pub(crate) fn create_calls(&self) -> usize {
         self.create_calls.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn vpa_delete_calls(&self) -> usize {
+        self.vpa_delete_calls.load(Ordering::Relaxed)
     }
 
     pub(crate) fn ducklake_maintenance_create_calls(&self) -> usize {
@@ -194,6 +200,7 @@ impl K8sClient for MockK8sClient {
         &self,
         _prefix: &str,
     ) -> Result<(), K8sError> {
+        self.state.vpa_delete_calls.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -638,6 +638,7 @@ async fn spawn_test_app_with_services(
                 cpu_request_millicores: 125,
                 destinations: Default::default(),
             },
+            replicator_autoscaling: Default::default(),
             vector_image: "timberio/vector:0.55.0-distroless-libc".to_owned(),
             vector_resources: DefaultVectorResourcesConfig {
                 memory_request_mib: 192,

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -270,10 +270,6 @@ where
             return Poll::Pending;
         }
 
-        // Snapshot the byte budget once per poll; it refreshes on its own
-        // 100ms cadence, so a per-item read only adds clock lookups.
-        let max_batch_size_bytes = this.cached_batch_budget.current_batch_size_bytes();
-
         // PRIORITY 2: Poll underlying stream for new items.
         loop {
             match this.stream.as_mut().poll_next(cx) {
@@ -308,8 +304,13 @@ where
                         return Poll::Ready(Some(Ok(std::mem::take(this.items))));
                     }
 
-                    // If byte budget is reached we want to return the accumulated data.
-                    if *this.current_batch_size_hint_bytes >= max_batch_size_bytes {
+                    // Consult the cached budget after every decoded item. A PostgreSQL COPY
+                    // stream can yield many ready rows during one outer poll, so checking only
+                    // once per poll would delay adaptation to a changed cgroup limit or active
+                    // stream count.
+                    if *this.current_batch_size_hint_bytes
+                        >= this.cached_batch_budget.current_batch_size_bytes()
+                    {
                         *this.reset_timer = true;
                         *this.current_batch_size_hint_bytes = 0;
 
@@ -436,6 +437,42 @@ mod tests {
                 }
                 _ => Poll::Pending,
             }
+        }
+    }
+
+    pin_project! {
+        struct ShrinksMemoryBetweenReadyItems {
+            emitted: usize,
+            memory: MemoryMonitor,
+        }
+    }
+
+    impl ShrinksMemoryBetweenReadyItems {
+        fn new(memory: MemoryMonitor) -> Self {
+            Self { emitted: 0, memory }
+        }
+    }
+
+    impl Stream for ShrinksMemoryBetweenReadyItems {
+        type Item = Result<SizedToken, &'static str>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let item = match self.emitted {
+                0 => SizedToken { value: 1, bytes: 400 },
+                1 => {
+                    self.memory.set_total_memory_bytes_for_test(500);
+                    // The production cache deliberately refreshes at most every 100ms. Keep
+                    // yielding ready items across that boundary to prove the outer batch poll
+                    // observes the new budget without relying on an inner `Pending` wakeup.
+                    std::thread::sleep(Duration::from_millis(110));
+                    SizedToken { value: 2, bytes: 100 }
+                }
+                2 => SizedToken { value: 3, bytes: 100 },
+                _ => return Poll::Ready(None),
+            };
+            self.emitted += 1;
+
+            Poll::Ready(Some(Ok(item)))
         }
     }
 
@@ -803,6 +840,33 @@ mod tests {
 
         let first = poll_fn(|cx| stream.as_mut().poll_next(cx)).await;
         assert_eq!(first, Some(Ok(items)));
+    }
+
+    #[tokio::test]
+    async fn refreshes_cached_budget_between_ready_items() {
+        let memory = MemoryMonitor::new_for_test();
+        memory.set_total_memory_bytes_for_test(5_000);
+        let cached_budget = BatchBudgetController::new(1, memory.clone(), 0.2, 10_000).cached();
+        let batch_config = test_batch_config(10_000);
+        let mut stream = Box::pin(TryBatchBackpressureStream::wrap(
+            ShrinksMemoryBetweenReadyItems::new(memory),
+            "test_stream",
+            batch_config,
+            None,
+            cached_budget,
+        ));
+
+        // The initial budget is 1,000 bytes. While the same outer poll drains ready
+        // rows, total memory shrinks and the refreshed budget becomes 100 bytes. The
+        // first two rows must therefore flush before the third row is consumed.
+        let first = poll_fn(|cx| stream.as_mut().poll_next(cx)).await;
+        assert_eq!(
+            first,
+            Some(Ok(vec![
+                SizedToken { value: 1, bytes: 400 },
+                SizedToken { value: 2, bytes: 100 },
+            ]))
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/xtask/src/commands/deploy_local.rs
+++ b/crates/xtask/src/commands/deploy_local.rs
@@ -25,11 +25,11 @@ const DEFAULT_APP_ENVIRONMENT: &str = "dev";
 /// Default CPU request for the local replicator pod.
 const DEFAULT_CPU_REQUEST: &str = "125m";
 /// Default CPU limit for the local replicator pod.
-const DEFAULT_CPU_LIMIT: &str = "250m";
+const DEFAULT_CPU_LIMIT: &str = DEFAULT_CPU_REQUEST;
 /// Default memory request for the local replicator pod.
 const DEFAULT_MEMORY_REQUEST: &str = "250Mi";
 /// Default memory limit for the local replicator pod.
-const DEFAULT_MEMORY_LIMIT: &str = "300Mi";
+const DEFAULT_MEMORY_LIMIT: &str = DEFAULT_MEMORY_REQUEST;
 /// Default log filter used by the local replicator.
 const DEFAULT_RUST_LOG: &str = "info";
 /// Default tracing flag used by the local replicator.
@@ -92,14 +92,15 @@ pub(crate) struct DeployLocalArgs {
     /// CPU request (defaults to CPU_REQUEST, MAC_CPU_REQUEST, or 125m).
     #[arg(long, value_name = "VALUE")]
     cpu_request: Option<String>,
-    /// CPU limit (defaults to CPU_LIMIT, MAC_CPU_LIMIT, or 250m).
+    /// CPU limit (defaults to CPU_LIMIT, MAC_CPU_LIMIT, or the CPU request).
     #[arg(long, value_name = "VALUE")]
     cpu_limit: Option<String>,
     /// Memory request (defaults to MEMORY_REQUEST, MAC_MEMORY_REQUEST, or
     /// 250Mi).
     #[arg(long, value_name = "VALUE")]
     memory_request: Option<String>,
-    /// Memory limit (defaults to MEMORY_LIMIT, MAC_MEMORY_LIMIT, or 300Mi).
+    /// Memory limit (defaults to MEMORY_LIMIT, MAC_MEMORY_LIMIT, or the memory
+    /// request).
     #[arg(long, value_name = "VALUE")]
     memory_limit: Option<String>,
     /// Skip the local Docker image build.
@@ -662,6 +663,8 @@ metadata:
 spec:
   serviceName: {headless_service_name}
   replicas: 1
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: {name}
@@ -675,6 +678,11 @@ spec:
       - name: replicator
         image: {image}
         imagePullPolicy: IfNotPresent
+        resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        - resourceName: memory
+          restartPolicy: NotRequired
         envFrom:
         - configMapRef:
             name: {env_config_map_name}


### PR DESCRIPTION
This PR creates vertical autoscaling resources that will be used to allow replicators to vertically scale based on CPU and memory metrics.

This has the goal of making it much cheaper to run replicators since they can be tightly packed based on their resource allocation that usually changes significantly between the initial sync and ongoing replication phases.