### PR TITLE
ref(api): Reset VPA when a table can be copied

### DIFF
--- a/crates/etl-api/README.md
+++ b/crates/etl-api/README.md
@@ -171,11 +171,21 @@ the measured workload so long-running streaming remains efficient. This is the
 interim phase model until the replicator can explicitly signal copy and
 streaming transitions to autoscaling.
 
-Restarting a running replicator deliberately preserves its VPA recommendation:
-a restart refreshes the process and configuration but is not an autoscaling
-phase transition. To discard the recommendation and return to the max-sized
-initial allocation, stop the pipeline and then start it again. Stop deletes the
-StatefulSet and VPA; start recreates both with fresh recommendation history.
+Before restarting a running replicator, the API uses durable table state to
+predict whether the restart will repeat an initial table copy. If any table is
+before `SyncDone` and is not stopped in an error state, the API deletes the VPA
+before reconciling the pipeline. Reconciliation then recreates the VPA with no
+steady-state recommendation history, so the restarted Pod begins with the
+initial copy allocation. `SyncDone` and `Ready` tables keep their destination
+data across restart and therefore preserve the existing VPA. This applies to
+explicit restarts and configuration updates that restart a running replicator.
+Source connection, query, or state-decoding failures preserve the VPA rather
+than making the restart less reliable.
+
+Kubernetes- or controller-initiated Pod restarts do not pass through the API
+restart path and therefore keep the learned VPA recommendation. Stopping and
+starting a pipeline still resets autoscaling unconditionally: stop deletes the
+StatefulSet and VPA, and start recreates both with fresh recommendation history.
 
 ### Encryption Keys
 

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -99,9 +99,8 @@ async fn restart_will_repeat_table_copy(
                 serde_json::from_value(metadata).map_err(PipelineError::InvalidTableState)?;
 
             // SyncDone and Ready keep their existing destination data after a
-            // restart. Earlier lifecycle states repeat the copy; errored
-            // tables remain stopped and are not automatically recopied.
-            if !state.as_type().has_completed_table_sync() && !state.is_errored() {
+            // restart. Other lifecycle states will repeat the copy (besides Errored).
+            if !state.as_type().has_completed_table_sync() {
                 return Ok(true);
             }
         }

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -31,7 +31,7 @@ use crate::{
 /// up those changes.
 ///
 /// Before reconciliation, this best-effort checks durable source state. If the
-/// restart will repeat an initial table copy, it resets the VPA so
+/// restart will repeat an initial table sync, it resets the VPA so
 /// reconciliation recreates it without a steady-state recommendation. Source
 /// inspection failures preserve the existing VPA and do not block restart.
 /// Kubernetes-initiated Pod restarts do not call this helper and preserve VPA
@@ -56,7 +56,7 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
         return Ok(false);
     }
 
-    if restart_will_repeat_table_copy(pipeline_id, source.id, &source.config, source_tls_config)
+    if restart_will_repeat_table_sync(pipeline_id, source.id, &source.config, source_tls_config)
         .await
     {
         let resource_prefix = create_k8s_object_prefix(tenant_id, replicator.id);
@@ -79,7 +79,7 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     Ok(true)
 }
 
-async fn restart_will_repeat_table_copy(
+async fn restart_will_repeat_table_sync(
     pipeline_id: i64,
     source_id: i64,
     source_config: &StoredSourceConfig,
@@ -98,7 +98,7 @@ async fn restart_will_repeat_table_copy(
             let state: TableState =
                 serde_json::from_value(metadata).map_err(PipelineError::InvalidTableState)?;
 
-            if !state.as_type().would_perform_table_copy() {
+            if !state.as_type().would_perform_table_sync() {
                 return Ok(true);
             }
         }
@@ -108,13 +108,13 @@ async fn restart_will_repeat_table_copy(
     .await;
 
     match result {
-        Ok(will_repeat_copy) => will_repeat_copy,
+        Ok(will_repeat_sync) => will_repeat_sync,
         Err(error) => {
             warn!(
                 pipeline_id,
                 source_id,
                 error = %error,
-                "failed to determine whether pipeline restart will repeat table copy, preserving vertical pod autoscaler",
+                "failed to determine whether pipeline restart will repeat table sync, preserving vertical pod autoscaler",
             );
             false
         }

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -98,9 +98,7 @@ async fn restart_will_repeat_table_copy(
             let state: TableState =
                 serde_json::from_value(metadata).map_err(PipelineError::InvalidTableState)?;
 
-            // SyncDone and Ready keep their existing destination data after a
-            // restart. Other lifecycle states will repeat the copy (besides Errored).
-            if !state.as_type().has_completed_table_sync() {
+            if !state.as_type().would_perform_table_copy() {
                 return Ok(true);
             }
         }

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -31,7 +31,7 @@ use crate::{
 /// up those changes.
 ///
 /// Before reconciliation, this best-effort checks durable source state. If the
-/// restart will perform an initial table sync, it resets the VPA so
+/// restart performed an initial table sync, it resets the VPA so
 /// reconciliation recreates it without a steady-state recommendation. Source
 /// inspection failures preserve the existing VPA and do not block restart.
 /// Kubernetes-initiated Pod restarts do not call this helper and preserve VPA
@@ -56,7 +56,7 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
         return Ok(false);
     }
 
-    if restart_will_perform_table_sync(pipeline_id, source.id, &source.config, source_tls_config)
+    if restart_would_perform_table_sync(pipeline_id, source.id, &source.config, source_tls_config)
         .await
     {
         let resource_prefix = create_k8s_object_prefix(tenant_id, replicator.id);
@@ -79,7 +79,7 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     Ok(true)
 }
 
-async fn restart_will_perform_table_sync(
+async fn restart_would_perform_table_sync(
     pipeline_id: i64,
     source_id: i64,
     source_config: &StoredSourceConfig,

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -31,7 +31,7 @@ use crate::{
 /// up those changes.
 ///
 /// Before reconciliation, this best-effort checks durable source state. If the
-/// restart will repeat an initial table sync, it resets the VPA so
+/// restart will perform an initial table sync, it resets the VPA so
 /// reconciliation recreates it without a steady-state recommendation. Source
 /// inspection failures preserve the existing VPA and do not block restart.
 /// Kubernetes-initiated Pod restarts do not call this helper and preserve VPA
@@ -56,7 +56,7 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
         return Ok(false);
     }
 
-    if restart_will_repeat_table_sync(pipeline_id, source.id, &source.config, source_tls_config)
+    if restart_will_perform_table_sync(pipeline_id, source.id, &source.config, source_tls_config)
         .await
     {
         let resource_prefix = create_k8s_object_prefix(tenant_id, replicator.id);
@@ -79,7 +79,7 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     Ok(true)
 }
 
-async fn restart_will_repeat_table_sync(
+async fn restart_will_perform_table_sync(
     pipeline_id: i64,
     source_id: i64,
     source_config: &StoredSourceConfig,
@@ -98,7 +98,7 @@ async fn restart_will_repeat_table_sync(
             let state: TableState =
                 serde_json::from_value(metadata).map_err(PipelineError::InvalidTableState)?;
 
-            if !state.as_type().would_perform_table_sync() {
+            if state.as_type().would_perform_table_sync() {
                 return Ok(true);
             }
         }

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -1,10 +1,17 @@
+use etl::store::TableState;
+use etl_postgres::store::table_state;
+use tracing::warn;
+
 use crate::{
     config::ApiConfig,
     configs::{encryption::EncryptionKeyring, source::StoredSourceConfig},
-    data::pipelines::read_pipeline_components,
+    data::{pipelines::read_pipeline_components, source_database},
     k8s::{
         K8sClient, SourceTlsConfig,
-        core::{create_or_update_pipeline_resources_in_k8s, should_reconcile_replicator_resources},
+        core::{
+            create_k8s_object_prefix, create_or_update_pipeline_resources_in_k8s,
+            should_reconcile_replicator_resources,
+        },
     },
     routes::pipelines::PipelineError,
     validation::{self, ValidationContext, ValidationError, ValidationFailure},
@@ -22,6 +29,13 @@ use crate::{
 /// mounted config and secret-backed environment when the process starts, so a
 /// running pod must be restarted after config materialization in order to pick
 /// up those changes.
+///
+/// Before reconciliation, this best-effort checks durable source state. If the
+/// restart will repeat an initial table copy, it resets the VPA so
+/// reconciliation recreates it without a steady-state recommendation. Source
+/// inspection failures preserve the existing VPA and do not block restart.
+/// Kubernetes-initiated Pod restarts do not call this helper and preserve VPA
+/// state.
 ///
 /// If Kubernetes support is unavailable, or the pipeline has no active
 /// Kubernetes resources, the call returns `false` without reconciling.
@@ -42,6 +56,13 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
         return Ok(false);
     }
 
+    if restart_will_repeat_table_copy(pipeline_id, source.id, &source.config, source_tls_config)
+        .await
+    {
+        let resource_prefix = create_k8s_object_prefix(tenant_id, replicator.id);
+        k8s_client.delete_replicator_vertical_pod_autoscaler(&resource_prefix).await?;
+    }
+
     create_or_update_pipeline_resources_in_k8s(
         k8s_client,
         tenant_id,
@@ -56,6 +77,51 @@ pub(crate) async fn restart_pipeline_replicator_if_running(
     .await?;
 
     Ok(true)
+}
+
+async fn restart_will_repeat_table_copy(
+    pipeline_id: i64,
+    source_id: i64,
+    source_config: &StoredSourceConfig,
+    source_tls_config: &SourceTlsConfig,
+) -> bool {
+    let result = async {
+        let connection_config =
+            source_config.clone().into_connection_config(source_tls_config.get_tls_config());
+        let source_pool = source_database::connect(&connection_config).await?;
+        let state_rows = table_state::get_table_state_rows(&source_pool, pipeline_id).await?;
+
+        for state_row in state_rows {
+            let Some(metadata) = state_row.metadata else {
+                return Err(PipelineError::MissingTableState);
+            };
+            let state: TableState =
+                serde_json::from_value(metadata).map_err(PipelineError::InvalidTableState)?;
+
+            // SyncDone and Ready keep their existing destination data after a
+            // restart. Earlier lifecycle states repeat the copy; errored
+            // tables remain stopped and are not automatically recopied.
+            if !state.as_type().has_completed_table_sync() && !state.is_errored() {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+    .await;
+
+    match result {
+        Ok(will_repeat_copy) => will_repeat_copy,
+        Err(error) => {
+            warn!(
+                pipeline_id,
+                source_id,
+                error = %error,
+                "failed to determine whether pipeline restart will repeat table copy, preserving vertical pod autoscaler",
+            );
+            false
+        }
+    }
 }
 
 /// Validates a source config against the trusted source profile, when enabled.

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -1033,7 +1033,7 @@ pub(crate) async fn start_pipeline(
     post,
     path = "/pipelines/{pipeline_id}/restart",
     summary = "Restart a pipeline",
-    description = "Reconciles the pipeline's Kubernetes resources and restarts its replicator while preserving its current VPA recommendation. Stop and start the pipeline to reset autoscaling and return to the initial allocation.",
+    description = "Reconciles the pipeline's Kubernetes resources and restarts its replicator. When durable source state shows that the restart will repeat an initial table copy, the endpoint resets the VPA so the copy starts from the initial allocation. If source state cannot be inspected, or all tables completed initial sync, the current VPA recommendation is preserved. System-initiated pod restarts do not use this endpoint and always preserve VPA state.",
     params(
         ("pipeline_id" = i64, Path, description = "Unique ID of the pipeline"),
         ("tenant_id" = String, Header, description = "Tenant ID used to scope the request")

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -841,6 +841,34 @@ async fn updating_a_running_pipeline_reapplies_replicator_resources() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn updating_a_running_pipeline_resets_vpa_when_table_copy_will_repeat() {
+    init_test_tracing();
+    let (app, tenant_id, pipeline_id, source_db_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
+    create_tables_with_states(
+        &source_db_pool,
+        pipeline_id,
+        &[("test_users", "data_sync", r#"{"type": "data_sync"}"#)],
+    )
+    .await;
+    let pipeline = app.read_pipeline(&tenant_id, pipeline_id).await;
+    let pipeline: ReadPipelineResponse =
+        pipeline.json().await.expect("failed to deserialize response");
+    let update_request = UpdatePipelineRequest {
+        source_id: pipeline.source_id,
+        destination_id: pipeline.destination_id,
+        config: UpdateApiPipelineConfig::default(),
+    };
+
+    let response = app.update_pipeline(&tenant_id, pipeline_id, &update_request).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(app.k8s_state.vpa_delete_calls(), 1);
+
+    drop_pg_database(&source_db_config).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn updating_a_stopped_pipeline_only_persists_replicator_resources() {
     init_test_tracing();
     let k8s_state = MockK8sState::default();
@@ -1437,7 +1465,69 @@ async fn a_running_pipeline_can_be_restarted() {
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
     assert!(k8s_state.create_calls() > create_calls_before);
-    assert_eq!(k8s_state.vpa_delete_calls(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restarting_pipeline_resets_vpa_when_table_copy_will_repeat() {
+    init_test_tracing();
+    let (app, tenant_id, pipeline_id, source_db_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
+    create_tables_with_states(
+        &source_db_pool,
+        pipeline_id,
+        &[("test_users", "data_sync", r#"{"type": "data_sync"}"#)],
+    )
+    .await;
+
+    let response = app.restart_pipeline(&tenant_id, pipeline_id).await;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(app.k8s_state.vpa_delete_calls(), 1);
+
+    drop_pg_database(&source_db_config).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restarting_pipeline_preserves_vpa_when_no_table_copy_will_repeat() {
+    init_test_tracing();
+    let (app, tenant_id, pipeline_id, source_db_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
+    create_tables_with_states(
+        &source_db_pool,
+        pipeline_id,
+        &[
+            ("test_users", "ready", r#"{"type": "ready"}"#),
+            ("test_events", "sync_done", r#"{"type": "sync_done", "lsn": "0/10"}"#),
+            (
+                "test_orders",
+                "errored",
+                r#"{"type": "errored", "reason": "manual intervention required", "retry_policy": {"type": "manual_retry"}}"#,
+            ),
+        ],
+    )
+    .await;
+
+    let response = app.restart_pipeline(&tenant_id, pipeline_id).await;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(app.k8s_state.vpa_delete_calls(), 0);
+
+    drop_pg_database(&source_db_config).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restarting_pipeline_preserves_vpa_when_source_inspection_fails() {
+    init_test_tracing();
+    let (app, tenant_id, pipeline_id, _source_db_pool, source_db_config) =
+        setup_pipeline_with_source_db().await;
+    let create_calls_before = app.k8s_state.create_calls();
+    drop_pg_database(&source_db_config).await;
+
+    let response = app.restart_pipeline(&tenant_id, pipeline_id).await;
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert!(app.k8s_state.create_calls() > create_calls_before);
+    assert_eq!(app.k8s_state.vpa_delete_calls(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/src/replication/state/lifecycle.rs
+++ b/crates/etl/src/replication/state/lifecycle.rs
@@ -386,9 +386,9 @@ impl TableStateType {
         matches!(self, Self::SyncDone | Self::Ready)
     }
 
-    /// Returns whether a table would perform a table copy if it was in this
-    /// state.
-    pub fn would_perform_table_copy(&self) -> bool {
+    /// Returns `true` if a table with this state would perform the initial table sync, `false`
+    /// otherwise.
+    pub fn would_perform_table_sync(&self) -> bool {
         !matches!(self, Self::SyncDone | Self::Ready | Self::Errored)
     }
 

--- a/crates/etl/src/replication/state/lifecycle.rs
+++ b/crates/etl/src/replication/state/lifecycle.rs
@@ -386,8 +386,8 @@ impl TableStateType {
         matches!(self, Self::SyncDone | Self::Ready)
     }
 
-    /// Returns `true` if a table with this state would perform the initial table sync, `false`
-    /// otherwise.
+    /// Returns `true` if a table with this state would perform the initial
+    /// table sync, `false` otherwise.
     pub fn would_perform_table_sync(&self) -> bool {
         !matches!(self, Self::SyncDone | Self::Ready | Self::Errored)
     }

--- a/crates/etl/src/replication/state/lifecycle.rs
+++ b/crates/etl/src/replication/state/lifecycle.rs
@@ -385,6 +385,12 @@ impl TableStateType {
     pub fn has_completed_table_sync(&self) -> bool {
         matches!(self, Self::SyncDone | Self::Ready)
     }
+    
+    /// Returns whether a table would perform a table copy if it was in this
+    /// state.
+    pub fn would_perform_table_copy(&self) -> bool {
+        !matches!(self, Self::SyncDone | Self::Ready | Self::Errored)
+    }
 
     /// Returns `true` if a table with this state is in error, `false`
     /// otherwise.

--- a/crates/etl/src/replication/state/lifecycle.rs
+++ b/crates/etl/src/replication/state/lifecycle.rs
@@ -385,7 +385,7 @@ impl TableStateType {
     pub fn has_completed_table_sync(&self) -> bool {
         matches!(self, Self::SyncDone | Self::Ready)
     }
-    
+
     /// Returns whether a table would perform a table copy if it was in this
     /// state.
     pub fn would_perform_table_copy(&self) -> bool {


### PR DESCRIPTION
This PR improves the restart endpoint semantics to reset the VPA when a pipeline has at least one table that will be copied.

The rationale behind this is that we want to make restarting aware of the tables so that VPA can restart as if the pipeline was just created.