### PR TITLE
fix(api): wait for DuckLake maintenance shutdown

### DIFF
--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -26,6 +26,19 @@ pub enum K8sError {
     /// server.
     #[error("An error occurred with kube when dealing with K8s: {0}")]
     Kube(#[from] kube::Error),
+    /// A Kubernetes resource remained present after deletion was requested.
+    #[error(
+        "Timed out waiting for Kubernetes {kind} resource '{name}' to be deleted after \
+         {timeout_seconds} seconds"
+    )]
+    ResourceDeletionTimeout {
+        /// Kubernetes resource kind.
+        kind: &'static str,
+        /// Kubernetes resource name.
+        name: String,
+        /// Deletion timeout in seconds.
+        timeout_seconds: u64,
+    },
 }
 
 /// A file to be stored in a [`ConfigMap`] that is used to configure a
@@ -356,7 +369,7 @@ pub trait K8sClient: Send + Sync {
         config: DuckLakeMaintenanceResourceConfig,
     ) -> Result<(), K8sError>;
 
-    /// Deletes the DuckLake maintenance CR.
+    /// Deletes the DuckLake maintenance CR and waits until it is absent.
     async fn delete_ducklake_maintenance(&self, resource_prefix: &str) -> Result<(), K8sError>;
 
     /// Retrieves the current status of a replicator pod.

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 
 use async_trait::async_trait;
 use base64::{Engine, prelude::BASE64_STANDARD};
@@ -131,6 +131,10 @@ const DUCKLAKE_MAINTENANCE_GROUP: &str = "etl.supabase.com";
 const DUCKLAKE_MAINTENANCE_VERSION: &str = "v1alpha1";
 /// DuckLake maintenance CRD kind.
 const DUCKLAKE_MAINTENANCE_KIND: &str = "DuckLakeMaintenance";
+/// Maximum time to wait for a deleted DuckLake maintenance CR to disappear.
+const DUCKLAKE_MAINTENANCE_DELETE_TIMEOUT: Duration = Duration::from_secs(300);
+/// Interval between checks for a deleted DuckLake maintenance CR.
+const DUCKLAKE_MAINTENANCE_DELETE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// Vertical Pod Autoscaler CRD group.
 const VERTICAL_POD_AUTOSCALER_GROUP: &str = "autoscaling.k8s.io";
 /// Vertical Pod Autoscaler CRD version.
@@ -1007,7 +1011,24 @@ impl K8sClient for HttpK8sClient {
             self.ducklake_maintenance_api.delete(&name, &dp).await,
         )?;
 
-        Ok(())
+        match tokio::time::timeout(DUCKLAKE_MAINTENANCE_DELETE_TIMEOUT, async {
+            loop {
+                if self.ducklake_maintenance_api.get_opt(&name).await?.is_none() {
+                    return Ok(());
+                }
+
+                tokio::time::sleep(DUCKLAKE_MAINTENANCE_DELETE_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(K8sError::ResourceDeletionTimeout {
+                kind: DUCKLAKE_MAINTENANCE_KIND,
+                name,
+                timeout_seconds: DUCKLAKE_MAINTENANCE_DELETE_TIMEOUT.as_secs(),
+            }),
+        }
     }
 
     async fn get_replicator_pod_status(

--- a/crates/etl-api/src/routes/pipelines.rs
+++ b/crates/etl-api/src/routes/pipelines.rs
@@ -1116,9 +1116,9 @@ pub(crate) async fn stop_pipeline(
         data::replicators::read_replicator_by_pipeline_id(txn.deref_mut(), tenant_id, pipeline_id)
             .await?
             .ok_or(PipelineError::ReplicatorNotFound(pipeline_id))?;
+    txn.commit().await?;
 
     delete_pipeline_runtime_in_k8s(k8s_client.as_ref(), tenant_id, replicator).await?;
-    txn.commit().await?;
 
     Ok(StatusCode::OK)
 }
@@ -1147,10 +1147,11 @@ pub(crate) async fn stop_all_pipelines(
 
     let mut txn = pool.begin().await?;
     let replicators = data::replicators::read_replicators(txn.deref_mut(), tenant_id).await?;
+    txn.commit().await?;
+
     for replicator in replicators {
         delete_pipeline_runtime_in_k8s(k8s_client.as_ref(), tenant_id, replicator).await?;
     }
-    txn.commit().await?;
 
     Ok(StatusCode::OK)
 }


### PR DESCRIPTION
## Summary

- Wait for the `DuckLakeMaintenance` resource to disappear after requesting deletion.
- Poll once per second for up to five minutes.
- Return a typed timeout error instead of continuing runtime teardown while maintenance may still be running.

## Why

DuckLake can have both the replicator and a maintenance Job accessing its catalog. The controller now retains the maintenance CR finalizer until every owned maintenance Job and Pod has terminated. Waiting for the CR to disappear therefore ensures pipeline shutdown does not continue while a maintenance writer may still exist.

## Rollout

Requires [etl-k8s #954](https://github.com/supabase/etl-k8s/pull/954) and [etl-controller #30](https://github.com/supabase/etl-controller/pull/30) to be deployed first in each environment (both are already live in staging).