### PR TITLE
expose internal endpoints to get credentials from different destinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tracing",

--- a/crates/etl-api/Cargo.toml
+++ b/crates/etl-api/Cargo.toml
@@ -53,6 +53,7 @@ metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 pg_escape = { workspace = true }
 rand = { workspace = true, features = ["std"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
+tokio-rustls = { workspace = true, features = ["aws-lc-rs", "logging", "tls12"] }
 secrecy = { workspace = true }
 sentry = { workspace = true, features = ["tower-http", "tower-axum-matched-path"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/etl-api/Cargo.toml
+++ b/crates/etl-api/Cargo.toml
@@ -53,7 +53,6 @@ metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 pg_escape = { workspace = true }
 rand = { workspace = true, features = ["std"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "logging"] }
-tokio-rustls = { workspace = true, features = ["aws-lc-rs", "logging", "tls12"] }
 secrecy = { workspace = true }
 sentry = { workspace = true, features = ["tower-http", "tower-axum-matched-path"] }
 serde = { workspace = true, features = ["derive"] }
@@ -68,6 +67,7 @@ sqlx = { workspace = true, features = [
 ] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio-rustls = { workspace = true, features = ["aws-lc-rs", "logging", "tls12"] }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true, default-features = false }

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt};
+use std::{collections::BTreeMap, fmt, path::PathBuf};
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 use etl_config::{
@@ -276,15 +276,31 @@ impl Config for ApiConfig {
 pub struct ApplicationSettings {
     /// Host address the API listens on.
     pub host: String,
-    /// Port number the API listens on.
+    /// Port number the public API listens on.
     pub port: u16,
+    /// Port number the cluster-internal API listens on.
+    pub internal_port: u16,
+    /// Optional TLS certificate and private key for the cluster-internal listener.
+    #[serde(default)]
+    pub internal_tls: Option<InternalTlsSettings>,
+}
+
+/// TLS files used by the cluster-internal API listener.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InternalTlsSettings {
+    /// PEM-encoded server certificate chain.
+    pub cert_path: PathBuf,
+    /// PEM-encoded server private key.
+    pub key_path: PathBuf,
 }
 
 impl fmt::Display for ApplicationSettings {
     /// Formats application settings for display.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "    host: {}", self.host)?;
-        writeln!(f, "    port: {}", self.port)
+        writeln!(f, "    port: {}", self.port)?;
+        writeln!(f, "    internal_port: {}", self.internal_port)?;
+        writeln!(f, "    internal_tls: {}", self.internal_tls.is_some())
     }
 }
 
@@ -403,6 +419,31 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn internal_listener_tls_configuration_is_optional() {
+        let plaintext: ApplicationSettings = serde_json::from_value(json!({
+            "host": "127.0.0.1",
+            "port": 8080,
+            "internal_port": 8081
+        }))
+        .unwrap();
+        assert!(plaintext.internal_tls.is_none());
+
+        let tls: ApplicationSettings = serde_json::from_value(json!({
+            "host": "127.0.0.1",
+            "port": 8080,
+            "internal_port": 8081,
+            "internal_tls": {
+                "cert_path": "/etc/etl-api/internal-tls/tls.crt",
+                "key_path": "/etc/etl-api/internal-tls/tls.key"
+            }
+        }))
+        .unwrap();
+        let tls = tls.internal_tls.unwrap();
+        assert_eq!(tls.cert_path, PathBuf::from("/etc/etl-api/internal-tls/tls.crt"));
+        assert_eq!(tls.key_path, PathBuf::from("/etc/etl-api/internal-tls/tls.key"));
+    }
 
     #[test]
     fn destination_replicator_resources_override_selected_global_fields() {

--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -280,7 +280,8 @@ pub struct ApplicationSettings {
     pub port: u16,
     /// Port number the cluster-internal API listens on.
     pub internal_port: u16,
-    /// Optional TLS certificate and private key for the cluster-internal listener.
+    /// Optional TLS certificate and private key for the cluster-internal
+    /// listener.
     #[serde(default)]
     pub internal_tls: Option<InternalTlsSettings>,
 }

--- a/crates/etl-api/src/data/pipelines.rs
+++ b/crates/etl-api/src/data/pipelines.rs
@@ -460,7 +460,7 @@ pub async fn read_pipeline_ids_for_destination_selector<'c, E>(
     executor: E,
     tenant_id: &str,
     destination_name: &str,
-    destination_kind: &str,
+    destination_config_key: &str,
 ) -> Result<Vec<(i64, i64)>, PipelinesDbError>
 where
     E: PgExecutor<'c>,
@@ -478,7 +478,7 @@ where
     )
     .bind(tenant_id)
     .bind(destination_name)
-    .bind(destination_kind)
+    .bind(destination_config_key)
     .fetch_all(executor)
     .await?;
 

--- a/crates/etl-api/src/data/pipelines.rs
+++ b/crates/etl-api/src/data/pipelines.rs
@@ -454,6 +454,37 @@ where
     Ok(records)
 }
 
+/// Reads the destination and pipeline ids for destinations with the requested
+/// name and kind.
+pub async fn read_pipeline_ids_for_destination_selector<'c, E>(
+    executor: E,
+    tenant_id: &str,
+    destination_name: &str,
+    destination_kind: &str,
+) -> Result<Vec<(i64, i64)>, PipelinesDbError>
+where
+    E: PgExecutor<'c>,
+{
+    let records = sqlx::query_as::<_, (i64, i64)>(
+        r#"
+        select p.destination_id, p.id
+        from app.pipelines p
+        join app.destinations d on p.destination_id = d.id
+        where p.tenant_id = $1
+          and d.name = $2
+          and d.config ? $3
+        order by p.id
+        "#,
+    )
+    .bind(tenant_id)
+    .bind(destination_name)
+    .bind(destination_kind)
+    .fetch_all(executor)
+    .await?;
+
+    Ok(records)
+}
+
 pub async fn read_pipelines_for_source_for_deletion<'c, E>(
     executor: E,
     tenant_id: &str,

--- a/crates/etl-api/src/routes/mod.rs
+++ b/crates/etl-api/src/routes/mod.rs
@@ -17,6 +17,7 @@ pub mod health_check;
 pub mod images;
 pub mod metrics;
 pub mod pipelines;
+pub mod runtime_config;
 pub mod sources;
 pub mod tenants;
 pub mod tenants_sources;

--- a/crates/etl-api/src/routes/runtime_config.rs
+++ b/crates/etl-api/src/routes/runtime_config.rs
@@ -24,15 +24,6 @@ use crate::{
     },
 };
 
-/// Criteria for resolving a runtime when the destination id is not known.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ResolveRuntimeConfigRequest {
-    /// Product kind of the destination to resolve.
-    pub destination_kind: DestinationKind,
-    /// Exact destination name to resolve.
-    pub destination_name: String,
-}
-
 /// Runtime configuration, including credentials, resolved for one destination.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolveRuntimeConfigResponse {
@@ -146,20 +137,23 @@ pub(crate) async fn resolve_runtime_config(
     .await
 }
 
-/// Resolves a tenant runtime using destination criteria supplied by the caller.
+/// Resolves a tenant runtime using destination criteria supplied in the request
+/// path.
 pub(crate) async fn resolve_tenant_runtime_config(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
     Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
     Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
-    Json(request): Json<ResolveRuntimeConfigRequest>,
+    destination_selector: Path<(DestinationKind, String)>,
 ) -> Result<Response, RuntimeConfigError> {
     let tenant_id = extract_tenant_id(&headers)?;
+    let (destination_kind, destination_name) = destination_selector.into_inner();
+    let destination_config_key = stored_destination_config_key(destination_kind);
     let runtimes = read_pipeline_ids_for_destination_selector(
         &pool,
         tenant_id,
-        &request.destination_name,
-        request.destination_kind.as_str(),
+        &destination_name,
+        destination_config_key,
     )
     .await?;
     let (destination_id, pipeline_id) = match runtimes.as_slice() {
@@ -177,6 +171,18 @@ pub(crate) async fn resolve_tenant_runtime_config(
         &source_tls_config,
     )
     .await
+}
+
+/// Returns the JSON key used by the encrypted destination configuration stored
+/// in the API database.
+const fn stored_destination_config_key(destination_kind: DestinationKind) -> &'static str {
+    match destination_kind {
+        DestinationKind::BigQuery => "big_query",
+        DestinationKind::ClickHouse => "click_house",
+        DestinationKind::Ducklake => "ducklake",
+        DestinationKind::Iceberg => "iceberg",
+        DestinationKind::Snowflake => "snowflake",
+    }
 }
 
 async fn resolve_runtime_config_inner(

--- a/crates/etl-api/src/routes/runtime_config.rs
+++ b/crates/etl-api/src/routes/runtime_config.rs
@@ -1,0 +1,212 @@
+use std::sync::Arc;
+
+use axum::{
+    Extension, Json,
+    extract::Path,
+    http::{HeaderMap, HeaderValue, StatusCode, header::CACHE_CONTROL},
+    response::{IntoResponse, Response},
+};
+use etl_config::shared::{DestinationKind, PgConnectionConfigWithoutSecrets};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use thiserror::Error;
+
+use crate::{
+    configs::{destination::ApiDestinationConfig, encryption::EncryptionKeyring},
+    data::pipelines::{
+        PipelinesDbError, read_pipeline_components, read_pipeline_ids_for_destination,
+        read_pipeline_ids_for_destination_selector,
+    },
+    k8s::SourceTlsConfig,
+    routes::{
+        IntoInner, TenantIdError, error_response_with_internal_error, extract_tenant_id,
+        pipelines::PipelineError,
+    },
+};
+
+/// Criteria for resolving a runtime when the destination id is not known.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResolveRuntimeConfigRequest {
+    /// Product kind of the destination to resolve.
+    pub destination_kind: DestinationKind,
+    /// Exact destination name to resolve.
+    pub destination_name: String,
+}
+
+/// Runtime configuration, including credentials, resolved for one destination.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveRuntimeConfigResponse {
+    /// Tenant owning the runtime.
+    pub tenant_id: String,
+    /// Destination selected by the request path.
+    pub destination_id: i64,
+    /// Human-readable destination name.
+    pub destination_name: String,
+    /// Pipeline using the destination.
+    pub pipeline_id: i64,
+    /// Replicator associated with the runtime.
+    pub replicator_id: i64,
+    /// Source connection configuration without its password.
+    pub source: PgConnectionConfigWithoutSecrets,
+    /// Destination configuration, including credentials required at runtime.
+    pub destination: ApiDestinationConfig,
+}
+
+/// Errors resolving an internal destination runtime configuration.
+#[derive(Debug, Error)]
+pub enum RuntimeConfigError {
+    /// The tenant header was missing or invalid.
+    #[error(transparent)]
+    TenantId(#[from] TenantIdError),
+
+    /// No pipeline for the requested destination was found in the tenant.
+    #[error("The destination with id {0} was not found or is not attached to a pipeline")]
+    DestinationNotFound(i64),
+
+    /// More than one pipeline uses the destination.
+    #[error("The destination with id {0} is attached to multiple pipelines")]
+    MultiplePipelines(i64),
+
+    /// The tenant has no runtime matching the requested selector.
+    #[error("The tenant has no destination matching the requested selector attached to a pipeline")]
+    TenantRuntimeNotFound,
+
+    /// More than one runtime matches the requested selector.
+    #[error("The tenant has multiple destinations matching the requested selector")]
+    MultipleTenantRuntimes,
+
+    /// Reading pipeline identifiers failed.
+    #[error(transparent)]
+    PipelinesDb(#[from] PipelinesDbError),
+
+    /// Reading the selected pipeline components failed.
+    #[error(transparent)]
+    Pipeline(#[from] PipelineError),
+
+    /// Acquiring an API database connection failed.
+    #[error("Error while acquiring an API database connection")]
+    Database(#[source] sqlx::Error),
+}
+
+impl RuntimeConfigError {
+    fn to_message(&self) -> String {
+        match self {
+            Self::TenantId(_)
+            | Self::DestinationNotFound(_)
+            | Self::MultiplePipelines(_)
+            | Self::TenantRuntimeNotFound
+            | Self::MultipleTenantRuntimes => self.to_string(),
+            Self::PipelinesDb(_) | Self::Pipeline(_) | Self::Database(_) => {
+                "Internal server error".to_owned()
+            }
+        }
+    }
+}
+
+impl IntoResponse for RuntimeConfigError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            Self::TenantId(_) => StatusCode::BAD_REQUEST,
+            Self::DestinationNotFound(_) | Self::TenantRuntimeNotFound => StatusCode::NOT_FOUND,
+            Self::MultiplePipelines(_) | Self::MultipleTenantRuntimes => StatusCode::CONFLICT,
+            Self::PipelinesDb(_) | Self::Pipeline(_) | Self::Database(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+
+        error_response_with_internal_error(status, self.to_message(), &self)
+    }
+}
+
+/// Resolves runtime metadata and credentials for one destination.
+pub(crate) async fn resolve_runtime_config(
+    headers: HeaderMap,
+    Extension(pool): Extension<PgPool>,
+    Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
+    Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
+    destination_id: Path<i64>,
+) -> Result<Response, RuntimeConfigError> {
+    let tenant_id = extract_tenant_id(&headers)?;
+    let destination_id = destination_id.into_inner();
+    let pipeline_ids = read_pipeline_ids_for_destination(&pool, tenant_id, destination_id).await?;
+    let pipeline_id = match pipeline_ids.as_slice() {
+        [] => return Err(RuntimeConfigError::DestinationNotFound(destination_id)),
+        [pipeline_id] => *pipeline_id,
+        _ => return Err(RuntimeConfigError::MultiplePipelines(destination_id)),
+    };
+
+    resolve_runtime_config_inner(
+        tenant_id,
+        destination_id,
+        pipeline_id,
+        &pool,
+        &encryption_key,
+        &source_tls_config,
+    )
+    .await
+}
+
+/// Resolves a tenant runtime using destination criteria supplied by the caller.
+pub(crate) async fn resolve_tenant_runtime_config(
+    headers: HeaderMap,
+    Extension(pool): Extension<PgPool>,
+    Extension(encryption_key): Extension<Arc<EncryptionKeyring>>,
+    Extension(source_tls_config): Extension<Arc<SourceTlsConfig>>,
+    Json(request): Json<ResolveRuntimeConfigRequest>,
+) -> Result<Response, RuntimeConfigError> {
+    let tenant_id = extract_tenant_id(&headers)?;
+    let runtimes = read_pipeline_ids_for_destination_selector(
+        &pool,
+        tenant_id,
+        &request.destination_name,
+        request.destination_kind.as_str(),
+    )
+    .await?;
+    let (destination_id, pipeline_id) = match runtimes.as_slice() {
+        [] => return Err(RuntimeConfigError::TenantRuntimeNotFound),
+        [(destination_id, pipeline_id)] => (*destination_id, *pipeline_id),
+        _ => return Err(RuntimeConfigError::MultipleTenantRuntimes),
+    };
+
+    resolve_runtime_config_inner(
+        tenant_id,
+        destination_id,
+        pipeline_id,
+        &pool,
+        &encryption_key,
+        &source_tls_config,
+    )
+    .await
+}
+
+async fn resolve_runtime_config_inner(
+    tenant_id: &str,
+    destination_id: i64,
+    pipeline_id: i64,
+    pool: &PgPool,
+    encryption_key: &EncryptionKeyring,
+    source_tls_config: &SourceTlsConfig,
+) -> Result<Response, RuntimeConfigError> {
+    let mut connection = pool.acquire().await.map_err(RuntimeConfigError::Database)?;
+    let (pipeline, replicator, _image, source, destination) =
+        read_pipeline_components(&mut connection, tenant_id, pipeline_id, encryption_key).await?;
+
+    let source = PgConnectionConfigWithoutSecrets::from(
+        source.config.into_connection_config(source_tls_config.get_tls_config()),
+    );
+    let destination = ApiDestinationConfig::from(destination.config);
+
+    let mut response = Json(ResolveRuntimeConfigResponse {
+        tenant_id: tenant_id.to_owned(),
+        destination_id,
+        destination_name: pipeline.destination_name,
+        pipeline_id: pipeline.id,
+        replicator_id: replicator.id,
+        source,
+        destination,
+    })
+    .into_response();
+    response.headers_mut().insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+
+    Ok(response)
+}

--- a/crates/etl-api/src/startup.rs
+++ b/crates/etl-api/src/startup.rs
@@ -638,8 +638,9 @@ pub fn run(
 
 #[cfg(test)]
 mod tests {
-    use super::internal_runtime_routes_enabled;
     use etl_config::Environment;
+
+    use super::internal_runtime_routes_enabled;
 
     #[test]
     fn internal_runtime_routes_require_tls_outside_development() {

--- a/crates/etl-api/src/startup.rs
+++ b/crates/etl-api/src/startup.rs
@@ -1,10 +1,16 @@
-use std::{io, net::TcpListener, sync::Arc};
+use std::{
+    io,
+    net::{SocketAddr, TcpListener},
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::Context;
 use aws_lc_rs::aead::{AES_256_GCM, RandomizedNonceKey};
 use axum::{
     Extension, Router, middleware,
     routing::{get, post, put},
+    serve::Listener,
 };
 use base64::{Engine, prelude::BASE64_STANDARD};
 use etl_config::{
@@ -14,6 +20,8 @@ use etl_config::{
 use etl_telemetry::metrics::init_metrics_handle;
 use kube::config::KubeConfigOptions;
 use sqlx::{PgPool, postgres::PgPoolOptions};
+use tokio::net::{TcpListener as TokioTcpListener, TcpStream};
+use tokio_rustls::{TlsAcceptor, server::TlsStream};
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info};
@@ -22,7 +30,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::{
     authentication::auth_validator,
-    config::{ApiConfig, EncryptionKeyConfig},
+    config::{ApiConfig, EncryptionKeyConfig, InternalTlsSettings},
     configs::encryption,
     data::publications::Publication,
     feature_flags::{FeatureFlagsClient, init_feature_flags},
@@ -57,6 +65,7 @@ use crate::{
             rollback_tables, start_pipeline, stop_all_pipelines, stop_pipeline, update_pipeline,
             update_pipeline_version, validate_pipeline,
         },
+        runtime_config::{resolve_runtime_config, resolve_tenant_runtime_config},
         sources::{
             CreateSourceRequest, CreateSourceResponse, ReadSourceResponse, ReadSourcesResponse,
             UpdateSourceRequest, ValidateSourceRequest, ValidateSourceResponse, create_source,
@@ -88,6 +97,74 @@ use crate::{
 /// Running API server task.
 pub type Server = tokio::task::JoinHandle<io::Result<()>>;
 
+/// Public and cluster-internal listeners used by the API application.
+pub struct ApplicationListeners {
+    /// Listener serving the public API surface.
+    pub public: TcpListener,
+    /// Listener serving cluster-internal routes.
+    pub internal: TcpListener,
+}
+
+struct TlsListener {
+    listener: TokioTcpListener,
+    acceptor: TlsAcceptor,
+}
+
+impl Listener for TlsListener {
+    type Io = TlsStream<TcpStream>;
+    type Addr = SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            let (stream, address) = match self.listener.accept().await {
+                Ok(connection) => connection,
+                Err(error) => {
+                    error!(%error, "failed to accept internal API TCP connection");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
+
+            match self.acceptor.accept(stream).await {
+                Ok(stream) => return (stream, address),
+                Err(error) => {
+                    tracing::debug!(%error, %address, "rejected internal API TLS connection");
+                }
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<Self::Addr> {
+        self.listener.local_addr()
+    }
+}
+
+fn internal_tls_acceptor(settings: &InternalTlsSettings) -> anyhow::Result<TlsAcceptor> {
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+
+    let certificates = CertificateDer::pem_file_iter(&settings.cert_path)
+        .with_context(|| {
+            format!("Opening internal API TLS certificate {}", settings.cert_path.display())
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .with_context(|| {
+            format!("Reading internal API TLS certificate {}", settings.cert_path.display())
+        })?;
+    let private_key = PrivateKeyDer::from_pem_file(&settings.key_path).with_context(|| {
+        format!("Reading internal API TLS private key {}", settings.key_path.display())
+    })?;
+    let server_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certificates, private_key)
+        .context("Building internal API TLS server configuration")?;
+
+    Ok(TlsAcceptor::from(Arc::new(server_config)))
+}
+
+fn internal_runtime_routes_enabled(environment: Environment, tls_enabled: bool) -> bool {
+    matches!(environment, Environment::Dev) || tls_enabled
+}
+
 /// Minimum number of connections for the API metadata database pool.
 ///
 /// The API pool is lazy and should not keep metadata database connections open
@@ -100,6 +177,7 @@ const MIN_DATABASE_POOL_CONNECTIONS: u32 = 0;
 /// shutdown.
 pub struct Application {
     port: u16,
+    internal_port: u16,
     server: Server,
 }
 
@@ -114,6 +192,10 @@ impl Application {
         let address = format!("{}:{}", config.application.host, config.application.port);
         let listener = TcpListener::bind(address)?;
         let port = listener.local_addr()?.port();
+        let internal_address =
+            format!("{}:{}", config.application.host, config.application.internal_port);
+        let internal_listener = TcpListener::bind(internal_address)?;
+        let internal_port = internal_listener.local_addr()?.port();
 
         let encryption_keyring = build_encryption_keyring(&config)?;
 
@@ -133,7 +215,7 @@ impl Application {
 
         let server = run(
             config,
-            listener,
+            ApplicationListeners { public: listener, internal: internal_listener },
             connection_pool,
             encryption_keyring,
             k8s_client,
@@ -141,7 +223,7 @@ impl Application {
             feature_flags_client,
         )?;
 
-        Ok(Self { port, server })
+        Ok(Self { port, internal_port, server })
     }
 
     /// Runs database migrations using the provided configuration.
@@ -158,6 +240,11 @@ impl Application {
     /// Returns the port the server is listening on.
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    /// Returns the port the cluster-internal server is listening on.
+    pub fn internal_port(&self) -> u16 {
+        self.internal_port
     }
 
     /// Runs the server until it receives a shutdown signal.
@@ -255,13 +342,20 @@ pub fn get_connection_pool(config: &PgConnectionConfig) -> PgPool {
 /// before the server starts accepting requests.
 pub fn run(
     config: ApiConfig,
-    listener: TcpListener,
+    listeners: ApplicationListeners,
     connection_pool: PgPool,
     encryption_keyring: encryption::EncryptionKeyring,
     k8s_client: Arc<dyn K8sClient>,
     source_tls_config: SourceTlsConfig,
     feature_flags_client: Option<FeatureFlagsClient>,
 ) -> Result<Server, anyhow::Error> {
+    let ApplicationListeners { public: listener, internal: internal_listener } = listeners;
+    let internal_tls_acceptor =
+        config.application.internal_tls.as_ref().map(internal_tls_acceptor).transpose()?;
+    let internal_runtime_routes_enabled = internal_runtime_routes_enabled(
+        Environment::load().context("Failed to load application environment")?,
+        internal_tls_acceptor.is_some(),
+    );
     let prometheus_handle = init_metrics_handle()?;
     let config = Arc::new(config);
     let encryption_keyring = Arc::new(encryption_keyring);
@@ -456,6 +550,15 @@ pub fn run(
         .merge(sensitive_routes)
         .layer(middleware::from_fn_with_state(Arc::clone(&config), auth_validator));
 
+    let internal_routes = Router::new()
+        .route("/runtime-config/resolve", post(resolve_tenant_runtime_config))
+        .route(
+            "/destinations/{destination_id}/runtime-config/resolve",
+            post(resolve_runtime_config),
+        )
+        .layer(middleware::from_fn(mark_sensitive_sentry_scope))
+        .layer(middleware::from_fn_with_state(Arc::clone(&config), auth_validator));
+
     let trace_layer = TraceLayer::new_for_http()
         .make_span_with(span_builder::make_span)
         .on_request(span_builder::on_request)
@@ -474,18 +577,18 @@ pub fn run(
         .route("/metrics", get(metrics))
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))
         .nest("/v1", v1_routes)
-        .layer(Extension(prometheus_handle))
+        .layer(Extension(prometheus_handle.clone()))
         .layer(Extension(Arc::clone(&config)))
-        .layer(Extension(connection_pool))
+        .layer(Extension(connection_pool.clone()))
         .layer(Extension(Arc::clone(&encryption_keyring)))
         .layer(middleware::from_fn(record_http_metrics))
         .layer(middleware::from_fn(capture_server_errors))
-        .layer(sentry_layer)
-        .layer(trace_layer);
+        .layer(sentry_layer.clone())
+        .layer(trace_layer.clone());
 
-    let app = app.layer(Extension(k8s_client));
+    let app = app.layer(Extension(Arc::clone(&k8s_client)));
 
-    let app = app.layer(Extension(source_tls_config));
+    let app = app.layer(Extension(Arc::clone(&source_tls_config)));
 
     let app = if let Some(feature_flags_client) = feature_flags_client {
         app.layer(Extension(feature_flags_client))
@@ -493,9 +596,57 @@ pub fn run(
         app
     };
 
+    let internal_app = Router::new().route("/health_check", get(health_check));
+    let internal_app = if internal_runtime_routes_enabled {
+        internal_app.nest("/v1/internal", internal_routes)
+    } else {
+        info!("internal runtime routes disabled because internal TLS is not configured");
+        internal_app
+    };
+    let internal_app = internal_app
+        .layer(Extension(prometheus_handle))
+        .layer(Extension(config))
+        .layer(Extension(connection_pool))
+        .layer(Extension(encryption_keyring))
+        .layer(Extension(k8s_client))
+        .layer(Extension(source_tls_config))
+        .layer(middleware::from_fn(record_http_metrics))
+        .layer(middleware::from_fn(capture_server_errors))
+        .layer(sentry_layer)
+        .layer(trace_layer);
+
     listener.set_nonblocking(true)?;
     let listener = tokio::net::TcpListener::from_std(listener)?;
-    let server = tokio::spawn(async move { axum::serve(listener, app.into_make_service()).await });
+    internal_listener.set_nonblocking(true)?;
+    let internal_listener = tokio::net::TcpListener::from_std(internal_listener)?;
+    let server = tokio::spawn(async move {
+        let public_server = axum::serve(listener, app.into_make_service());
+        if let Some(acceptor) = internal_tls_acceptor {
+            let internal_server = axum::serve(
+                TlsListener { listener: internal_listener, acceptor },
+                internal_app.into_make_service(),
+            );
+            tokio::try_join!(public_server, internal_server).map(|_| ())
+        } else {
+            let internal_server = axum::serve(internal_listener, internal_app.into_make_service());
+            tokio::try_join!(public_server, internal_server).map(|_| ())
+        }
+    });
 
     Ok(server)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::internal_runtime_routes_enabled;
+    use etl_config::Environment;
+
+    #[test]
+    fn internal_runtime_routes_require_tls_outside_development() {
+        assert!(internal_runtime_routes_enabled(Environment::Dev, false));
+        assert!(internal_runtime_routes_enabled(Environment::Staging, true));
+        assert!(internal_runtime_routes_enabled(Environment::Prod, true));
+        assert!(!internal_runtime_routes_enabled(Environment::Staging, false));
+        assert!(!internal_runtime_routes_enabled(Environment::Prod, false));
+    }
 }

--- a/crates/etl-api/src/startup.rs
+++ b/crates/etl-api/src/startup.rs
@@ -1,7 +1,10 @@
 use std::{
+    future::Future,
     io,
     net::{SocketAddr, TcpListener},
+    pin::Pin,
     sync::Arc,
+    task::{Context as TaskContext, Poll},
     time::Duration,
 };
 
@@ -20,8 +23,11 @@ use etl_config::{
 use etl_telemetry::metrics::init_metrics_handle;
 use kube::config::KubeConfigOptions;
 use sqlx::{PgPool, postgres::PgPoolOptions};
-use tokio::net::{TcpListener as TokioTcpListener, TcpStream};
-use tokio_rustls::{TlsAcceptor, server::TlsStream};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::{TcpListener as TokioTcpListener, TcpStream},
+};
+use tokio_rustls::{Accept, TlsAcceptor, server::TlsStream as ServerTlsStream};
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info};
@@ -105,13 +111,17 @@ pub struct ApplicationListeners {
     pub internal: TcpListener,
 }
 
+/// Listener that accepts internal TCP connections without waiting for their TLS
+/// handshakes to complete.
 struct TlsListener {
+    /// TCP listener serving the internal API.
     listener: TokioTcpListener,
+    /// TLS acceptor used to start each connection handshake.
     acceptor: TlsAcceptor,
 }
 
 impl Listener for TlsListener {
-    type Io = TlsStream<TcpStream>;
+    type Io = LazyTlsStream;
     type Addr = SocketAddr;
 
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {
@@ -125,12 +135,8 @@ impl Listener for TlsListener {
                 }
             };
 
-            match self.acceptor.accept(stream).await {
-                Ok(stream) => return (stream, address),
-                Err(error) => {
-                    tracing::debug!(%error, %address, "rejected internal API TLS connection");
-                }
-            }
+            let stream = LazyTlsStream::new(self.acceptor.accept(stream), address);
+            return (stream, address);
         }
     }
 
@@ -139,6 +145,105 @@ impl Listener for TlsListener {
     }
 }
 
+/// TLS connection that defers its handshake until Axum polls its I/O.
+struct LazyTlsStream {
+    /// Current handshake or streaming state.
+    state: LazyTlsStreamState,
+    /// Remote peer address used for handshake diagnostics.
+    address: SocketAddr,
+}
+
+/// State of a lazily negotiated internal TLS connection.
+enum LazyTlsStreamState {
+    /// TLS handshake waiting to be polled by the connection task.
+    Handshaking(Pin<Box<Accept<TcpStream>>>),
+    /// Established TLS stream.
+    Streaming(Box<ServerTlsStream<TcpStream>>),
+    /// Terminal state after a failed handshake.
+    Failed,
+}
+
+impl LazyTlsStream {
+    /// Creates a stream that will negotiate TLS on its first I/O poll.
+    fn new(handshake: Accept<TcpStream>, address: SocketAddr) -> Self {
+        Self { state: LazyTlsStreamState::Handshaking(Box::pin(handshake)), address }
+    }
+
+    /// Polls the handshake and returns the established TLS stream when ready.
+    fn poll_stream(
+        &mut self,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<io::Result<&mut ServerTlsStream<TcpStream>>> {
+        if let LazyTlsStreamState::Handshaking(handshake) = &mut self.state {
+            match handshake.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Ok(stream)) => {
+                    self.state = LazyTlsStreamState::Streaming(Box::new(stream));
+                }
+                Poll::Ready(Err(error)) => {
+                    tracing::debug!(error = %error, address = %self.address, "rejected internal API TLS connection");
+                    self.state = LazyTlsStreamState::Failed;
+                    return Poll::Ready(Err(error));
+                }
+            }
+        }
+
+        match &mut self.state {
+            LazyTlsStreamState::Streaming(stream) => Poll::Ready(Ok(stream.as_mut())),
+            LazyTlsStreamState::Failed => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "TLS handshake failed",
+            ))),
+            LazyTlsStreamState::Handshaking(_) => unreachable!("pending handshake returned early"),
+        }
+    }
+}
+
+impl AsyncRead for LazyTlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut().poll_stream(cx) {
+            Poll::Ready(Ok(stream)) => Pin::new(stream).poll_read(cx, buffer),
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl AsyncWrite for LazyTlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut().poll_stream(cx) {
+            Poll::Ready(Ok(stream)) => Pin::new(stream).poll_write(cx, buffer),
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut().poll_stream(cx) {
+            Poll::Ready(Ok(stream)) => Pin::new(stream).poll_flush(cx),
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut().poll_stream(cx) {
+            Poll::Ready(Ok(stream)) => Pin::new(stream).poll_shutdown(cx),
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Builds the TLS acceptor used by the internal API listener.
 fn internal_tls_acceptor(settings: &InternalTlsSettings) -> anyhow::Result<TlsAcceptor> {
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
 
@@ -161,6 +266,7 @@ fn internal_tls_acceptor(settings: &InternalTlsSettings) -> anyhow::Result<TlsAc
     Ok(TlsAcceptor::from(Arc::new(server_config)))
 }
 
+/// Returns whether sensitive internal runtime routes may be exposed.
 fn internal_runtime_routes_enabled(environment: Environment, tls_enabled: bool) -> bool {
     matches!(environment, Environment::Dev) || tls_enabled
 }
@@ -551,11 +657,11 @@ pub fn run(
         .layer(middleware::from_fn_with_state(Arc::clone(&config), auth_validator));
 
     let internal_routes = Router::new()
-        .route("/runtime-config/resolve", post(resolve_tenant_runtime_config))
         .route(
-            "/destinations/{destination_id}/runtime-config/resolve",
-            post(resolve_runtime_config),
+            "/destinations/{destination_kind}/{destination_name}/config",
+            get(resolve_tenant_runtime_config),
         )
+        .route("/destinations/{destination_id}/config", get(resolve_runtime_config))
         .layer(middleware::from_fn(mark_sensitive_sentry_scope))
         .layer(middleware::from_fn_with_state(Arc::clone(&config), auth_validator));
 
@@ -638,9 +744,39 @@ pub fn run(
 
 #[cfg(test)]
 mod tests {
-    use etl_config::Environment;
+    use std::{sync::Arc, time::Duration};
 
-    use super::internal_runtime_routes_enabled;
+    use axum::serve::Listener;
+    use etl_config::Environment;
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_rustls::TlsAcceptor;
+
+    use super::{TlsListener, internal_runtime_routes_enabled};
+
+    #[tokio::test]
+    async fn tls_listener_accepts_connections_without_waiting_for_handshakes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_config = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_no_client_auth()
+        .with_cert_resolver(Arc::new(rustls::server::ResolvesServerCertUsingSni::new()));
+        let mut listener =
+            TlsListener { listener, acceptor: TlsAcceptor::from(Arc::new(server_config)) };
+
+        let _first_stalled_client = TcpStream::connect(address).await.unwrap();
+        let _first_connection = tokio::time::timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .expect("TCP acceptance should not wait for the TLS handshake");
+        let _second_stalled_client = TcpStream::connect(address).await.unwrap();
+        let _second_connection =
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .expect("a stalled TLS handshake should not block later TCP connections");
+    }
 
     #[test]
     fn internal_runtime_routes_require_tls_outside_development() {

--- a/crates/etl-api/tests/main.rs
+++ b/crates/etl-api/tests/main.rs
@@ -7,6 +7,7 @@ mod images;
 mod metrics;
 mod missing_etl_tables;
 mod pipelines;
+mod runtime_config;
 mod sources;
 mod tenants;
 mod tenants_sources;

--- a/crates/etl-api/tests/runtime_config.rs
+++ b/crates/etl-api/tests/runtime_config.rs
@@ -215,7 +215,7 @@ async fn runtime_config_is_not_exposed_on_the_public_listener() {
 
     let response = app
         .api_client
-        .post(format!("{}/v1/internal/destinations/1/runtime-config/resolve", app.address))
+        .get(format!("{}/v1/internal/destinations/1/config", app.address))
         .bearer_auth(&app.api_key)
         .header("tenant_id", "abcdefghijklmnopqrst")
         .send()
@@ -232,7 +232,7 @@ async fn runtime_config_requires_existing_api_authentication() {
 
     let response = app
         .api_client
-        .post(format!("{}/v1/internal/destinations/1/runtime-config/resolve", app.internal_address))
+        .get(format!("{}/v1/internal/destinations/1/config", app.internal_address))
         .header("tenant_id", "abcdefghijklmnopqrst")
         .send()
         .await
@@ -273,6 +273,74 @@ async fn tenant_runtime_config_resolves_a_destination_matching_the_requested_sel
         response.json().await.expect("failed to deserialize runtime config response");
     assert_eq!(response["destination_id"], destination_id);
     assert_eq!(response["pipeline_id"], pipeline_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tenant_runtime_config_resolves_multiword_destination_kind_tags() {
+    init_test_tracing();
+    let destinations = [
+        ("bigquery", new_bigquery_destination_config()),
+        (
+            "clickhouse",
+            ApiDestinationConfig::ClickHouse {
+                url: "https://clickhouse.example.com:8443".parse().unwrap(),
+                user: "etl_user".to_owned(),
+                password: Some(SerializableSecretString::from(
+                    "fake-clickhouse-password".to_owned(),
+                )),
+                database: "analytics".to_owned(),
+                engine: ClickHouseEngine::default(),
+            },
+        ),
+    ];
+
+    for (destination_kind, destination_config) in destinations {
+        let app = spawn_test_app().await;
+        let tenant_id = create_tenant(&app).await;
+        let destination_name = format!("requested_{destination_kind}_destination");
+        let (destination_id, pipeline_id) = create_pipeline_with_destination_name(
+            &app,
+            &tenant_id,
+            &destination_name,
+            destination_config,
+        )
+        .await;
+
+        let response = app
+            .resolve_tenant_runtime_config(&tenant_id, destination_kind, &destination_name)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let response: serde_json::Value =
+            response.json().await.expect("failed to deserialize runtime config response");
+        assert_eq!(response["destination_id"], destination_id);
+        assert_eq!(response["pipeline_id"], pipeline_id);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tenant_runtime_config_decodes_the_destination_name_path_segment() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let destination_name = "requested destination/with?#%ü";
+    let (destination_id, pipeline_id) = create_pipeline_with_destination_name(
+        &app,
+        &tenant_id,
+        destination_name,
+        new_ducklake_destination_config(),
+    )
+    .await;
+
+    let response =
+        app.resolve_tenant_runtime_config(&tenant_id, "ducklake", destination_name).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    assert_eq!(response["destination_id"], destination_id);
+    assert_eq!(response["pipeline_id"], pipeline_id);
+    assert_eq!(response["destination_name"], destination_name);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/runtime_config.rs
+++ b/crates/etl-api/tests/runtime_config.rs
@@ -1,0 +1,308 @@
+use etl_api::{
+    configs::destination::{ApiDestinationConfig, ApiIcebergConfig},
+    routes::{destinations::CreateDestinationResponse, pipelines::CreatePipelineResponse},
+};
+use etl_config::{SerializableSecretString, shared::ClickHouseEngine};
+use etl_telemetry::tracing::init_test_tracing;
+use reqwest::StatusCode;
+
+use crate::support::{
+    mocks::{
+        create_default_image,
+        destinations::{
+            new_bigquery_destination_config, new_ducklake_destination_config,
+            new_iceberg_supabase_destination_config, new_snowflake_destination_config,
+        },
+        pipelines::new_pipeline_config,
+        sources::create_source,
+        tenants::create_tenant,
+    },
+    test_app::{TestApp, spawn_test_app},
+};
+
+async fn create_pipeline(
+    app: &TestApp,
+    tenant_id: &str,
+    destination_config: ApiDestinationConfig,
+) -> (i64, i64) {
+    create_pipeline_with_destination_name(app, tenant_id, "Runtime destination", destination_config)
+        .await
+}
+
+async fn create_pipeline_with_destination_name(
+    app: &TestApp,
+    tenant_id: &str,
+    destination_name: &str,
+    destination_config: ApiDestinationConfig,
+) -> (i64, i64) {
+    let source_id = create_source(app, tenant_id).await;
+    create_default_image(app).await;
+
+    let destination = etl_api::routes::destinations::CreateDestinationRequest {
+        name: destination_name.to_owned(),
+        config: destination_config,
+    };
+    let response = app.create_destination(tenant_id, &destination).await;
+    assert!(response.status().is_success());
+    let destination: CreateDestinationResponse =
+        response.json().await.expect("failed to deserialize destination response");
+
+    let pipeline = etl_api::routes::pipelines::CreatePipelineRequest {
+        source_id,
+        destination_id: destination.id,
+        config: new_pipeline_config(),
+    };
+    let response = app.create_pipeline(tenant_id, &pipeline).await;
+    assert!(response.status().is_success());
+    let pipeline: CreatePipelineResponse =
+        response.json().await.expect("failed to deserialize pipeline response");
+
+    (destination.id, pipeline.id)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ducklake_runtime_config_returns_credentials_without_writing_kubernetes() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let (destination_id, pipeline_id) =
+        create_pipeline(&app, &tenant_id, new_ducklake_destination_config()).await;
+
+    let k8s_create_calls = app.k8s_state.create_calls();
+    let response = app.resolve_runtime_config(&tenant_id, destination_id).await;
+
+    assert!(response.status().is_success());
+    assert_eq!(response.headers()["cache-control"], "no-store");
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    assert_eq!(response["tenant_id"], tenant_id);
+    assert_eq!(response["pipeline_id"], pipeline_id);
+    assert_eq!(response["destination_id"], destination_id);
+    assert_eq!(response["destination_name"], "Runtime destination");
+    assert_eq!(response["destination"]["ducklake"]["data_path"], "s3://ducklake/");
+    assert_eq!(
+        response["destination"]["ducklake"]["catalog_url"],
+        "postgres://postgres:postgres@localhost:5432/postgres"
+    );
+    assert_eq!(response["destination"]["ducklake"]["s3_access_key_id"], "access-key-id");
+    assert_eq!(response["destination"]["ducklake"]["s3_secret_access_key"], "secret-access-key");
+    assert!(response["source"].get("password").is_none());
+    assert!(response.get("source_secret").is_none());
+    assert!(response.get("destination_secret").is_none());
+    assert_eq!(app.k8s_state.create_calls(), k8s_create_calls);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bigquery_runtime_config_returns_credentials() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let (destination_id, _) =
+        create_pipeline(&app, &tenant_id, new_bigquery_destination_config()).await;
+
+    let response = app.resolve_runtime_config(&tenant_id, destination_id).await;
+
+    assert!(response.status().is_success());
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    assert_eq!(response["destination"]["big_query"]["project_id"], "project-id");
+    assert_eq!(response["destination"]["big_query"]["service_account_key"], "service-account-key");
+    assert!(response.get("destination_secret").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clickhouse_runtime_config_returns_credentials() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let destination = ApiDestinationConfig::ClickHouse {
+        url: "https://clickhouse.example.com:8443".parse().unwrap(),
+        user: "etl_user".to_owned(),
+        password: Some(SerializableSecretString::from("fake-clickhouse-password".to_owned())),
+        database: "analytics".to_owned(),
+        engine: ClickHouseEngine::default(),
+    };
+    let (destination_id, _) = create_pipeline(&app, &tenant_id, destination).await;
+
+    let response = app.resolve_runtime_config(&tenant_id, destination_id).await;
+
+    assert!(response.status().is_success());
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    assert_eq!(
+        response["destination"]["clickhouse"]["url"],
+        "https://clickhouse.example.com:8443/"
+    );
+    assert_eq!(response["destination"]["clickhouse"]["password"], "fake-clickhouse-password");
+    assert!(response.get("destination_secret").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn iceberg_supabase_runtime_config_returns_credentials() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let (destination_id, _) =
+        create_pipeline(&app, &tenant_id, new_iceberg_supabase_destination_config()).await;
+
+    let response = app.resolve_runtime_config(&tenant_id, destination_id).await;
+
+    assert!(response.status().is_success());
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    let config = &response["destination"]["iceberg"]["supabase"];
+    assert_eq!(config["project_ref"], "abcdefghijklmnopqrst");
+    assert!(config["catalog_token"].as_str().is_some());
+    assert!(config["s3_access_key_id"].as_str().is_some());
+    assert!(config["s3_secret_access_key"].as_str().is_some());
+    assert!(response.get("destination_secret").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn iceberg_rest_runtime_config_returns_credentials() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let destination = ApiDestinationConfig::Iceberg {
+        config: ApiIcebergConfig::Rest {
+            catalog_uri: "https://catalog.example.com".to_owned(),
+            warehouse_name: "analytics".to_owned(),
+            namespace: Some("public".to_owned()),
+            s3_access_key_id: SerializableSecretString::from("fake-rest-access-key".to_owned()),
+            s3_secret_access_key: SerializableSecretString::from("fake-rest-secret-key".to_owned()),
+            s3_endpoint: "https://s3.example.com".to_owned(),
+        },
+    };
+    let (destination_id, _) = create_pipeline(&app, &tenant_id, destination).await;
+
+    let response = app.resolve_runtime_config(&tenant_id, destination_id).await;
+
+    assert!(response.status().is_success());
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    let config = &response["destination"]["iceberg"]["rest"];
+    assert_eq!(config["catalog_uri"], "https://catalog.example.com");
+    assert_eq!(config["s3_access_key_id"], "fake-rest-access-key");
+    assert_eq!(config["s3_secret_access_key"], "fake-rest-secret-key");
+    assert!(response.get("source_secret").is_none());
+    assert!(response.get("destination_secret").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn snowflake_runtime_config_returns_credentials() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let (destination_id, _) =
+        create_pipeline(&app, &tenant_id, new_snowflake_destination_config()).await;
+
+    let response = app.resolve_runtime_config(&tenant_id, destination_id).await;
+
+    assert!(response.status().is_success());
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    let config = &response["destination"]["snowflake"];
+    assert_eq!(config["account_id"], "myorg-myaccount");
+    assert!(config["private_key"].as_str().is_some());
+    assert!(config.get("private_key_passphrase").is_none());
+    assert!(response.get("destination_secret").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn runtime_config_is_not_exposed_on_the_public_listener() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+
+    let response = app
+        .api_client
+        .post(format!("{}/v1/internal/destinations/1/runtime-config/resolve", app.address))
+        .bearer_auth(&app.api_key)
+        .header("tenant_id", "abcdefghijklmnopqrst")
+        .send()
+        .await
+        .expect("failed to execute request");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn runtime_config_requires_existing_api_authentication() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+
+    let response = app
+        .api_client
+        .post(format!("{}/v1/internal/destinations/1/runtime-config/resolve", app.internal_address))
+        .header("tenant_id", "abcdefghijklmnopqrst")
+        .send()
+        .await
+        .expect("failed to execute request");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn runtime_config_returns_not_found_for_an_unknown_destination() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+
+    let response = app.resolve_runtime_config(&tenant_id, i64::MAX).await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tenant_runtime_config_resolves_a_destination_matching_the_requested_selector() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    let (destination_id, pipeline_id) = create_pipeline_with_destination_name(
+        &app,
+        &tenant_id,
+        "requested_destination",
+        new_ducklake_destination_config(),
+    )
+    .await;
+
+    let response =
+        app.resolve_tenant_runtime_config(&tenant_id, "ducklake", "requested_destination").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response: serde_json::Value =
+        response.json().await.expect("failed to deserialize runtime config response");
+    assert_eq!(response["destination_id"], destination_id);
+    assert_eq!(response["pipeline_id"], pipeline_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tenant_runtime_config_does_not_select_a_differently_named_ducklake_destination() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    create_pipeline(&app, &tenant_id, new_ducklake_destination_config()).await;
+
+    let response =
+        app.resolve_tenant_runtime_config(&tenant_id, "ducklake", "requested_destination").await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tenant_runtime_config_does_not_select_a_different_destination_kind() {
+    init_test_tracing();
+    let app = spawn_test_app().await;
+    let tenant_id = create_tenant(&app).await;
+    create_pipeline_with_destination_name(
+        &app,
+        &tenant_id,
+        "requested_destination",
+        new_bigquery_destination_config(),
+    )
+    .await;
+
+    let response =
+        app.resolve_tenant_runtime_config(&tenant_id, "ducklake", "requested_destination").await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -294,8 +294,8 @@ impl TestApp {
         tenant_id: &str,
         destination_id: i64,
     ) -> reqwest::Response {
-        self.post_authenticated(format!(
-            "{}/v1/internal/destinations/{destination_id}/runtime-config/resolve",
+        self.get_authenticated(format!(
+            "{}/v1/internal/destinations/{destination_id}/config",
             &self.internal_address
         ))
         .header("tenant_id", tenant_id)
@@ -310,18 +310,24 @@ impl TestApp {
         destination_kind: &str,
         destination_name: &str,
     ) -> reqwest::Response {
-        self.post_authenticated(format!(
-            "{}/v1/internal/runtime-config/resolve",
-            &self.internal_address
-        ))
-        .header("tenant_id", tenant_id)
-        .json(&serde_json::json!({
-            "destination_kind": destination_kind,
-            "destination_name": destination_name,
-        }))
-        .send()
-        .await
-        .expect("failed to execute request")
+        let mut url = reqwest::Url::parse(&self.internal_address)
+            .expect("internal test application address should be a valid URL");
+        url.path_segments_mut()
+            .expect("internal test application address should be a base URL")
+            .extend([
+                "v1",
+                "internal",
+                "destinations",
+                destination_kind,
+                destination_name,
+                "config",
+            ]);
+
+        self.get_authenticated(url)
+            .header("tenant_id", tenant_id)
+            .send()
+            .await
+            .expect("failed to execute request")
     }
 
     pub(crate) async fn create_pipeline(

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -29,7 +29,7 @@ use etl_api::{
         tenants::{CreateOrUpdateTenantRequest, CreateTenantRequest, UpdateTenantRequest},
         tenants_sources::CreateTenantSourceRequest,
     },
-    startup::run,
+    startup::{ApplicationListeners, run},
 };
 use etl_config::{
     Environment,
@@ -49,6 +49,7 @@ use crate::support::{
 
 pub(crate) struct TestApp {
     pub address: String,
+    pub internal_address: String,
     pub api_client: reqwest::Client,
     pub api_key: String,
     config: ApiConfig,
@@ -286,6 +287,41 @@ impl TestApp {
             .send()
             .await
             .expect("failed to execute request")
+    }
+
+    pub(crate) async fn resolve_runtime_config(
+        &self,
+        tenant_id: &str,
+        destination_id: i64,
+    ) -> reqwest::Response {
+        self.post_authenticated(format!(
+            "{}/v1/internal/destinations/{destination_id}/runtime-config/resolve",
+            &self.internal_address
+        ))
+        .header("tenant_id", tenant_id)
+        .send()
+        .await
+        .expect("failed to execute request")
+    }
+
+    pub(crate) async fn resolve_tenant_runtime_config(
+        &self,
+        tenant_id: &str,
+        destination_kind: &str,
+        destination_name: &str,
+    ) -> reqwest::Response {
+        self.post_authenticated(format!(
+            "{}/v1/internal/runtime-config/resolve",
+            &self.internal_address
+        ))
+        .header("tenant_id", tenant_id)
+        .json(&serde_json::json!({
+            "destination_kind": destination_kind,
+            "destination_name": destination_name,
+        }))
+        .send()
+        .await
+        .expect("failed to execute request")
     }
 
     pub(crate) async fn create_pipeline(
@@ -609,6 +645,9 @@ async fn spawn_test_app_with_services(
     let listener =
         TcpListener::bind(format!("{base_address}:0")).expect("failed to bind random port");
     let port = listener.local_addr().unwrap().port();
+    let internal_listener =
+        TcpListener::bind(format!("{base_address}:0")).expect("failed to bind random port");
+    let internal_port = internal_listener.local_addr().unwrap().port();
 
     let database_config = get_test_db_config();
     let api_db_pool = create_etl_api_database(&database_config).await;
@@ -627,7 +666,12 @@ async fn spawn_test_app_with_services(
 
     let config = ApiConfig {
         database: database_config,
-        application: ApplicationSettings { host: base_address.to_owned(), port },
+        application: ApplicationSettings {
+            host: base_address.to_owned(),
+            port,
+            internal_port,
+            internal_tls: None,
+        },
         k8s: K8sConfig {
             replicator_namespace: "etl-data-plane".to_owned(),
             replicator_service_account_name: "etl-replicator".to_owned(),
@@ -666,7 +710,7 @@ async fn spawn_test_app_with_services(
 
     let server = run(
         config.clone(),
-        listener,
+        ApplicationListeners { public: listener, internal: internal_listener },
         api_db_pool,
         encryption_keyring,
         k8s_client,
@@ -677,6 +721,7 @@ async fn spawn_test_app_with_services(
 
     TestApp {
         address: format!("http://{base_address}:{port}"),
+        internal_address: format!("http://{base_address}:{internal_port}"),
         api_client: reqwest::Client::new(),
         api_key,
         config,


### PR DESCRIPTION
This PR adds support for internal endpoints, only exposed when TLS is enabled, so only reachable through TLS. These 2 internals endpoints will expose runtime config including destination config with credentials