### PR TITLE
feat(bigquery): Add support for flexible names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "gcp-bigquery-client"
 version = "0.28.0"
-source = "git+https://github.com/iambriccardo/gcp-bigquery-client?rev=4407c2e325084713fa16219494251217054a98c8#4407c2e325084713fa16219494251217054a98c8"
+source = "git+https://github.com/iambriccardo/gcp-bigquery-client?rev=7da9cd7f140f4a5e6dff8c8593ba8fee4bc20904#7da9cd7f140f4a5e6dff8c8593ba8fee4bc20904"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ etl-postgres = { path = "crates/etl-postgres", default-features = false }
 etl-telemetry = { path = "crates/etl-telemetry", default-features = false }
 fail = { version = "0.5.1", default-features = false }
 futures = { version = "0.3.31", default-features = false }
-gcp-bigquery-client = { git = "https://github.com/iambriccardo/gcp-bigquery-client", rev = "4407c2e325084713fa16219494251217054a98c8", default-features = false }
+gcp-bigquery-client = { git = "https://github.com/iambriccardo/gcp-bigquery-client", rev = "7da9cd7f140f4a5e6dff8c8593ba8fee4bc20904", default-features = false }
 hex = { version = "0.4", default-features = false }
 humantime = { version = "2.3.0", default-features = false }
 iceberg = { version = "0.8.0", default-features = false }

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -1349,20 +1349,6 @@ where
     }
 }
 
-/// Returns whether a column name can be used directly as a protobuf field.
-///
-/// ETL supplies source column names directly in the protobuf descriptor used by
-/// the BigQuery Storage Write API. Flexible BigQuery column names require a
-/// separate `column_name` annotation, which the current writer does not emit.
-fn is_bigquery_storage_write_column_name(column_name: &str) -> bool {
-    let Some((&first, rest)) = column_name.as_bytes().split_first() else {
-        return false;
-    };
-
-    (first.is_ascii_alphabetic() || first == b'_')
-        && rest.iter().all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-}
-
 /// Returns the reserved BigQuery prefix matched by a source column name.
 fn bigquery_reserved_column_prefix(column_name: &str) -> Option<&'static str> {
     BIGQUERY_RESERVED_COLUMN_PREFIXES.into_iter().find(|prefix| {
@@ -1372,7 +1358,10 @@ fn bigquery_reserved_column_prefix(column_name: &str) -> Option<&'static str> {
     })
 }
 
-/// Validates that a source column name is writable through BigQuery CDC.
+/// Validates a source column name against BigQuery's reserved prefixes.
+///
+/// The Storage Write client maps flexible BigQuery column names to
+/// protobuf-safe placeholders using BigQuery's `column_name` field option.
 fn validate_bigquery_column_name(
     replicated_table_schema: &ReplicatedTableSchema,
     column_name: &str,
@@ -1390,27 +1379,14 @@ fn validate_bigquery_column_name(
         );
     }
 
-    if !is_bigquery_storage_write_column_name(column_name) {
-        bail!(
-            ErrorKind::SourceSchemaError,
-            "BigQuery source column name is unsupported",
-            format!(
-                "Table '{}' column '{}' is not an ASCII protobuf identifier. BigQuery flexible \
-                 column names are not supported by the current Storage Write encoder.",
-                replicated_table_schema.name(),
-                column_name
-            )
-        );
-    }
-
     Ok(())
 }
 
 /// Validates BigQuery-specific schema capabilities.
 ///
 /// Shared planning owns destination name-equivalence validation during schema
-/// changes. This check owns protobuf syntax, reserved names, and the source
-/// primary-key requirements used by BigQuery CDC.
+/// changes. This check owns reserved names and the source primary-key
+/// requirements used by BigQuery CDC.
 fn validate_bigquery_table_capabilities(
     replicated_table_schema: &ReplicatedTableSchema,
 ) -> EtlResult<()> {
@@ -2405,14 +2381,11 @@ mod tests {
     }
 
     #[test]
-    fn validate_bigquery_table_shape_rejects_flexible_column_names() {
+    fn validate_bigquery_table_shape_accepts_flexible_column_names() {
         for column_name in ["2fa", "user-name", "naïve"] {
             let replicated_table_schema = replicated_schema_with_column_name(column_name);
 
-            let error = validate_bigquery_table_shape(&replicated_table_schema).unwrap_err();
-
-            assert_eq!(error.kind(), ErrorKind::SourceSchemaError);
-            assert_eq!(error.description(), Some("BigQuery source column name is unsupported"));
+            validate_bigquery_table_shape(&replicated_table_schema).unwrap();
         }
     }
 

--- a/crates/etl-destinations/tests/bigquery/destination.rs
+++ b/crates/etl-destinations/tests/bigquery/destination.rs
@@ -2,11 +2,17 @@ use std::sync::Arc;
 
 use etl::{
     data::{Cell, TableRow},
-    schema::{ColumnSchema, ReplicatedTableSchema, TableId, TableName, TableSchema, Type},
+    destination::WriteEventsDurability,
+    event::{Event, InsertEvent, RelationEvent},
+    schema::{
+        ColumnSchema, PgLsn, ReplicatedTableSchema, SnapshotId, TableId, TableName, TableSchema,
+        Type,
+    },
     store::{MemoryStore, SchemaStore, StateStore, TableStateLifecycleStore},
+    test_utils::destination::write_events,
 };
 use etl_destinations::bigquery::test_utils::{
-    setup_bigquery_database, skip_if_missing_bigquery_env_vars,
+    parse_table_cell, setup_bigquery_database, skip_if_missing_bigquery_env_vars,
 };
 use etl_telemetry::tracing::init_test_tracing;
 
@@ -25,6 +31,190 @@ fn make_users_schema(table_name: &str) -> TableSchema {
             ColumnSchema::new("age".to_owned(), Type::INT4, -1, 3, true),
         ],
     )
+}
+
+/// Creates a synthetic schema snapshot identifier for destination tests.
+fn test_snapshot_id(value: u64) -> SnapshotId {
+    let lsn = PgLsn::from(value);
+    SnapshotId::new(lsn, lsn)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flexible_column_names_work_for_copy_cdc_and_schema_changes() {
+    install_crypto_provider();
+    init_test_tracing();
+
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    let bigquery_database = setup_bigquery_database().await;
+    let store = MemoryStore::new();
+    let table_id = TableId::new(1);
+    let table_name = TableName::new(
+        "public".to_owned(),
+        format!("destination_flexible_names_{}", uuid::Uuid::new_v4().simple()),
+    );
+    let initial_table_schema = store
+        .store_table_schema(TableSchema::with_snapshot_id(
+            table_id,
+            table_name.clone(),
+            vec![
+                ColumnSchema::new("Record ID".to_owned(), Type::INT4, -1, 1, false)
+                    .with_primary_key(1),
+                ColumnSchema::new("Display Label".to_owned(), Type::TEXT, -1, 2, false)
+                    .with_default_expression("'copy-default'::text".to_owned()),
+                ColumnSchema::new("2nd metric".to_owned(), Type::INT4, -1, 3, false),
+                ColumnSchema::new("Café Score".to_owned(), Type::INT4, -1, 4, false),
+            ],
+            test_snapshot_id(100),
+        ))
+        .await
+        .unwrap();
+    let initial_schema = ReplicatedTableSchema::all(initial_table_schema);
+    let destination = bigquery_database.build_destination(1_u64, store.clone()).await;
+
+    destination
+        .write_table_rows_for_tests(
+            &initial_schema,
+            vec![TableRow::new(vec![
+                Cell::I32(1),
+                Cell::String("copied".to_owned()),
+                Cell::I32(10),
+                Cell::I32(80),
+            ])],
+        )
+        .await
+        .unwrap();
+
+    let changed_table_schema = store
+        .store_table_schema(TableSchema::with_snapshot_id(
+            table_id,
+            table_name.clone(),
+            vec![
+                ColumnSchema::new("Record ID".to_owned(), Type::INT4, -1, 1, false)
+                    .with_primary_key(1),
+                ColumnSchema::new("Shipping Label".to_owned(), Type::TEXT, -1, 2, true),
+                ColumnSchema::new("Café Rating".to_owned(), Type::INT4, -1, 4, false),
+                ColumnSchema::new("Service %".to_owned(), Type::TEXT, -1, 5, true)
+                    .with_default_expression("'standard'::text".to_owned()),
+            ],
+            test_snapshot_id(200),
+        ))
+        .await
+        .unwrap();
+    let changed_schema = ReplicatedTableSchema::all(changed_table_schema);
+
+    write_events(
+        &destination,
+        WriteEventsDurability::RequireDurable,
+        vec![
+            Event::Relation(RelationEvent { replicated_table_schema: changed_schema.clone() }),
+            Event::Insert(InsertEvent {
+                commit_lsn: PgLsn::from(300_u64),
+                tx_ordinal: 0,
+                replicated_table_schema: changed_schema,
+                table_row: TableRow::new(vec![
+                    Cell::I32(2),
+                    Cell::String("streamed".to_owned()),
+                    Cell::I32(95),
+                    Cell::String("priority".to_owned()),
+                ]),
+            }),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let table_schema = bigquery_database.query_table_schema(table_name.clone()).await.unwrap();
+    table_schema.assert_columns(&["record id", "shipping label", "café rating", "service %"]);
+
+    let destination_metadata =
+        store.get_destination_table_metadata(table_id).await.unwrap().unwrap();
+    let defaults =
+        bigquery_database.query_column_defaults_by_id(destination_metadata.table_id()).await;
+    assert_eq!(
+        defaults
+            .iter()
+            .find(|column| column.column_name == "shipping label")
+            .and_then(|column| column.column_default.as_deref()),
+        None
+    );
+    assert_eq!(
+        defaults
+            .iter()
+            .find(|column| column.column_name == "service %")
+            .and_then(|column| column.column_default.as_deref()),
+        Some("'standard'")
+    );
+
+    let mut rows = bigquery_database
+        .query_table(table_name)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            let columns = row.columns.unwrap();
+            (
+                parse_table_cell::<i64>(columns[0].clone()).unwrap(),
+                parse_table_cell::<String>(columns[1].clone()).unwrap(),
+                parse_table_cell::<i64>(columns[2].clone()).unwrap(),
+                parse_table_cell::<String>(columns[3].clone()),
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort();
+
+    assert_eq!(
+        rows,
+        [
+            (1, "copied".to_owned(), 80, None),
+            (2, "streamed".to_owned(), 95, Some("priority".to_owned())),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn nullable_array_is_stored_as_empty_array() {
+    install_crypto_provider();
+    init_test_tracing();
+
+    if skip_if_missing_bigquery_env_vars() {
+        return;
+    }
+
+    let bigquery_database = setup_bigquery_database().await;
+    let store = MemoryStore::new();
+    let table_name = TableName::new(
+        "public".to_owned(),
+        format!("destination_nullable_array_{}", uuid::Uuid::new_v4().simple()),
+    );
+    let table_schema = store
+        .store_table_schema(TableSchema::new(
+            TableId::new(1),
+            table_name.clone(),
+            vec![
+                ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false).with_primary_key(1),
+                ColumnSchema::new("values".to_owned(), Type::INT4_ARRAY, -1, 2, true),
+            ],
+        ))
+        .await
+        .unwrap();
+    let replicated_table_schema = ReplicatedTableSchema::all(table_schema);
+    let destination = bigquery_database.build_destination(1_u64, store).await;
+
+    destination
+        .write_table_rows_for_tests(
+            &replicated_table_schema,
+            vec![TableRow::new(vec![Cell::I32(1), Cell::Null])],
+        )
+        .await
+        .unwrap();
+
+    let table_rows = bigquery_database.query_table(table_name).await.unwrap();
+    assert_eq!(table_rows.len(), 1);
+    let columns = table_rows[0].columns.as_ref().unwrap();
+    assert!(columns[1].value.as_ref().unwrap().as_array().unwrap().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-destinations/tests/bigquery/destination.rs
+++ b/crates/etl-destinations/tests/bigquery/destination.rs
@@ -51,59 +51,116 @@ async fn flexible_column_names_work_for_copy_cdc_and_schema_changes() {
     let bigquery_database = setup_bigquery_database().await;
     let store = MemoryStore::new();
     let table_id = TableId::new(1);
+    let flexible_column_names = [
+        "1st_value",
+        "café",
+        "metric١",
+        "link‿value",
+        "dash-value",
+        "accent\u{301}mark",
+        "value&unit",
+        "value%unit",
+        "value=unit",
+        "value+unit",
+        "value:unit",
+        "value'unit",
+        "value<unit",
+        "value>unit",
+        "value#unit",
+        "value|unit",
+        "display label",
+    ];
     let table_name = TableName::new(
         "public".to_owned(),
         format!("destination_flexible_names_{}", uuid::Uuid::new_v4().simple()),
     );
+    let initial_column_schemas = flexible_column_names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| {
+            let column_schema = ColumnSchema::new(
+                (*name).to_owned(),
+                if index == 0 { Type::INT4 } else { Type::TEXT },
+                -1,
+                i32::try_from(index).unwrap() + 1,
+                false,
+            );
+
+            match index {
+                0 => column_schema.with_primary_key(1),
+                1 => column_schema.with_default_expression("'copy-default'::text".to_owned()),
+                _ => column_schema,
+            }
+        })
+        .collect();
     let initial_table_schema = store
         .store_table_schema(TableSchema::with_snapshot_id(
             table_id,
             table_name.clone(),
-            vec![
-                ColumnSchema::new("Record ID".to_owned(), Type::INT4, -1, 1, false)
-                    .with_primary_key(1),
-                ColumnSchema::new("Display Label".to_owned(), Type::TEXT, -1, 2, false)
-                    .with_default_expression("'copy-default'::text".to_owned()),
-                ColumnSchema::new("2nd metric".to_owned(), Type::INT4, -1, 3, false),
-                ColumnSchema::new("Café Score".to_owned(), Type::INT4, -1, 4, false),
-            ],
+            initial_column_schemas,
             test_snapshot_id(100),
         ))
         .await
         .unwrap();
     let initial_schema = ReplicatedTableSchema::all(initial_table_schema);
     let destination = bigquery_database.build_destination(1_u64, store.clone()).await;
+    let mut cells = vec![Cell::I32(1)];
+    cells.extend(
+        flexible_column_names
+            .iter()
+            .enumerate()
+            .skip(1)
+            .map(|(index, _)| Cell::String(format!("copied_{index}"))),
+    );
 
     destination
-        .write_table_rows_for_tests(
-            &initial_schema,
-            vec![TableRow::new(vec![
-                Cell::I32(1),
-                Cell::String("copied".to_owned()),
-                Cell::I32(10),
-                Cell::I32(80),
-            ])],
-        )
+        .write_table_rows_for_tests(&initial_schema, vec![TableRow::new(cells)])
         .await
         .unwrap();
 
+    let mut changed_column_schemas = flexible_column_names
+        .iter()
+        .enumerate()
+        .filter_map(|(index, name)| {
+            if index == 2 {
+                return None;
+            }
+
+            let name = if index == 1 { "renamed label" } else { name };
+            let column_schema = ColumnSchema::new(
+                name.to_owned(),
+                if index == 0 { Type::INT4 } else { Type::TEXT },
+                -1,
+                i32::try_from(index).unwrap() + 1,
+                index == 1,
+            );
+
+            Some(if index == 0 { column_schema.with_primary_key(1) } else { column_schema })
+        })
+        .collect::<Vec<_>>();
+    changed_column_schemas.push(
+        ColumnSchema::new("service %".to_owned(), Type::TEXT, -1, 18, true)
+            .with_default_expression("'standard'::text".to_owned()),
+    );
     let changed_table_schema = store
         .store_table_schema(TableSchema::with_snapshot_id(
             table_id,
             table_name.clone(),
-            vec![
-                ColumnSchema::new("Record ID".to_owned(), Type::INT4, -1, 1, false)
-                    .with_primary_key(1),
-                ColumnSchema::new("Shipping Label".to_owned(), Type::TEXT, -1, 2, true),
-                ColumnSchema::new("Café Rating".to_owned(), Type::INT4, -1, 4, false),
-                ColumnSchema::new("Service %".to_owned(), Type::TEXT, -1, 5, true)
-                    .with_default_expression("'standard'::text".to_owned()),
-            ],
+            changed_column_schemas,
             test_snapshot_id(200),
         ))
         .await
         .unwrap();
     let changed_schema = ReplicatedTableSchema::all(changed_table_schema);
+    let mut streamed_cells = vec![Cell::I32(2), Cell::String("streamed_1".to_owned())];
+    streamed_cells.extend(
+        flexible_column_names
+            .iter()
+            .enumerate()
+            .skip(3)
+            .map(|(index, _)| Cell::String(format!("streamed_{index}"))),
+    );
+    streamed_cells.push(Cell::String("priority".to_owned()));
 
     write_events(
         &destination,
@@ -114,12 +171,7 @@ async fn flexible_column_names_work_for_copy_cdc_and_schema_changes() {
                 commit_lsn: PgLsn::from(300_u64),
                 tx_ordinal: 0,
                 replicated_table_schema: changed_schema,
-                table_row: TableRow::new(vec![
-                    Cell::I32(2),
-                    Cell::String("streamed".to_owned()),
-                    Cell::I32(95),
-                    Cell::String("priority".to_owned()),
-                ]),
+                table_row: TableRow::new(streamed_cells),
             }),
         ],
     )
@@ -127,7 +179,12 @@ async fn flexible_column_names_work_for_copy_cdc_and_schema_changes() {
     .unwrap();
 
     let table_schema = bigquery_database.query_table_schema(table_name.clone()).await.unwrap();
-    table_schema.assert_columns(&["record id", "shipping label", "café rating", "service %"]);
+    let expected_names = std::iter::once(flexible_column_names[0])
+        .chain(std::iter::once("renamed label"))
+        .chain(flexible_column_names.into_iter().skip(3))
+        .chain(std::iter::once("service %"))
+        .collect::<Vec<_>>();
+    table_schema.assert_columns(&expected_names);
 
     let destination_metadata =
         store.get_destination_table_metadata(table_id).await.unwrap().unwrap();
@@ -136,7 +193,7 @@ async fn flexible_column_names_work_for_copy_cdc_and_schema_changes() {
     assert_eq!(
         defaults
             .iter()
-            .find(|column| column.column_name == "shipping label")
+            .find(|column| column.column_name == "renamed label")
             .and_then(|column| column.column_default.as_deref()),
         None
     );
@@ -157,21 +214,25 @@ async fn flexible_column_names_work_for_copy_cdc_and_schema_changes() {
             let columns = row.columns.unwrap();
             (
                 parse_table_cell::<i64>(columns[0].clone()).unwrap(),
-                parse_table_cell::<String>(columns[1].clone()).unwrap(),
-                parse_table_cell::<i64>(columns[2].clone()).unwrap(),
-                parse_table_cell::<String>(columns[3].clone()),
+                columns[1..]
+                    .iter()
+                    .map(|column| parse_table_cell::<String>(column.clone()))
+                    .collect::<Vec<_>>(),
             )
         })
         .collect::<Vec<_>>();
     rows.sort();
 
-    assert_eq!(
-        rows,
-        [
-            (1, "copied".to_owned(), 80, None),
-            (2, "streamed".to_owned(), 95, Some("priority".to_owned())),
-        ]
-    );
+    let mut copied_values = vec![Some("copied_1".to_owned())];
+    copied_values
+        .extend((3..flexible_column_names.len()).map(|index| Some(format!("copied_{index}"))));
+    copied_values.push(None);
+    let mut streamed_values = vec![Some("streamed_1".to_owned())];
+    streamed_values
+        .extend((3..flexible_column_names.len()).map(|index| Some(format!("streamed_{index}"))));
+    streamed_values.push(Some("priority".to_owned()));
+
+    assert_eq!(rows, [(1, copied_values), (2, streamed_values)]);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl-destinations/tests/bigquery/pipeline.rs
+++ b/crates/etl-destinations/tests/bigquery/pipeline.rs
@@ -4,7 +4,6 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use etl::{
     config::BatchConfig,
     data::{Cell, OldTableRow, PgNumeric, TableRow, UpdatedTableRow},
-    error::ErrorKind,
     event::{Event, EventType},
     pipeline::PipelineId,
     store::StateStore,
@@ -23,7 +22,6 @@ use etl_destinations::bigquery::test_utils::{
 use etl_postgres::{below_version, tokio::test_utils::TableModification, version::POSTGRES_15};
 use etl_telemetry::tracing::init_test_tracing;
 use rand::{Rng, distr::Alphanumeric, random};
-use tokio::time::sleep;
 
 use crate::support::{
     bigquery::{
@@ -1018,73 +1016,6 @@ async fn table_nullable_scalar_columns() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn table_nullable_array_columns_follow_bigquery_null_coercion() {
-    if skip_if_missing_bigquery_env_vars() {
-        return;
-    }
-
-    init_test_tracing();
-    install_crypto_provider();
-
-    let database = spawn_source_database().await;
-    let bigquery_database = setup_bigquery_database().await;
-    let table_name = test_table_name("nullable_cols_array");
-    let table_id =
-        database.create_table(table_name.clone(), true, &[("values", "integer[]")]).await.unwrap();
-    database
-        .client
-        .as_ref()
-        .unwrap()
-        .execute(
-            &format!(
-                "insert into {} (values) values (array[]::integer[])",
-                table_name.as_quoted_identifier()
-            ),
-            &[],
-        )
-        .await
-        .unwrap();
-
-    let publication_name = "test_pub_array";
-    database.create_publication(publication_name, std::slice::from_ref(&table_name)).await.unwrap();
-
-    let store = NotifyingStore::new();
-    let pipeline_id: PipelineId = random();
-    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
-    let destination = TestDestinationWrapper::wrap(raw_destination);
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name.to_owned(),
-        store.clone(),
-        destination.clone(),
-    );
-
-    let table_sync_complete_notify = store.notify_on_table_sync_complete(table_id).await;
-    pipeline.start().await.unwrap();
-    table_sync_complete_notify.notified().await;
-
-    let events_notify = destination
-        .wait_for_events(vec![EventCondition::TableCount(EventType::Update, table_id, 1)])
-        .await;
-    database
-        .client
-        .as_ref()
-        .unwrap()
-        .execute(&format!("update {} set values = null", table_name.as_quoted_identifier()), &[])
-        .await
-        .unwrap();
-
-    events_notify.notified().await;
-    pipeline.shutdown_and_wait().await.unwrap();
-
-    let table_rows = bigquery_database.query_table(table_name).await.unwrap();
-    assert_eq!(table_rows.len(), 1);
-    let columns = table_rows[0].columns.as_ref().unwrap();
-    assert_eq!(columns[1].value.as_ref().unwrap().as_array().unwrap().len(), 0);
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn table_non_nullable_scalar_columns() {
     if skip_if_missing_bigquery_env_vars() {
         return;
@@ -1600,142 +1531,6 @@ async fn table_non_nullable_array_columns() {
     assert!(bigquery_database.wait_for_no_rows(table_name.clone()).await);
 
     pipeline.shutdown_and_wait().await.unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn table_array_with_null_values() {
-    if skip_if_missing_bigquery_env_vars() {
-        return;
-    }
-
-    init_test_tracing();
-    install_crypto_provider();
-
-    let database = spawn_source_database().await;
-    let bigquery_database = setup_bigquery_database().await;
-    let table_name = test_table_name("array_with_nulls");
-    let table_id = database
-        .create_table(table_name.clone(), true, &[("int_array", "int4[] not null")])
-        .await
-        .unwrap();
-
-    let store = NotifyingStore::new();
-    let pipeline_id: PipelineId = random();
-    let raw_destination = bigquery_database.build_destination(pipeline_id, store.clone()).await;
-    let destination = TestDestinationWrapper::wrap(raw_destination);
-
-    let publication_name = "test_pub_array_nulls".to_owned();
-    database
-        .create_publication(&publication_name, std::slice::from_ref(&table_name))
-        .await
-        .unwrap();
-
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name.clone(),
-        store.clone(),
-        destination.clone(),
-    );
-
-    let table_sync_complete_notify = store.notify_on_table_sync_complete(table_id).await;
-
-    pipeline.start().await.unwrap();
-
-    table_sync_complete_notify.notified().await;
-
-    // Insert array with null value
-    database
-        .client
-        .as_ref()
-        .unwrap()
-        .execute(
-            &format!(
-                "insert into {} (int_array) values (array[1, null])",
-                table_name.as_quoted_identifier()
-            ),
-            &[],
-        )
-        .await
-        .unwrap();
-
-    // We sleep to wait for the event to be processed. This is not ideal, but if we
-    // wanted to do this better, we would have to also implement error handling
-    // within the apply worker to write in the state store.
-    sleep(Duration::from_secs(5)).await;
-
-    // Wait for the pipeline expecting an error to be returned.
-    let err = pipeline.shutdown_and_wait().await.err().unwrap();
-    assert_eq!(err.kinds().len(), 1);
-    assert_eq!(err.kinds()[0], ErrorKind::NullValuesNotSupportedInArrayInDestination);
-
-    // Reset and try with valid array (no nulls)
-    database
-        .client
-        .as_ref()
-        .unwrap()
-        .execute(&format!("delete from {} where true", table_name.as_quoted_identifier()), &[])
-        .await
-        .unwrap();
-
-    // We have to reset the state of the table and copy it from scratch, otherwise
-    // the CDC will contain the inserts and deletes, failing again.
-    store.reset_table_state(table_id).await.unwrap();
-
-    // We recreate the pipeline and try again.
-    let mut pipeline = create_pipeline(
-        &database.config,
-        pipeline_id,
-        publication_name,
-        store.clone(),
-        destination.clone(),
-    );
-
-    let table_sync_complete_notify = store.notify_on_table_sync_complete(table_id).await;
-
-    pipeline.start().await.unwrap();
-
-    // BigQuery can keep the default Storage Write stream for a dropped and
-    // re-created table unavailable for several minutes. The destination is
-    // expected to keep retrying while preserving the physical `*_0` table id.
-    table_sync_complete_notify.wait_for(BIGQUERY_RECREATED_TABLE_READY_TIMEOUT).notified().await;
-
-    let events_notify = destination
-        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
-        .await;
-
-    // Insert array without null values
-    database
-        .client
-        .as_ref()
-        .unwrap()
-        .execute(
-            &format!(
-                "insert into {} (int_array) values (array[1, 2, 3])",
-                table_name.as_quoted_identifier()
-            ),
-            &[],
-        )
-        .await
-        .unwrap();
-
-    events_notify.notified().await;
-
-    pipeline.shutdown_and_wait().await.unwrap();
-
-    // Verify the valid array was successfully replicated to BigQuery
-    let table_rows = bigquery_database.query_table(table_name.clone()).await.unwrap();
-
-    // Check that there is only the valid row in BigQuery
-    assert_eq!(table_rows.len(), 1);
-
-    // Check that the int array contains 3 elements, meaning it must be the second
-    // insert with all NON-NULL values
-    let row = &table_rows[0];
-    if let Some(columns) = &row.columns {
-        assert_eq!(columns.len(), 2);
-        assert_eq!(columns[1].value.clone().unwrap().as_array().unwrap().len(), 3);
-    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/src/schema.rs
+++ b/crates/etl/src/schema.rs
@@ -360,12 +360,6 @@ impl<I: Iterator> ExactSizeIterator for SizedIterator<I> {
 /// existing tables may need compatibility handling or a resync before this
 /// mapping can change safely. Otherwise the planner could reject a valid
 /// schema, miss a collision, or classify a required rename as a no-op.
-///
-/// Destination-specific options that refer to source columns, such as
-/// partitioning, clustering, or sorting configuration, must also apply this
-/// mapping before rendering a physical identifier. In contrast, column names
-/// returned by [`SchemaPlan::ordered_operations`] are already mapped and must
-/// be executed without mapping them again.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColumnNameMapping {
     /// Preserves the source name exactly.


### PR DESCRIPTION
## Summary

Adds support for BigQuery flexible column names across initial copy, CDC, schema changes, partitioning, and clustering.

- Updates the Storage Write client to encode flexible names through BigQuery’s protobuf `column_name` field option.
- Removes the restriction requiring source columns to be ASCII protobuf identifiers.
- Preserves validation for BigQuery-reserved column prefixes.
- Applies the destination’s ASCII-lowercase name mapping consistently to partitioning and clustering columns.
- Updates integration coverage for copy, CDC, column additions, removals and renames, defaults, nullable arrays, and table options.

## Motivation

BigQuery supports column names containing spaces, Unicode characters, punctuation, and leading digits. ETL previously rejected these names because they could not be used directly as protobuf field identifiers.

The updated client uses protobuf-safe placeholders while retaining the actual BigQuery column names in field metadata, allowing these schemas to replicate without changing their source names.