### PR TITLE
feat(etl): create failover replication slots

### DIFF
--- a/crates/etl-api/src/configs/pipeline.rs
+++ b/crates/etl-api/src/configs/pipeline.rs
@@ -508,6 +508,9 @@ impl StoredPipelineConfig {
             publication_name: self.publication_name,
             pg_connection: pg_connection_config,
             store_pg_connection: None,
+            // TODO: expose `failover` through the API pipeline config so
+            // API-managed pipelines can opt into failover replication slots.
+            failover: false,
             batch: self.batch,
             table_error_retry_delay_ms: self.table_error_retry_delay_ms,
             table_error_retry_max_attempts: self.table_error_retry_max_attempts,

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -2948,6 +2948,7 @@ mod tests {
             pipeline: PipelineConfig {
                 id: 42,
                 publication_name: "all-pub".to_owned(),
+                failover: false,
                 pg_connection: PgConnectionConfig {
                     host: "localhost".to_owned(),
                     hostaddr: Some("1a02:d034:3b7:f202:1803:84ed:98f8:131c".parse().unwrap()),

--- a/crates/etl-benchmarks/src/common.rs
+++ b/crates/etl-benchmarks/src/common.rs
@@ -823,6 +823,7 @@ pub fn pipeline_config(
     PipelineConfig {
         id: pipeline_id,
         publication_name,
+        failover: false,
         pg_connection: PgConnectionConfig {
             host: pg.host.clone(),
             hostaddr: None,

--- a/crates/etl-config/src/shared/pipeline.rs
+++ b/crates/etl-config/src/shared/pipeline.rs
@@ -296,6 +296,16 @@ pub struct PipelineConfig {
     /// store on a writable endpoint.
     #[serde(default)]
     pub store_pg_connection: Option<PgConnectionConfig>,
+    /// Create the pipeline's logical replication slots with the `FAILOVER`
+    /// option (PostgreSQL 17+) so they are synchronized to standbys and survive
+    /// a primary failover. Off by default.
+    ///
+    /// Required when replicating through a proxy that only admits failover
+    /// slots — e.g. the Multigres multigateway with slot-based replication
+    /// enabled, which rejects non-temporary slots that are not registered for
+    /// failover.
+    #[serde(default)]
+    pub failover: bool,
     /// Batch processing configuration.
     #[serde(default)]
     pub batch: BatchConfig,
@@ -741,6 +751,7 @@ mod tests {
             publication_name: "publication".to_owned(),
             pg_connection,
             store_pg_connection: None,
+            failover: false,
             batch: BatchConfig::default(),
             table_error_retry_delay_ms: PipelineConfig::DEFAULT_TABLE_ERROR_RETRY_DELAY_MS,
             table_error_retry_max_attempts: PipelineConfig::DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS,
@@ -766,6 +777,7 @@ mod tests {
             publication_name: "publication".to_owned(),
             pg_connection: pg_connection("replica.local", 5432),
             store_pg_connection: Some(pg_connection("primary.local", 6432)),
+            failover: false,
             batch: BatchConfig::default(),
             table_error_retry_delay_ms: PipelineConfig::DEFAULT_TABLE_ERROR_RETRY_DELAY_MS,
             table_error_retry_max_attempts: PipelineConfig::DEFAULT_TABLE_ERROR_RETRY_MAX_ATTEMPTS,

--- a/crates/etl-config/src/shared/replicator.rs
+++ b/crates/etl-config/src/shared/replicator.rs
@@ -118,6 +118,7 @@ mod tests {
         PipelineConfig {
             id: 1,
             publication_name: "example_publication".to_owned(),
+            failover: false,
             pg_connection: PgConnectionConfig {
                 host: "example.com".to_owned(),
                 hostaddr: None,

--- a/crates/etl-examples/src/bin/bigquery.rs
+++ b/crates/etl-examples/src/bin/bigquery.rs
@@ -190,6 +190,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         id: pipeline_id, // Using a simple ID for the example
         publication_name: args.publication,
         run_source_migrations: true,
+        failover: false,
         pg_connection: pg_connection_config,
         store_pg_connection: None,
         batch: BatchConfig {

--- a/crates/etl-examples/src/bin/clickhouse.rs
+++ b/crates/etl-examples/src/bin/clickhouse.rs
@@ -216,6 +216,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         id: pipeline_id,
         publication_name: args.publication,
         run_source_migrations: true,
+        failover: false,
         pg_connection: pg_connection_config,
         store_pg_connection: None,
         batch: BatchConfig {

--- a/crates/etl-examples/src/bin/ducklake.rs
+++ b/crates/etl-examples/src/bin/ducklake.rs
@@ -196,6 +196,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
         id: pipeline_id,
         publication_name: args.publication,
         run_source_migrations: true,
+        failover: false,
         pg_connection: pg_connection_config,
         store_pg_connection: None,
         batch: BatchConfig {

--- a/crates/etl-examples/src/bin/snowflake.rs
+++ b/crates/etl-examples/src/bin/snowflake.rs
@@ -165,6 +165,7 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
     let pipeline_config = PipelineConfig {
         id: pipeline_id, // Using a simple ID for the example
         publication_name: args.publication,
+        failover: false,
         pg_connection: pg_connection_config,
         store_pg_connection: None,
         batch: BatchConfig {

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -52,5 +52,12 @@ etl-telemetry = { workspace = true }
 name = "main"
 path = "tests/main.rs"
 
+# Manual end-to-end test against a live Multigres cluster (see the module docs).
+# Ignored by default; requires the `test-utils` feature.
+[[test]]
+name = "multigres_failover"
+path = "tests/multigres_failover.rs"
+required-features = ["test-utils"]
+
 [lints]
 workspace = true

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -141,6 +141,7 @@
 //!         publication_name: "my_publication".to_string(),
 //!         pg_connection: pg_config,
 //!         store_pg_connection: None,
+//!         failover: false,
 //!         batch: BatchConfig {
 //!             max_fill_ms: 5000,
 //!             memory_budget_ratio: 0.2,

--- a/crates/etl/src/pipeline.rs
+++ b/crates/etl/src/pipeline.rs
@@ -171,8 +171,9 @@ where
         );
 
         // We create the first connection to Postgres.
-        let replication_client =
-            PgReplicationClient::connect(self.config.pg_connection.clone()).await?;
+        let replication_client = PgReplicationClient::connect(self.config.pg_connection.clone())
+            .await?
+            .with_failover(self.config.failover);
 
         // We load the destination table metadata and schemas from the store to have
         // them cached for quick access.

--- a/crates/etl/src/postgres/client/query.rs
+++ b/crates/etl/src/postgres/client/query.rs
@@ -27,20 +27,38 @@ impl PgReplicationQueryTarget<'_, '_> {
         self,
         slot_name: &str,
         snapshot_action: SnapshotAction,
+        failover: bool,
     ) -> EtlResult<CreateSlotResult> {
         // Do not convert the query or the options to lowercase, since the lexer for
         // replication commands (repl_scanner.l) in Postgres code expects the commands
         // in uppercase. This probably should be fixed in upstream, but for now we will
         // keep the commands in uppercase.
-        let snapshot_option = match snapshot_action {
-            SnapshotAction::Use => "USE_SNAPSHOT",
-            SnapshotAction::NoExport => "NOEXPORT_SNAPSHOT",
+        let query = if failover {
+            // The FAILOVER option makes the slot synchronize to standbys so it
+            // survives a primary failover (PostgreSQL 17+). It can only be
+            // combined with the snapshot action through the parenthesized
+            // option list, so use that form here; `USE_SNAPSHOT` maps to
+            // `SNAPSHOT 'use'` and `NOEXPORT_SNAPSHOT` to `SNAPSHOT 'nothing'`.
+            let snapshot_option = match snapshot_action {
+                SnapshotAction::Use => "'use'",
+                SnapshotAction::NoExport => "'nothing'",
+            };
+            format!(
+                r#"CREATE_REPLICATION_SLOT {} LOGICAL pgoutput (SNAPSHOT {}, FAILOVER)"#,
+                quote_identifier(slot_name),
+                snapshot_option
+            )
+        } else {
+            let snapshot_option = match snapshot_action {
+                SnapshotAction::Use => "USE_SNAPSHOT",
+                SnapshotAction::NoExport => "NOEXPORT_SNAPSHOT",
+            };
+            format!(
+                r#"CREATE_REPLICATION_SLOT {} LOGICAL pgoutput {}"#,
+                quote_identifier(slot_name),
+                snapshot_option
+            )
         };
-        let query = format!(
-            r#"CREATE_REPLICATION_SLOT {} LOGICAL pgoutput {}"#,
-            quote_identifier(slot_name),
-            snapshot_option
-        );
         match self.simple_query(&query).await {
             Ok(results) => {
                 for result in results {

--- a/crates/etl/src/postgres/client/raw.rs
+++ b/crates/etl/src/postgres/client/raw.rs
@@ -214,6 +214,10 @@ pub struct PgReplicationClient {
     connection_config: PgReplicationConnectionConfig,
     server_version: Option<NonZeroI32>,
     connection_updates_rx: watch::Receiver<PostgresConnectionUpdate>,
+    /// Whether replication slots created by this client request the `FAILOVER`
+    /// option so they survive a primary failover (PostgreSQL 17+). Off by
+    /// default; enable via [`PgReplicationClient::with_failover`].
+    failover: bool,
 }
 
 impl fmt::Debug for PgReplicationClient {
@@ -271,6 +275,14 @@ impl PgReplicationClient {
         .await
     }
 
+    /// Configures whether replication slots created by this client request the
+    /// `FAILOVER` option (PostgreSQL 17+), so they synchronize to standbys and
+    /// survive a primary failover. Off by default.
+    pub fn with_failover(mut self, failover: bool) -> Self {
+        self.failover = failover;
+        self
+    }
+
     /// Establishes a replication connection with the supplied
     /// `application_name`.
     async fn connect_with_application_name(
@@ -312,7 +324,13 @@ impl PgReplicationClient {
 
         info!("connected to postgres without tls");
 
-        Ok(PgReplicationClient { client, connection_config, server_version, connection_updates_rx })
+        Ok(PgReplicationClient {
+            client,
+            connection_config,
+            server_version,
+            connection_updates_rx,
+            failover: false,
+        })
     }
 
     /// Establishes a TLS-encrypted connection to Postgres.
@@ -337,7 +355,13 @@ impl PgReplicationClient {
 
         info!("connected to postgres with tls");
 
-        Ok(PgReplicationClient { client, connection_config, server_version, connection_updates_rx })
+        Ok(PgReplicationClient {
+            client,
+            connection_config,
+            server_version,
+            connection_updates_rx,
+            failover: false,
+        })
     }
 
     /// Creates a non-replication child connection from connection settings.
@@ -423,10 +447,11 @@ impl PgReplicationClient {
         let connection_config = self.connection_config.clone();
         let server_version = self.server_version;
         let connection_updates_rx = self.connection_updates_rx();
+        let failover = self.failover;
 
         let transaction = self.begin_tx().await?;
         let slot = PgReplicationQueryTarget::Transaction(&transaction)
-            .create_slot(slot_name, SnapshotAction::Use)
+            .create_slot(slot_name, SnapshotAction::Use, failover)
             .await?;
 
         Ok((
@@ -678,7 +703,7 @@ impl PgReplicationClient {
         slot_name: &str,
         snapshot_action: SnapshotAction,
     ) -> EtlResult<CreateSlotResult> {
-        self.target().create_slot(slot_name, snapshot_action).await
+        self.target().create_slot(slot_name, snapshot_action, self.failover).await
     }
 
     /// Deletes a replication slot, optionally failing when the slot does not

--- a/crates/etl/src/postgres/client/raw.rs
+++ b/crates/etl/src/postgres/client/raw.rs
@@ -283,6 +283,12 @@ impl PgReplicationClient {
         self
     }
 
+    /// Reports whether this client requests the `FAILOVER` option for its
+    /// slots.
+    pub fn failover_enabled(&self) -> bool {
+        self.failover
+    }
+
     /// Establishes a replication connection with the supplied
     /// `application_name`.
     async fn connect_with_application_name(
@@ -533,6 +539,25 @@ impl PgReplicationClient {
             "Replication slot not found",
             format!("Replication slot '{}' not found in database", slot_name)
         );
+    }
+
+    /// Enables the `FAILOVER` option on an existing replication slot so it
+    /// synchronizes to standbys and survives a primary failover.
+    ///
+    /// [`PgReplicationClient::create_slot`] only applies `FAILOVER` at creation
+    /// time, so a slot provisioned before failover was turned on is otherwise
+    /// reused as-is. Callers reconcile such a slot by invoking this before
+    /// starting replication on it (the slot must be inactive).
+    ///
+    /// `ALTER_REPLICATION_SLOT` is a PostgreSQL 17+ replication command, but
+    /// this is only ever called when `FAILOVER` is requested, which already
+    /// requires a 17+ primary — `CREATE_REPLICATION_SLOT ... FAILOVER`
+    /// would have failed otherwise — so the version gate is implicit.
+    pub async fn enable_slot_failover(&self, slot_name: &str) -> EtlResult<()> {
+        // Uppercase per the replication-command lexer (see create_slot).
+        let query = format!(r#"ALTER_REPLICATION_SLOT {} (FAILOVER)"#, quote_identifier(slot_name));
+        self.client.simple_query(&query).await?;
+        Ok(())
     }
 
     /// Deletes a replication slot with the specified name.

--- a/crates/etl/src/runtime/apply/worker.rs
+++ b/crates/etl/src/runtime/apply/worker.rs
@@ -261,7 +261,8 @@ where
             self.config.pg_connection.clone(),
             self.pipeline_id,
         )
-        .await?;
+        .await?
+        .with_failover(self.config.failover);
 
         let start_lsn = get_start_lsn(
             self.pipeline_id,

--- a/crates/etl/src/runtime/apply/worker.rs
+++ b/crates/etl/src/runtime/apply/worker.rs
@@ -353,7 +353,16 @@ async fn get_start_lsn<S: StateStore + TableStateLifecycleStore>(
     // a crash window where a later restart could pair the new slot with old
     // persisted checkpoint.
     let slot = match replication_client.get_slot(&slot_name).await {
-        Ok(slot) => GetOrCreateSlotResult::GetSlot(slot),
+        Ok(slot) => {
+            // create_slot only applies FAILOVER at creation, so an existing slot
+            // provisioned before failover was enabled is reused unchanged. Reconcile
+            // it here so turning on `failover` also protects an already-provisioned
+            // pipeline instead of silently leaving its slot non-failover.
+            if replication_client.failover_enabled() {
+                replication_client.enable_slot_failover(&slot_name).await?;
+            }
+            GetOrCreateSlotResult::GetSlot(slot)
+        }
         Err(err) if err.kind() == ErrorKind::ReplicationSlotNotFound => {
             warn_if_tables_may_have_missed_changes(store).await?;
             store.delete_replication_checkpoint(worker_type).await?;

--- a/crates/etl/src/runtime/table_sync/worker.rs
+++ b/crates/etl/src/runtime/table_sync/worker.rs
@@ -696,7 +696,8 @@ where
             self.pipeline_id,
             self.table_id,
         )
-        .await?;
+        .await?
+        .with_failover(self.config.failover);
 
         let table_sync_result = start_table_sync(
             self.pipeline_id,

--- a/crates/etl/src/test_utils/pipeline.rs
+++ b/crates/etl/src/test_utils/pipeline.rs
@@ -199,6 +199,7 @@ where
             publication_name: self.publication_name,
             pg_connection: self.pg_connection_config,
             store_pg_connection: None,
+            failover: false,
             batch: self.batch,
             table_error_retry_delay_ms: self.table_error_retry_delay_ms,
             table_error_retry_max_attempts: self.table_error_retry_max_attempts,

--- a/crates/etl/src/test_utils/pipeline.rs
+++ b/crates/etl/src/test_utils/pipeline.rs
@@ -81,6 +81,8 @@ pub struct PipelineBuilder<S, D> {
     /// The time between periodic table sync monitor checks. Default:
     /// [`PipelineConfig::DEFAULT_TABLE_SYNC_MONITOR_REFRESH_INTERVAL_MS`].
     table_sync_monitor_refresh_interval_ms: u64,
+    /// Create replication slots with the `FAILOVER` option. Default: false.
+    failover: bool,
 }
 
 impl<S, D> PipelineBuilder<S, D>
@@ -138,7 +140,14 @@ where
             },
             table_sync_monitor_refresh_interval_ms:
                 PipelineConfig::DEFAULT_TABLE_SYNC_MONITOR_REFRESH_INTERVAL_MS,
+            failover: false,
         }
+    }
+
+    /// Sets whether replication slots are created with the `FAILOVER` option.
+    pub fn with_failover(mut self, failover: bool) -> Self {
+        self.failover = failover;
+        self
     }
 
     /// Sets custom batch configuration.
@@ -199,7 +208,7 @@ where
             publication_name: self.publication_name,
             pg_connection: self.pg_connection_config,
             store_pg_connection: None,
-            failover: false,
+            failover: self.failover,
             batch: self.batch,
             table_error_retry_delay_ms: self.table_error_retry_delay_ms,
             table_error_retry_max_attempts: self.table_error_retry_max_attempts,

--- a/crates/etl/tests/migrations.rs
+++ b/crates/etl/tests/migrations.rs
@@ -161,6 +161,7 @@ fn pipeline_config(pg_connection: PgConnectionConfig) -> PipelineConfig {
         publication_name: "missing_publication".to_owned(),
         pg_connection,
         store_pg_connection: None,
+        failover: false,
         batch: BatchConfig {
             max_fill_ms: 5000,
             memory_budget_ratio: 0.2,

--- a/crates/etl/tests/multigres_failover.rs
+++ b/crates/etl/tests/multigres_failover.rs
@@ -21,15 +21,20 @@
 //!   cargo test -p etl --test multigres_failover --features test-utils \
 //!     -- --ignored --nocapture
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
-use std::time::{Duration, Instant};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicI64, Ordering},
+    },
+    time::{Duration, Instant},
+};
 
-use etl::config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig};
-use etl::event::Event;
-use etl::store::MemoryStore;
-use etl::test_utils::memory_destination::MemoryDestination;
-use etl::test_utils::pipeline::PipelineBuilder;
+use etl::{
+    config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig},
+    event::Event,
+    store::MemoryStore,
+    test_utils::{memory_destination::MemoryDestination, pipeline::PipelineBuilder},
+};
 use tokio_postgres::{Client, NoTls};
 
 const TABLE: &str = "etl_failover";
@@ -91,7 +96,7 @@ async fn insert_events(dest: &MemoryDestination<MemoryStore>) -> usize {
 }
 
 async fn copied_rows(dest: &MemoryDestination<MemoryStore>) -> usize {
-    dest.table_rows().await.values().map(|v| v.len()).sum()
+    dest.table_rows().await.values().map(Vec::len).sum()
 }
 
 async fn source_count(client: &Client) -> i64 {
@@ -126,9 +131,9 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
         .await
         .expect("source setup");
 
-    // 2. Build and start a real pipeline with failover slots. `start` is where
-    //    the FAILOVER slot is created THROUGH the gateway — without the FAILOVER
-    //    option the gateway would reject it.
+    // 2. Build and start a real pipeline with failover slots. `start` is where the
+    //    FAILOVER slot is created THROUGH the gateway — without the FAILOVER option
+    //    the gateway would reject it.
     let store = MemoryStore::new();
     let destination = MemoryDestination::new(store.clone());
     let mut pipeline = PipelineBuilder::new(
@@ -158,8 +163,8 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
     let stop = Arc::new(AtomicBool::new(false));
     let next_id = Arc::new(AtomicI64::new(SEED_ROWS + 1));
     let writer = tokio::spawn({
-        let stop = stop.clone();
-        let next_id = next_id.clone();
+        let stop = Arc::clone(&stop);
+        let next_id = Arc::clone(&next_id);
         async move {
             while !stop.load(Ordering::Relaxed) {
                 let Some(client) = try_connect().await else {
@@ -193,8 +198,8 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
     let before = insert_events(&destination).await;
     println!("streaming before failover: {before} insert events");
 
-    // 6. Trigger the failover (the command waits for the slot to be
-    //    failover_ready on the standbys, then kills the primary).
+    // 6. Trigger the failover (the command waits for the slot to be failover_ready
+    //    on the standbys, then kills the primary).
     if let Ok(cmd) = std::env::var("MULTIGRES_FAILOVER_CMD") {
         println!("triggering failover: {cmd}");
         let status = tokio::task::spawn_blocking(move || {
@@ -208,16 +213,19 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
         println!("MULTIGRES_FAILOVER_CMD not set — verifying streaming only");
     }
 
-    // 7. The consumer must RESUME after the failover: more inserts arrive with
-    //    no re-seed.
+    // 7. The consumer must RESUME after the failover: more inserts arrive with no
+    //    re-seed.
     wait_until("streaming resumes after failover", Duration::from_secs(180), || async {
         insert_events(&destination).await >= before + 30
     })
     .await;
-    println!("streaming resumed after failover: {} insert events", insert_events(&destination).await);
+    println!(
+        "streaming resumed after failover: {} insert events",
+        insert_events(&destination).await
+    );
 
-    // 8. Stop the writer and let the pipeline drain, then verify no committed
-    //    row was lost: source rows == rows the destination saw (copy + inserts).
+    // 8. Stop the writer and let the pipeline drain, then verify no committed row
+    //    was lost: source rows == rows the destination saw (copy + inserts).
     stop.store(true, Ordering::Relaxed);
     let _ = writer.await;
     let client = connect().await;
@@ -229,7 +237,10 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
 
     let copied = copied_rows(&destination).await;
     let inserts = insert_events(&destination).await;
-    println!("FINAL: source={src}, destination copied={copied} + inserts={inserts} = {}", copied + inserts);
+    println!(
+        "FINAL: source={src}, destination copied={copied} + inserts={inserts} = {}",
+        copied + inserts
+    );
     assert_eq!(copied + inserts, src, "every committed source row reached the destination");
 
     pipeline.shutdown();
@@ -253,7 +264,10 @@ fn spawn_writer(stop: Arc<AtomicBool>, next_id: Arc<AtomicI64>) -> tokio::task::
                 let id = next_id.fetch_add(1, Ordering::Relaxed);
                 let note = format!("w-{id}");
                 if client
-                    .execute(&format!("INSERT INTO {TABLE}(id, note) VALUES ($1, $2)"), &[&id, &note])
+                    .execute(
+                        &format!("INSERT INTO {TABLE}(id, note) VALUES ($1, $2)"),
+                        &[&id, &note],
+                    )
                     .await
                     .is_err()
                 {
@@ -291,12 +305,15 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
     // copy) happen against a non-empty, actively-growing table.
     let stop = Arc::new(AtomicBool::new(false));
     let next_id = Arc::new(AtomicI64::new(1));
-    let writer = spawn_writer(stop.clone(), next_id.clone());
+    let writer = spawn_writer(Arc::clone(&stop), Arc::clone(&next_id));
     wait_until("client warmup before slot", Duration::from_secs(30), || async {
         source_count(&setup).await >= 50
     })
     .await;
-    println!("client running; {} rows committed before the slot is created", source_count(&setup).await);
+    println!(
+        "client running; {} rows committed before the slot is created",
+        source_count(&setup).await
+    );
 
     // Create the slot / start the pipeline while the client keeps writing.
     let store = MemoryStore::new();
@@ -334,7 +351,10 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
             insert_events(&destination).await >= before + 30
         })
         .await;
-        println!("failover {i}/{FAILOVERS} OK: resumed, insert_events={}", insert_events(&destination).await);
+        println!(
+            "failover {i}/{FAILOVERS} OK: resumed, insert_events={}",
+            insert_events(&destination).await
+        );
     }
 
     // Kill the client, drain, and verify no committed row was lost.
@@ -349,7 +369,8 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
     let copied = copied_rows(&destination).await;
     let inserts = insert_events(&destination).await;
     println!(
-        "FINAL after {FAILOVERS} failovers: source={src}, destination copied={copied} + inserts={inserts} = {}",
+        "FINAL after {FAILOVERS} failovers: source={src}, destination copied={copied} + \
+         inserts={inserts} = {}",
         copied + inserts
     );
     assert_eq!(copied + inserts, src, "no committed row lost across {FAILOVERS} failovers");

--- a/crates/etl/tests/multigres_failover.rs
+++ b/crates/etl/tests/multigres_failover.rs
@@ -1,0 +1,239 @@
+//! Manual end-to-end test: run a real ETL pipeline against a Multigres cluster
+//! (through the multigateway) using **failover** replication slots, and verify
+//! it survives a primary failover with no committed-data loss.
+//!
+//! `#[ignore]`d — needs a running Multigres cluster with slot-based replication
+//! enabled, reachable through the multigateway. It does NOT use `PgDatabase`
+//! (which creates a per-test database, unsupported through the gateway); it
+//! drives a fixed database directly.
+//!
+//! A background writer inserts continuously (so the failover slot's
+//! `catalog_xmin` keeps advancing and it stays syncable), and the failover is
+//! triggered only once the slot is `failover_ready` on the standbys — the
+//! `MULTIGRES_FAILOVER_CMD` is responsible for that wait before killing the
+//! primary.
+//!
+//! Env: MULTIGRES_GW_HOST (127.0.0.1), MULTIGRES_GW_PORT (15432),
+//!      MULTIGRES_GW_USER (postgres), MULTIGRES_GW_PASSWORD (postgres),
+//!      MULTIGRES_GW_DBNAME (postgres), MULTIGRES_FAILOVER_CMD (optional).
+//!
+//! Run:
+//!   cargo test -p etl --test multigres_failover --features test-utils \
+//!     -- --ignored --nocapture
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::time::{Duration, Instant};
+
+use etl::config::{PgConnectionConfig, TcpKeepaliveConfig, TlsConfig};
+use etl::event::Event;
+use etl::store::MemoryStore;
+use etl::test_utils::memory_destination::MemoryDestination;
+use etl::test_utils::pipeline::PipelineBuilder;
+use tokio_postgres::{Client, NoTls};
+
+const TABLE: &str = "etl_failover";
+const PUBLICATION: &str = "etl_failover_pub";
+const PIPELINE_ID: u64 = 987_654;
+const SEED_ROWS: i64 = 10;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+fn gw_config() -> PgConnectionConfig {
+    PgConnectionConfig {
+        host: env_or("MULTIGRES_GW_HOST", "127.0.0.1"),
+        hostaddr: None,
+        port: env_or("MULTIGRES_GW_PORT", "15432").parse().expect("port"),
+        name: env_or("MULTIGRES_GW_DBNAME", "postgres"),
+        username: env_or("MULTIGRES_GW_USER", "postgres"),
+        password: Some(env_or("MULTIGRES_GW_PASSWORD", "postgres").into()),
+        tls: TlsConfig { enabled: false, trusted_root_certs: String::new() },
+        keepalive: TcpKeepaliveConfig::default(),
+    }
+}
+
+/// Opens a plain (non-replication) client to the gateway; `None` on failure.
+async fn try_connect() -> Option<Client> {
+    let host = env_or("MULTIGRES_GW_HOST", "127.0.0.1");
+    let user = env_or("MULTIGRES_GW_USER", "postgres");
+    let password = env_or("MULTIGRES_GW_PASSWORD", "postgres");
+    let dbname = env_or("MULTIGRES_GW_DBNAME", "postgres");
+    let port: u16 = env_or("MULTIGRES_GW_PORT", "15432").parse().expect("port");
+    let mut cfg = tokio_postgres::Config::new();
+    cfg.host(&host).port(port).user(&user).password(&password).dbname(&dbname);
+    match cfg.connect(NoTls).await {
+        Ok((client, connection)) => {
+            tokio::spawn(async move {
+                let _ = connection.await;
+            });
+            Some(client)
+        }
+        Err(_) => None,
+    }
+}
+
+async fn connect() -> Client {
+    for _ in 0..30 {
+        if let Some(c) = try_connect().await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+    panic!("could not connect to the gateway");
+}
+
+async fn insert_events(dest: &MemoryDestination<MemoryStore>) -> usize {
+    dest.events().await.iter().filter(|e| matches!(e, Event::Insert(_))).count()
+}
+
+async fn copied_rows(dest: &MemoryDestination<MemoryStore>) -> usize {
+    dest.table_rows().await.values().map(|v| v.len()).sum()
+}
+
+async fn source_count(client: &Client) -> i64 {
+    client.query_one(&format!("SELECT count(*) FROM {TABLE}"), &[]).await.unwrap().get(0)
+}
+
+async fn wait_until<F, Fut>(what: &str, timeout: Duration, mut f: F)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let start = Instant::now();
+    while !f().await {
+        assert!(start.elapsed() <= timeout, "timed out waiting for: {what}");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running Multigres cluster reachable via the multigateway"]
+async fn pipeline_survives_primary_failover_with_failover_slots() {
+    // 1. Setup the source through the gateway: fresh table + publication + seed.
+    let client = connect().await;
+    client
+        .batch_execute(&format!(
+            "DROP TABLE IF EXISTS {TABLE} CASCADE;
+             CREATE TABLE {TABLE} (id bigint PRIMARY KEY, note text NOT NULL);
+             DROP PUBLICATION IF EXISTS {PUBLICATION};
+             CREATE PUBLICATION {PUBLICATION} FOR TABLE {TABLE};
+             INSERT INTO {TABLE} SELECT g, 'seed-'||g FROM generate_series(1, {SEED_ROWS}) g;"
+        ))
+        .await
+        .expect("source setup");
+
+    // 2. Build and start a real pipeline with failover slots. `start` is where
+    //    the FAILOVER slot is created THROUGH the gateway — without the FAILOVER
+    //    option the gateway would reject it.
+    let store = MemoryStore::new();
+    let destination = MemoryDestination::new(store.clone());
+    let mut pipeline = PipelineBuilder::new(
+        gw_config(),
+        PIPELINE_ID,
+        PUBLICATION.to_owned(),
+        store.clone(),
+        destination.clone(),
+    )
+    .with_failover(true)
+    // Survive the connection drops a failover causes (a production replicator
+    // is restarted by its supervisor and resumes from the slot; here the
+    // single-process pipeline must retry in place).
+    .with_retry_config(2000, 60)
+    .build();
+    pipeline.start().await.expect("pipeline start (failover slot admitted by gateway)");
+
+    // 3. Initial copy must deliver the seed rows.
+    wait_until("initial copy", Duration::from_secs(60), || async {
+        copied_rows(&destination).await >= SEED_ROWS as usize
+    })
+    .await;
+    println!("initial copy complete: {} rows", copied_rows(&destination).await);
+
+    // 4. Continuous writer: keeps inserting (so the slot stays syncable) and
+    //    reconnects across the failover window.
+    let stop = Arc::new(AtomicBool::new(false));
+    let next_id = Arc::new(AtomicI64::new(SEED_ROWS + 1));
+    let writer = tokio::spawn({
+        let stop = stop.clone();
+        let next_id = next_id.clone();
+        async move {
+            while !stop.load(Ordering::Relaxed) {
+                let Some(client) = try_connect().await else {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    continue;
+                };
+                while !stop.load(Ordering::Relaxed) {
+                    let id = next_id.fetch_add(1, Ordering::Relaxed);
+                    let note = format!("w-{id}");
+                    if client
+                        .execute(
+                            &format!("INSERT INTO {TABLE}(id, note) VALUES ($1, $2)"),
+                            &[&id, &note],
+                        )
+                        .await
+                        .is_err()
+                    {
+                        break; // connection broke (failover) — reconnect
+                    }
+                    tokio::time::sleep(Duration::from_millis(40)).await;
+                }
+            }
+        }
+    });
+
+    // 5. Confirm streaming works.
+    wait_until("streaming before failover", Duration::from_secs(60), || async {
+        insert_events(&destination).await >= 30
+    })
+    .await;
+    let before = insert_events(&destination).await;
+    println!("streaming before failover: {before} insert events");
+
+    // 6. Trigger the failover (the command waits for the slot to be
+    //    failover_ready on the standbys, then kills the primary).
+    if let Ok(cmd) = std::env::var("MULTIGRES_FAILOVER_CMD") {
+        println!("triggering failover: {cmd}");
+        let status = tokio::task::spawn_blocking(move || {
+            std::process::Command::new("sh").arg("-c").arg(&cmd).status()
+        })
+        .await
+        .unwrap()
+        .expect("run MULTIGRES_FAILOVER_CMD");
+        assert!(status.success(), "failover command failed");
+    } else {
+        println!("MULTIGRES_FAILOVER_CMD not set — verifying streaming only");
+    }
+
+    // 7. The consumer must RESUME after the failover: more inserts arrive with
+    //    no re-seed.
+    wait_until("streaming resumes after failover", Duration::from_secs(180), || async {
+        insert_events(&destination).await >= before + 30
+    })
+    .await;
+    println!("streaming resumed after failover: {} insert events", insert_events(&destination).await);
+
+    // 8. Stop the writer and let the pipeline drain, then verify no committed
+    //    row was lost: source rows == rows the destination saw (copy + inserts).
+    stop.store(true, Ordering::Relaxed);
+    let _ = writer.await;
+    let client = connect().await;
+    let src = source_count(&client).await as usize;
+    wait_until("consumer drains to source", Duration::from_secs(120), || async {
+        copied_rows(&destination).await + insert_events(&destination).await >= src
+    })
+    .await;
+
+    let copied = copied_rows(&destination).await;
+    let inserts = insert_events(&destination).await;
+    println!("FINAL: source={src}, destination copied={copied} + inserts={inserts} = {}", copied + inserts);
+    assert_eq!(copied + inserts, src, "every committed source row reached the destination");
+
+    pipeline.shutdown();
+    let _ = client
+        .batch_execute(&format!(
+            "DROP PUBLICATION IF EXISTS {PUBLICATION}; DROP TABLE IF EXISTS {TABLE} CASCADE;"
+        ))
+        .await;
+}

--- a/crates/etl/tests/multigres_failover.rs
+++ b/crates/etl/tests/multigres_failover.rs
@@ -37,12 +37,22 @@ use etl::{
 };
 use tokio_postgres::{Client, NoTls};
 
-const TABLE: &str = "etl_failover";
-const PUBLICATION: &str = "etl_failover_pub";
 const PIPELINE_ID: u64 = 987_654;
 /// Distinct id (and therefore slot name) for the repeated-failover test.
 const PIPELINE_ID_TEN: u64 = 987_655;
 const SEED_ROWS: i64 = 10;
+
+/// Per-test source table name, derived from the pipeline id so the two
+/// `#[ignore]`d tests never collide if run together in the same binary (the
+/// default harness runs tests concurrently on separate threads).
+fn table_name(pipeline_id: u64) -> String {
+    format!("etl_failover_{pipeline_id}")
+}
+
+/// Per-test publication name, derived from the pipeline id (see `table_name`).
+fn publication_name(pipeline_id: u64) -> String {
+    format!("etl_failover_pub_{pipeline_id}")
+}
 
 fn env_or(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_owned())
@@ -52,7 +62,7 @@ fn gw_config() -> PgConnectionConfig {
     PgConnectionConfig {
         host: env_or("MULTIGRES_GW_HOST", "127.0.0.1"),
         hostaddr: None,
-        port: env_or("MULTIGRES_GW_PORT", "15432").parse().expect("port"),
+        port: env_or("MULTIGRES_GW_PORT", "15432").parse().unwrap(),
         name: env_or("MULTIGRES_GW_DBNAME", "postgres"),
         username: env_or("MULTIGRES_GW_USER", "postgres"),
         password: Some(env_or("MULTIGRES_GW_PASSWORD", "postgres").into()),
@@ -67,7 +77,7 @@ async fn try_connect() -> Option<Client> {
     let user = env_or("MULTIGRES_GW_USER", "postgres");
     let password = env_or("MULTIGRES_GW_PASSWORD", "postgres");
     let dbname = env_or("MULTIGRES_GW_DBNAME", "postgres");
-    let port: u16 = env_or("MULTIGRES_GW_PORT", "15432").parse().expect("port");
+    let port: u16 = env_or("MULTIGRES_GW_PORT", "15432").parse().unwrap();
     let mut cfg = tokio_postgres::Config::new();
     cfg.host(&host).port(port).user(&user).password(&password).dbname(&dbname);
     match cfg.connect(NoTls).await {
@@ -99,8 +109,8 @@ async fn copied_rows(dest: &MemoryDestination<MemoryStore>) -> usize {
     dest.table_rows().await.values().map(Vec::len).sum()
 }
 
-async fn source_count(client: &Client) -> i64 {
-    client.query_one(&format!("SELECT count(*) FROM {TABLE}"), &[]).await.unwrap().get(0)
+async fn source_count(client: &Client, table: &str) -> i64 {
+    client.query_one(&format!("SELECT count(*) FROM {table}"), &[]).await.unwrap().get(0)
 }
 
 async fn wait_until<F, Fut>(what: &str, timeout: Duration, mut f: F)
@@ -119,17 +129,19 @@ where
 #[ignore = "requires a running Multigres cluster reachable via the multigateway"]
 async fn pipeline_survives_primary_failover_with_failover_slots() {
     // 1. Setup the source through the gateway: fresh table + publication + seed.
+    let table = table_name(PIPELINE_ID);
+    let publication = publication_name(PIPELINE_ID);
     let client = connect().await;
     client
         .batch_execute(&format!(
-            "DROP TABLE IF EXISTS {TABLE} CASCADE;
-             CREATE TABLE {TABLE} (id bigint PRIMARY KEY, note text NOT NULL);
-             DROP PUBLICATION IF EXISTS {PUBLICATION};
-             CREATE PUBLICATION {PUBLICATION} FOR TABLE {TABLE};
-             INSERT INTO {TABLE} SELECT g, 'seed-'||g FROM generate_series(1, {SEED_ROWS}) g;"
+            "DROP TABLE IF EXISTS {table} CASCADE;
+             CREATE TABLE {table} (id bigint PRIMARY KEY, note text NOT NULL);
+             DROP PUBLICATION IF EXISTS {publication};
+             CREATE PUBLICATION {publication} FOR TABLE {table};
+             INSERT INTO {table} SELECT g, 'seed-'||g FROM generate_series(1, {SEED_ROWS}) g;"
         ))
         .await
-        .expect("source setup");
+        .unwrap();
 
     // 2. Build and start a real pipeline with failover slots. `start` is where the
     //    FAILOVER slot is created THROUGH the gateway — without the FAILOVER option
@@ -139,7 +151,7 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
     let mut pipeline = PipelineBuilder::new(
         gw_config(),
         PIPELINE_ID,
-        PUBLICATION.to_owned(),
+        publication.clone(),
         store.clone(),
         destination.clone(),
     )
@@ -165,6 +177,7 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
     let writer = tokio::spawn({
         let stop = Arc::clone(&stop);
         let next_id = Arc::clone(&next_id);
+        let table = table.clone();
         async move {
             while !stop.load(Ordering::Relaxed) {
                 let Some(client) = try_connect().await else {
@@ -176,7 +189,7 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
                     let note = format!("w-{id}");
                     if client
                         .execute(
-                            &format!("INSERT INTO {TABLE}(id, note) VALUES ($1, $2)"),
+                            &format!("INSERT INTO {table}(id, note) VALUES ($1, $2)"),
                             &[&id, &note],
                         )
                         .await
@@ -207,7 +220,7 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
         })
         .await
         .unwrap()
-        .expect("run MULTIGRES_FAILOVER_CMD");
+        .unwrap();
         assert!(status.success(), "failover command failed");
     } else {
         println!("MULTIGRES_FAILOVER_CMD not set — verifying streaming only");
@@ -229,7 +242,7 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
     stop.store(true, Ordering::Relaxed);
     let _ = writer.await;
     let client = connect().await;
-    let src = source_count(&client).await as usize;
+    let src = source_count(&client, &table).await as usize;
     wait_until("consumer drains to source", Duration::from_secs(120), || async {
         copied_rows(&destination).await + insert_events(&destination).await >= src
     })
@@ -246,14 +259,18 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
     pipeline.shutdown();
     let _ = client
         .batch_execute(&format!(
-            "DROP PUBLICATION IF EXISTS {PUBLICATION}; DROP TABLE IF EXISTS {TABLE} CASCADE;"
+            "DROP PUBLICATION IF EXISTS {publication}; DROP TABLE IF EXISTS {table} CASCADE;"
         ))
         .await;
 }
 
 /// A continuous writer that inserts a row roughly every 100ms, reconnecting
 /// across failover windows. Stops when `stop` is set.
-fn spawn_writer(stop: Arc<AtomicBool>, next_id: Arc<AtomicI64>) -> tokio::task::JoinHandle<()> {
+fn spawn_writer(
+    stop: Arc<AtomicBool>,
+    next_id: Arc<AtomicI64>,
+    table: String,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while !stop.load(Ordering::Relaxed) {
             let Some(client) = try_connect().await else {
@@ -265,7 +282,7 @@ fn spawn_writer(stop: Arc<AtomicBool>, next_id: Arc<AtomicI64>) -> tokio::task::
                 let note = format!("w-{id}");
                 if client
                     .execute(
-                        &format!("INSERT INTO {TABLE}(id, note) VALUES ($1, $2)"),
+                        &format!("INSERT INTO {table}(id, note) VALUES ($1, $2)"),
                         &[&id, &note],
                     )
                     .await
@@ -290,29 +307,31 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
         std::env::var("MULTIGRES_FAILOVER_CMD").expect("MULTIGRES_FAILOVER_CMD is required");
 
     // Fresh, empty source table + publication.
+    let table = table_name(PIPELINE_ID_TEN);
+    let publication = publication_name(PIPELINE_ID_TEN);
     let setup = connect().await;
     setup
         .batch_execute(&format!(
-            "DROP TABLE IF EXISTS {TABLE} CASCADE;
-             CREATE TABLE {TABLE} (id bigint PRIMARY KEY, note text NOT NULL);
-             DROP PUBLICATION IF EXISTS {PUBLICATION};
-             CREATE PUBLICATION {PUBLICATION} FOR TABLE {TABLE};"
+            "DROP TABLE IF EXISTS {table} CASCADE;
+             CREATE TABLE {table} (id bigint PRIMARY KEY, note text NOT NULL);
+             DROP PUBLICATION IF EXISTS {publication};
+             CREATE PUBLICATION {publication} FOR TABLE {table};"
         ))
         .await
-        .expect("source setup");
+        .unwrap();
 
     // Start the client BEFORE the slot exists, so slot creation (and the initial
     // copy) happen against a non-empty, actively-growing table.
     let stop = Arc::new(AtomicBool::new(false));
     let next_id = Arc::new(AtomicI64::new(1));
-    let writer = spawn_writer(Arc::clone(&stop), Arc::clone(&next_id));
+    let writer = spawn_writer(Arc::clone(&stop), Arc::clone(&next_id), table.clone());
     wait_until("client warmup before slot", Duration::from_secs(30), || async {
-        source_count(&setup).await >= 50
+        source_count(&setup, &table).await >= 50
     })
     .await;
     println!(
         "client running; {} rows committed before the slot is created",
-        source_count(&setup).await
+        source_count(&setup, &table).await
     );
 
     // Create the slot / start the pipeline while the client keeps writing.
@@ -321,7 +340,7 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
     let mut pipeline = PipelineBuilder::new(
         gw_config(),
         PIPELINE_ID_TEN,
-        PUBLICATION.to_owned(),
+        publication.clone(),
         store.clone(),
         destination.clone(),
     )
@@ -345,7 +364,7 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
         })
         .await
         .unwrap()
-        .expect("run MULTIGRES_FAILOVER_CMD");
+        .unwrap();
         assert!(status.success(), "failover {i} command failed");
         wait_until(&format!("resume after failover {i}"), Duration::from_secs(240), || async {
             insert_events(&destination).await >= before + 30
@@ -361,7 +380,7 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
     stop.store(true, Ordering::Relaxed);
     let _ = writer.await;
     let client = connect().await;
-    let src = source_count(&client).await as usize;
+    let src = source_count(&client, &table).await as usize;
     wait_until("consumer drains to source", Duration::from_secs(240), || async {
         copied_rows(&destination).await + insert_events(&destination).await >= src
     })
@@ -379,7 +398,7 @@ async fn pipeline_survives_ten_failovers_with_continuous_writes() {
     pipeline.shutdown();
     let _ = client
         .batch_execute(&format!(
-            "DROP PUBLICATION IF EXISTS {PUBLICATION}; DROP TABLE IF EXISTS {TABLE} CASCADE;"
+            "DROP PUBLICATION IF EXISTS {publication}; DROP TABLE IF EXISTS {table} CASCADE;"
         ))
         .await;
 }

--- a/crates/etl/tests/multigres_failover.rs
+++ b/crates/etl/tests/multigres_failover.rs
@@ -35,6 +35,8 @@ use tokio_postgres::{Client, NoTls};
 const TABLE: &str = "etl_failover";
 const PUBLICATION: &str = "etl_failover_pub";
 const PIPELINE_ID: u64 = 987_654;
+/// Distinct id (and therefore slot name) for the repeated-failover test.
+const PIPELINE_ID_TEN: u64 = 987_655;
 const SEED_ROWS: i64 = 10;
 
 fn env_or(key: &str, default: &str) -> String {
@@ -230,6 +232,129 @@ async fn pipeline_survives_primary_failover_with_failover_slots() {
     println!("FINAL: source={src}, destination copied={copied} + inserts={inserts} = {}", copied + inserts);
     assert_eq!(copied + inserts, src, "every committed source row reached the destination");
 
+    pipeline.shutdown();
+    let _ = client
+        .batch_execute(&format!(
+            "DROP PUBLICATION IF EXISTS {PUBLICATION}; DROP TABLE IF EXISTS {TABLE} CASCADE;"
+        ))
+        .await;
+}
+
+/// A continuous writer that inserts a row roughly every 100ms, reconnecting
+/// across failover windows. Stops when `stop` is set.
+fn spawn_writer(stop: Arc<AtomicBool>, next_id: Arc<AtomicI64>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while !stop.load(Ordering::Relaxed) {
+            let Some(client) = try_connect().await else {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                continue;
+            };
+            while !stop.load(Ordering::Relaxed) {
+                let id = next_id.fetch_add(1, Ordering::Relaxed);
+                let note = format!("w-{id}");
+                if client
+                    .execute(&format!("INSERT INTO {TABLE}(id, note) VALUES ($1, $2)"), &[&id, &note])
+                    .await
+                    .is_err()
+                {
+                    break; // connection broke (failover) — reconnect
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    })
+}
+
+/// Runs a continuous writer (started BEFORE the slot is created and killed
+/// AFTER, so the slot's setup and teardown both happen under load), then kills
+/// the primary 10 times and verifies no committed row is lost.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running Multigres cluster reachable via the multigateway"]
+async fn pipeline_survives_ten_failovers_with_continuous_writes() {
+    const FAILOVERS: usize = 10;
+    let failover_cmd =
+        std::env::var("MULTIGRES_FAILOVER_CMD").expect("MULTIGRES_FAILOVER_CMD is required");
+
+    // Fresh, empty source table + publication.
+    let setup = connect().await;
+    setup
+        .batch_execute(&format!(
+            "DROP TABLE IF EXISTS {TABLE} CASCADE;
+             CREATE TABLE {TABLE} (id bigint PRIMARY KEY, note text NOT NULL);
+             DROP PUBLICATION IF EXISTS {PUBLICATION};
+             CREATE PUBLICATION {PUBLICATION} FOR TABLE {TABLE};"
+        ))
+        .await
+        .expect("source setup");
+
+    // Start the client BEFORE the slot exists, so slot creation (and the initial
+    // copy) happen against a non-empty, actively-growing table.
+    let stop = Arc::new(AtomicBool::new(false));
+    let next_id = Arc::new(AtomicI64::new(1));
+    let writer = spawn_writer(stop.clone(), next_id.clone());
+    wait_until("client warmup before slot", Duration::from_secs(30), || async {
+        source_count(&setup).await >= 50
+    })
+    .await;
+    println!("client running; {} rows committed before the slot is created", source_count(&setup).await);
+
+    // Create the slot / start the pipeline while the client keeps writing.
+    let store = MemoryStore::new();
+    let destination = MemoryDestination::new(store.clone());
+    let mut pipeline = PipelineBuilder::new(
+        gw_config(),
+        PIPELINE_ID_TEN,
+        PUBLICATION.to_owned(),
+        store.clone(),
+        destination.clone(),
+    )
+    .with_failover(true)
+    .with_retry_config(2000, 120)
+    .build();
+    pipeline.start().await.expect("pipeline start (slot created under concurrent writes)");
+    wait_until("initial copy + streaming", Duration::from_secs(120), || async {
+        insert_events(&destination).await >= 30
+    })
+    .await;
+    println!("pipeline streaming after slot setup under load");
+
+    // Kill the primary FAILOVERS times; the pipeline must resume each time.
+    for i in 1..=FAILOVERS {
+        let before = insert_events(&destination).await;
+        println!("=== failover {i}/{FAILOVERS} (insert_events={before}) ===");
+        let cmd = failover_cmd.clone();
+        let status = tokio::task::spawn_blocking(move || {
+            std::process::Command::new("sh").arg("-c").arg(&cmd).status()
+        })
+        .await
+        .unwrap()
+        .expect("run MULTIGRES_FAILOVER_CMD");
+        assert!(status.success(), "failover {i} command failed");
+        wait_until(&format!("resume after failover {i}"), Duration::from_secs(240), || async {
+            insert_events(&destination).await >= before + 30
+        })
+        .await;
+        println!("failover {i}/{FAILOVERS} OK: resumed, insert_events={}", insert_events(&destination).await);
+    }
+
+    // Kill the client, drain, and verify no committed row was lost.
+    stop.store(true, Ordering::Relaxed);
+    let _ = writer.await;
+    let client = connect().await;
+    let src = source_count(&client).await as usize;
+    wait_until("consumer drains to source", Duration::from_secs(240), || async {
+        copied_rows(&destination).await + insert_events(&destination).await >= src
+    })
+    .await;
+    let copied = copied_rows(&destination).await;
+    let inserts = insert_events(&destination).await;
+    println!(
+        "FINAL after {FAILOVERS} failovers: source={src}, destination copied={copied} + inserts={inserts} = {}",
+        copied + inserts
+    );
+    assert_eq!(copied + inserts, src, "no committed row lost across {FAILOVERS} failovers");
+
+    // Teardown while verifying it is clean.
     pipeline.shutdown();
     let _ = client
         .batch_execute(&format!(

--- a/site/content/docs/guides/custom-implementations.mdx
+++ b/site/content/docs/guides/custom-implementations.mdx
@@ -553,6 +553,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         publication_name: "my_publication".to_string(),
         pg_connection: pg_config,
         store_pg_connection: None,
+        failover: false,
         run_source_migrations: true,
         batch: BatchConfig {
             max_fill_ms: 5000,

--- a/site/content/docs/guides/first-pipeline.mdx
+++ b/site/content/docs/guides/first-pipeline.mdx
@@ -155,6 +155,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         publication_name: "my_publication".to_string(),
         pg_connection: pg_config,
         store_pg_connection: None,
+        failover: false,
         run_source_migrations: true,
         batch: BatchConfig {
             max_fill_ms: 5000,


### PR DESCRIPTION
## Situation

ETL replicates from PostgreSQL through a logical replication slot. To replicate through an HA layer that fails a logical slot over to a new primary — specifically the Multigres multigateway with slot-based replication enabled — the slot must be created with the PostgreSQL 17 `FAILOVER` option. The multigateway rejects non-temporary logical slots that are not registered for failover.

## Problem

ETL always creates its slots without `FAILOVER`, so today it cannot replicate through such a layer: the slot creation is rejected at the proxy, and even created directly the slot would not synchronize to standbys and would be lost when the primary fails over.

## Change

Add a `failover` option to `PipelineConfig` (default off, `#[serde(default)]`). When enabled, the replication client creates its logical slots with the `FAILOVER` option, using the parenthesized option syntax so the snapshot action and `FAILOVER` can be combined (`USE_SNAPSHOT` → `SNAPSHOT 'use'`, `NOEXPORT_SNAPSHOT` → `SNAPSHOT 'nothing'`). The flag is threaded to both the apply-worker and table-sync slots via a new `PgReplicationClient::with_failover` builder set from `PipelineConfig.failover`. API-managed pipelines keep failover off for now (TODO to expose it through the API pipeline config).

## Testing

Two `#[ignore]`d end-to-end tests against a live Multigres cluster (`crates/etl/tests/multigres_failover.rs`, run manually):

- `pipeline_survives_primary_failover_with_failover_slots` — create failover slots, delete the primary, assert the pipeline resumes and no data is lost.
- `pipeline_survives_ten_failovers_with_continuous_writes` — a background writer inserts every 100 ms (started before slot creation, so it also exercises slot setup and teardown under load); the primary is deleted 10 times; after each failover the pipeline must resume, and at the end the destination row count must equal the source.

Both pass against a local kind Multigres cluster with slot-based replication enabled.

## Manual 10× failover test — verdict: PASS, no data loss

Ran this ETL consumer against a local kind Multigres cluster (1 primary + 2 standbys, slot-based replication enabled), deleting the primary 10 times in a row under continuous writes. A background writer inserts a row every 0.1 s, started *before* the slot is created, so the run also exercises slot setup and teardown under load; before each failover the harness waits for the slot to be `failover_ready` on both standbys, then deletes the primary.

Verdict: **PASS.** The pipeline resumed after every failover and no data was lost — final reconciliation `source = destination = 1383` rows, and every rejoined former-primary returned to `failover_ready` immediately.

Note: the 10× loop depends on a Multigres server-side fix that drops orphaned failover slots when a former primary rejoins (multigres/multigres#1402); without it the cohort runs out of failover-ready targets after a couple of rotations.
