### PR TITLE
feat(api): allow simulator tenants to select non-default images

### DIFF
--- a/crates/etl-api/src/config.rs
+++ b/crates/etl-api/src/config.rs
@@ -34,6 +34,16 @@ pub struct ApiConfig {
     ///
     /// All keys in this list are considered valid for authentication.
     pub api_keys: Vec<String>,
+    /// Tenant IDs used by staging destination simulators.
+    ///
+    /// Pipelines belonging to these tenants may select registered non-default
+    /// replicator images so each simulator can test an experimental build
+    /// without changing the default image for other tenants.
+    ///
+    /// Production tenant IDs must never be included. An empty list preserves
+    /// the default-only image policy for every tenant.
+    #[serde(default)]
+    pub simulator_tenant_ids: Vec<String>,
     /// Optional Sentry configuration for error tracking.
     pub sentry: Option<SentryConfig>,
     /// Optional Supabase API URL for error notifications.
@@ -240,6 +250,11 @@ impl ApiConfig {
 
         Ok(())
     }
+
+    /// Returns whether `tenant_id` identifies an allowlisted staging simulator.
+    pub(crate) fn is_simulator_tenant(&self, tenant_id: &str) -> bool {
+        self.simulator_tenant_ids.iter().any(|id| id == tenant_id)
+    }
 }
 
 impl ReplicatorAutoscalingConfig {
@@ -356,7 +371,7 @@ pub struct SourceConfig {
 }
 
 impl Config for ApiConfig {
-    const LIST_PARSE_KEYS: &'static [&'static str] = &["api_keys"];
+    const LIST_PARSE_KEYS: &'static [&'static str] = &["api_keys", "simulator_tenant_ids"];
 }
 
 /// HTTP server configuration settings.

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -124,6 +124,9 @@ pub enum PipelineError {
     DuplicatePipeline,
 
     #[error("The selected pipeline version is not available")]
+    ImageIdNotFound(i64),
+
+    #[error("The selected pipeline version is not available")]
     ImageIdNotDefault(i64),
 
     #[error("This project has reached its maximum of {limit} pipelines")]
@@ -263,6 +266,7 @@ impl IntoResponse for PipelineError {
             | PipelineError::DuplicatePipeline => StatusCode::CONFLICT,
             PipelineError::PipelineNotFound(_)
             | PipelineError::EtlStateNotInitialized
+            | PipelineError::ImageIdNotFound(_)
             | PipelineError::ImageIdNotDefault(_)
             | PipelineError::DestinationNotFound(_)
             | PipelineError::SourceNotFound(_) => StatusCode::NOT_FOUND,
@@ -1549,18 +1553,17 @@ pub(crate) async fn update_pipeline_version(
     let (_, replicator, current_image, _, destination) =
         read_pipeline_components(&mut txn, tenant_id, pipeline_id, &encryption_key).await?;
 
-    // Only allow updating to the current default image. The client must provide the
-    // version id and it must match the default version id. If it does not, we
-    // consider this a race condition and we fail the update.
-    let default_image = data::images::read_default_image(txn.deref_mut())
+    // For regular tenants, the requested image must be the current default;
+    // rejecting any other id preserves the existing stale-client race guard.
+    // Simulator tenants may additionally select a registered non-default image
+    // without changing the global default.
+    let target_image = data::images::read_image(txn.deref_mut(), update_request.version_id)
         .await?
-        .ok_or(PipelineError::NoDefaultImageFound)?;
+        .ok_or(PipelineError::ImageIdNotFound(update_request.version_id))?;
 
-    if update_request.version_id != default_image.id {
+    if !target_image.is_default && !api_config.is_simulator_tenant(tenant_id) {
         return Err(PipelineError::ImageIdNotDefault(update_request.version_id));
     }
-
-    let target_image = default_image;
 
     // If the image ids are different, we change the database entry.
     if target_image.id != current_image.id {

--- a/crates/etl-api/tests/pipelines.rs
+++ b/crates/etl-api/tests/pipelines.rs
@@ -39,7 +39,10 @@ use crate::support::{
         sources::create_source,
         tenants::{create_tenant, create_tenant_with_id_and_name},
     },
-    test_app::{TestApp, spawn_test_app, spawn_test_app_with_k8s_state},
+    test_app::{
+        TestApp, spawn_test_app, spawn_test_app_with_k8s_state,
+        spawn_test_app_with_simulator_tenants,
+    },
 };
 
 /// Finds a named property in a possibly composed OpenAPI schema.
@@ -1403,7 +1406,7 @@ async fn update_version_fails_for_non_existing_pipeline() {
 async fn update_version_fails_when_version_is_not_default() {
     init_test_tracing();
     // Arrange
-    let app = spawn_test_app().await;
+    let app = spawn_test_app_with_simulator_tenants(vec!["etl-sf-test-sim".to_owned()]).await;
     create_default_image(&app).await;
     let tenant_id = &create_tenant(&app).await;
     let source_id = create_source(&app, tenant_id).await;
@@ -1418,16 +1421,53 @@ async fn update_version_fails_when_version_is_not_default() {
     )
     .await;
 
-    // Create a non-default image
+    // Create a non-default image.
     let non_default_image_id =
         create_image_with_name(&app, "another/image".to_owned(), false).await;
 
-    // Act - attempt update with a non-default image id
+    // Act as a tenant that is not allowlisted.
     let update_request = UpdatePipelineVersionRequest { version_id: non_default_image_id };
     let response = app.update_pipeline_version(tenant_id, pipeline_id, &update_request).await;
 
-    // Assert - mismatching image id should be rejected
+    // Assert that another tenant's allowlisting does not expand access.
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn simulator_tenant_can_update_pipeline_to_registered_non_default_version() {
+    init_test_tracing();
+    // Arrange
+    let tenant_id = "etl-sf-test-sim".to_owned();
+    let app = spawn_test_app_with_simulator_tenants(vec![tenant_id.clone()]).await;
+    let default_image_id = create_default_image(&app).await;
+    create_tenant_with_id_and_name(&app, tenant_id.clone(), "Snowflake Simulator".to_owned()).await;
+    let source_id = create_source(&app, &tenant_id).await;
+    let destination_id = create_destination(&app, &tenant_id).await;
+    let pipeline_id = create_pipeline_with_config(
+        &app,
+        &tenant_id,
+        source_id,
+        destination_id,
+        new_pipeline_config(),
+    )
+    .await;
+    let non_default_image_name = "public.ecr.aws/supabase/etl-replicator:experimental".to_owned();
+    let non_default_image_id =
+        create_image_with_name(&app, non_default_image_name.clone(), false).await;
+
+    // Act
+    let update_request = UpdatePipelineVersionRequest { version_id: non_default_image_id };
+    let response = app.update_pipeline_version(&tenant_id, pipeline_id, &update_request).await;
+
+    // Assert
+    assert!(response.status().is_success());
+    assert_eq!(app.k8s_state.last_replicator_image().await, Some(non_default_image_name));
+
+    let response = app.get_pipeline_version(&tenant_id, pipeline_id).await;
+    let version: GetPipelineVersionResponse =
+        response.json().await.expect("failed to deserialize response");
+    assert_eq!(version.version.id, non_default_image_id);
+    assert_eq!(version.new_version.map(|image| image.id), Some(default_image_id));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-api/tests/support/k8s_client.rs
+++ b/crates/etl-api/tests/support/k8s_client.rs
@@ -21,6 +21,7 @@ pub(crate) struct MockK8sState {
     create_calls: Arc<AtomicUsize>,
     vpa_delete_calls: Arc<AtomicUsize>,
     ducklake_maintenance_create_calls: Arc<AtomicUsize>,
+    last_replicator_image: Arc<RwLock<Option<String>>>,
     last_replicator_resources: Arc<RwLock<Option<ReplicatorResourcesConfig>>>,
 }
 
@@ -31,6 +32,7 @@ impl Default for MockK8sState {
             create_calls: Arc::new(AtomicUsize::new(0)),
             vpa_delete_calls: Arc::new(AtomicUsize::new(0)),
             ducklake_maintenance_create_calls: Arc::new(AtomicUsize::new(0)),
+            last_replicator_image: Arc::new(RwLock::new(None)),
             last_replicator_resources: Arc::new(RwLock::new(None)),
         }
     }
@@ -51,6 +53,10 @@ impl MockK8sState {
 
     pub(crate) fn ducklake_maintenance_create_calls(&self) -> usize {
         self.ducklake_maintenance_create_calls.load(Ordering::Relaxed)
+    }
+
+    pub(crate) async fn last_replicator_image(&self) -> Option<String> {
+        self.last_replicator_image.read().await.clone()
     }
 
     pub(crate) async fn last_replicator_resources(&self) -> Option<ReplicatorResourcesConfig> {
@@ -188,6 +194,7 @@ impl K8sClient for MockK8sClient {
         _identity: &PipelineRuntimeIdentity,
         config: ReplicatorStatefulSetConfig,
     ) -> Result<(), K8sError> {
+        *self.state.last_replicator_image.write().await = Some(config.replicator_image);
         self.set_last_replicator_resources(config.replicator_resources.as_ref()).await;
         self.record_create_call();
         Ok(())

--- a/crates/etl-api/tests/support/test_app.rs
+++ b/crates/etl-api/tests/support/test_app.rs
@@ -637,13 +637,22 @@ pub(crate) async fn spawn_test_app_with_k8s_state(
 ) -> TestApp {
     let k8s_client: Arc<dyn K8sClient> = Arc::new(MockK8sClient::new(k8s_state.clone()));
 
-    spawn_test_app_with_services(trusted_source_username, k8s_client, k8s_state).await
+    spawn_test_app_with_services(trusted_source_username, k8s_client, k8s_state, Vec::new()).await
+}
+
+/// Spawns an app that classifies the supplied tenant IDs as staging simulators.
+pub(crate) async fn spawn_test_app_with_simulator_tenants(tenant_ids: Vec<String>) -> TestApp {
+    let k8s_state = MockK8sState::default();
+    let k8s_client: Arc<dyn K8sClient> = Arc::new(MockK8sClient::new(k8s_state.clone()));
+
+    spawn_test_app_with_services(None, k8s_client, k8s_state, tenant_ids).await
 }
 
 async fn spawn_test_app_with_services(
     trusted_source_username: Option<String>,
     k8s_client: Arc<dyn K8sClient>,
     k8s_state: MockK8sState,
+    simulator_tenant_ids: Vec<String>,
 ) -> TestApp {
     Environment::Dev.set();
 
@@ -700,6 +709,7 @@ async fn spawn_test_app_with_services(
             key: BASE64_STANDARD.encode(key_bytes),
         }],
         api_keys: vec![api_key.clone()],
+        simulator_tenant_ids,
         sentry: None,
         supabase_api_url: None,
         configcat_sdk_key: None,


### PR DESCRIPTION
## Summary

Allow explicitly configured staging simulator tenants to select registered non-default replicator images for their pipelines.

- Add `simulator_tenant_ids`; an empty list preserves existing behavior.
- Keep the default-only policy and stale-client guard for all other tenants.
- Reject unknown image IDs and reconcile only the requested pipeline.
- Test simulator access and non-simulator rejection.

This is API-side support only. Simulator pinning/reapplication and staging configuration will follow separately.