### PR TITLE
fix(ddl): Handle noop schema changes

### DIFF
--- a/crates/etl-config/src/shared/pipeline.rs
+++ b/crates/etl-config/src/shared/pipeline.rs
@@ -612,32 +612,25 @@ mod tests {
     }
 
     #[test]
-    fn batch_config_deserializes_without_max_bytes() {
-        let json = r#"{"max_fill_ms":5000,"memory_budget_ratio":0.2}"#;
-        let config: BatchConfig = serde_json::from_str(json).unwrap();
+    fn batch_config_deserializes_defaults_overrides_and_unknown_fields() {
+        for (json, expected_max_bytes) in [
+            (r#"{"max_fill_ms":5000,"memory_budget_ratio":0.2}"#, BatchConfig::DEFAULT_MAX_BYTES),
+            (
+                r#"{"max_fill_ms":5000,"memory_budget_ratio":0.2,"max_bytes":4194304}"#,
+                4 * 1024 * 1024,
+            ),
+            (
+                r#"{"max_fill_ms":5000,"memory_budget_ratio":0.2,"max_bytes":4194304,"future_field":true}"#,
+                4 * 1024 * 1024,
+            ),
+        ] {
+            let config: BatchConfig = serde_json::from_str(json).unwrap();
 
-        assert_eq!(config.max_fill_ms, 5000);
-        assert_eq!(config.memory_budget_ratio, 0.2);
-        assert_eq!(config.max_bytes, BatchConfig::DEFAULT_MAX_BYTES);
-        config.validate().unwrap();
-    }
-
-    #[test]
-    fn batch_config_deserializes_with_max_bytes() {
-        let json = r#"{"max_fill_ms":5000,"memory_budget_ratio":0.2,"max_bytes":4194304}"#;
-        let config: BatchConfig = serde_json::from_str(json).unwrap();
-
-        assert_eq!(config.max_bytes, 4 * 1024 * 1024);
-        config.validate().unwrap();
-    }
-
-    #[test]
-    fn batch_config_deserialization_ignores_unknown_fields() {
-        let json = r#"{"max_fill_ms":5000,"memory_budget_ratio":0.2,"max_bytes":4194304,"future_field":true}"#;
-        let config: BatchConfig = serde_json::from_str(json).unwrap();
-
-        assert_eq!(config.max_bytes, 4 * 1024 * 1024);
-        config.validate().unwrap();
+            assert_eq!(config.max_fill_ms, 5000);
+            assert_eq!(config.memory_budget_ratio, 0.2);
+            assert_eq!(config.max_bytes, expected_max_bytes);
+            config.validate().unwrap();
+        }
     }
 
     #[test]
@@ -693,30 +686,17 @@ mod tests {
     }
 
     #[test]
-    fn table_sync_copy_serialization_skip_all() {
-        let selection = TableSyncCopyConfig::SkipAllTables;
-        let json = serde_json::to_string(&selection).unwrap();
-        let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
+    fn table_sync_copy_serialization_roundtrips_variants() {
+        for selection in [
+            TableSyncCopyConfig::SkipAllTables,
+            TableSyncCopyConfig::IncludeTables { table_ids: vec![1, 2, 3] },
+            TableSyncCopyConfig::SkipTables { table_ids: vec![4, 5] },
+        ] {
+            let json = serde_json::to_string(&selection).unwrap();
+            let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(selection, decoded);
-    }
-
-    #[test]
-    fn table_sync_copy_serialization_include_tables() {
-        let selection = TableSyncCopyConfig::IncludeTables { table_ids: vec![1, 2, 3] };
-        let json = serde_json::to_string(&selection).unwrap();
-        let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(selection, decoded);
-    }
-
-    #[test]
-    fn table_sync_copy_serialization_exclude_tables() {
-        let selection = TableSyncCopyConfig::SkipTables { table_ids: vec![4, 5] };
-        let json = serde_json::to_string(&selection).unwrap();
-        let decoded: TableSyncCopyConfig = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(selection, decoded);
+            assert_eq!(selection, decoded);
+        }
     }
 
     #[test]

--- a/crates/etl-destinations/src/bigquery/core.rs
+++ b/crates/etl-destinations/src/bigquery/core.rs
@@ -2133,15 +2133,15 @@ mod tests {
     }
 
     #[test]
-    fn table_name_to_bigquery_table_id_no_underscores() {
-        let table_name = TableName::new("schema".to_owned(), "table".to_owned());
-        assert_eq!(table_name_to_bigquery_table_id(&table_name).unwrap(), "schema_table");
-    }
-
-    #[test]
-    fn table_name_to_bigquery_table_id_with_underscores() {
-        let table_name = TableName::new("a_b".to_owned(), "c_d".to_owned());
-        assert_eq!(table_name_to_bigquery_table_id(&table_name).unwrap(), "a__b_c__d");
+    fn table_name_to_bigquery_table_id_uses_escaped_components() {
+        for (schema, table, expected) in [
+            ("schema", "table", "schema_table"),
+            ("a_b", "c_d", "a__b_c__d"),
+            ("a__b", "c__d", "a____b_c____d"),
+        ] {
+            let table_name = TableName::new(schema.to_owned(), table.to_owned());
+            assert_eq!(table_name_to_bigquery_table_id(&table_name).unwrap(), expected);
+        }
     }
 
     #[test]
@@ -2159,101 +2159,32 @@ mod tests {
     }
 
     #[test]
-    fn table_name_to_bigquery_table_id_multiple_underscores() {
-        let table_name = TableName::new("a__b".to_owned(), "c__d".to_owned());
-        assert_eq!(table_name_to_bigquery_table_id(&table_name).unwrap(), "a____b_c____d");
+    fn sequenced_bigquery_table_id_parses_and_roundtrips_valid_ids() {
+        for (input, base, sequence) in [
+            ("users_table_123", "users_table", 123),
+            ("simple_table_0", "simple_table", 0),
+            ("test_table_18446744073709551615", "test_table", u64::MAX),
+            ("a__b_c__d_42", "a__b_c__d", 42),
+        ] {
+            let parsed = input.parse::<SequencedBigQueryTableId>().unwrap();
+            assert_eq!(parsed.to_bigquery_table_id(), base);
+            assert_eq!(parsed.1, sequence);
+            assert_eq!(parsed.to_string(), input);
+        }
     }
 
     #[test]
-    fn sequenced_bigquery_table_id_from_str_valid() {
-        let table_id = "users_table_123";
-        let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
-        assert_eq!(parsed.to_bigquery_table_id(), "users_table");
-        assert_eq!(parsed.1, 123);
-    }
+    fn sequenced_bigquery_table_id_starts_at_zero_and_increments() {
+        let initial = SequencedBigQueryTableId::new("users_table".to_owned());
+        assert_eq!(initial, SequencedBigQueryTableId("users_table".to_owned(), 0));
 
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_zero_sequence() {
-        let table_id = "simple_table_0";
-        let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
-        assert_eq!(parsed.to_bigquery_table_id(), "simple_table");
-        assert_eq!(parsed.1, 0);
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_large_sequence() {
-        let table_id = "test_table_18446744073709551615"; // u64::MAX
-        let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
-        assert_eq!(parsed.to_bigquery_table_id(), "test_table");
-        assert_eq!(parsed.1, u64::MAX);
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_escaped_underscores() {
-        let table_id = "a__b_c__d_42";
-        let parsed = table_id.parse::<SequencedBigQueryTableId>().unwrap();
-        assert_eq!(parsed.to_bigquery_table_id(), "a__b_c__d");
-        assert_eq!(parsed.1, 42);
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_new() {
-        let table_id = SequencedBigQueryTableId::new("users_table".to_owned());
-        assert_eq!(table_id.to_bigquery_table_id(), "users_table");
-        assert_eq!(table_id.1, 0);
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_new_with_underscores() {
-        let table_id = SequencedBigQueryTableId::new("a__b_c__d".to_owned());
-        assert_eq!(table_id.to_bigquery_table_id(), "a__b_c__d");
-        assert_eq!(table_id.1, 0);
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_next() {
-        let table_id = SequencedBigQueryTableId::new("users_table".to_owned());
-        let next_table_id = table_id.next();
-
-        assert_eq!(table_id.1, 0);
-        assert_eq!(next_table_id.1, 1);
-        assert_eq!(next_table_id.to_bigquery_table_id(), "users_table");
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_next_increments_correctly() {
-        let table_id = SequencedBigQueryTableId("test_table".to_owned(), 42);
-        let next_table_id = table_id.next();
-
-        assert_eq!(next_table_id.1, 43);
-        assert_eq!(next_table_id.to_bigquery_table_id(), "test_table");
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_next_max_value() {
-        let table_id = SequencedBigQueryTableId("test_table".to_owned(), u64::MAX - 1);
-        let next_table_id = table_id.next();
-
-        assert_eq!(next_table_id.1, u64::MAX);
-        assert_eq!(next_table_id.to_bigquery_table_id(), "test_table");
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_to_bigquery_table_id() {
-        let table_id = SequencedBigQueryTableId("users_table".to_owned(), 123);
-        assert_eq!(table_id.to_bigquery_table_id(), "users_table");
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_to_bigquery_table_id_with_underscores() {
-        let table_id = SequencedBigQueryTableId("a__b_c__d".to_owned(), 42);
-        assert_eq!(table_id.to_bigquery_table_id(), "a__b_c__d");
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_to_bigquery_table_id_zero_sequence() {
-        let table_id = SequencedBigQueryTableId("simple_table".to_owned(), 0);
-        assert_eq!(table_id.to_bigquery_table_id(), "simple_table");
+        for sequence in [0, 42, u64::MAX - 1] {
+            let current = SequencedBigQueryTableId("users_table".to_owned(), sequence);
+            assert_eq!(
+                current.next(),
+                SequencedBigQueryTableId("users_table".to_owned(), sequence + 1)
+            );
+        }
     }
 
     #[test]
@@ -2645,264 +2576,76 @@ mod tests {
     }
 
     #[test]
-    fn sequenced_bigquery_table_id_from_str_no_underscore() {
-        let result = "tablewithoutsequence".parse::<SequencedBigQueryTableId>();
-        assert!(result.is_err());
+    fn sequenced_bigquery_table_id_rejects_invalid_ids() {
+        for (input, expected_detail) in [
+            ("tablewithoutsequence", "No underscore found"),
+            ("", "No underscore found"),
+            ("users_table_not_a_number", "Failed to parse sequence number"),
+            ("table_word", "Failed to parse sequence number"),
+            ("users_table_-123", "Failed to parse sequence number"),
+            ("users_table_18446744073709551616", "Failed to parse sequence number"),
+            ("users_table_", "Sequence number cannot be empty"),
+            ("_123", "Table name cannot be empty"),
+        ] {
+            let error = input.parse::<SequencedBigQueryTableId>().unwrap_err();
 
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("No underscore found"));
-        assert!(err.to_string().contains("tablewithoutsequence"));
-        assert!(err.to_string().contains("Expected format: 'table_name_sequence'"));
+            assert_eq!(error.kind(), ErrorKind::DestinationTableNameInvalid);
+            assert!(error.to_string().contains(expected_detail), "input: {input}");
+            assert!(error.to_string().contains(input), "input: {input}");
+        }
     }
 
     #[test]
-    fn sequenced_bigquery_table_id_from_str_invalid_sequence_number() {
-        let result = "users_table_not_a_number".parse::<SequencedBigQueryTableId>();
-        assert!(result.is_err());
+    fn split_table_rows_distributes_rows_across_target_batches() {
+        for (row_count, target_batches, expected_batch_sizes) in [
+            (0, 4, vec![]),
+            (1, 0, vec![1]),
+            (2, 1, vec![2]),
+            (2, 5, vec![2]),
+            (4, 2, vec![2, 2]),
+            (5, 3, vec![2, 2, 1]),
+            (10, 4, vec![3, 3, 2, 2]),
+        ] {
+            let rows = (0..row_count)
+                .map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap())
+                .collect();
+            let batches = split_table_rows(rows, target_batches);
+            let batch_sizes: Vec<_> = batches.iter().map(Vec::len).collect();
 
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("Failed to parse sequence number"));
-        assert!(err.to_string().contains("not_a_number"));
-        assert!(err.to_string().contains("users_table_not_a_number"));
-        assert!(err.to_string().contains("Expected a non-negative integer"));
+            assert_eq!(batch_sizes, expected_batch_sizes);
+            assert_eq!(batches.iter().map(Vec::len).sum::<usize>(), row_count);
+        }
     }
 
     #[test]
-    fn sequenced_bigquery_table_id_from_str_sequence_is_word() {
-        let result = "table_word".parse::<SequencedBigQueryTableId>();
-        assert!(result.is_err());
+    fn calculate_target_batches_handles_empty_small_and_oversized_rows() {
+        assert_eq!(calculate_target_batches_for_table_copy(&[]).unwrap(), 0);
 
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("Failed to parse sequence number"));
-        assert!(err.to_string().contains("word"));
-        assert!(err.to_string().contains("table_word"));
-        assert!(err.to_string().contains("Expected a non-negative integer"));
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_negative_sequence() {
-        let result = "users_table_-123".parse::<SequencedBigQueryTableId>();
-        assert!(result.is_err());
-
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("Failed to parse sequence number"));
-        assert!(err.to_string().contains("-123"));
-        assert!(err.to_string().contains("users_table_-123"));
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_sequence_overflow() {
-        let result = "users_table_18446744073709551616".parse::<SequencedBigQueryTableId>(); // u64::MAX + 1
-        assert!(result.is_err());
-
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("Failed to parse sequence number"));
-        assert!(err.to_string().contains("18446744073709551616"));
-        assert!(err.to_string().contains("users_table_18446744073709551616"));
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_empty_string() {
-        let result = "".parse::<SequencedBigQueryTableId>();
-        assert!(result.is_err());
-
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("No underscore found"));
-        assert!(err.to_string().contains("''"));
-        assert!(err.to_string().contains("Expected format: 'table_name_sequence'"));
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_empty_sequence() {
-        let result = "users_table_".parse::<SequencedBigQueryTableId>();
-        assert!(result.is_err());
-
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("Sequence number cannot be empty"));
-        assert!(err.to_string().contains("users_table_"));
-        assert!(err.to_string().contains("Expected format: 'table_name_sequence'"));
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_from_str_empty_table_name() {
-        let result = "_123".parse::<SequencedBigQueryTableId>();
-        assert!(result.is_err());
-
-        let err = result.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::DestinationTableNameInvalid);
-        assert!(err.to_string().contains("Table name cannot be empty"));
-        assert!(err.to_string().contains("_123"));
-        assert!(err.to_string().contains("Expected format: 'table_name_sequence'"));
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_round_trip() {
-        let original = "users_table_123";
-        let parsed = original.parse::<SequencedBigQueryTableId>().unwrap();
-        let formatted = parsed.to_string();
-        assert_eq!(original, formatted);
-    }
-
-    #[test]
-    fn sequenced_bigquery_table_id_round_trip_complex() {
-        let original = "a__b_c__d_999";
-        let parsed = original.parse::<SequencedBigQueryTableId>().unwrap();
-        let formatted = parsed.to_string();
-        assert_eq!(original, formatted);
-        assert_eq!(parsed.to_bigquery_table_id(), "a__b_c__d");
-        assert_eq!(parsed.1, 999);
-    }
-
-    #[test]
-    fn split_table_rows_empty_input() {
-        let rows: Vec<BigQueryTableRow> = vec![];
-        let result = split_table_rows(rows, 4);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn split_table_rows_zero_concurrent_streams() {
-        let rows = vec![BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()];
-        let result = split_table_rows(rows, 0);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].len(), 1);
-    }
-
-    #[test]
-    fn split_table_rows_single_concurrent_stream() {
-        let rows = vec![
-            BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
-            BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
-        ];
-        let result = split_table_rows(rows, 1);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].len(), 2);
-    }
-
-    #[test]
-    fn split_table_rows_fewer_rows_than_streams() {
-        let rows = vec![
-            BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
-            BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
-        ];
-        let result = split_table_rows(rows, 5);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].len(), 2);
-    }
-
-    #[test]
-    fn split_table_rows_equal_distribution() {
-        let rows =
-            (0..4).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
-        let result = split_table_rows(rows, 2);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].len(), 2);
-        assert_eq!(result[1].len(), 2);
-    }
-
-    #[test]
-    fn split_table_rows_uneven_distribution() {
-        let rows =
-            (0..5).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
-        let result = split_table_rows(rows, 3);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].len(), 2); // Gets extra row
-        assert_eq!(result[1].len(), 2); // Gets extra row
-        assert_eq!(result[2].len(), 1);
-    }
-
-    #[test]
-    fn split_table_rows_many_streams() {
-        let rows =
-            (0..10).map(|_| BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()).collect();
-        let result = split_table_rows(rows, 4);
-        assert_eq!(result.len(), 4);
-
-        // Verify all rows are accounted for
-        let total_rows: usize = result.iter().map(Vec::len).sum();
-        assert_eq!(total_rows, 10);
-
-        // Verify approximately equal distribution
-        assert_eq!(result[0].len(), 3); // Gets extra row
-        assert_eq!(result[1].len(), 3); // Gets extra row
-        assert_eq!(result[2].len(), 2);
-        assert_eq!(result[3].len(), 2);
-    }
-
-    #[test]
-    fn split_table_rows_single_row() {
-        let rows = vec![BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap()];
-        let result = split_table_rows(rows, 5);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].len(), 1);
-    }
-
-    #[test]
-    fn calculate_target_batches_empty_rows() {
-        let rows: Vec<BigQueryTableRow> = vec![];
-        let result = calculate_target_batches_for_table_copy(&rows).unwrap();
-        assert_eq!(result, 0);
-    }
-
-    #[test]
-    fn calculate_target_batches_single_small_row() {
-        // Create a single row with one small string value
-        let rows = vec![
+        let small_row =
             BigQueryTableRow::try_from(TableRow::new(vec![Cell::String("test".to_owned())]))
-                .unwrap(),
-        ];
-        let result = calculate_target_batches_for_table_copy(&rows).unwrap();
-        assert_eq!(result, 1);
+                .unwrap();
+        assert_eq!(calculate_target_batches_for_table_copy(&[small_row]).unwrap(), 1);
+
+        let oversized_row = BigQueryTableRow::try_from(TableRow::new(vec![Cell::String(
+            "x".repeat(MAX_BATCH_SIZE_BYTES + 1),
+        )]))
+        .unwrap();
+        assert_eq!(calculate_target_batches_for_table_copy(&[oversized_row]).unwrap(), 1);
     }
 
     #[test]
-    fn calculate_target_batches_many_small_rows() {
-        // Create many rows with small values (estimated ~50 bytes each when encoded)
-        let rows: Vec<BigQueryTableRow> = (0..100_000)
-            .map(|i| {
-                BigQueryTableRow::try_from(TableRow::new(vec![Cell::String(format!("value_{i}"))]))
-                    .unwrap()
-            })
-            .collect();
-
-        let result = calculate_target_batches_for_table_copy(&rows).unwrap();
-        assert_eq!(result, 1);
-    }
-
-    #[test]
-    fn calculate_target_batches_large_rows() {
-        // Create rows with large string values (each ~1MB)
-        let large_string = "x".repeat(1024 * 1024); // 1MB string
-        let rows: Vec<BigQueryTableRow> = (0..50)
-            .map(|_| {
-                BigQueryTableRow::try_from(TableRow::new(vec![Cell::String(large_string.clone())]))
-                    .unwrap()
-            })
-            .collect();
-
-        let result = calculate_target_batches_for_table_copy(&rows).unwrap();
-        assert_eq!(result, 3);
-    }
-
-    #[test]
-    fn calculate_target_batches_very_large_single_row() {
-        // Create a row larger than the client's batch target.
-        let huge_string = "x".repeat(MAX_BATCH_SIZE_BYTES + 1);
-        let rows = vec![
-            BigQueryTableRow::try_from(TableRow::new(vec![Cell::String(huge_string)])).unwrap(),
+    fn calculate_target_batches_estimates_multiple_batches_from_the_first_row() {
+        let estimated_large_row = BigQueryTableRow::try_from(TableRow::new(vec![Cell::String(
+            "x".repeat(MAX_BATCH_SIZE_BYTES / 2 + 1),
+        )]))
+        .unwrap();
+        let rows = [
+            estimated_large_row,
+            BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
+            BigQueryTableRow::try_from(TableRow::new(vec![])).unwrap(),
         ];
 
-        let result = calculate_target_batches_for_table_copy(&rows).unwrap();
-        // Even though the row is too large, we should still get 1 batch
-        // (the actual send will fail, but batching logic should handle it)
-        assert_eq!(result, 1);
+        assert_eq!(calculate_target_batches_for_table_copy(&rows).unwrap(), 3);
     }
 
     #[test]

--- a/crates/etl-destinations/src/table_name.rs
+++ b/crates/etl-destinations/src/table_name.rs
@@ -75,35 +75,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn stringifies_valid_table_name() {
-        let table_name = TableName::new("a_b".to_owned(), "c_d".to_owned());
-        let escaped = try_stringify_table_name(&table_name).unwrap();
-
-        assert_eq!(escaped, "a__b_c__d");
-    }
-
-    #[test]
-    fn rejects_leading_underscore() {
-        let table_name = TableName::new("_schema".to_owned(), "users".to_owned());
-        let err = try_stringify_table_name(&table_name).unwrap_err();
-
-        assert_eq!(err.kind(), ErrorKind::ValidationError);
-        assert_eq!(
-            err.description(),
-            Some("Destination table name cannot use leading or trailing underscores")
-        );
-    }
-
-    #[test]
-    fn rejects_trailing_underscore() {
-        let table_name = TableName::new("public".to_owned(), "users_".to_owned());
-        let err = try_stringify_table_name(&table_name).unwrap_err();
-
-        assert_eq!(err.kind(), ErrorKind::ValidationError);
-        assert_eq!(
-            err.description(),
-            Some("Destination table name cannot use leading or trailing underscores")
-        );
+    fn stringifies_valid_table_names() {
+        for (schema, table, expected) in
+            [("a_b", "c_d", "a__b_c__d"), ("a__b", "c__d", "a____b_c____d")]
+        {
+            let table_name = TableName::new(schema.to_owned(), table.to_owned());
+            assert_eq!(try_stringify_table_name(&table_name).unwrap(), expected);
+        }
     }
 
     #[test]
@@ -120,34 +98,34 @@ mod tests {
     }
 
     #[test]
-    fn preserves_multiple_underscores() {
-        let table_name = TableName::new("a__b".to_owned(), "c__d".to_owned());
+    fn rejects_ambiguous_or_unsupported_components() {
+        for (schema, table, description) in [
+            (
+                "_schema",
+                "users",
+                "Destination table name cannot use leading or trailing underscores",
+            ),
+            (
+                "public",
+                "users_",
+                "Destination table name cannot use leading or trailing underscores",
+            ),
+            (
+                "public",
+                "users\"quoted",
+                "Destination table name contains an unsupported SQL identifier character",
+            ),
+            (
+                "public",
+                "users;drop",
+                "Destination table name contains an unsupported SQL identifier character",
+            ),
+        ] {
+            let table_name = TableName::new(schema.to_owned(), table.to_owned());
+            let error = try_stringify_table_name(&table_name).unwrap_err();
 
-        assert_eq!(try_stringify_table_name(&table_name).unwrap(), "a____b_c____d");
-    }
-
-    #[test]
-    fn rejects_double_quote() {
-        let table_name =
-            TableName::new("public".to_owned(), "users\"; drop table x; --".to_owned());
-        let err = try_stringify_table_name(&table_name).unwrap_err();
-
-        assert_eq!(err.kind(), ErrorKind::ValidationError);
-        assert_eq!(
-            err.description(),
-            Some("Destination table name contains an unsupported SQL identifier character")
-        );
-    }
-
-    #[test]
-    fn rejects_semicolon() {
-        let table_name = TableName::new("public".to_owned(), "users;drop".to_owned());
-        let err = try_stringify_table_name(&table_name).unwrap_err();
-
-        assert_eq!(err.kind(), ErrorKind::ValidationError);
-        assert_eq!(
-            err.description(),
-            Some("Destination table name contains an unsupported SQL identifier character")
-        );
+            assert_eq!(error.kind(), ErrorKind::ValidationError);
+            assert_eq!(error.description(), Some(description));
+        }
     }
 }

--- a/crates/etl-postgres/src/application_name.rs
+++ b/crates/etl-postgres/src/application_name.rs
@@ -69,25 +69,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn apply_worker_name_appends_tag_and_pipeline_id() {
-        // --- GIVEN: a base name and pipeline id ---
-        let name = apply_worker_application_name("supabase_etl_replicator_replication", 42);
+    fn worker_names_include_their_identity() {
+        let base = "supabase_etl_replicator_replication";
 
-        // --- THEN: the name carries the apply tag and pipeline id ---
-        assert_eq!(name, "supabase_etl_replicator_replication:apply:42");
-    }
-
-    #[test]
-    fn table_sync_worker_name_appends_tag_pipeline_id_and_table_oid() {
-        // --- GIVEN: a base name, pipeline id, and table id ---
-        let name = table_sync_worker_application_name(
-            "supabase_etl_replicator_replication",
-            42,
-            TableId::new(16384),
+        assert_eq!(apply_worker_application_name(base, 42), format!("{base}:apply:42"));
+        assert_eq!(
+            table_sync_worker_application_name(base, 42, TableId::new(16384)),
+            format!("{base}:table_sync:42:16384")
         );
-
-        // --- THEN: the name carries the table_sync tag, pipeline id, and table oid ---
-        assert_eq!(name, "supabase_etl_replicator_replication:table_sync:42:16384");
     }
 
     #[test]

--- a/crates/etl-postgres/src/numeric.rs
+++ b/crates/etl-postgres/src/numeric.rs
@@ -564,38 +564,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_simple_integer() {
-        let result = PgNumeric::from_str("123").unwrap();
-        if let PgNumeric::Value { sign, weight: _, scale, digits } = result {
-            assert_eq!(sign, Sign::Positive);
-            assert_eq!(scale, 0);
-            assert_eq!(digits, vec![123]);
-        } else {
-            panic!("Invalid PgNumeric value");
-        }
-    }
+    fn parses_finite_values_into_base_10000_digits() {
+        for (input, expected_sign, expected_scale, expected_digits) in [
+            ("123", Sign::Positive, 0, vec![123]),
+            ("-456", Sign::Negative, 0, vec![456]),
+            ("123.45", Sign::Positive, 2, vec![123, 4500]),
+        ] {
+            let PgNumeric::Value { sign, scale, digits, .. } = PgNumeric::from_str(input).unwrap()
+            else {
+                panic!("Expected Value variant");
+            };
 
-    #[test]
-    fn parse_negative() {
-        let result = PgNumeric::from_str("-456").unwrap();
-        if let PgNumeric::Value { sign, weight: _, scale, digits } = result {
-            assert_eq!(sign, Sign::Negative);
-            assert_eq!(scale, 0);
-            assert_eq!(digits, vec![456]);
-        } else {
-            panic!("Invalid PgNumeric value");
-        }
-    }
-
-    #[test]
-    fn parse_decimal() {
-        let result = PgNumeric::from_str("123.45").unwrap();
-        if let PgNumeric::Value { sign, weight: _, scale, digits } = result {
-            assert_eq!(sign, Sign::Positive);
-            assert_eq!(scale, 2);
-            assert_eq!(digits, vec![123, 4500]);
-        } else {
-            panic!("Invalid PgNumeric value");
+            assert_eq!(sign, expected_sign);
+            assert_eq!(scale, expected_scale);
+            assert_eq!(digits, expected_digits);
         }
     }
 
@@ -724,55 +706,67 @@ mod tests {
     }
 
     #[test]
-    fn display_simple_integers() {
-        let num = PgNumeric::Value { sign: Sign::Positive, weight: 0, scale: 0, digits: vec![123] };
-        assert_eq!(format!("{num}"), "123");
-
-        let num = PgNumeric::Value { sign: Sign::Negative, weight: 0, scale: 0, digits: vec![456] };
-        assert_eq!(format!("{num}"), "-456");
-    }
-
-    #[test]
-    fn display_decimals() {
-        let num = PgNumeric::Value {
-            sign: Sign::Positive,
-            weight: 0,
-            scale: 2,
-            digits: vec![1234, 5000],
-        };
-        assert_eq!(format!("{num}"), "1234.50");
-    }
-
-    #[test]
-    fn display_zero() {
-        let num = PgNumeric::Value { sign: Sign::Positive, weight: 0, scale: 0, digits: vec![] };
-        assert_eq!(format!("{num}"), "0");
-    }
-
-    #[test]
-    fn zero_canonicalization_basic() {
-        for (s, expected) in [("0", "0"), ("0.0", "0.0"), ("000", "0"), ("000.000", "0.000")] {
-            let num = PgNumeric::from_str(s).unwrap();
+    fn displays_finite_values() {
+        for (num, expected) in [
+            (
+                PgNumeric::Value { sign: Sign::Positive, weight: 0, scale: 0, digits: vec![123] },
+                "123",
+            ),
+            (
+                PgNumeric::Value { sign: Sign::Negative, weight: 0, scale: 0, digits: vec![456] },
+                "-456",
+            ),
+            (
+                PgNumeric::Value {
+                    sign: Sign::Positive,
+                    weight: 0,
+                    scale: 2,
+                    digits: vec![1234, 5000],
+                },
+                "1234.50",
+            ),
+            (PgNumeric::Value { sign: Sign::Positive, weight: 0, scale: 0, digits: vec![] }, "0"),
+            (
+                PgNumeric::Value {
+                    sign: Sign::Positive,
+                    weight: 1,
+                    scale: 0,
+                    digits: vec![1234, 5678],
+                },
+                "12345678",
+            ),
+            (
+                PgNumeric::Value { sign: Sign::Positive, weight: -1, scale: 4, digits: vec![1234] },
+                "0.1234",
+            ),
+            (
+                PgNumeric::Value {
+                    sign: Sign::Positive,
+                    weight: 0,
+                    scale: 4,
+                    digits: vec![1200, 0],
+                },
+                "1200.0000",
+            ),
+        ] {
             assert_eq!(num.to_string(), expected);
-
-            if let PgNumeric::Value { sign, weight, scale: _, digits } = num {
-                assert_eq!(sign, Sign::Positive);
-                assert_eq!(weight, 0);
-                assert!(digits.is_empty());
-            } else {
-                panic!("Expected Value variant");
-            }
         }
     }
 
     #[test]
-    fn zero_canonicalization_negative_zero() {
-        for (s, expected) in [("-0", "0"), ("-0.00", "0.00")] {
+    fn zero_canonicalization_normalizes_sign_and_preserves_scale() {
+        for (s, expected) in [
+            ("0", "0"),
+            ("0.0", "0.0"),
+            ("000", "0"),
+            ("000.000", "0.000"),
+            ("-0", "0"),
+            ("-0.00", "0.00"),
+        ] {
             let num = PgNumeric::from_str(s).unwrap();
             assert_eq!(num.to_string(), expected);
 
             if let PgNumeric::Value { sign, weight, scale: _, digits } = num {
-                // Normalize to positive zero.
                 assert_eq!(sign, Sign::Positive);
                 assert_eq!(weight, 0);
                 assert!(digits.is_empty());
@@ -810,51 +804,6 @@ mod tests {
                 panic!("Expected Value variant");
             }
         }
-    }
-
-    #[test]
-    fn display_large_numbers() {
-        let num = PgNumeric::Value {
-            sign: Sign::Positive,
-            weight: 1,
-            scale: 0,
-            digits: vec![1234, 5678],
-        };
-        assert_eq!(format!("{num}"), "12345678");
-    }
-
-    #[test]
-    fn display_small_decimals() {
-        let num =
-            PgNumeric::Value { sign: Sign::Positive, weight: -1, scale: 4, digits: vec![1234] };
-        assert_eq!(format!("{num}"), "0.1234");
-    }
-
-    #[test]
-    fn leading_zero_suppression() {
-        let num = PgNumeric::Value {
-            sign: Sign::Positive,
-            weight: 0,
-            scale: 0,
-            // The first digit has leading zeros when formatted as 4 digits.
-            digits: vec![123],
-        };
-        // Formatting should suppress those leading zeros.
-        assert_eq!(format!("{num}"), "123");
-    }
-
-    #[test]
-    fn trailing_decimal_zeros() {
-        let num = PgNumeric::Value {
-            sign: Sign::Positive,
-            weight: 0,
-            scale: 4,
-            // This represents 120.0000.
-            digits: vec![1200, 0],
-        };
-        let output = format!("{num}");
-        // Display should preserve trailing zeros according to scale.
-        assert!(output.ends_with("0000"));
     }
 
     #[test]

--- a/crates/etl/src/data/cell.rs
+++ b/crates/etl/src/data/cell.rs
@@ -157,32 +157,3 @@ impl ArrayCell {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cell_types_equality() {
-        // Test that equal cells are actually equal
-        assert_eq!(Cell::I32(42), Cell::I32(42));
-        assert_ne!(Cell::I32(42), Cell::I32(43));
-
-        assert_eq!(Cell::String("test".to_owned()), Cell::String("test".to_owned()));
-        assert_ne!(Cell::String("test".to_owned()), Cell::String("different".to_owned()));
-
-        assert_eq!(Cell::Null, Cell::Null);
-        assert_ne!(Cell::Null, Cell::I32(0));
-    }
-
-    #[test]
-    fn cell_types_clone() {
-        let cell = Cell::String("test".to_owned());
-        let cloned = cell.clone();
-        assert_eq!(cell, cloned);
-
-        let array_cell = Cell::Array(ArrayCell::I32(vec![Some(1), None, Some(3)]));
-        let cloned_array = array_cell.clone();
-        assert_eq!(array_cell, cloned_array);
-    }
-}

--- a/crates/etl/src/postgres/codec/bool.rs
+++ b/crates/etl/src/postgres/codec/bool.rs
@@ -24,80 +24,24 @@ mod tests {
     use crate::error::ErrorKind;
 
     #[test]
-    fn parse_bool_true() {
+    fn parse_bool_accepts_postgres_text_values() {
         assert!(parse_bool("t").unwrap());
-    }
-
-    #[test]
-    fn parse_bool_false() {
         assert!(!parse_bool("f").unwrap());
     }
 
     #[test]
-    fn parse_bool_invalid_empty() {
-        let result = parse_bool("");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::InvalidData));
-        assert!(err.to_string().contains("Boolean value must be 't' or 'f'"));
-        assert!(!err.to_string().contains("received: "));
-    }
+    fn parse_bool_rejects_other_values_with_a_generic_error() {
+        let invalid_values = [
+            "", "true", "false", "0", "1", "T", "F", " t", "t ", " f ", "t\n", "f\t", "t\0", "🤔",
+            "ÿ", "tt", "tf", "ft", "ff",
+        ];
 
-    #[test]
-    fn parse_bool_invalid_true_word() {
-        let result = parse_bool("true");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::InvalidData));
-        assert!(!err.to_string().contains("true"));
-    }
+        for value in invalid_values {
+            let err = parse_bool(value).unwrap_err();
 
-    #[test]
-    fn parse_bool_invalid_false_word() {
-        let result = parse_bool("false");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::InvalidData));
-        assert!(!err.to_string().contains("false"));
-    }
-
-    #[test]
-    fn parse_bool_invalid_numbers() {
-        assert!(parse_bool("0").is_err());
-        assert!(parse_bool("1").is_err());
-    }
-
-    #[test]
-    fn parse_bool_invalid_case_sensitive() {
-        assert!(parse_bool("T").is_err());
-        assert!(parse_bool("F").is_err());
-    }
-
-    #[test]
-    fn parse_bool_invalid_whitespace() {
-        assert!(parse_bool(" t").is_err());
-        assert!(parse_bool("t ").is_err());
-        assert!(parse_bool(" f ").is_err());
-    }
-
-    #[test]
-    fn parse_bool_invalid_special_chars() {
-        assert!(parse_bool("t\n").is_err());
-        assert!(parse_bool("f\t").is_err());
-        assert!(parse_bool("t\0").is_err());
-    }
-
-    #[test]
-    fn parse_bool_invalid_unicode() {
-        assert!(parse_bool("🤔").is_err());
-        assert!(parse_bool("ÿ").is_err());
-    }
-
-    #[test]
-    fn parse_bool_invalid_multiple_chars() {
-        assert!(parse_bool("tt").is_err());
-        assert!(parse_bool("tf").is_err());
-        assert!(parse_bool("ft").is_err());
-        assert!(parse_bool("ff").is_err());
+            assert_eq!(err.kind(), ErrorKind::InvalidData, "value: {value:?}");
+            assert_eq!(err.description(), Some("Invalid boolean value"), "value: {value:?}");
+            assert_eq!(err.detail(), Some("Boolean value must be 't' or 'f'"), "value: {value:?}");
+        }
     }
 }

--- a/crates/etl/src/postgres/codec/hex.rs
+++ b/crates/etl/src/postgres/codec/hex.rs
@@ -57,158 +57,42 @@ mod tests {
     use crate::error::ErrorKind;
 
     #[test]
-    fn parse_bytea_hex_empty() {
-        let result = parse_bytea_hex_string("\\x").unwrap();
-        assert_eq!(result, Vec::<u8>::new());
-    }
+    fn parse_bytea_hex_accepts_valid_values() {
+        let cases: &[(&str, &[u8])] = &[
+            ("\\x", &[]),
+            ("\\x41", &[0x41]),
+            ("\\x48656c6c6f", b"Hello"),
+            ("\\x0000", &[0x00, 0x00]),
+            ("\\xffff", &[0xff, 0xff]),
+            ("\\xaBcD", &[0xab, 0xcd]),
+            ("\\x0123456789abcdef", &[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]),
+            ("\\x00010203040506070809", &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        ];
 
-    #[test]
-    fn parse_bytea_hex_single_byte() {
-        let result = parse_bytea_hex_string("\\x41").unwrap();
-        assert_eq!(result, vec![0x41]);
-    }
-
-    #[test]
-    fn parse_bytea_hex_multiple_bytes() {
-        let result = parse_bytea_hex_string("\\x48656c6c6f").unwrap();
-        assert_eq!(result, b"Hello");
-    }
-
-    #[test]
-    fn parse_bytea_hex_all_zero() {
-        let result = parse_bytea_hex_string("\\x0000").unwrap();
-        assert_eq!(result, vec![0x00, 0x00]);
-    }
-
-    #[test]
-    fn parse_bytea_hex_all_ff() {
-        let result = parse_bytea_hex_string("\\xffff").unwrap();
-        assert_eq!(result, vec![0xff, 0xff]);
-    }
-
-    #[test]
-    fn parse_bytea_hex_mixed_case() {
-        let result = parse_bytea_hex_string("\\xaBcD").unwrap();
-        assert_eq!(result, vec![0xab, 0xcd]);
-    }
-
-    #[test]
-    fn parse_bytea_hex_long_sequence() {
-        let result = parse_bytea_hex_string("\\x0123456789abcdef").unwrap();
-        assert_eq!(result, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
-    }
-
-    #[test]
-    fn parse_bytea_hex_missing_prefix() {
-        let result = parse_bytea_hex_string("41");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::ConversionError));
-        assert!(err.to_string().contains("Missing '\\x' prefix"));
-    }
-
-    #[test]
-    fn parse_bytea_hex_wrong_prefix() {
-        let result = parse_bytea_hex_string("0x41");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::ConversionError));
-        assert!(err.to_string().contains("Missing '\\x' prefix"));
-    }
-
-    #[test]
-    fn parse_bytea_hex_empty_string() {
-        let result = parse_bytea_hex_string("");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::ConversionError));
-        assert!(err.to_string().contains("Missing '\\x' prefix"));
-    }
-
-    #[test]
-    fn parse_bytea_hex_only_prefix() {
-        let result = parse_bytea_hex_string("\\");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::ConversionError));
-        assert!(err.to_string().contains("Missing '\\x' prefix"));
-    }
-
-    #[test]
-    fn parse_bytea_hex_odd_length() {
-        let result = parse_bytea_hex_string("\\x4");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::ConversionError));
-        assert!(err.to_string().contains("Odd number of hexadecimal digits"));
-    }
-
-    #[test]
-    fn parse_bytea_hex_odd_length_multiple() {
-        let result = parse_bytea_hex_string("\\x41424");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind(), ErrorKind::ConversionError));
-        assert!(err.to_string().contains("Odd number of hexadecimal digits"));
-    }
-
-    #[test]
-    fn parse_bytea_hex_invalid_hex_char() {
-        let result = parse_bytea_hex_string("\\x4g");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("Invalid hexadecimal digit"));
-    }
-
-    #[test]
-    fn parse_bytea_hex_invalid_hex_chars() {
-        assert!(parse_bytea_hex_string("\\xgg").is_err());
-        assert!(parse_bytea_hex_string("\\x4z").is_err());
-        assert!(parse_bytea_hex_string("\\xZZ").is_err());
-    }
-
-    #[test]
-    fn parse_bytea_hex_non_ascii() {
-        let result = parse_bytea_hex_string("\\x4🤔");
-        assert!(result.is_err());
-
-        let result = parse_bytea_hex_string("\\xaéa");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_bytea_hex_rejects_utf8_boundary_inputs() {
-        for value in ["aé", "\\é", "\\x🤔🤔"] {
-            let result = parse_bytea_hex_string(value);
-            assert!(result.is_err());
+        for (value, expected) in cases {
+            assert_eq!(parse_bytea_hex_string(value).unwrap(), *expected, "value: {value:?}");
         }
     }
 
     #[test]
-    fn parse_bytea_hex_whitespace() {
-        let result = parse_bytea_hex_string("\\x4 1");
-        assert!(result.is_err());
-    }
+    fn parse_bytea_hex_rejects_malformed_values() {
+        let cases = [
+            ("", "Missing '\\x' prefix"),
+            ("0x41", "Missing '\\x' prefix"),
+            ("\\", "Missing '\\x' prefix"),
+            ("aé", "Missing '\\x' prefix"),
+            ("\\x4", "Odd number of hexadecimal digits"),
+            ("\\x4g", "Invalid hexadecimal digit"),
+            ("\\x 1", "Invalid hexadecimal digit"),
+            ("\\xaéa", "Invalid hexadecimal digit"),
+            ("\\x🤔🤔", "Invalid hexadecimal digit"),
+        ];
 
-    #[test]
-    fn parse_bytea_hex_with_separator() {
-        let result = parse_bytea_hex_string("\\x41-42");
-        assert!(result.is_err());
-    }
+        for (value, expected_detail) in cases {
+            let err = parse_bytea_hex_string(value).unwrap_err();
 
-    #[test]
-    fn parse_bytea_hex_binary_data() {
-        // Test conversion of various binary data patterns
-        let result = parse_bytea_hex_string("\\x00010203040506070809").unwrap();
-        assert_eq!(result, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    }
-
-    #[test]
-    fn parse_bytea_hex_capacity_optimization() {
-        // Test that the Vec capacity is set correctly
-        let result = parse_bytea_hex_string("\\x414243444546").unwrap();
-        assert_eq!(result, b"ABCDEF");
-        // Vector should be exactly the right size
-        assert_eq!(result.len(), 6);
+            assert_eq!(err.kind(), ErrorKind::ConversionError, "value: {value:?}");
+            assert_eq!(err.detail(), Some(expected_detail), "value: {value:?}");
+        }
     }
 }

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -2319,9 +2319,8 @@ where
     /// Handles Postgres MESSAGE messages (pg_logical_emit_message).
     ///
     /// For `supabase_etl_ddl`, we persist the new table schema as soon as the
-    /// logical message is decoded and invalidate any cached replication mask
-    /// for that table before more changes in the same transaction are
-    /// processed.
+    /// logical message is decoded and record the exact snapshot that any
+    /// following relation must materialize.
     ///
     /// This ordering matches how `pgoutput` produces the stream:
     /// - `pgoutput_message()` writes logical `Message` records directly and
@@ -2336,8 +2335,11 @@ where
     /// `... -> ddl Message -> Relation(new schema) -> Insert/Update/Delete
     /// ...`. Because the DDL message itself is not a DML event, we must
     /// record the new schema cursor here so the next `Relation` rebuilds the
-    /// masks against that exact snapshot. A table-sync worker cannot hand over
-    /// this incomplete state until the relation provides both masks.
+    /// masks against that exact snapshot. PostgreSQL omits the relation when
+    /// the DDL did not invalidate pgoutput's cached relation state. In that
+    /// case the previous decoder remains valid and is retained for row data.
+    /// Without a previous decoder, a table-sync worker cannot hand over this
+    /// incomplete state until a relation provides both masks.
     async fn handle_message(
         &mut self,
         message: &protocol::MessageBody,
@@ -2421,8 +2423,9 @@ where
         // The `remote_final_lsn` is the `commit_lsn` of the current transaction.
         let snapshot_id = schema_snapshot_id_from_message(remote_final_lsn, message);
         let table_schema = Arc::new(schema_change_message.into_table_schema(snapshot_id));
+        let previous_state = self.table_decoding_states.remove(&table_id);
         self.table_decoding_states
-            .insert(table_id, TableDecodingState::WaitingForRelation { snapshot_id });
+            .insert(table_id, TableDecodingState::pending_relation(snapshot_id, previous_state));
 
         debug!(
             table_id = %table_id,
@@ -2616,7 +2619,7 @@ where
     /// synchronization. Therefore, an empty entry after the ownership boundary
     /// means the relation must rebuild the connection-local decoder.
     ///
-    /// A preceding DDL message installs `WaitingForRelation`, which takes
+    /// A preceding DDL message installs `PendingRelation`, which takes
     /// priority because it identifies a newer exact snapshot observed by this
     /// connection. Otherwise the schema lookup uses the later of the connection
     /// bootstrap and an applicable `SyncDone.lsn`. This lets the same
@@ -2652,7 +2655,7 @@ where
     ///
     /// Under normal non-streaming pgoutput ordering, a relation arrives either
     /// with no connection-local state or after a DDL message has installed
-    /// [`TableDecodingState::WaitingForRelation`]. A table-sync worker can
+    /// [`TableDecodingState::PendingRelation`]. A table-sync worker can
     /// instead start with a materialized bootstrap schema before its first
     /// catch-up relation arrives. A materialized state also covers repeated
     /// relation metadata.
@@ -2671,7 +2674,7 @@ where
         sync_done_lsn: Option<PgLsn>,
     ) -> RelationSchemaSelection {
         match decoding_state {
-            Some(TableDecodingState::WaitingForRelation { snapshot_id }) => {
+            Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => {
                 RelationSchemaSelection::Exact(snapshot_id)
             }
             Some(TableDecodingState::WithSchema(schema)) => {
@@ -2818,9 +2821,9 @@ where
     /// owned the table.
     ///
     /// Existing local state is authoritative. A materialized schema needs no
-    /// recovery. [`TableDecodingState::WaitingForRelation`] means a DDL message
-    /// invalidated the decoder but PostgreSQL did not send the required
-    /// relation before DML, which is an invalid protocol sequence.
+    /// recovery. [`TableDecodingState::PendingRelation`] uses its previous
+    /// decoder when PostgreSQL sends row data without a new relation. A pending
+    /// relation without a previous decoder remains incomplete.
     ///
     /// `SyncDone` rows written before durable decoders were introduced
     /// deserialize without a stored snapshot or masks. ETL cannot safely infer
@@ -2832,8 +2835,13 @@ where
         current_lsn: PgLsn,
     ) -> EtlResult<()> {
         match self.table_decoding_states.get(&table_id) {
-            Some(TableDecodingState::WithSchema(_)) => return Ok(()),
-            Some(TableDecodingState::WaitingForRelation { snapshot_id }) => {
+            Some(
+                TableDecodingState::WithSchema(_)
+                | TableDecodingState::PendingRelation { previous_schema: Some(_), .. },
+            ) => {
+                return Ok(());
+            }
+            Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => {
                 return Err(etl_error!(
                     ErrorKind::InvalidState,
                     "Relation message missing after schema change",
@@ -2908,9 +2916,12 @@ where
     ) -> EtlResult<ReplicatedTableSchema> {
         self.install_sync_done_decoding_state_if_missing(table_id, remote_final_lsn).await?;
 
-        let replicated_table_schema = match self.table_decoding_states.get(&table_id).cloned() {
-            Some(TableDecodingState::WithSchema(schema)) => schema,
-            Some(TableDecodingState::WaitingForRelation { snapshot_id }) => {
+        let replicated_table_schema = match self.table_decoding_states.get(&table_id) {
+            Some(
+                TableDecodingState::WithSchema(schema)
+                | TableDecodingState::PendingRelation { previous_schema: Some(schema), .. },
+            ) => schema.clone(),
+            Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => {
                 return Err(etl_error!(
                     ErrorKind::InvalidState,
                     "Relation state is waiting for refresh",
@@ -3778,10 +3789,10 @@ mod apply_worker {
         if let Some(worker_state) = worker_state {
             let mut worker_state_guard = worker_state.lock().await;
             let state = worker_state_guard.table_state();
-            let has_materialized_decoding_state = matches!(
-                table_decoding_states.get(&table_id),
-                Some(TableDecodingState::WithSchema(_))
-            );
+            let has_materialized_decoding_state = table_decoding_states
+                .get(&table_id)
+                .and_then(TableDecodingState::schema_for_row)
+                .is_some();
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -3821,10 +3832,10 @@ mod apply_worker {
                 }
             }
         } else {
-            let has_materialized_decoding_state = matches!(
-                table_decoding_states.get(&table_id),
-                Some(TableDecodingState::WithSchema(_))
-            );
+            let has_materialized_decoding_state = table_decoding_states
+                .get(&table_id)
+                .and_then(TableDecodingState::schema_for_row)
+                .is_some();
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -3964,10 +3975,10 @@ mod apply_worker {
         if let Some(worker_state) = worker_state {
             let mut worker_state_guard = worker_state.lock().await;
             let state = worker_state_guard.table_state();
-            let has_materialized_decoding_state = matches!(
-                table_decoding_states.get(&table_id),
-                Some(TableDecodingState::WithSchema(_))
-            );
+            let has_materialized_decoding_state = table_decoding_states
+                .get(&table_id)
+                .and_then(TableDecodingState::schema_for_row)
+                .is_some();
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -4068,10 +4079,10 @@ mod apply_worker {
                 }
             }
         } else {
-            let has_materialized_decoding_state = matches!(
-                table_decoding_states.get(&table_id),
-                Some(TableDecodingState::WithSchema(_))
-            );
+            let has_materialized_decoding_state = table_decoding_states
+                .get(&table_id)
+                .and_then(TableDecodingState::schema_for_row)
+                .is_some();
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -4173,9 +4184,10 @@ mod apply_worker {
     /// same check only because the restarted loop is now the current
     /// connection whose decoder must be established before it stores `Ready`.
     ///
-    /// A handled DDL replaces `WithSchema` with `WaitingForRelation`,
-    /// preventing `Ready` until PostgreSQL's following relation
-    /// materializes the new exact snapshot and masks.
+    /// A handled DDL records a pending relation while retaining any previous
+    /// decoder. PostgreSQL's following relation materializes the new exact
+    /// snapshot and masks; relation-less rows continue using the previous
+    /// decoder because pgoutput did not invalidate its relation state.
     ///
     /// A table which lacks local decoding state remains in `SyncDone`; this
     /// does not block owned changes at or after the boundary. Its first
@@ -4396,10 +4408,11 @@ mod table_sync_worker {
             Some(TableDecodingState::WithSchema(replicated_table_schema)) => {
                 Ok(TableState::sync_done(sync_done_lsn, replicated_table_schema))
             }
-            // TODO: Make this handover recoverable when catch-up observes a
-            //  schema or publication change without a following relation,
-            //  without guessing the historical publication and identity masks.
-            Some(TableDecodingState::WaitingForRelation { snapshot_id }) => Err(etl_error!(
+            Some(TableDecodingState::PendingRelation {
+                previous_schema: Some(replicated_table_schema),
+                ..
+            }) => Ok(TableState::sync_done(sync_done_lsn, replicated_table_schema)),
+            Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => Err(etl_error!(
                 ErrorKind::InvalidState,
                 "Table-sync decoding state is incomplete",
                 format!(
@@ -4512,5 +4525,37 @@ mod tests {
         assert_eq!(loaded_schema.inner().snapshot_id, snapshot_id);
         assert_eq!(loaded_schema.replication_mask(), replicated_table_schema.replication_mask());
         assert_eq!(loaded_schema.identity_mask(), replicated_table_schema.identity_mask());
+    }
+
+    #[test]
+    fn repeated_pending_relations_retain_the_previous_decoder() {
+        let previous_snapshot_id = test_snapshot_id(10, 10);
+        let first_pending_snapshot_id = test_snapshot_id(20, 20);
+        let second_pending_snapshot_id = test_snapshot_id(30, 30);
+        let previous_schema = replicated_schema(previous_snapshot_id);
+
+        let first_pending = TableDecodingState::pending_relation(
+            first_pending_snapshot_id,
+            Some(TableDecodingState::WithSchema(previous_schema)),
+        );
+        let second_pending =
+            TableDecodingState::pending_relation(second_pending_snapshot_id, Some(first_pending));
+
+        let TableDecodingState::PendingRelation { snapshot_id, .. } = &second_pending else {
+            panic!("expected pending relation state");
+        };
+        assert_eq!(*snapshot_id, second_pending_snapshot_id);
+        assert_eq!(
+            second_pending.schema_for_row().unwrap().inner().snapshot_id,
+            previous_snapshot_id
+        );
+    }
+
+    #[test]
+    fn pending_relation_without_previous_decoder_has_no_row_schema() {
+        let snapshot_id = test_snapshot_id(20, 20);
+        let pending = TableDecodingState::pending_relation(snapshot_id, None);
+
+        assert!(pending.schema_for_row().is_none());
     }
 }

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -2814,23 +2814,24 @@ where
         Ok(table_schema)
     }
 
-    /// Restores row-decoding state from an applicable durable `SyncDone` state.
+    /// Resolves row-decoding state from an applicable durable `SyncDone` state.
     ///
     /// Before the ownership boundary, rows remain owned by table sync and no
     /// apply decoding state is needed. At or after the boundary, the first
-    /// relation-less DML can use the stored snapshot and masks because
-    /// PostgreSQL may have sent the relevant relation while table sync still
-    /// owned the table.
+    /// relation-less DML can use the stored snapshot and masks directly or as
+    /// fallback masks for a preceding DDL snapshot. PostgreSQL may have sent
+    /// the relevant relation while table sync still owned the table and need
+    /// not send it again on the same connection.
     ///
     /// `SyncDone` rows written before durable decoders were introduced
     /// deserialize without a stored snapshot or masks. ETL cannot safely infer
     /// that historical decoder from the physical schema, so it waits for a
     /// later relation and rejects relation-less DML.
     ///
-    /// This method is called only when no connection-local decoding state
-    /// exists.
-    async fn restore_sync_done_replicated_table_schema(
-        &mut self,
+    /// This method is called only when connection-local state cannot provide a
+    /// complete decoder.
+    async fn resolve_sync_done_replicated_table_schema(
+        &self,
         table_id: TableId,
         current_lsn: PgLsn,
     ) -> EtlResult<Option<ReplicatedTableSchema>> {
@@ -2861,15 +2862,13 @@ where
             .await?;
         let replicated_table_schema =
             table_decoding_state.materialize(table_schema, sync_done_lsn)?;
-        self.table_decoding_states
-            .insert(table_id, TableDecodingState::WithSchema(replicated_table_schema.clone()));
 
         info!(
             worker_type = %WorkerType::Apply,
             table_id = table_id.0,
             %sync_done_lsn,
             %current_lsn,
-            "installed missing sync_done table decoding state",
+            "resolved sync_done table decoding state",
         );
 
         Ok(Some(replicated_table_schema))
@@ -2911,10 +2910,10 @@ where
     /// - `WithSchema` is returned immediately.
     /// - `PendingRelation` with fallback masks combines them with the stored
     ///   schema at its DDL snapshot and installs `WithSchema`.
-    /// - `PendingRelation` without fallback masks fails because DML cannot
-    ///   reconstruct relation metadata.
-    /// - No local state attempts restoration from an applicable durable
-    ///   `SyncDone` decoder. If none exists, row decoding fails.
+    /// - `PendingRelation` without local fallback masks attempts to recover
+    ///   them from an applicable durable `SyncDone` decoder.
+    /// - No local state attempts to resolve an applicable durable `SyncDone`
+    ///   decoder directly. If neither path finds one, row decoding fails.
     ///
     /// The last case covers a same-connection table-sync handover where apply
     /// skipped the relation while table sync still owned the table. PostgreSQL
@@ -2929,10 +2928,30 @@ where
             Some(TableDecodingState::WithSchema(replicated_table_schema)) => {
                 Ok(replicated_table_schema)
             }
-            Some(TableDecodingState::PendingRelation {
-                snapshot_id,
-                previous_relation_masks: Some(previous_relation_masks),
-            }) => {
+            Some(TableDecodingState::PendingRelation { snapshot_id, previous_relation_masks }) => {
+                let previous_relation_masks = match previous_relation_masks {
+                    Some(previous_relation_masks) => previous_relation_masks,
+                    None => {
+                        let previous_schema = self
+                            .resolve_sync_done_replicated_table_schema(table_id, remote_final_lsn)
+                            .await?
+                            .ok_or_else(|| {
+                                etl_error!(
+                                    ErrorKind::InvalidState,
+                                    "Relation message missing after schema change",
+                                    format!(
+                                        "Table {} received a row event while waiting for relation \
+                                         snapshot {}, and no complete SyncDone decoder was \
+                                         available",
+                                        table_id, snapshot_id
+                                    )
+                                )
+                            })?;
+
+                        PreviousRelationMasks::from_schema(&previous_schema)
+                    }
+                };
+
                 self.materialize_pending_replicated_table_schema(
                     table_id,
                     snapshot_id,
@@ -2940,27 +2959,26 @@ where
                 )
                 .await
             }
-            Some(TableDecodingState::PendingRelation {
-                snapshot_id,
-                previous_relation_masks: None,
-            }) => Err(etl_error!(
-                ErrorKind::InvalidState,
-                "Relation message missing after schema change",
-                format!(
-                    "Table {} received a row event while waiting for relation snapshot {}",
-                    table_id, snapshot_id
-                )
-            )),
-            None => self
-                .restore_sync_done_replicated_table_schema(table_id, remote_final_lsn)
-                .await?
-                .ok_or_else(|| {
-                    etl_error!(
-                        ErrorKind::InvalidState,
-                        "Relation state missing for row event",
-                        format!("Table {table_id} has no relation or complete SyncDone decoder")
-                    )
-                }),
+            None => {
+                let replicated_table_schema = self
+                    .resolve_sync_done_replicated_table_schema(table_id, remote_final_lsn)
+                    .await?
+                    .ok_or_else(|| {
+                        etl_error!(
+                            ErrorKind::InvalidState,
+                            "Relation state missing for row event",
+                            format!(
+                                "Table {table_id} has no relation or complete SyncDone decoder"
+                            )
+                        )
+                    })?;
+                self.table_decoding_states.insert(
+                    table_id,
+                    TableDecodingState::WithSchema(replicated_table_schema.clone()),
+                );
+
+                Ok(replicated_table_schema)
+            }
         }
     }
 
@@ -4574,7 +4592,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_relation_without_previous_masks_cannot_materialize_schema() {
+    fn pending_relation_without_previous_state_has_no_local_fallback_masks() {
         let snapshot_id = test_snapshot_id(20, 20);
         let pending = TableDecodingState::pending_relation(snapshot_id, None);
 

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -75,7 +75,7 @@ use crate::{
         },
     },
     replication::{
-        TableDecodingState, WorkerType,
+        PreviousRelationMasks, TableDecodingState, WorkerType,
         state::{TableState, TableStateType},
     },
     runtime::{
@@ -2814,7 +2814,7 @@ where
         Ok(table_schema)
     }
 
-    /// Installs missing stored decoding state when row decoding first needs it.
+    /// Restores row-decoding state from an applicable durable `SyncDone` state.
     ///
     /// Before the ownership boundary, rows remain owned by table sync and no
     /// apply decoding state is needed. At or after the boundary, the first
@@ -2822,58 +2822,35 @@ where
     /// PostgreSQL may have sent the relevant relation while table sync still
     /// owned the table.
     ///
-    /// Existing local state is authoritative. A materialized schema needs no
-    /// recovery. [`TableDecodingState::PendingRelation`] combines its previous
-    /// masks with the stored new schema when PostgreSQL sends row data without
-    /// a new relation. A pending relation without previous masks remains
-    /// incomplete.
-    ///
     /// `SyncDone` rows written before durable decoders were introduced
     /// deserialize without a stored snapshot or masks. ETL cannot safely infer
     /// that historical decoder from the physical schema, so it waits for a
     /// later relation and rejects relation-less DML.
-    async fn install_sync_done_decoding_state_if_missing(
+    ///
+    /// This method is called only when no connection-local decoding state
+    /// exists.
+    async fn restore_sync_done_replicated_table_schema(
         &mut self,
         table_id: TableId,
         current_lsn: PgLsn,
-    ) -> EtlResult<()> {
-        match self.table_decoding_states.get(&table_id) {
-            Some(TableDecodingState::WithSchema(_)) => return Ok(()),
-            Some(TableDecodingState::PendingRelation {
-                previous_relation_masks: Some(_), ..
-            }) => {
-                return Ok(());
-            }
-            Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => {
-                return Err(etl_error!(
-                    ErrorKind::InvalidState,
-                    "Relation message missing after schema change",
-                    format!(
-                        "Table {} received a row event while waiting for relation snapshot {}",
-                        table_id, snapshot_id
-                    )
-                ));
-            }
-            None => {}
-        }
-
+    ) -> EtlResult<Option<ReplicatedTableSchema>> {
         let Some(table_state) = self.get_table_state_for_decoding(table_id).await? else {
-            return Ok(());
+            return Ok(None);
         };
 
         // DML ownership normally establishes the boundary in
         // `should_apply_changes`. Recheck it here because decoder recovery
         // independently reads durable table state across an async boundary.
         let TableState::SyncDone { lsn: sync_done_lsn, table_decoding_state } = table_state else {
-            return Ok(());
+            return Ok(None);
         };
 
         if sync_done_lsn > current_lsn {
-            return Ok(());
+            return Ok(None);
         }
 
         let Some(table_decoding_state) = table_decoding_state else {
-            return Ok(());
+            return Ok(None);
         };
 
         let table_schema = self
@@ -2885,7 +2862,7 @@ where
         let replicated_table_schema =
             table_decoding_state.materialize(table_schema, sync_done_lsn)?;
         self.table_decoding_states
-            .insert(table_id, TableDecodingState::WithSchema(replicated_table_schema));
+            .insert(table_id, TableDecodingState::WithSchema(replicated_table_schema.clone()));
 
         info!(
             worker_type = %WorkerType::Apply,
@@ -2895,78 +2872,96 @@ where
             "installed missing sync_done table decoding state",
         );
 
-        Ok(())
+        Ok(Some(replicated_table_schema))
     }
 
-    /// Returns the materialized decoding state for a row event.
+    /// Materializes and installs `WithSchema` after DML arrives without a new
+    /// relation message.
     ///
-    /// The normal first-use sequence is `RELATION → DML`, so the relation
-    /// handler materializes this state. PostgreSQL does not resend relation
-    /// metadata when it already sent it earlier on the same connection,
-    /// however. If apply skipped that relation while table sync still owned the
-    /// table, the first owned DML at or after `SyncDone.lsn` arrives with no
-    /// local decoder. In that case the compact `SyncDone` state supplies the
-    /// exact schema snapshot and both masks on demand.
+    /// The DDL event trigger emits a logical message for every handled schema
+    /// command, including commands whose successful no-op path does not
+    /// invalidate pgoutput's cached relation metadata. ETL therefore stores a
+    /// new table-schema snapshot and enters `PendingRelation`, but pgoutput may
+    /// send the next row without first sending another `RELATION`. In that
+    /// sequence, the stored snapshot is the current table schema and the masks
+    /// from the previous relation are still the current positional decoding
+    /// metadata. Combining them produces the complete decoder for the row and
+    /// returns the connection-local state to `WithSchema`.
+    async fn materialize_pending_replicated_table_schema(
+        &mut self,
+        table_id: TableId,
+        snapshot_id: SnapshotId,
+        previous_relation_masks: PreviousRelationMasks,
+    ) -> EtlResult<ReplicatedTableSchema> {
+        let table_schema = self
+            .get_table_schema_for_relation(table_id, RelationSchemaSelection::Exact(snapshot_id))
+            .await?;
+        let replicated_table_schema = previous_relation_masks.materialize(table_schema);
+
+        self.table_decoding_states
+            .insert(table_id, TableDecodingState::WithSchema(replicated_table_schema.clone()));
+
+        Ok(replicated_table_schema)
+    }
+
+    /// Resolves the complete decoding schema for a row event.
     ///
-    /// A DDL instead leaves a pending relation at its exact schema snapshot. If
-    /// row data arrives before a new relation, the retained previous masks are
-    /// combined with that stored schema and immediately materialized as
-    /// [`TableDecodingState::WithSchema`].
+    /// Resolution follows the connection-local state directly:
     ///
-    /// A missing decoder without an applicable complete `SyncDone` state is an
-    /// error: unlike a relation message, DML does not contain the column and
-    /// identity metadata needed to reconstruct the masks from a bootstrap
-    /// schema alone.
+    /// - `WithSchema` is returned immediately.
+    /// - `PendingRelation` with fallback masks combines them with the stored
+    ///   schema at its DDL snapshot and installs `WithSchema`.
+    /// - `PendingRelation` without fallback masks fails because DML cannot
+    ///   reconstruct relation metadata.
+    /// - No local state attempts restoration from an applicable durable
+    ///   `SyncDone` decoder. If none exists, row decoding fails.
+    ///
+    /// The last case covers a same-connection table-sync handover where apply
+    /// skipped the relation while table sync still owned the table. PostgreSQL
+    /// need not resend that relation before the first apply-owned DML.
     async fn get_replicated_table_schema(
         &mut self,
         table_id: TableId,
         remote_final_lsn: PgLsn,
     ) -> EtlResult<ReplicatedTableSchema> {
-        self.install_sync_done_decoding_state_if_missing(table_id, remote_final_lsn).await?;
-
         let table_decoding_state = self.table_decoding_states.get(&table_id).cloned();
-        let replicated_table_schema = match table_decoding_state {
-            Some(TableDecodingState::WithSchema(replicated_table_schema)) => replicated_table_schema,
+        match table_decoding_state {
+            Some(TableDecodingState::WithSchema(replicated_table_schema)) => {
+                Ok(replicated_table_schema)
+            }
             Some(TableDecodingState::PendingRelation {
                 snapshot_id,
                 previous_relation_masks: Some(previous_relation_masks),
             }) => {
-                let table_schema = self
-                    .get_table_schema_for_relation(
-                        table_id,
-                        RelationSchemaSelection::Exact(snapshot_id),
-                    )
-                    .await?;
-
-                let replicated_table_schema = previous_relation_masks.materialize(table_schema);
-                self.table_decoding_states
-                    .insert(table_id, TableDecodingState::WithSchema(replicated_table_schema.clone()));
-
-                replicated_table_schema
+                self.materialize_pending_replicated_table_schema(
+                    table_id,
+                    snapshot_id,
+                    previous_relation_masks,
+                )
+                .await
             }
-            Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => {
-                return Err(etl_error!(
-                    ErrorKind::InvalidState,
-                    "Relation state is waiting for refresh",
-                    format!(
-                        "Table {} requires relation snapshot {} before row decoding",
-                        table_id, snapshot_id
+            Some(TableDecodingState::PendingRelation {
+                snapshot_id,
+                previous_relation_masks: None,
+            }) => Err(etl_error!(
+                ErrorKind::InvalidState,
+                "Relation message missing after schema change",
+                format!(
+                    "Table {} received a row event while waiting for relation snapshot {}",
+                    table_id, snapshot_id
+                )
+            )),
+            None => self
+                .restore_sync_done_replicated_table_schema(table_id, remote_final_lsn)
+                .await?
+                .ok_or_else(|| {
+                    etl_error!(
+                        ErrorKind::InvalidState,
+                        "Relation state missing for row event",
+                        format!("Table {table_id} has no relation or complete SyncDone decoder")
                     )
-                ));
-            }
-            None => {
-                return Err(etl_error!(
-                    ErrorKind::InvalidState,
-                    "Relation state missing for row event",
-                    format!(
-                        "Table {} has no materialized relation or complete SyncDone decoding state",
-                        table_id
-                    )
-                ));
-            }
-        };
-
-        Ok(replicated_table_schema)
+                }),
+        }
     }
 
     /// Handles Postgres INSERT messages.

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -2337,9 +2337,11 @@ where
     /// record the new schema cursor here so the next `Relation` rebuilds the
     /// masks against that exact snapshot. PostgreSQL omits the relation when
     /// the DDL did not invalidate pgoutput's cached relation state. In that
-    /// case the previous decoder remains valid and is retained for row data.
-    /// Without a previous decoder, a table-sync worker cannot hand over this
-    /// incomplete state until a relation provides both masks.
+    /// case the first row combines the stored new table schema with the
+    /// previous relation masks and materializes `WithSchema`. The retained
+    /// masks are only a fallback: a new relation replaces them before any row
+    /// is decoded. Without previous masks, a table-sync worker cannot hand over
+    /// this incomplete state until a relation provides both masks.
     async fn handle_message(
         &mut self,
         message: &protocol::MessageBody,
@@ -2422,7 +2424,7 @@ where
 
         // The `remote_final_lsn` is the `commit_lsn` of the current transaction.
         let snapshot_id = schema_snapshot_id_from_message(remote_final_lsn, message);
-        let table_schema = Arc::new(schema_change_message.into_table_schema(snapshot_id));
+        let table_schema = schema_change_message.into_table_schema(snapshot_id);
         let previous_state = self.table_decoding_states.remove(&table_id);
         self.table_decoding_states
             .insert(table_id, TableDecodingState::pending_relation(snapshot_id, previous_state));
@@ -2437,7 +2439,7 @@ where
         );
 
         // Store the new schema version in the store.
-        if let Err(err) = self.schema_store.store_table_schema((*table_schema).clone()).await {
+        if let Err(err) = self.schema_store.store_table_schema(table_schema).await {
             counter!(
                 ETL_DDL_SCHEMA_CHANGES_TOTAL,
                 WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
@@ -2821,9 +2823,10 @@ where
     /// owned the table.
     ///
     /// Existing local state is authoritative. A materialized schema needs no
-    /// recovery. [`TableDecodingState::PendingRelation`] uses its previous
-    /// decoder when PostgreSQL sends row data without a new relation. A pending
-    /// relation without a previous decoder remains incomplete.
+    /// recovery. [`TableDecodingState::PendingRelation`] combines its previous
+    /// masks with the stored new schema when PostgreSQL sends row data without
+    /// a new relation. A pending relation without previous masks remains
+    /// incomplete.
     ///
     /// `SyncDone` rows written before durable decoders were introduced
     /// deserialize without a stored snapshot or masks. ETL cannot safely infer
@@ -2835,10 +2838,10 @@ where
         current_lsn: PgLsn,
     ) -> EtlResult<()> {
         match self.table_decoding_states.get(&table_id) {
-            Some(
-                TableDecodingState::WithSchema(_)
-                | TableDecodingState::PendingRelation { previous_schema: Some(_), .. },
-            ) => {
+            Some(TableDecodingState::WithSchema(_)) => return Ok(()),
+            Some(TableDecodingState::PendingRelation {
+                previous_relation_masks: Some(_), ..
+            }) => {
                 return Ok(());
             }
             Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => {
@@ -2905,6 +2908,11 @@ where
     /// local decoder. In that case the compact `SyncDone` state supplies the
     /// exact schema snapshot and both masks on demand.
     ///
+    /// A DDL instead leaves a pending relation at its exact schema snapshot. If
+    /// row data arrives before a new relation, the retained previous masks are
+    /// combined with that stored schema and immediately materialized as
+    /// [`TableDecodingState::WithSchema`].
+    ///
     /// A missing decoder without an applicable complete `SyncDone` state is an
     /// error: unlike a relation message, DML does not contain the column and
     /// identity metadata needed to reconstruct the masks from a bootstrap
@@ -2916,11 +2924,26 @@ where
     ) -> EtlResult<ReplicatedTableSchema> {
         self.install_sync_done_decoding_state_if_missing(table_id, remote_final_lsn).await?;
 
-        let replicated_table_schema = match self.table_decoding_states.get(&table_id) {
-            Some(
-                TableDecodingState::WithSchema(schema)
-                | TableDecodingState::PendingRelation { previous_schema: Some(schema), .. },
-            ) => schema.clone(),
+        let table_decoding_state = self.table_decoding_states.get(&table_id).cloned();
+        let replicated_table_schema = match table_decoding_state {
+            Some(TableDecodingState::WithSchema(replicated_table_schema)) => replicated_table_schema,
+            Some(TableDecodingState::PendingRelation {
+                snapshot_id,
+                previous_relation_masks: Some(previous_relation_masks),
+            }) => {
+                let table_schema = self
+                    .get_table_schema_for_relation(
+                        table_id,
+                        RelationSchemaSelection::Exact(snapshot_id),
+                    )
+                    .await?;
+
+                let replicated_table_schema = previous_relation_masks.materialize(table_schema);
+                self.table_decoding_states
+                    .insert(table_id, TableDecodingState::WithSchema(replicated_table_schema.clone()));
+
+                replicated_table_schema
+            }
             Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => {
                 return Err(etl_error!(
                     ErrorKind::InvalidState,
@@ -3789,10 +3812,10 @@ mod apply_worker {
         if let Some(worker_state) = worker_state {
             let mut worker_state_guard = worker_state.lock().await;
             let state = worker_state_guard.table_state();
-            let has_materialized_decoding_state = table_decoding_states
-                .get(&table_id)
-                .and_then(TableDecodingState::schema_for_row)
-                .is_some();
+            let has_materialized_decoding_state = matches!(
+                table_decoding_states.get(&table_id),
+                Some(TableDecodingState::WithSchema(_))
+            );
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -3832,10 +3855,10 @@ mod apply_worker {
                 }
             }
         } else {
-            let has_materialized_decoding_state = table_decoding_states
-                .get(&table_id)
-                .and_then(TableDecodingState::schema_for_row)
-                .is_some();
+            let has_materialized_decoding_state = matches!(
+                table_decoding_states.get(&table_id),
+                Some(TableDecodingState::WithSchema(_))
+            );
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -3975,10 +3998,10 @@ mod apply_worker {
         if let Some(worker_state) = worker_state {
             let mut worker_state_guard = worker_state.lock().await;
             let state = worker_state_guard.table_state();
-            let has_materialized_decoding_state = table_decoding_states
-                .get(&table_id)
-                .and_then(TableDecodingState::schema_for_row)
-                .is_some();
+            let has_materialized_decoding_state = matches!(
+                table_decoding_states.get(&table_id),
+                Some(TableDecodingState::WithSchema(_))
+            );
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -4079,10 +4102,10 @@ mod apply_worker {
                 }
             }
         } else {
-            let has_materialized_decoding_state = table_decoding_states
-                .get(&table_id)
-                .and_then(TableDecodingState::schema_for_row)
-                .is_some();
+            let has_materialized_decoding_state = matches!(
+                table_decoding_states.get(&table_id),
+                Some(TableDecodingState::WithSchema(_))
+            );
 
             debug!(
                 worker_type = %WorkerType::Apply,
@@ -4185,9 +4208,9 @@ mod apply_worker {
     /// connection whose decoder must be established before it stores `Ready`.
     ///
     /// A handled DDL records a pending relation while retaining any previous
-    /// decoder. PostgreSQL's following relation materializes the new exact
-    /// snapshot and masks; relation-less rows continue using the previous
-    /// decoder because pgoutput did not invalidate its relation state.
+    /// masks. PostgreSQL's following relation materializes the new exact
+    /// snapshot and masks. A relation-less row instead combines the retained
+    /// masks with the stored new table schema and transitions to `WithSchema`.
     ///
     /// A table which lacks local decoding state remains in `SyncDone`; this
     /// does not block owned changes at or after the boundary. Its first
@@ -4408,10 +4431,6 @@ mod table_sync_worker {
             Some(TableDecodingState::WithSchema(replicated_table_schema)) => {
                 Ok(TableState::sync_done(sync_done_lsn, replicated_table_schema))
             }
-            Some(TableDecodingState::PendingRelation {
-                previous_schema: Some(replicated_table_schema),
-                ..
-            }) => Ok(TableState::sync_done(sync_done_lsn, replicated_table_schema)),
             Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => Err(etl_error!(
                 ErrorKind::InvalidState,
                 "Table-sync decoding state is incomplete",
@@ -4528,11 +4547,15 @@ mod tests {
     }
 
     #[test]
-    fn repeated_pending_relations_retain_the_previous_decoder() {
+    fn repeated_pending_relations_retain_previous_masks_for_the_latest_schema() {
         let previous_snapshot_id = test_snapshot_id(10, 10);
         let first_pending_snapshot_id = test_snapshot_id(20, 20);
         let second_pending_snapshot_id = test_snapshot_id(30, 30);
         let previous_schema = replicated_schema(previous_snapshot_id);
+        let previous_replication_mask = previous_schema.replication_mask().clone();
+        let previous_identity_mask = previous_schema.identity_mask().clone();
+        let second_table_schema =
+            Arc::new(replicated_schema(second_pending_snapshot_id).inner().clone());
 
         let first_pending = TableDecodingState::pending_relation(
             first_pending_snapshot_id,
@@ -4541,21 +4564,28 @@ mod tests {
         let second_pending =
             TableDecodingState::pending_relation(second_pending_snapshot_id, Some(first_pending));
 
-        let TableDecodingState::PendingRelation { snapshot_id, .. } = &second_pending else {
+        let TableDecodingState::PendingRelation {
+            snapshot_id,
+            previous_relation_masks: Some(previous_relation_masks),
+        } = second_pending
+        else {
             panic!("expected pending relation state");
         };
-        assert_eq!(*snapshot_id, second_pending_snapshot_id);
-        assert_eq!(
-            second_pending.schema_for_row().unwrap().inner().snapshot_id,
-            previous_snapshot_id
-        );
+        assert_eq!(snapshot_id, second_pending_snapshot_id);
+        let pending_schema = previous_relation_masks.materialize(second_table_schema);
+        assert_eq!(pending_schema.inner().snapshot_id, second_pending_snapshot_id);
+        assert_eq!(pending_schema.replication_mask(), &previous_replication_mask);
+        assert_eq!(pending_schema.identity_mask(), &previous_identity_mask);
     }
 
     #[test]
-    fn pending_relation_without_previous_decoder_has_no_row_schema() {
+    fn pending_relation_without_previous_masks_cannot_materialize_schema() {
         let snapshot_id = test_snapshot_id(20, 20);
         let pending = TableDecodingState::pending_relation(snapshot_id, None);
 
-        assert!(pending.schema_for_row().is_none());
+        assert!(matches!(
+            pending,
+            TableDecodingState::PendingRelation { previous_relation_masks: None, .. }
+        ));
     }
 }

--- a/crates/etl/src/replication/decoding_state.rs
+++ b/crates/etl/src/replication/decoding_state.rs
@@ -9,13 +9,15 @@
 //!
 //! A table-sync worker seeds this state from its consistent initial-copy
 //! snapshot and updates it whenever PostgreSQL emits a new `RELATION` message.
-//! A DDL message moves the table into `WaitingForRelation` with the exact
-//! snapshot that the next relation must materialize. Only a complete
-//! `WithSchema` state can be converted into the compact
+//! A DDL message records the exact snapshot that the next relation must
+//! materialize while retaining any previous decoder. PostgreSQL emits a new
+//! relation before row data when its pgoutput relation state changed; otherwise
+//! the previous decoder remains valid for relation-less rows. Any complete
+//! decoder can be converted into the compact
 //! [`crate::replication::state::StoredTableDecodingState`] persisted in
-//! `SyncDone`. Reaching the ownership boundary while still waiting for a
-//! relation fails closed because the publication and replica-identity masks
-//! are not known.
+//! `SyncDone`. Reaching the ownership boundary without either a new relation or
+//! a previous decoder fails closed because the publication and replica-identity
+//! masks are not known.
 //!
 //! The apply worker clears its entry before starting table synchronization.
 //! After `SyncDone`, an owned relation materializes a new entry, while
@@ -28,13 +30,38 @@ use crate::schema::{ReplicatedTableSchema, SnapshotId};
 /// Per-table row-decoding state for one logical replication connection.
 #[derive(Debug, Clone)]
 pub(crate) enum TableDecodingState {
-    /// A DDL message was observed and a new relation is required before rows
-    /// can be decoded.
-    WaitingForRelation {
+    /// A DDL message was observed and the next relation belongs to its schema
+    /// snapshot.
+    PendingRelation {
         /// Exact schema snapshot that the next relation must materialize.
         snapshot_id: SnapshotId,
+        /// Previous complete decoder used when PostgreSQL emits row data
+        /// without a new relation.
+        previous_schema: Option<ReplicatedTableSchema>,
     },
     /// Complete row-decoding state materialized from a relation or restored
     /// `SyncDone` decoding state.
     WithSchema(ReplicatedTableSchema),
+}
+
+impl TableDecodingState {
+    /// Records a pending relation while retaining any complete decoder from
+    /// the previous state.
+    pub(crate) fn pending_relation(snapshot_id: SnapshotId, previous: Option<Self>) -> Self {
+        let previous_schema = match previous {
+            Some(Self::PendingRelation { previous_schema, .. }) => previous_schema,
+            Some(Self::WithSchema(schema)) => Some(schema),
+            None => None,
+        };
+
+        Self::PendingRelation { snapshot_id, previous_schema }
+    }
+
+    /// Returns the complete decoder available for relation-less row data.
+    pub(crate) fn schema_for_row(&self) -> Option<&ReplicatedTableSchema> {
+        match self {
+            Self::PendingRelation { previous_schema, .. } => previous_schema.as_ref(),
+            Self::WithSchema(schema) => Some(schema),
+        }
+    }
 }

--- a/crates/etl/src/replication/decoding_state.rs
+++ b/crates/etl/src/replication/decoding_state.rs
@@ -7,24 +7,29 @@
 //! column filter for that snapshot, and the replica-identity semantics for
 //! that same snapshot.
 //!
-//! A table-sync worker seeds this state from its consistent initial-copy
-//! snapshot and updates it whenever PostgreSQL emits a new `RELATION` message.
-//! A DDL message records the exact snapshot that the next relation must
-//! materialize while retaining any previous relation masks. PostgreSQL emits a
-//! new relation before row data when its pgoutput relation state changed;
-//! otherwise ETL combines the retained masks with the new stored table schema
-//! and transitions back to `WithSchema`. Any complete decoder can be converted
-//! into the compact
-//! [`crate::replication::state::StoredTableDecodingState`] persisted in
-//! `SyncDone`. Reaching the ownership boundary while still pending fails closed
-//! because relation-less DML has not yet confirmed that the previous masks are
-//! still authoritative.
+//! The connection-local map has two states:
 //!
-//! The apply worker clears its entry before starting table synchronization.
-//! After `SyncDone`, an owned relation materializes a new entry, while
-//! relation-less DML restores the compact durable state on demand.
-//! Consequently, `WithSchema` also proves that the current apply connection can
-//! keep decoding after `SyncDone` is replaced by `Ready`.
+//! - [`TableDecodingState::WithSchema`] is a complete decoder and can decode a
+//!   row immediately.
+//! - [`TableDecodingState::PendingRelation`] records a DDL snapshot while ETL
+//!   waits to see whether pgoutput sends replacement relation metadata. When a
+//!   previous complete decoder exists, the pending state retains both of its
+//!   relation masks as a fallback. A new `RELATION` replaces those masks. If a
+//!   row arrives first, ETL combines the fallback masks with the stored schema
+//!   at the pending snapshot and transitions to `WithSchema`. Without fallback
+//!   masks, rows cannot be decoded until a `RELATION` arrives.
+//!
+//! An absent map entry is not another [`TableDecodingState`]: it means this
+//! connection has not established any state for the table. After table-sync
+//! handover, the apply worker may restore that missing state from the compact
+//! [`crate::replication::state::StoredTableDecodingState`] persisted in
+//! `SyncDone`.
+//!
+//! A table-sync worker seeds `WithSchema` from its consistent initial-copy
+//! snapshot. The apply worker clears its entry before starting table sync, then
+//! establishes `WithSchema` from an owned relation or durable `SyncDone` state
+//! after handover. Consequently, `WithSchema` also proves that the current
+//! apply connection can keep decoding after `SyncDone` becomes `Ready`.
 
 use std::sync::Arc;
 
@@ -59,22 +64,22 @@ impl PreviousRelationMasks {
 /// Per-table row-decoding state for one logical replication connection.
 #[derive(Debug, Clone)]
 pub(crate) enum TableDecodingState {
-    /// A DDL message was observed and the next relation belongs to its schema
-    /// snapshot.
+    /// A DDL message was observed, but pgoutput has not yet shown whether it
+    /// will send replacement relation metadata before the next row.
     PendingRelation {
-        /// Exact schema snapshot that the next relation must materialize.
+        /// Exact stored schema snapshot for the DDL message.
         snapshot_id: SnapshotId,
-        /// Complete masks from the previous pgoutput relation, if known.
+        /// Complete masks from the previous decoder, retained only as a
+        /// relation-less row fallback.
         previous_relation_masks: Option<PreviousRelationMasks>,
     },
-    /// Complete row-decoding state materialized from a relation or restored
-    /// `SyncDone` decoding state.
+    /// Complete row-decoding state ready for immediate use.
     WithSchema(ReplicatedTableSchema),
 }
 
 impl TableDecodingState {
     /// Records a pending relation while retaining masks from the previous
-    /// pgoutput relation.
+    /// complete decoder.
     pub(crate) fn pending_relation(snapshot_id: SnapshotId, previous: Option<Self>) -> Self {
         let previous_relation_masks = match previous {
             Some(Self::PendingRelation { previous_relation_masks, .. }) => previous_relation_masks,

--- a/crates/etl/src/replication/decoding_state.rs
+++ b/crates/etl/src/replication/decoding_state.rs
@@ -10,14 +10,15 @@
 //! A table-sync worker seeds this state from its consistent initial-copy
 //! snapshot and updates it whenever PostgreSQL emits a new `RELATION` message.
 //! A DDL message records the exact snapshot that the next relation must
-//! materialize while retaining any previous decoder. PostgreSQL emits a new
-//! relation before row data when its pgoutput relation state changed; otherwise
-//! the previous decoder remains valid for relation-less rows. Any complete
-//! decoder can be converted into the compact
+//! materialize while retaining any previous relation masks. PostgreSQL emits a
+//! new relation before row data when its pgoutput relation state changed;
+//! otherwise ETL combines the retained masks with the new stored table schema
+//! and transitions back to `WithSchema`. Any complete decoder can be converted
+//! into the compact
 //! [`crate::replication::state::StoredTableDecodingState`] persisted in
-//! `SyncDone`. Reaching the ownership boundary without either a new relation or
-//! a previous decoder fails closed because the publication and replica-identity
-//! masks are not known.
+//! `SyncDone`. Reaching the ownership boundary while still pending fails closed
+//! because relation-less DML has not yet confirmed that the previous masks are
+//! still authoritative.
 //!
 //! The apply worker clears its entry before starting table synchronization.
 //! After `SyncDone`, an owned relation materializes a new entry, while
@@ -25,7 +26,35 @@
 //! Consequently, `WithSchema` also proves that the current apply connection can
 //! keep decoding after `SyncDone` is replaced by `Ready`.
 
-use crate::schema::{ReplicatedTableSchema, SnapshotId};
+use std::sync::Arc;
+
+use crate::schema::{
+    IdentityMask, ReplicatedTableSchema, ReplicationMask, SnapshotId, TableSchema,
+};
+
+/// Complete relation masks retained across a DDL message.
+#[derive(Debug, Clone)]
+pub(crate) struct PreviousRelationMasks {
+    /// Publication-column membership from the previous relation.
+    replication_mask: ReplicationMask,
+    /// Replica-identity membership from the previous relation.
+    identity_mask: IdentityMask,
+}
+
+impl PreviousRelationMasks {
+    /// Captures both masks from a materialized decoder.
+    fn from_schema(schema: &ReplicatedTableSchema) -> Self {
+        Self {
+            replication_mask: schema.replication_mask().clone(),
+            identity_mask: schema.identity_mask().clone(),
+        }
+    }
+
+    /// Combines the retained masks with the actual new table schema.
+    pub(crate) fn materialize(self, table_schema: Arc<TableSchema>) -> ReplicatedTableSchema {
+        ReplicatedTableSchema::from_masks(table_schema, self.replication_mask, self.identity_mask)
+    }
+}
 
 /// Per-table row-decoding state for one logical replication connection.
 #[derive(Debug, Clone)]
@@ -35,9 +64,8 @@ pub(crate) enum TableDecodingState {
     PendingRelation {
         /// Exact schema snapshot that the next relation must materialize.
         snapshot_id: SnapshotId,
-        /// Previous complete decoder used when PostgreSQL emits row data
-        /// without a new relation.
-        previous_schema: Option<ReplicatedTableSchema>,
+        /// Complete masks from the previous pgoutput relation, if known.
+        previous_relation_masks: Option<PreviousRelationMasks>,
     },
     /// Complete row-decoding state materialized from a relation or restored
     /// `SyncDone` decoding state.
@@ -45,23 +73,15 @@ pub(crate) enum TableDecodingState {
 }
 
 impl TableDecodingState {
-    /// Records a pending relation while retaining any complete decoder from
-    /// the previous state.
+    /// Records a pending relation while retaining masks from the previous
+    /// pgoutput relation.
     pub(crate) fn pending_relation(snapshot_id: SnapshotId, previous: Option<Self>) -> Self {
-        let previous_schema = match previous {
-            Some(Self::PendingRelation { previous_schema, .. }) => previous_schema,
-            Some(Self::WithSchema(schema)) => Some(schema),
+        let previous_relation_masks = match previous {
+            Some(Self::PendingRelation { previous_relation_masks, .. }) => previous_relation_masks,
+            Some(Self::WithSchema(schema)) => Some(PreviousRelationMasks::from_schema(&schema)),
             None => None,
         };
 
-        Self::PendingRelation { snapshot_id, previous_schema }
-    }
-
-    /// Returns the complete decoder available for relation-less row data.
-    pub(crate) fn schema_for_row(&self) -> Option<&ReplicatedTableSchema> {
-        match self {
-            Self::PendingRelation { previous_schema, .. } => previous_schema.as_ref(),
-            Self::WithSchema(schema) => Some(schema),
-        }
+        Self::PendingRelation { snapshot_id, previous_relation_masks }
     }
 }

--- a/crates/etl/src/replication/decoding_state.rs
+++ b/crates/etl/src/replication/decoding_state.rs
@@ -16,8 +16,10 @@
 //!   previous complete decoder exists, the pending state retains both of its
 //!   relation masks as a fallback. A new `RELATION` replaces those masks. If a
 //!   row arrives first, ETL combines the fallback masks with the stored schema
-//!   at the pending snapshot and transitions to `WithSchema`. Without fallback
-//!   masks, rows cannot be decoded until a `RELATION` arrives.
+//!   at the pending snapshot and transitions to `WithSchema`. Without locally
+//!   retained fallback masks, the apply worker can still resolve them from an
+//!   applicable complete `SyncDone` decoder; otherwise rows cannot be decoded
+//!   until a `RELATION` arrives.
 //!
 //! An absent map entry is not another [`TableDecodingState`]: it means this
 //! connection has not established any state for the table. After table-sync
@@ -48,7 +50,7 @@ pub(crate) struct PreviousRelationMasks {
 
 impl PreviousRelationMasks {
     /// Captures both masks from a materialized decoder.
-    fn from_schema(schema: &ReplicatedTableSchema) -> Self {
+    pub(super) fn from_schema(schema: &ReplicatedTableSchema) -> Self {
         Self {
             replication_mask: schema.replication_mask().clone(),
             identity_mask: schema.identity_mask().clone(),

--- a/crates/etl/src/replication/mod.rs
+++ b/crates/etl/src/replication/mod.rs
@@ -12,6 +12,6 @@ mod worker_type;
 pub(crate) use apply::{
     ApplyLoop, ApplyLoopResult, ApplyWorkerContext, TableSyncWorkerContext, WorkerContext,
 };
-pub(crate) use decoding_state::TableDecodingState;
+pub(crate) use decoding_state::{PreviousRelationMasks, TableDecodingState};
 pub(crate) use table_sync::{TableSyncResult, start_table_sync};
 pub use worker_type::WorkerType;

--- a/crates/etl/src/runtime/concurrency/stream.rs
+++ b/crates/etl/src/runtime/concurrency/stream.rs
@@ -528,23 +528,15 @@ mod tests {
     }
 
     #[test]
-    fn builds_table_sync_copy_stream_id() {
+    fn builds_worker_stream_ids() {
         assert_eq!(
             table_sync_worker_copy_stream_id(TableId::new(123)),
             "table_sync_worker_copy_123_stream"
         );
-    }
-
-    #[test]
-    fn builds_table_sync_apply_stream_id() {
         assert_eq!(
             table_sync_worker_apply_stream_id(TableId::new(456)),
             "table_sync_worker_apply_456_stream"
         );
-    }
-
-    #[test]
-    fn builds_apply_worker_apply_stream_id() {
         assert_eq!(apply_worker_apply_stream_id(), "apply_worker_apply_stream");
     }
 

--- a/crates/etl/src/runtime/memory_monitor.rs
+++ b/crates/etl/src/runtime/memory_monitor.rs
@@ -362,15 +362,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn memory_used_percent_handles_zero_total() {
-        let snapshot = MemorySnapshot { used: 100, total: 0 };
-        assert_eq!(snapshot.used_percent(), 1.0);
-    }
-
-    #[test]
-    fn memory_used_percent_half() {
-        let snapshot = MemorySnapshot { used: 50, total: 100 };
-        assert_eq!(snapshot.used_percent(), 0.5);
+    fn memory_used_percent_handles_regular_and_zero_totals() {
+        assert_eq!(MemorySnapshot { used: 50, total: 100 }.used_percent(), 0.5);
+        assert_eq!(MemorySnapshot { used: 100, total: 0 }.used_percent(), 1.0);
     }
 
     #[test]

--- a/crates/etl/tests/pipeline_with_failpoints.rs
+++ b/crates/etl/tests/pipeline_with_failpoints.rs
@@ -595,7 +595,7 @@ async fn table_copy_is_consistent_during_data_sync_threw_an_error_with_timed_ret
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn table_sync_handover_preserves_decoder_for_post_handoff_dml() {
+async fn table_sync_handover_preserves_decoder_across_post_handoff_noop_ddl() {
     let _scenario = FailScenario::setup();
     fail::cfg(START_TABLE_SYNC_AFTER_FINISHED_COPY_FP, "pause").unwrap();
 
@@ -637,16 +637,18 @@ async fn table_sync_handover_preserves_decoder_for_post_handoff_dml() {
         .await;
 
     // Rows inserted while the worker is paused after copy must be replayed by
-    // table-sync streaming. The apply worker skips those row events while
-    // table sync owns the table, but still writes each transaction's commit.
-    // Acknowledging the commits proves that apply already consumed the
-    // preceding relation and row messages before handoff.
+    // table-sync streaming. Both replication connections receive these WAL
+    // records: table sync processes its Relation and rows, while apply skips
+    // the table-owned messages but still writes each transaction's commit.
+    // Acknowledging the apply commits proves that its pgoutput connection has
+    // already sent and cached the table's Relation before handoff.
     insert_users_data(
         &mut database,
         &users_schema.name,
         copied_rows + 1..=copied_rows + catchup_rows,
     )
     .await;
+
     apply_commits_notify.notified().await;
 
     let all_rows_notify = destination
@@ -666,10 +668,26 @@ async fn table_sync_handover_preserves_decoder_for_post_handoff_dml() {
     all_rows_notify.notified().await;
     sync_done_notify.notified().await;
 
-    // The apply connection already saw and skipped the relation used by the
-    // table-sync worker. PostgreSQL does not resend it merely because ETL
-    // handed ownership over, so this row can only be decoded from the
-    // complete decoding state stored in SyncDone.
+    // Make the first apply-owned table event a no-op DDL. ETL stores a new
+    // snapshot for its transactional DDL message, but PostgreSQL keeps the
+    // warmed pgoutput relation cache and therefore emits no new Relation.
+    let schema_stored_notify = store.notify_on_table_schema_count(table_id, 2).await;
+
+    database
+        .run_sql(&format!(
+            "alter table {} owner to current_user",
+            users_schema.name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+
+    schema_stored_notify.notified().await;
+
+    // The apply connection already saw and skipped its copy of the relation
+    // used by table sync. Because the no-op DDL does not invalidate that
+    // connection's pgoutput cache, this row arrives without another Relation.
+    // It can only be decoded by carrying the masks stored in SyncDone into the
+    // pending DDL snapshot.
     let post_handover_notify = destination
         .wait_for_all_events(vec![EventCondition::TableCount(
             EventType::Insert,
@@ -677,12 +695,14 @@ async fn table_sync_handover_preserves_decoder_for_post_handoff_dml() {
             (copied_rows + catchup_rows + 1) as u64,
         )])
         .await;
+
     insert_users_data(
         &mut database,
         &users_schema.name,
         copied_rows + catchup_rows + 1..=copied_rows + catchup_rows + 1,
     )
     .await;
+
     post_handover_notify.notified().await;
     ready_notify.notified().await;
 
@@ -694,6 +714,13 @@ async fn table_sync_handover_preserves_decoder_for_post_handoff_dml() {
 
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
+
+    // The only destination-visible Relation came from table-sync streaming.
+    // Apply consumed its pre-handoff copy only to advance WAL, and pgoutput did
+    // not send another one after the no-op DDL.
+    let relation_events = grouped_events.get(&(EventType::Relation, table_id)).unwrap();
+    assert_eq!(relation_events.len(), 1);
+
     let catchup_events = grouped_events.get(&(EventType::Insert, table_id)).unwrap();
     let expected_catchup_events = build_expected_users_inserts(
         (copied_rows + 1) as i64,
@@ -701,6 +728,38 @@ async fn table_sync_handover_preserves_decoder_for_post_handoff_dml() {
         vec![("user_4", 4), ("user_5", 5), ("user_6", 6)],
     );
     assert_events_equal(catchup_events, &expected_catchup_events);
+
+    let Event::Relation(relation) = &relation_events[0] else {
+        unreachable!("grouped relation event should be a relation");
+    };
+    let Event::Insert(post_handoff_insert) = catchup_events.last().unwrap() else {
+        unreachable!("grouped insert event should be an insert");
+    };
+
+    // The relation-less row must use the new schema snapshot stored for the
+    // no-op DDL, rather than the older snapshot attached to the table-sync
+    // Relation event.
+    let latest_table_schemas = store.get_latest_table_schemas().await;
+    assert_eq!(
+        post_handoff_insert.replicated_table_schema.inner(),
+        latest_table_schemas.get(&table_id).unwrap()
+    );
+    assert_ne!(
+        post_handoff_insert.replicated_table_schema.inner().snapshot_id,
+        relation.replicated_table_schema.inner().snapshot_id
+    );
+
+    // Only the snapshot changed. Since PostgreSQL sent no replacement
+    // Relation, both positional masks must come from the decoder persisted in
+    // SyncDone, which was built from the table-sync Relation above.
+    assert_eq!(
+        post_handoff_insert.replicated_table_schema.replication_mask(),
+        relation.replicated_table_schema.replication_mask()
+    );
+    assert_eq!(
+        post_handoff_insert.replicated_table_schema.identity_mask(),
+        relation.replicated_table_schema.identity_mask()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/pipeline_with_schema_changes.rs
+++ b/crates/etl/tests/pipeline_with_schema_changes.rs
@@ -347,8 +347,8 @@ async fn relationless_noop_schema_changes_reuse_previous_decoder() {
 
     let events = destination.get_events().await;
     let grouped = group_events_by_type_and_table_id(&events);
-    assert_eq!(grouped.get(&(EventType::Relation, table_id)).map(Vec::len), None);
-    assert_eq!(grouped.get(&(EventType::Insert, table_id)).unwrap().len(), 1);
+    assert_eq!(grouped.get(&(EventType::Relation, table_id)).unwrap().len(), 1);
+    assert_eq!(grouped.get(&(EventType::Insert, table_id)).unwrap().len(), 2);
 
     let Event::Insert(insert) = get_last_insert_event(&events, table_id) else {
         panic!("expected insert event");

--- a/crates/etl/tests/pipeline_with_schema_changes.rs
+++ b/crates/etl/tests/pipeline_with_schema_changes.rs
@@ -297,6 +297,67 @@ async fn relation_message_updates_when_column_nullability_changes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn relationless_noop_schema_changes_reuse_previous_decoder() {
+    init_test_tracing();
+
+    let (database, table_name, table_id, store, destination, pipeline, _, _) =
+        create_database_and_sync_done_pipeline_with_table(
+            "relationless_noop_schema_changes",
+            &[("name", "text not null"), ("age", "integer")],
+        )
+        .await;
+
+    let ready_notify = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+    let warm_insert_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
+
+    database.insert_values(table_name.clone(), &["name", "age"], &[&"Before", &1]).await.unwrap();
+
+    ready_notify.notified().await;
+    warm_insert_notify.notified().await;
+
+    let schemas_stored_notify = store.notify_on_table_schema_count(table_id, 3).await;
+    let insert_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 2)])
+        .await;
+
+    // Both commands succeed and reach ddl_command_end, but neither changes a
+    // catalog tuple which invalidates pgoutput's cached relation state.
+    database
+        .run_sql(&format!(
+            "alter table {} owner to current_user",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+    database
+        .run_sql(&format!(
+            "alter table {} alter column age drop not null",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+    database.insert_values(table_name, &["name", "age"], &[&"Alice", &25]).await.unwrap();
+
+    schemas_stored_notify.notified().await;
+    insert_notify.notified().await;
+
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let events = destination.get_events().await;
+    let grouped = group_events_by_type_and_table_id(&events);
+    assert_eq!(grouped.get(&(EventType::Relation, table_id)).map(Vec::len), None);
+    assert_eq!(grouped.get(&(EventType::Insert, table_id)).unwrap().len(), 1);
+
+    let Event::Insert(insert) = get_last_insert_event(&events, table_id) else {
+        panic!("expected insert event");
+    };
+    assert_eq!(insert.table_row.values()[1], Cell::String("Alice".to_owned()));
+    assert_eq!(insert.table_row.values()[2], Cell::I32(25));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn alter_table_without_dml_stores_schema_snapshot() {
     init_test_tracing();
 

--- a/crates/etl/tests/pipeline_with_schema_changes.rs
+++ b/crates/etl/tests/pipeline_with_schema_changes.rs
@@ -297,7 +297,7 @@ async fn relation_message_updates_when_column_nullability_changes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn relationless_noop_schema_changes_reuse_previous_decoder() {
+async fn relationless_noop_schema_changes_reuse_previous_relation_masks() {
     init_test_tracing();
 
     let (database, table_name, table_id, store, destination, pipeline, _, _) =
@@ -353,8 +353,32 @@ async fn relationless_noop_schema_changes_reuse_previous_decoder() {
     let Event::Insert(insert) = get_last_insert_event(&events, table_id) else {
         panic!("expected insert event");
     };
+    let Event::Relation(relation) = get_last_relation_event(&events, table_id) else {
+        panic!("expected relation event");
+    };
     assert_eq!(insert.table_row.values()[1], Cell::String("Alice".to_owned()));
     assert_eq!(insert.table_row.values()[2], Cell::I32(25));
+    assert_eq!(
+        insert.replicated_table_schema.replication_mask(),
+        relation.replicated_table_schema.replication_mask()
+    );
+    assert_eq!(
+        insert.replicated_table_schema.identity_mask(),
+        relation.replicated_table_schema.identity_mask()
+    );
+
+    let table_schemas = store.get_table_schemas().await;
+    let (_, newest_table_schema) = table_schemas
+        .get(&table_id)
+        .unwrap()
+        .iter()
+        .max_by_key(|(snapshot_id, _)| *snapshot_id)
+        .unwrap();
+    assert_eq!(insert.replicated_table_schema.inner(), newest_table_schema);
+    assert_ne!(
+        insert.replicated_table_schema.inner().snapshot_id,
+        relation.replicated_table_schema.inner().snapshot_id
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/replication_stream.rs
+++ b/crates/etl/tests/replication_stream.rs
@@ -1500,6 +1500,85 @@ async fn logical_replication_orders_concurrent_ddl_transactions_by_commit_lsn() 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn logical_replication_omits_relation_after_noop_alter_table_commands() {
+    init_test_tracing();
+    let database = spawn_source_database().await;
+
+    let table_name = test_table_name("noop_alter_table_relation_cache");
+    let quoted_table_name = table_name.as_quoted_identifier();
+    let table_id = database
+        .create_table(table_name.clone(), true, &[("name", "text not null"), ("age", "integer")])
+        .await
+        .unwrap();
+
+    let publication_name = "noop_alter_table_relation_cache_pub";
+    database.create_publication(publication_name, std::slice::from_ref(&table_name)).await.unwrap();
+
+    let (client, initial_stream, slot_name, start_lsn) = start_replayable_stream(
+        &database,
+        publication_name,
+        "noop_alter_table_relation_cache_slot",
+    )
+    .await;
+
+    // Warm pgoutput's relation cache before issuing the no-op DDL commands.
+    database.insert_values(table_name.clone(), &["name", "age"], &[&"before", &1]).await.unwrap();
+
+    // These commands are collected by ddl_command_end, but their successful
+    // no-op paths do not invalidate the table's relcache entry.
+    let alter_table_commands = [
+        format!("alter table {quoted_table_name} owner to current_user"),
+        format!("alter table {quoted_table_name} alter column age drop not null"),
+        format!("alter table {quoted_table_name} disable trigger user"),
+        format!("alter table {quoted_table_name} replica identity default"),
+        format!("alter table {quoted_table_name} add column if not exists age integer"),
+        format!("alter table {quoted_table_name} drop column if exists missing_column"),
+        format!("alter table {quoted_table_name} drop constraint if exists missing_constraint"),
+        format!("alter table {quoted_table_name} alter column age drop identity if exists"),
+        format!("alter table {quoted_table_name} set logged"),
+        format!("alter table {quoted_table_name} set access method heap"),
+        format!("alter table {quoted_table_name} set tablespace pg_default"),
+        format!("alter table {quoted_table_name} set without cluster"),
+        format!("alter table {quoted_table_name} set without oids"),
+    ];
+    for command in &alter_table_commands {
+        database.run_sql(command).await.unwrap();
+    }
+    database.insert_values(table_name, &["name", "age"], &[&"after", &2]).await.unwrap();
+
+    let columns = vec!["id".to_owned(), "name".to_owned(), "age".to_owned()];
+    let mut expected = vec![
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::Relation(table_id.into_inner(), columns.clone()),
+        ExpectedStreamMarker::Insert(table_id.into_inner()),
+        ExpectedStreamMarker::Commit,
+    ];
+    for _ in alter_table_commands {
+        expected.extend([
+            ExpectedStreamMarker::Begin,
+            ExpectedStreamMarker::DdlMessage(table_id.into_inner(), None, columns.clone()),
+            ExpectedStreamMarker::Commit,
+        ]);
+    }
+    expected.extend([
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::Insert(table_id.into_inner()),
+        ExpectedStreamMarker::Commit,
+    ]);
+
+    assert_stream_markers_and_replay(
+        client,
+        initial_stream,
+        &database,
+        publication_name,
+        &slot_name,
+        start_lsn,
+        &expected,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn logical_replication_replays_schema_changes_before_first_dml() {
     init_test_tracing();
     let database = spawn_source_database().await;

--- a/crates/etl/tests/replication_stream.rs
+++ b/crates/etl/tests/replication_stream.rs
@@ -1526,7 +1526,7 @@ async fn logical_replication_omits_relation_after_noop_alter_table_commands() {
 
     // These commands are collected by ddl_command_end, but their successful
     // no-op paths do not invalidate the table's relcache entry.
-    let alter_table_commands = [
+    let mut alter_table_commands = vec![
         format!("alter table {quoted_table_name} owner to current_user"),
         format!("alter table {quoted_table_name} alter column age drop not null"),
         format!("alter table {quoted_table_name} disable trigger user"),
@@ -1536,11 +1536,14 @@ async fn logical_replication_omits_relation_after_noop_alter_table_commands() {
         format!("alter table {quoted_table_name} drop constraint if exists missing_constraint"),
         format!("alter table {quoted_table_name} alter column age drop identity if exists"),
         format!("alter table {quoted_table_name} set logged"),
-        format!("alter table {quoted_table_name} set access method heap"),
         format!("alter table {quoted_table_name} set tablespace pg_default"),
         format!("alter table {quoted_table_name} set without cluster"),
         format!("alter table {quoted_table_name} set without oids"),
     ];
+    if !below_version!(database.server_version(), POSTGRES_15) {
+        alter_table_commands
+            .push(format!("alter table {quoted_table_name} set access method heap"));
+    }
     for command in &alter_table_commands {
         database.run_sql(command).await.unwrap();
     }


### PR DESCRIPTION
## Summary

Preserve the previous pgoutput relation masks when a DDL message is not followed by a new `RELATION` message.

PostgreSQL event triggers report successful `ALTER TABLE` commands even when they are no-ops. These commands can leave the pgoutput relation cache valid, so the next row event is emitted without repeating relation metadata. ETL previously discarded its complete decoder after every DDL message and required a new `RELATION`, causing valid relation-less row events to fail with `InvalidState`.

## Implementation

- Replace `WaitingForRelation` with `PendingRelation`, which records the exact new schema snapshot and optionally retains the previous replication and identity masks.
- Keep both masks together in `PreviousRelationMasks` so they are either both present or both absent.
- When a new `RELATION` arrives, rebuild the decoder from that message against the pending snapshot as usual.
- When DML arrives first, combine the pending table schema with the previous masks, transition immediately back to `WithSchema`, and decode the row.
- Carry the fallback masks across consecutive DDL messages while updating to the latest pending snapshot.
- Continue failing closed when no previous complete decoder exists.
- Restore an applicable durable `SyncDone` decoder only when no connection-local decoding state exists.

This relies on the pgoutput protocol behavior that updated relation metadata is sent before row data whenever the cached row-decoding layout changes. The fallback is therefore used only when PostgreSQL has kept the previous relation metadata valid.

## PostgreSQL behavior covered

The replication-stream coverage warms the pgoutput relation cache and verifies that successful no-op forms emit DDL messages but no subsequent `RELATION`, including:

- setting the existing owner;
- dropping `NOT NULL` from an already-nullable column;
- disabling user triggers when none exist;
- setting the existing replica identity;
- `ADD COLUMN IF NOT EXISTS` for an existing column;
- missing column, constraint, and identity drops using `IF EXISTS`;
- setting the existing persistence, access method, and tablespace;
- `SET WITHOUT CLUSTER`;
- `SET WITHOUT OIDS`.

The pipeline regression test then verifies that consecutive relation-less schema messages retain the latest schema snapshot, reuse the previous masks for DML, and continue replication without resetting the decoder.

## Test cleanup

- Consolidate repetitive unit tests into table-driven cases across `etl`, `etl-config`, `etl-postgres`, and `etl-destinations`.
- Remove tests that only exercise derived `Clone` or `PartialEq` behavior.
- Replace allocation-heavy BigQuery batching fixtures with small boundary-equivalent cases.
- Reduce the workspace library suite from 1,132 to 1,050 test processes without removing distinct protocol, state-machine, parser-boundary, or concurrency coverage.