### PR TITLE
fix(snowflake): disable automatic schema evolution

### DIFF
--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -341,21 +341,44 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         }
     }
 
-    /// Ensure the table exists in Snowflake and is ready to receive data.
-    ///
-    /// Returns `true` when streaming was newly set up for this table in the
-    /// current process (the Snowflake table itself may have already existed).
-    #[allow(clippy::map_entry)]
-    pub async fn ensure_table(
+    /// Returns whether this process already has an open channel for `table_id`.
+    pub(super) async fn has_channel(&self, table_id: TableId) -> bool {
+        self.channels.read().await.contains_key(&table_id)
+    }
+
+    /// Creates a table when needed and prepares it for initial-copy writes.
+    pub(super) async fn initialize_table(
         &self,
         table_id: TableId,
         table_name: &str,
         columns: &[ColumnSchema],
-    ) -> Result<bool> {
+    ) -> Result<()> {
+        self.prepare_channel(table_id, table_name, columns, true).await
+    }
+
+    /// Opens and validates an existing table for streaming writes.
+    pub(super) async fn prepare_existing_table(
+        &self,
+        table_id: TableId,
+        table_name: &str,
+        columns: &[ColumnSchema],
+    ) -> Result<()> {
+        self.prepare_channel(table_id, table_name, columns, false).await
+    }
+
+    /// Prepares one table and caches its validated channel.
+    #[allow(clippy::map_entry)]
+    async fn prepare_channel(
+        &self,
+        table_id: TableId,
+        table_name: &str,
+        columns: &[ColumnSchema],
+        create_if_missing: bool,
+    ) -> Result<()> {
         // Fast path: read lock, check if already set up.
         let channels = self.channels.read().await;
         if channels.contains_key(&table_id) {
-            return Ok(false);
+            return Ok(());
         }
         drop(channels);
 
@@ -364,13 +387,15 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         // during startup is acceptable.
         let mut channels = self.channels.write().await;
         if channels.contains_key(&table_id) {
-            return Ok(false);
+            return Ok(());
         }
 
-        // Create Snowflake table.
         schema::validate_no_cdc_collisions(columns)?;
-        let column_defs = schema::build_column_defs(columns);
-        self.sql_client.create_table_if_not_exists(table_name, &column_defs).await?;
+        if create_if_missing {
+            let column_defs = schema::build_column_defs(columns);
+            self.sql_client.create_table_if_not_exists(table_name, &column_defs).await?;
+        }
+        self.validate_table(table_name, columns).await?;
 
         // Obtain table channel.
         let mut handle = ChannelHandle::new(
@@ -384,7 +409,20 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
 
         // Persist table-channel mapping.
         channels.insert(table_id, Arc::new(Mutex::new(handle)));
-        Ok(true)
+        Ok(())
+    }
+
+    /// Validates a table before opening or reopening its streaming channel.
+    ///
+    /// Physical validation intentionally runs only at channel lifecycle
+    /// boundaries, not during ordinary writes.
+    async fn validate_table(&self, table_name: &str, columns: &[ColumnSchema]) -> Result<()> {
+        let expected_column_names = columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .chain([schema::CDC_OPERATION_COLUMN, schema::CDC_SEQUENCE_COLUMN])
+            .collect::<Vec<_>>();
+        self.sql_client.validate_table_schema(table_name, &expected_column_names).await
     }
 
     /// Apply column additions, renames, updates, and removals from a schema
@@ -493,7 +531,6 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
     pub async fn truncate_table(
         &self,
         table_id: TableId,
-        table_name: &str,
         truncate_offset: &OffsetToken,
     ) -> Result<()> {
         loop {
@@ -507,6 +544,8 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
                 drop(guard);
                 continue;
             }
+
+            let table_name = guard.table_name().to_owned();
 
             // Open at the truncate offset before clearing the table. This waits for
             // any in-flight rowset to commit and invalidates the previous owner's
@@ -522,13 +561,13 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
                 table_id,
                 database: &self.database,
                 schema: &self.schema,
-                table: table_name,
+                table: &table_name,
                 truncate_offset,
                 channel_created_on_ms,
                 rows_inserted: status.rows_inserted,
             }
             .request_id();
-            self.sql_client.truncate_table(table_name, request_id).await?;
+            self.sql_client.truncate_table(&table_name, request_id).await?;
 
             // TRUNCATE may invalidate that token, so reopen at the same offset before
             // allowing another sender to acquire the channel lock.
@@ -587,18 +626,20 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         self.sql_client.drop_table(&table_name).await
     }
 
-    /// Refresh the table's ingestion state after a schema change.
+    /// Validates and refreshes the table's ingestion state after a schema
+    /// change.
     ///
-    /// Channels must be reopened after ALTER TABLE so Snowpipe picks up the
-    /// new column list. Without this, inserts would fail (and fall back to
-    /// the auto-recovery path in `accept_streaming_batches`, so after one error
-    /// round-trip data would still be pushed, but we can avoid that extra
-    /// trip).
+    /// Channels are reopened after ALTER TABLE so Snowpipe picks up the new
+    /// column list.
     ///
     /// Ref: <https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-classic-recommendation>
-    pub async fn refresh_table(&self, table_id: &TableId) -> Result<()> {
+    pub async fn refresh_table(&self, table_id: &TableId, columns: &[ColumnSchema]) -> Result<()> {
         self.wait_for_pending_durability().await?;
-        self.get_channel(*table_id).await?.lock().await.open().await.map(|_| ())
+        let channel = self.get_channel(*table_id).await?;
+        let mut channel = channel.lock().await;
+        let table_name = channel.table_name().to_owned();
+        self.validate_table(&table_name, columns).await?;
+        channel.open().await.map(|_| ())
     }
 
     /// Send table-copy row batches and retain their pending durability target.

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -83,8 +83,8 @@ impl TableInitializer {
         Self { gates: Arc::new(Mutex::new(HashMap::new())) }
     }
 
-    /// Ensures the Snowflake table, channel, and durable metadata exist.
-    async fn ensure<S, T, C>(
+    /// Initializes the Snowflake table, channel, and durable metadata for copy.
+    async fn initialize<S, T, C>(
         &self,
         client: &Client<T, C>,
         store: &S,
@@ -101,12 +101,13 @@ impl TableInitializer {
 
         // Applied metadata needs no transition coordination, but this process
         // may still need to reopen its local channel state.
-        if store
-            .get_destination_table_metadata(table_id)
-            .await?
-            .is_some_and(|metadata| metadata.is_applied())
+        if let Some(metadata) = store.get_destination_table_metadata(table_id).await?
+            && metadata.is_applied()
         {
-            client.ensure_table(table_id, &table_name, &columns).await.map_err(EtlError::from)?;
+            client
+                .prepare_existing_table(table_id, &metadata.destination_table_id, &columns)
+                .await
+                .map_err(EtlError::from)?;
             return Ok(());
         }
 
@@ -140,7 +141,11 @@ impl TableInitializer {
             }
             Some(metadata) if metadata.is_applied() => {
                 // Another copy partition completed setup while this caller waited.
-                None
+                client
+                    .prepare_existing_table(table_id, &metadata.destination_table_id, &columns)
+                    .await
+                    .map_err(EtlError::from)?;
+                return Ok(());
             }
             Some(metadata) if metadata.previous_snapshot_id.is_none() => {
                 // Resume a matching initial setup left by an earlier failure or
@@ -177,7 +182,7 @@ impl TableInitializer {
         };
 
         // Remote setup is retry-safe and remains inside the per-table permit.
-        client.ensure_table(table_id, &table_name, &columns).await.map_err(EtlError::from)?;
+        client.initialize_table(table_id, &table_name, &columns).await.map_err(EtlError::from)?;
 
         // Publish completion only after both the table and channel exist.
         if let Some(metadata) = applying_metadata {
@@ -264,12 +269,57 @@ where
     T: TokenProvider + 'static,
     C: StreamClient,
 {
-    /// Ensures the Snowflake table and streaming channel exist for this table.
-    async fn prepare_table_for_streaming(
-        &self,
-        table_schema: &ReplicatedTableSchema,
-    ) -> EtlResult<()> {
-        self.table_initializer.ensure(&self.client, &self.store, table_schema).await
+    /// Initializes a Snowflake table and channel for initial-copy writes.
+    async fn initialize_table(&self, table_schema: &ReplicatedTableSchema) -> EtlResult<()> {
+        self.table_initializer.initialize(&self.client, &self.store, table_schema).await
+    }
+
+    /// Loads the durable applied schema and prepares its existing table for
+    /// events.
+    async fn prepare_table(&self, table_id: TableId) -> EtlResult<()> {
+        // Check durable state before the warm-channel fast path so an interrupted
+        // schema change continues to block DML.
+        let metadata =
+            self.store.get_applied_destination_table_metadata(table_id).await?.ok_or_else(
+                || {
+                    etl_error!(
+                        ErrorKind::CorruptedTableSchema,
+                        "Destination metadata missing for Snowflake streaming table",
+                        format!(
+                            "Table {table_id} received a streaming event before initial copy \
+                             created applied destination metadata."
+                        )
+                    )
+                },
+            )?;
+
+        if self.client.has_channel(table_id).await {
+            return Ok(());
+        }
+
+        let table_schema =
+            self.store.get_table_schema(&table_id, metadata.snapshot_id).await?.ok_or_else(
+                || {
+                    etl_error!(
+                        ErrorKind::MissingTableSchema,
+                        "Stored schema snapshot missing for Snowflake streaming table",
+                        format!(
+                            "Table {table_id} needs stored schema snapshot {} to prepare the \
+                             destination channel.",
+                            metadata.snapshot_id
+                        )
+                    )
+                },
+            )?;
+        let replicated_schema =
+            ReplicatedTableSchema::from_mask(table_schema, metadata.replication_mask.clone());
+        let columns: Vec<_> = replicated_schema.column_schemas().cloned().collect();
+        self.client
+            .prepare_existing_table(table_id, &metadata.destination_table_id, &columns)
+            .await
+            .map_err(EtlError::from)?;
+
+        Ok(())
     }
 
     /// Processes an event batch after its task was admitted into [`TaskSet`].
@@ -352,12 +402,8 @@ where
         let had_truncates = !operations.is_empty();
 
         for (schema, offset) in operations {
-            self.prepare_table_for_streaming(&schema).await?;
-            let table_name = try_stringify_table_name(schema.name())?.to_uppercase();
-            self.client
-                .truncate_table(schema.id(), &table_name, &offset)
-                .await
-                .map_err(EtlError::from)?;
+            self.prepare_table(schema.id()).await?;
+            self.client.truncate_table(schema.id(), &offset).await.map_err(EtlError::from)?;
         }
 
         Ok(had_truncates)
@@ -466,7 +512,7 @@ where
     ) -> EtlResult<()> {
         #[allow(clippy::map_entry)]
         if !column_cache.contains_key(&table_id) {
-            self.prepare_table_for_streaming(table_schema).await?;
+            self.prepare_table(table_id).await?;
             let cols: Vec<_> = table_schema.column_schemas().cloned().collect();
             column_cache.insert(table_id, cols);
         }
@@ -515,6 +561,9 @@ where
             "schema change detected: snapshot_id {current_snapshot_id} -> {new_snapshot_id}"
         );
 
+        let target_columns: Vec<_> = new_schema.column_schemas().cloned().collect();
+        schema::validate_no_cdc_collisions(&target_columns).map_err(EtlError::from)?;
+
         let current_table_schema = self
             .store
             .get_table_schema(&table_id, current_snapshot_id)
@@ -534,8 +583,13 @@ where
             current_table_schema,
             current_replication_mask.clone(),
         );
+        let current_columns: Vec<_> = current_schema.column_schemas().cloned().collect();
+        let table_name = metadata.destination_table_id.clone();
+        self.client
+            .prepare_existing_table(table_id, &table_name, &current_columns)
+            .await
+            .map_err(EtlError::from)?;
 
-        let table_name = try_stringify_table_name(new_schema.name())?.to_uppercase();
         self.client.wait_for_pending_durability().await.map_err(EtlError::from)?;
 
         let updated_metadata = DestinationTableMetadata::new_applied(
@@ -562,13 +616,10 @@ where
             return Err(err);
         }
 
+        self.client.refresh_table(&table_id, &target_columns).await.map_err(EtlError::from)?;
         self.store
             .store_destination_table_metadata(table_id, updated_metadata.to_applied())
             .await?;
-
-        let new_columns: Vec<_> = new_schema.column_schemas().cloned().collect();
-        schema::validate_no_cdc_collisions(&new_columns).map_err(EtlError::from)?;
-        self.client.refresh_table(&table_id).await.map_err(EtlError::from)?;
 
         info!(table_id = ?table_id, "schema change applied");
         Ok(true)
@@ -685,7 +736,7 @@ where
     ) -> EtlResult<()> {
         let result: EtlResult<DestinationWriteStatus> = async {
             // Table must exist even for empty snapshots, CDC events may arrive later.
-            self.writer.prepare_table_for_streaming(replicated_table_schema).await?;
+            self.writer.initialize_table(replicated_table_schema).await?;
 
             if table_rows.is_empty() {
                 self.writer
@@ -880,7 +931,7 @@ mod tests {
         ));
         let schema = ReplicatedTableSchema::all(table_schema);
 
-        let error = destination.writer.prepare_table_for_streaming(&schema).await.unwrap_err();
+        let error = destination.writer.initialize_table(&schema).await.unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::ConfigError);
         let metadata = store

--- a/crates/etl-destinations/src/snowflake/encoding.rs
+++ b/crates/etl-destinations/src/snowflake/encoding.rs
@@ -59,12 +59,17 @@ pub(crate) fn serialize_row(
     row: &TableRow,
     cdc: CdcMeta<'_>,
 ) -> Result<()> {
-    let serializable = RowSerializer {
-        cols,
-        cells: row.values(),
-        operation: cdc.operation.as_str(),
-        sequence: cdc.sequence,
-    };
+    let cells = row.values();
+    if cells.len() != cols.len() {
+        return Err(Error::Encoding(format!(
+            "Row value count ({}) does not match column count ({}).",
+            cells.len(),
+            cols.len()
+        )));
+    }
+
+    let serializable =
+        RowSerializer { cols, cells, operation: cdc.operation.as_str(), sequence: cdc.sequence };
     serde_json::to_writer(&mut *writer, &serializable)
         .map_err(|e| Error::Encoding(e.to_string()))?;
     writer.write_all(b"\n").map_err(|e| Error::Encoding(e.to_string()))?;

--- a/crates/etl-destinations/src/snowflake/error.rs
+++ b/crates/etl-destinations/src/snowflake/error.rs
@@ -28,6 +28,12 @@ pub enum Error {
     #[error("Configuration error: {0}")]
     Config(String),
 
+    #[error("Snowflake table '{table_name}' is missing column '{column_name}'")]
+    MissingTableColumn { table_name: String, column_name: String },
+
+    #[error("Snowflake table '{table_name}' has unexpected column '{column_name}'")]
+    UnexpectedTableColumn { table_name: String, column_name: String },
+
     #[error("database '{0}' not found")]
     DatabaseNotFound(String),
 
@@ -88,15 +94,25 @@ impl Error {
             Self::Snowpipe(SnowpipeError::ApiStatus { .. }) => AppendFailureType::SnowpipeApi,
             Self::Snowpipe(SnowpipeError::HttpStatus { .. }) => AppendFailureType::Provider,
             Self::Encoding(_) => AppendFailureType::Encoding,
-            Self::Config(_) | Self::DatabaseNotFound(_) | Self::SchemaNotFound { .. } => {
-                AppendFailureType::Configuration
-            }
+            Self::Config(_)
+            | Self::MissingTableColumn { .. }
+            | Self::UnexpectedTableColumn { .. }
+            | Self::DatabaseNotFound(_)
+            | Self::SchemaNotFound { .. } => AppendFailureType::Configuration,
         }
     }
 }
 
 impl From<Error> for EtlError {
     fn from(err: Error) -> Self {
+        if matches!(&err, Error::MissingTableColumn { .. } | Error::UnexpectedTableColumn { .. }) {
+            return etl::etl_error!(
+                ErrorKind::CorruptedTableSchema,
+                "Snowflake table schema is incompatible",
+                source: err
+            );
+        }
+
         let (kind, description) = match &err {
             Error::HttpTransport(_) => {
                 (ErrorKind::DestinationError, "Snowflake HTTP transport error")
@@ -111,6 +127,9 @@ impl From<Error> for EtlError {
             Error::Channel(_) => (ErrorKind::DestinationError, "Snowflake channel error"),
             Error::Encoding(_) => (ErrorKind::InvalidData, "Snowflake encoding error"),
             Error::Config(_) => (ErrorKind::ConfigError, "Snowflake configuration error"),
+            Error::MissingTableColumn { .. } | Error::UnexpectedTableColumn { .. } => {
+                unreachable!("schema errors return above")
+            }
             Error::DatabaseNotFound(_) => (ErrorKind::ConfigError, "Snowflake database not found"),
             Error::SchemaNotFound { .. } => (ErrorKind::ConfigError, "Snowflake schema not found"),
         };
@@ -211,7 +230,23 @@ struct SnowpipeErrorResponse {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
+
+    #[test]
+    fn table_schema_error_is_preserved() {
+        let error = Error::MissingTableColumn {
+            table_name: "events".to_owned(),
+            column_name: "id".to_owned(),
+        };
+
+        let error = EtlError::from(error);
+        let source = error.source().expect("Snowflake error should be preserved");
+
+        assert_eq!(error.kind(), ErrorKind::CorruptedTableSchema);
+        assert_eq!(source.to_string(), "Snowflake table 'events' is missing column 'id'");
+    }
 
     #[test]
     fn response_errors_are_classified_by_stable_protocol_signals() {

--- a/crates/etl-destinations/src/snowflake/schema.rs
+++ b/crates/etl-destinations/src/snowflake/schema.rs
@@ -246,7 +246,7 @@ mod tests {
             (&Type::JSONB, "VARIANT"),
             (&Type::OID, "BIGINT"),
             (&Type::BYTEA, "VARCHAR"),
-            // Arrays all map to VARIANT
+            // Arrays all map to ARRAY.
             (&Type::BOOL_ARRAY, "ARRAY"),
             (&Type::INT4_ARRAY, "ARRAY"),
             (&Type::TEXT_ARRAY, "ARRAY"),

--- a/crates/etl-destinations/src/snowflake/sql_client.rs
+++ b/crates/etl-destinations/src/snowflake/sql_client.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -62,6 +62,28 @@ pub(crate) struct StatementResponse {
     pub(crate) message: Option<String>,
     #[serde(default)]
     pub(crate) data: Option<Vec<Vec<serde_json::Value>>>,
+    /// Names and positions for values in each result row.
+    #[serde(default)]
+    result_set_meta_data: Option<ResultSetMetadata>,
+}
+
+/// Column metadata returned with a Snowflake SQL result set.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResultSetMetadata {
+    /// Total rows across every result partition.
+    #[serde(default)]
+    num_rows: Option<u64>,
+    /// Result columns in row order.
+    #[serde(default)]
+    row_type: Vec<ResultColumnMetadata>,
+}
+
+/// One named Snowflake SQL result column.
+#[derive(Debug, Deserialize)]
+struct ResultColumnMetadata {
+    /// Column name supplied by Snowflake.
+    name: String,
 }
 
 impl<T: TokenProvider> SqlClient<T> {
@@ -80,7 +102,8 @@ impl<T: TokenProvider> SqlClient<T> {
         Ok(())
     }
 
-    /// Create a table with the given columns, enabling schema evolution.
+    /// Create a table with the given columns and provider-driven evolution
+    /// disabled.
     pub async fn create_table_if_not_exists(
         &self,
         table_name: &str,
@@ -88,9 +111,23 @@ impl<T: TokenProvider> SqlClient<T> {
     ) -> Result<()> {
         let fqn = self.fully_qualified_name(table_name);
         let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {fqn} ({column_defs}) ENABLE_SCHEMA_EVOLUTION = TRUE"
+            "CREATE TABLE IF NOT EXISTS {fqn} ({column_defs}) ENABLE_SCHEMA_EVOLUTION = FALSE"
         );
         self.execute_ddl(&sql).await
+    }
+
+    /// Validates a table's write schema.
+    pub(crate) async fn validate_table_schema(
+        &self,
+        table_name: &str,
+        expected_column_names: &[&str],
+    ) -> Result<()> {
+        let fqn = self.fully_qualified_name(table_name);
+        let columns_response =
+            self.execute_statement(&format!("SHOW COLUMNS IN TABLE {fqn}")).await?;
+        let columns = parse_show_columns(&columns_response)?;
+
+        validate_column_names(table_name, expected_column_names, &columns)
     }
 
     /// Remove all rows from a table without dropping it.
@@ -359,6 +396,89 @@ impl<T: TokenProvider> SqlClient<T> {
     }
 }
 
+/// Parse exact column identifiers from `SHOW COLUMNS`.
+fn parse_show_columns(response: &StatementResponse) -> Result<Vec<&str>> {
+    fn malformed_show_response(response: &StatementResponse, message: String) -> Error {
+        Error::Sql { statement_handle: response.statement_handle.clone(), message }
+    }
+
+    let metadata = response.result_set_meta_data.as_ref().ok_or_else(|| {
+        malformed_show_response(response, "SHOW COLUMNS omitted result metadata".to_owned())
+    })?;
+    let column_name_index = metadata
+        .row_type
+        .iter()
+        .position(|column| column.name.eq_ignore_ascii_case("column_name"))
+        .ok_or_else(|| {
+            malformed_show_response(
+                response,
+                "SHOW COLUMNS result metadata omitted column 'column_name'".to_owned(),
+            )
+        })?;
+    let num_rows = metadata.num_rows.ok_or_else(|| {
+        malformed_show_response(response, "SHOW COLUMNS result metadata omitted numRows".to_owned())
+    })?;
+    let rows = response.data.as_deref().ok_or_else(|| {
+        malformed_show_response(response, "SHOW COLUMNS omitted result data".to_owned())
+    })?;
+    let actual_rows = u64::try_from(rows.len()).map_err(|_| {
+        malformed_show_response(response, "SHOW COLUMNS result row count overflowed".to_owned())
+    })?;
+
+    // Exact validation must not treat the first result partition as the whole
+    // table.
+    if actual_rows != num_rows {
+        return Err(malformed_show_response(
+            response,
+            format!(
+                "SHOW COLUMNS returned {actual_rows} rows, but metadata declared {num_rows} total \
+                 rows"
+            ),
+        ));
+    }
+
+    let mut columns = Vec::with_capacity(rows.len());
+
+    for (row_index, row) in rows.iter().enumerate() {
+        let column_name =
+            row.get(column_name_index).and_then(serde_json::Value::as_str).ok_or_else(|| {
+                malformed_show_response(
+                    response,
+                    format!("SHOW COLUMNS row {row_index} has no string column_name"),
+                )
+            })?;
+        columns.push(column_name);
+    }
+
+    Ok(columns)
+}
+
+/// Validates exact column names without relying on column order.
+fn validate_column_names(
+    table_name: &str,
+    expected_column_names: &[&str],
+    actual_column_names: &[&str],
+) -> Result<()> {
+    let expected_column_names = expected_column_names.iter().copied().collect::<BTreeSet<_>>();
+    let actual_column_names = actual_column_names.iter().copied().collect::<BTreeSet<_>>();
+
+    if let Some(column_name) = expected_column_names.difference(&actual_column_names).next() {
+        return Err(Error::MissingTableColumn {
+            table_name: table_name.to_owned(),
+            column_name: (*column_name).to_owned(),
+        });
+    }
+
+    if let Some(column_name) = actual_column_names.difference(&expected_column_names).next() {
+        return Err(Error::UnexpectedTableColumn {
+            table_name: table_name.to_owned(),
+            column_name: (*column_name).to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
 fn classify_for_retry(error: &Error) -> RetryDecision {
     match error {
         Error::HttpTransport(_) => RetryDecision::Retry,
@@ -396,6 +516,108 @@ mod tests {
         let config = Config::new("example-account", "test-user", "test-db", "test-schema")
             .expect("test configuration should be valid");
         SqlClient::new(config, Arc::new(TestTokenProvider), Client::new())
+    }
+
+    /// Build a resolved statement response with named result columns.
+    fn statement_response(
+        column_names: &[&str],
+        data: Vec<Vec<serde_json::Value>>,
+    ) -> StatementResponse {
+        let row_count = u64::try_from(data.len()).expect("test result row count should fit in u64");
+        StatementResponse {
+            statement_handle: Some("test-statement".to_owned()),
+            message: None,
+            data: Some(data),
+            result_set_meta_data: Some(ResultSetMetadata {
+                num_rows: Some(row_count),
+                row_type: column_names
+                    .iter()
+                    .map(|name| ResultColumnMetadata { name: (*name).to_owned() })
+                    .collect(),
+            }),
+        }
+    }
+
+    #[test]
+    fn parses_show_columns_by_result_metadata_name() {
+        let response = statement_response(
+            &["ignored", "column_name"],
+            vec![vec![serde_json::Value::Null, serde_json::Value::String("id".to_owned())]],
+        );
+
+        let columns = parse_show_columns(&response).expect("SHOW COLUMNS should parse");
+
+        assert_eq!(columns, vec!["id"]);
+    }
+
+    #[test]
+    fn table_column_validation_is_order_independent() {
+        let expected = ["id", "_cdc_operation", "_cdc_sequence_number"];
+        let actual = ["_cdc_sequence_number", "id", "_cdc_operation"];
+
+        validate_column_names("events", &expected, &actual)
+            .expect("physical column order should not affect compatibility");
+    }
+
+    #[test]
+    fn table_column_validation_rejects_contract_mismatches() {
+        let expected = ["id", "_cdc_operation", "_cdc_sequence_number"];
+
+        let missing = ["_cdc_operation", "_cdc_sequence_number"];
+        assert!(matches!(
+            validate_column_names("events", &expected, &missing),
+            Err(Error::MissingTableColumn { table_name, column_name })
+                if table_name == "events" && column_name == "id"
+        ));
+
+        let unexpected = ["id", "_cdc_operation", "_cdc_sequence_number", "extra"];
+        assert!(matches!(
+            validate_column_names("events", &expected, &unexpected),
+            Err(Error::UnexpectedTableColumn { table_name, column_name })
+                if table_name == "events" && column_name == "extra"
+        ));
+
+        let differently_cased = ["ID", "_cdc_operation", "_cdc_sequence_number"];
+        assert!(matches!(
+            validate_column_names("events", &expected, &differently_cased),
+            Err(Error::MissingTableColumn { table_name, column_name })
+                if table_name == "events" && column_name == "id"
+        ));
+    }
+
+    #[test]
+    fn malformed_show_metadata_is_a_structural_sql_error() {
+        let response = statement_response(&["ignored"], vec![vec![serde_json::Value::Null]]);
+
+        let error = parse_show_columns(&response).expect_err("column_name metadata is required");
+
+        assert!(matches!(
+            error,
+            Error::Sql {
+                statement_handle: Some(handle),
+                message,
+            } if handle == "test-statement"
+                && message == "SHOW COLUMNS result metadata omitted column 'column_name'"
+        ));
+    }
+
+    #[test]
+    fn incomplete_show_result_fails_closed() {
+        let mut response = statement_response(
+            &["column_name"],
+            vec![vec![serde_json::Value::String("id".to_owned())]],
+        );
+        let metadata =
+            response.result_set_meta_data.as_mut().expect("test response should contain metadata");
+        metadata.num_rows = Some(2);
+
+        let error = parse_show_columns(&response).expect_err("incomplete SHOW must fail closed");
+
+        assert!(matches!(
+            error,
+            Error::Sql { message, .. }
+                if message == "SHOW COLUMNS returned 1 rows, but metadata declared 2 total rows"
+        ));
     }
 
     #[test]

--- a/crates/etl-destinations/src/snowflake/streaming/batch.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/batch.rs
@@ -354,6 +354,44 @@ mod tests {
     }
 
     #[test]
+    fn row_column_count_mismatch_rejected() {
+        let cols = [col("id"), col("name")];
+        let cases = [
+            (TableRow::new(vec![Cell::I32(1)]), 1),
+            (
+                TableRow::new(vec![
+                    Cell::I32(1),
+                    Cell::String("Alice".into()),
+                    Cell::String("extra".into()),
+                ]),
+                3,
+            ),
+        ];
+
+        for (row, row_value_count) in cases {
+            let mut builder = RowBatchBuilder::new();
+            let err = builder
+                .push_row(
+                    &cols,
+                    &row,
+                    CdcMeta::new(CdcOperation::Insert, "0"),
+                    &OffsetToken::zero(),
+                )
+                .unwrap_err();
+
+            assert!(matches!(
+                err,
+                Error::Encoding(message)
+                    if message
+                        == format!(
+                            "Row value count ({row_value_count}) does not match column count (2)."
+                        )
+            ));
+            assert!(builder.finish().unwrap().is_empty());
+        }
+    }
+
+    #[test]
     fn end_offset_tracks_last_row() {
         let cols = [col("id")];
         let mut builder = RowBatchBuilder::new();

--- a/crates/etl-destinations/src/snowflake/streaming/channel.rs
+++ b/crates/etl-destinations/src/snowflake/streaming/channel.rs
@@ -408,6 +408,11 @@ impl<C: StreamClient> ChannelHandle<C> {
         }
     }
 
+    /// Returns the Snowflake table owned by this channel.
+    pub(in crate::snowflake) fn table_name(&self) -> &str {
+        &self.table
+    }
+
     /// Opens or reopens the channel while preserving Snowflake's stored offset.
     ///
     /// Opening fences older continuation tokens. If rows are still in flight,

--- a/crates/etl-destinations/tests/snowflake/destination.rs
+++ b/crates/etl-destinations/tests/snowflake/destination.rs
@@ -95,6 +95,17 @@ async fn write_table_copy_and_wait(
     assert_eq!(barrier, DestinationWriteStatus::Durable);
 }
 
+/// Initializes an empty table through the initial-copy path.
+async fn initialize_empty_table(
+    destination: &SnowflakeTestDestination,
+    schema: &ReplicatedTableSchema,
+) {
+    let status = invoke_write_table_rows(destination, schema, vec![])
+        .await
+        .expect("empty table-copy initialization failed");
+    assert_eq!(status, DestinationWriteStatus::Durable);
+}
+
 async fn poll_and_query_rows(
     destination: &SnowflakeTestDestination,
     harness: &TestHarness,
@@ -402,6 +413,8 @@ async fn write_events_insert_update_delete() {
     // Send Insert, Update (Full), Delete (Full) events.
     // Poll and verify 3 rows with operations "insert", "update", "delete".
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
+        initialize_empty_table(&harness.destination, &schema).await;
+
         invoke_write_events(
             &harness.destination,
             WriteEventsDurability::MayDefer,
@@ -480,6 +493,8 @@ async fn whole_transaction_replay_restores_post_truncate_rows() {
     harness.store.store_table_schema(table_schema).await.unwrap();
 
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
+        initialize_empty_table(&harness.destination, &schema).await;
+
         let first_status = invoke_write_events(
             &harness.destination,
             WriteEventsDurability::RequireDurable,
@@ -572,6 +587,8 @@ async fn write_events_delete_key_only() {
     // Delete event with `OldTableRow::Key`.
     // Verify the delete row has PK value present but non-PK columns are NULL.
     with_table_cleanup(&harness.sql, &[&sf_table], || async {
+        initialize_empty_table(&harness.destination, &schema).await;
+
         invoke_write_events(
             &harness.destination,
             WriteEventsDurability::MayDefer,
@@ -600,6 +617,78 @@ async fn write_events_delete_key_only() {
         assert_eq!(&rows[0][0], &serde_json::Value::String("42".into()),);
         assert_eq!(&rows[0][1], &serde_json::Value::Null);
         assert_eq!(&rows[0][2], &serde_json::Value::String("delete".into()),);
+    })
+    .await;
+}
+
+/// A fresh process must validate the physical table before accepting DML.
+#[tokio::test]
+#[ignore = "requires Snowflake credentials"]
+async fn cold_open_rejects_unexpected_column() {
+    let harness = TestHarness::new();
+    let src_table = format!("ETL_TEST_{}", uuid::Uuid::new_v4().simple()).to_uppercase();
+    let sf_table = snowflake_table_name("public", &src_table);
+
+    let table_id = TableId::new(1016);
+    let table_schema = make_table_schema(1016, "public", &src_table);
+    let schema = ReplicatedTableSchema::all(Arc::new(table_schema.clone()));
+    harness.store.store_table_schema(table_schema).await.unwrap();
+
+    with_table_cleanup(&harness.sql, &[&sf_table], || async {
+        write_table_copy_and_wait(
+            &harness.destination,
+            &schema,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("Alice".into())])],
+        )
+        .await;
+
+        let fqn = format!(
+            "\"{}\".\"{}\".\"{sf_table}\"",
+            harness.config.database(),
+            harness.config.schema()
+        );
+        harness
+            .sql
+            .execute_ddl(&format!("alter table {fqn} add column \"unexpected\" varchar"))
+            .await
+            .expect("out-of-band alter table failed");
+
+        let restarted_destination = Destination::new(
+            Client::new(build_auth(), PipelineId::from(1_u64)),
+            harness.store.clone(),
+        );
+        let error = invoke_write_events(
+            &restarted_destination,
+            WriteEventsDurability::RequireDurable,
+            vec![Event::Insert(InsertEvent {
+                commit_lsn: PgLsn::from(10_u64),
+                tx_ordinal: 0,
+                replicated_table_schema: schema,
+                table_row: TableRow::new(vec![Cell::I32(2), Cell::String("Rejected".into())]),
+            })],
+        )
+        .await
+        .expect_err("a cold open must reject an unexpected physical column before append");
+        assert_eq!(error.kind(), ErrorKind::CorruptedTableSchema);
+
+        let rows = query_rows(
+            &harness.sql,
+            &format!("select \"id\", \"name\" from {fqn} order by \"id\""),
+        )
+        .await
+        .expect("query after physical drift rejection failed");
+        assert_eq!(rows, vec![vec![serde_json::json!("1"), serde_json::json!("Alice")]]);
+
+        let columns = column_names(&harness.sql, &fqn).await;
+        assert!(columns.iter().any(|column| column == "unexpected"));
+
+        let metadata = harness
+            .store
+            .get_applied_destination_table_metadata(table_id)
+            .await
+            .unwrap()
+            .expect("destination metadata should remain applied");
+        assert_eq!(metadata.snapshot_id, SnapshotId::initial());
     })
     .await;
 }


### PR DESCRIPTION
## Summary

- disable Snowflake automatic schema evolution
- make initial copy and Relation DDL the only schema mutation paths
- validate exact table columns before opening or reopening Snowpipe channels
- fail closed on missing, unexpected, or incomplete schema metadata
