### PR TITLE
fix(snowflake): reject tables without ownership metadata

### DIFF
--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -346,6 +346,11 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         self.channels.read().await.contains_key(&table_id)
     }
 
+    /// Checks whether a table exists in the configured Snowflake namespace.
+    pub(super) async fn table_exists(&self, table_name: &str) -> Result<bool> {
+        self.sql_client.table_exists(table_name).await
+    }
+
     /// Creates a table when needed and prepares it for initial-copy writes.
     pub(super) async fn initialize_table(
         &self,

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -127,8 +127,21 @@ impl TableInitializer {
         // completed setup after the fast-path read.
         let snapshot_id = table_schema.inner().snapshot_id;
         let replication_mask = table_schema.replication_mask().clone();
+        schema::validate_no_cdc_collisions(&columns).map_err(EtlError::from)?;
         let applying_metadata = match store.get_destination_table_metadata(table_id).await? {
             None => {
+                if client.table_exists(&table_name).await.map_err(EtlError::from)? {
+                    bail!(
+                        ErrorKind::DestinationTableAlreadyExists,
+                        "Snowflake destination table already exists",
+                        format!(
+                            "Table {table_name} exists, but this pipeline has no destination \
+                             metadata proving ownership. Remove the table or use another \
+                             destination schema before retrying."
+                        )
+                    );
+                }
+
                 // Record ownership before creating remote state so a restart can
                 // find and remove a partial setup.
                 let metadata = DestinationTableMetadata::new_applying(
@@ -922,7 +935,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initial_setup_failure_leaves_metadata_applying() {
+    async fn interrupted_initial_setup_failure_preserves_metadata_applying() {
         let (destination, store) = test_destination();
         let table_schema = Arc::new(TableSchema::new(
             TableId::new(2),
@@ -930,6 +943,12 @@ mod tests {
             vec![ColumnSchema::new("_cdc_operation".to_owned(), Type::TEXT, -1, 1, true)],
         ));
         let schema = ReplicatedTableSchema::all(table_schema);
+        let metadata = DestinationTableMetadata::new_applying(
+            try_stringify_table_name(schema.name()).unwrap().to_uppercase(),
+            schema.inner().snapshot_id,
+            schema.replication_mask().clone(),
+        );
+        store.store_destination_table_metadata(schema.id(), metadata).await.unwrap();
 
         let error = destination.writer.initialize_table(&schema).await.unwrap_err();
 
@@ -947,6 +966,22 @@ mod tests {
             metadata.destination_table_id,
             try_stringify_table_name(schema.name()).unwrap().to_uppercase()
         );
+    }
+
+    #[tokio::test]
+    async fn fresh_invalid_schema_is_rejected_before_remote_probe() {
+        let (destination, store) = test_destination();
+        let table_schema = Arc::new(TableSchema::new(
+            TableId::new(4),
+            TableName::new("public".to_owned(), "reserved_column".to_owned()),
+            vec![ColumnSchema::new("_cdc_operation".to_owned(), Type::TEXT, -1, 1, true)],
+        ));
+        let schema = ReplicatedTableSchema::all(table_schema);
+
+        let error = destination.writer.initialize_table(&schema).await.unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ConfigError);
+        assert!(store.get_destination_table_metadata(schema.id()).await.unwrap().is_none());
     }
 
     /// A stale relation event must fail before driving reverse Snowflake DDL.

--- a/crates/etl-destinations/src/snowflake/sql_client.rs
+++ b/crates/etl-destinations/src/snowflake/sql_client.rs
@@ -460,9 +460,9 @@ fn parse_show_columns(response: &StatementResponse) -> Result<Vec<&str>> {
     parse_named_show_column(response, "SHOW COLUMNS", "column_name")
 }
 
-/// Parse exact table identifiers from `SHOW TABLES`.
+/// Parse exact table identifiers from `SHOW TERSE TABLES`.
 fn parse_show_table_names(response: &StatementResponse) -> Result<Vec<&str>> {
-    parse_named_show_column(response, "SHOW TABLES", "name")
+    parse_named_show_column(response, "SHOW TERSE TABLES", "name")
 }
 
 /// Validates exact column names without relying on column order.
@@ -569,7 +569,8 @@ mod tests {
             vec![vec![serde_json::Value::String("EVENTS".to_owned()), serde_json::Value::Null]],
         );
 
-        let table_names = parse_show_table_names(&response).expect("SHOW TABLES should parse");
+        let table_names =
+            parse_show_table_names(&response).expect("SHOW TERSE TABLES should parse");
 
         assert_eq!(table_names, vec!["EVENTS"]);
     }
@@ -586,7 +587,7 @@ mod tests {
                 statement_handle: Some(handle),
                 message,
             } if handle == "test-statement"
-                && message == "SHOW TABLES result metadata omitted column 'name'"
+                && message == "SHOW TERSE TABLES result metadata omitted column 'name'"
         ));
     }
 

--- a/crates/etl-destinations/src/snowflake/sql_client.rs
+++ b/crates/etl-destinations/src/snowflake/sql_client.rs
@@ -154,10 +154,8 @@ impl<T: TokenProvider> SqlClient<T> {
         let name_prefix = quote_string_literal(table_name);
         let sql = format!("SHOW TERSE TABLES IN SCHEMA {db}.{schema} STARTS WITH {name_prefix}");
         let resp = self.execute_statement(&sql).await?;
-        Ok(resp.data.is_some_and(|rows| {
-            rows.iter()
-                .any(|row| row.get(1).and_then(serde_json::Value::as_str) == Some(table_name))
-        }))
+        let table_names = parse_show_table_names(&resp)?;
+        Ok(table_names.contains(&table_name))
     }
 
     /// Add a nullable column to an existing table.
@@ -396,33 +394,37 @@ impl<T: TokenProvider> SqlClient<T> {
     }
 }
 
-/// Parse exact column identifiers from `SHOW COLUMNS`.
-fn parse_show_columns(response: &StatementResponse) -> Result<Vec<&str>> {
+/// Parse one named string column from a `SHOW` response.
+fn parse_named_show_column<'a>(
+    response: &'a StatementResponse,
+    command: &str,
+    result_column: &str,
+) -> Result<Vec<&'a str>> {
     fn malformed_show_response(response: &StatementResponse, message: String) -> Error {
         Error::Sql { statement_handle: response.statement_handle.clone(), message }
     }
 
     let metadata = response.result_set_meta_data.as_ref().ok_or_else(|| {
-        malformed_show_response(response, "SHOW COLUMNS omitted result metadata".to_owned())
+        malformed_show_response(response, format!("{command} omitted result metadata"))
     })?;
-    let column_name_index = metadata
+    let result_column_index = metadata
         .row_type
         .iter()
-        .position(|column| column.name.eq_ignore_ascii_case("column_name"))
+        .position(|column| column.name.eq_ignore_ascii_case(result_column))
         .ok_or_else(|| {
             malformed_show_response(
                 response,
-                "SHOW COLUMNS result metadata omitted column 'column_name'".to_owned(),
+                format!("{command} result metadata omitted column '{result_column}'"),
             )
         })?;
     let num_rows = metadata.num_rows.ok_or_else(|| {
-        malformed_show_response(response, "SHOW COLUMNS result metadata omitted numRows".to_owned())
+        malformed_show_response(response, format!("{command} result metadata omitted numRows"))
     })?;
     let rows = response.data.as_deref().ok_or_else(|| {
-        malformed_show_response(response, "SHOW COLUMNS omitted result data".to_owned())
+        malformed_show_response(response, format!("{command} omitted result data"))
     })?;
     let actual_rows = u64::try_from(rows.len()).map_err(|_| {
-        malformed_show_response(response, "SHOW COLUMNS result row count overflowed".to_owned())
+        malformed_show_response(response, format!("{command} result row count overflowed"))
     })?;
 
     // Exact validation must not treat the first result partition as the whole
@@ -431,7 +433,7 @@ fn parse_show_columns(response: &StatementResponse) -> Result<Vec<&str>> {
         return Err(malformed_show_response(
             response,
             format!(
-                "SHOW COLUMNS returned {actual_rows} rows, but metadata declared {num_rows} total \
+                "{command} returned {actual_rows} rows, but metadata declared {num_rows} total \
                  rows"
             ),
         ));
@@ -440,17 +442,27 @@ fn parse_show_columns(response: &StatementResponse) -> Result<Vec<&str>> {
     let mut columns = Vec::with_capacity(rows.len());
 
     for (row_index, row) in rows.iter().enumerate() {
-        let column_name =
-            row.get(column_name_index).and_then(serde_json::Value::as_str).ok_or_else(|| {
+        let value =
+            row.get(result_column_index).and_then(serde_json::Value::as_str).ok_or_else(|| {
                 malformed_show_response(
                     response,
-                    format!("SHOW COLUMNS row {row_index} has no string column_name"),
+                    format!("{command} row {row_index} has no string {result_column}"),
                 )
             })?;
-        columns.push(column_name);
+        columns.push(value);
     }
 
     Ok(columns)
+}
+
+/// Parse exact column identifiers from `SHOW COLUMNS`.
+fn parse_show_columns(response: &StatementResponse) -> Result<Vec<&str>> {
+    parse_named_show_column(response, "SHOW COLUMNS", "column_name")
+}
+
+/// Parse exact table identifiers from `SHOW TABLES`.
+fn parse_show_table_names(response: &StatementResponse) -> Result<Vec<&str>> {
+    parse_named_show_column(response, "SHOW TABLES", "name")
 }
 
 /// Validates exact column names without relying on column order.
@@ -548,6 +560,34 @@ mod tests {
         let columns = parse_show_columns(&response).expect("SHOW COLUMNS should parse");
 
         assert_eq!(columns, vec!["id"]);
+    }
+
+    #[test]
+    fn parses_show_table_names_by_result_metadata_name() {
+        let response = statement_response(
+            &["name", "created_on"],
+            vec![vec![serde_json::Value::String("EVENTS".to_owned()), serde_json::Value::Null]],
+        );
+
+        let table_names = parse_show_table_names(&response).expect("SHOW TABLES should parse");
+
+        assert_eq!(table_names, vec!["EVENTS"]);
+    }
+
+    #[test]
+    fn malformed_show_table_metadata_is_a_structural_sql_error() {
+        let response = statement_response(&["created_on"], vec![vec![serde_json::Value::Null]]);
+
+        let error = parse_show_table_names(&response).expect_err("name metadata is required");
+
+        assert!(matches!(
+            error,
+            Error::Sql {
+                statement_handle: Some(handle),
+                message,
+            } if handle == "test-statement"
+                && message == "SHOW TABLES result metadata omitted column 'name'"
+        ));
     }
 
     #[test]

--- a/crates/etl-destinations/tests/snowflake/destination.rs
+++ b/crates/etl-destinations/tests/snowflake/destination.rs
@@ -49,6 +49,10 @@ struct TestHarness {
 
 impl TestHarness {
     fn new() -> Self {
+        Self::with_pipeline_id(1)
+    }
+
+    fn with_pipeline_id(pipeline_id: PipelineId) -> Self {
         let config = load_test_config().clone_without_credentials();
         let auth = build_auth();
         let sql = SqlClient::new(
@@ -57,7 +61,6 @@ impl TestHarness {
             reqwest::Client::new(),
         );
         let store = NotifyingStore::new();
-        let pipeline_id: PipelineId = 1;
 
         let client = Client::new(Arc::clone(&auth), pipeline_id);
         let destination = Destination::new(client, store.clone());
@@ -393,6 +396,74 @@ async fn write_table_rows_empty() {
 
         let exists = harness.sql.table_exists(&sf_table).await.expect("table_exists failed");
         assert!(exists, "table should have been created even with empty row set");
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Snowflake credentials"]
+async fn fresh_generation_rejects_existing_table_without_destination_metadata() {
+    let first = TestHarness::with_pipeline_id(1);
+    let second = TestHarness::with_pipeline_id(2);
+    let src_table = format!("ETL_TEST_{}", uuid::Uuid::new_v4().simple()).to_uppercase();
+    let sf_table = snowflake_table_name("public", &src_table);
+    let table_id = TableId::new(1013);
+
+    let retained_table_schema = TableSchema::new(
+        table_id,
+        TableName::new("public".to_owned(), src_table.clone()),
+        vec![
+            ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+            ColumnSchema::new("ddl_col_2_1".to_owned(), Type::TEXT, -1, 2, true),
+        ],
+    );
+    let retained_schema = ReplicatedTableSchema::all(Arc::new(retained_table_schema.clone()));
+    first.store.store_table_schema(retained_table_schema).await.unwrap();
+
+    let fresh_table_schema = TableSchema::new(
+        table_id,
+        TableName::new("public".to_owned(), src_table),
+        vec![
+            ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+            ColumnSchema::new("ddl_col_2_1".to_owned(), Type::TEXT, -1, 2, true),
+        ],
+    );
+    let fresh_schema = ReplicatedTableSchema::all(Arc::new(fresh_table_schema.clone()));
+    second.store.store_table_schema(fresh_table_schema).await.unwrap();
+
+    with_table_cleanup(&first.sql, &[&sf_table], || async {
+        write_table_copy_and_wait(
+            &first.destination,
+            &retained_schema,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::String("retained".to_owned())])],
+        )
+        .await;
+
+        let fqn =
+            format!("\"{}\".\"{}\".\"{sf_table}\"", first.config.database(), first.config.schema());
+
+        let error = invoke_write_table_rows(
+            &second.destination,
+            &fresh_schema,
+            vec![TableRow::new(vec![Cell::I32(2), Cell::String("fresh".to_owned())])],
+        )
+        .await
+        .expect_err("fresh pipeline should reject a retained Snowflake table");
+
+        assert_eq!(error.kind(), ErrorKind::DestinationTableAlreadyExists);
+        assert_eq!(error.description(), Some("Snowflake destination table already exists"));
+        let detail = error.detail().expect("ownership rejection should explain the conflict");
+        assert!(detail.contains(&sf_table));
+        assert!(detail.contains("no destination metadata proving ownership"));
+        assert!(second.store.get_destination_table_metadata(table_id).await.unwrap().is_none());
+
+        let rows = query_rows(
+            &first.sql,
+            &format!("select \"id\", \"ddl_col_2_1\" from {fqn} order by \"id\""),
+        )
+        .await
+        .expect("query after rejected setup failed");
+        assert_eq!(rows, vec![vec![serde_json::json!("1"), serde_json::json!("retained")]]);
     })
     .await;
 }


### PR DESCRIPTION
## Summary

Follow-up to #971.

Reject fresh Snowflake initialization when the physical table already exists but the pipeline has no destination metadata proving ownership. 

This is a fail-closed safeguard. A follow-up will introduce durable ownership identity and explicit recreation of verified ETL-owned tables, while foreign or unmarked tables will continue to be rejected.