### PR TITLE
fix(ducklake): recreate pool of duckdb connections when a maintenance completed

### DIFF
--- a/crates/etl-destinations/src/ducklake/client.rs
+++ b/crates/etl-destinations/src/ducklake/client.rs
@@ -315,10 +315,8 @@ pub(super) struct DuckLakeInterruptRegistry {
 impl DuckLakeInterruptRegistry {
     /// Registers one live DuckLake connection interrupt handle.
     fn register(&self, handle: &Arc<RegisteredDuckLakeInterrupt>) {
-        let mut handles = self
-            .handles
-            .lock()
-            .expect("ducklake interrupt registry mutex should not be poisoned");
+        let mut handles =
+            self.handles.lock().expect("ducklake interrupt registry mutex should not be poisoned");
         handles.retain(|registered| registered.strong_count() > 0);
         handles.push(Arc::downgrade(handle));
     }

--- a/crates/etl-destinations/src/ducklake/client.rs
+++ b/crates/etl-destinations/src/ducklake/client.rs
@@ -315,10 +315,12 @@ pub(super) struct DuckLakeInterruptRegistry {
 impl DuckLakeInterruptRegistry {
     /// Registers one live DuckLake connection interrupt handle.
     fn register(&self, handle: &Arc<RegisteredDuckLakeInterrupt>) {
-        self.handles
+        let mut handles = self
+            .handles
             .lock()
-            .expect("ducklake interrupt registry mutex should not be poisoned")
-            .push(Arc::downgrade(handle));
+            .expect("ducklake interrupt registry mutex should not be poisoned");
+        handles.retain(|registered| registered.strong_count() > 0);
+        handles.push(Arc::downgrade(handle));
     }
 
     /// Interrupts all currently live registered DuckLake connections.
@@ -1047,6 +1049,26 @@ mod tests {
         state.clear();
 
         assert_eq!(state.reason(), DuckLakeInterruptReason::None);
+    }
+
+    #[test]
+    fn interrupt_registry_prunes_dropped_handles_during_registration() {
+        let registry = DuckLakeInterruptRegistry::default();
+        let first_conn =
+            duckdb::Connection::open_in_memory().expect("failed to open first test connection");
+        let first = Arc::new(RegisteredDuckLakeInterrupt::new(first_conn.interrupt_handle()));
+        registry.register(&first);
+        assert_eq!(registry.handles.lock().unwrap().len(), 1);
+
+        drop(first);
+
+        let second_conn =
+            duckdb::Connection::open_in_memory().expect("failed to open second test connection");
+        let second = Arc::new(RegisteredDuckLakeInterrupt::new(second_conn.interrupt_handle()));
+        registry.register(&second);
+
+        assert_eq!(registry.handles.lock().unwrap().len(), 1);
+        assert_eq!(registry.interrupt_all(), 1);
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -30,7 +30,7 @@ use etl_config::{
     },
 };
 use metrics::gauge;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock as ParkingLotRwLock};
 use pg_escape::{quote_identifier as quote_postgres_identifier, quote_literal};
 use sqlx::{AssertSqlSafe, PgPool, postgres::PgPoolOptions};
 #[cfg(unix)]
@@ -394,6 +394,70 @@ fn active_sort_order_matches(
 // ── destination
 // ───────────────────────────────────────────────────────────────
 
+/// Shared handle to one initialized DuckDB connection pool.
+type DuckLakePool = Arc<r2d2::Pool<DuckLakeConnectionManager>>;
+
+/// Streaming and initial-copy pools installed as one destination generation.
+#[derive(Clone)]
+struct DuckLakePools {
+    /// Connections attached with streaming data inlining enabled.
+    streaming: DuckLakePool,
+    /// Connections attached with data inlining disabled for initial copy.
+    copy: DuckLakePool,
+}
+
+impl DuckLakePools {
+    /// Creates one fully initialized pair of DuckLake connection pools.
+    fn new(streaming: DuckLakePool, copy: DuckLakePool) -> Self {
+        Self { streaming, copy }
+    }
+}
+
+/// Atomically replaceable DuckLake pool pair shared by destination clones.
+struct DuckLakePoolHandle {
+    /// Currently installed pools, or `None` after a failed maintenance refresh.
+    current: ParkingLotRwLock<Option<DuckLakePools>>,
+}
+
+impl DuckLakePoolHandle {
+    /// Creates a handle with an initialized pool pair.
+    fn new(pools: DuckLakePools) -> Self {
+        Self { current: ParkingLotRwLock::new(Some(pools)) }
+    }
+
+    /// Returns the currently installed streaming pool.
+    fn streaming(&self) -> EtlResult<DuckLakePool> {
+        self.current.read().as_ref().map(|pools| Arc::clone(&pools.streaming)).ok_or_else(|| {
+            etl_error!(
+                ErrorKind::DestinationConnectionFailed,
+                "DuckLake connection pools are unavailable",
+                "Pool refresh failed after external maintenance"
+            )
+        })
+    }
+
+    /// Returns the currently installed initial-copy pool.
+    fn copy(&self) -> EtlResult<DuckLakePool> {
+        self.current.read().as_ref().map(|pools| Arc::clone(&pools.copy)).ok_or_else(|| {
+            etl_error!(
+                ErrorKind::DestinationConnectionFailed,
+                "DuckLake connection pools are unavailable",
+                "Pool refresh failed after external maintenance"
+            )
+        })
+    }
+
+    /// Installs a fully initialized pair and returns the previous pools.
+    fn replace(&self, pools: DuckLakePools) -> Option<DuckLakePools> {
+        self.current.write().replace(pools)
+    }
+
+    /// Removes every installed pool after replacement initialization fails.
+    fn invalidate(&self) -> Option<DuckLakePools> {
+        self.current.write().take()
+    }
+}
+
 /// A DuckLake destination that implements the ETL [`Destination`] trait.
 ///
 /// Writes data to a DuckLake data lake. DuckDB connections are pre-initialized,
@@ -409,12 +473,11 @@ fn active_sort_order_matches(
 pub struct DuckLakeDestination<S> {
     manager: Arc<DuckLakeConnectionManager>,
     /// Connection manager for the pool dedicated to initial-copy writes.
-    #[cfg(feature = "test-utils")]
     copy_manager: DuckLakeConnectionManager,
-    pool: Arc<r2d2::Pool<DuckLakeConnectionManager>>,
-    /// Connections attached with data inlining disabled for initial-copy
-    /// transactions.
-    copy_pool: Arc<r2d2::Pool<DuckLakeConnectionManager>>,
+    /// Atomically replaceable streaming and initial-copy connection pools.
+    pools: Arc<DuckLakePoolHandle>,
+    /// Number of warm connections created in each DuckDB pool.
+    pool_size: u32,
     blocking_slots: Arc<Semaphore>,
     /// Shared gate that keeps external maintenance pauses from overlapping
     /// active foreground or table-scoped mutations.
@@ -1526,9 +1589,6 @@ where
             #[cfg(feature = "test-utils")]
             open_count: Arc::new(AtomicUsize::new(0)),
         };
-        #[cfg(feature = "test-utils")]
-        let copy_manager_for_tests = copy_manager.clone();
-
         let pool =
             Arc::new(build_warm_ducklake_pool(manager.as_ref().clone(), pool_size, "write").await?);
         let blocking_slots = Arc::new(Semaphore::new(pool_size as usize));
@@ -1624,15 +1684,17 @@ where
         )
         .await?;
 
-        let copy_pool = Arc::new(build_warm_ducklake_pool(copy_manager, pool_size, "copy").await?);
+        let copy_pool =
+            Arc::new(build_warm_ducklake_pool(copy_manager.clone(), pool_size, "copy").await?);
+        let pools =
+            Arc::new(DuckLakePoolHandle::new(DuckLakePools::new(Arc::clone(&pool), copy_pool)));
         let applied_tables = Arc::default();
         let checkpoint_gate = Arc::new(RwLock::new(()));
         let mut destination = Self {
             manager: Arc::clone(&manager),
-            #[cfg(feature = "test-utils")]
-            copy_manager: copy_manager_for_tests,
-            pool: Arc::clone(&pool),
-            copy_pool,
+            copy_manager,
+            pools,
+            pool_size,
             blocking_slots: Arc::clone(&blocking_slots),
             checkpoint_gate: Arc::clone(&checkpoint_gate),
             tasks: TaskSet::new(),
@@ -1877,7 +1939,7 @@ where
             prepare_copy_table_batch(replicated_table_schema, table_name, replay_epoch, table_rows)?
         };
         apply_table_batch_with_retry(
-            Arc::clone(&self.copy_pool),
+            self.copy_pool()?,
             Arc::clone(&self.blocking_slots),
             prepared_batch,
         )
@@ -2037,7 +2099,7 @@ where
         let table_name = table_name.clone();
         let plan = plan.clone();
 
-        run_duckdb_blocking(Arc::clone(&self.pool), Arc::clone(&self.blocking_slots), move |conn| {
+        run_duckdb_blocking(self.streaming_pool()?, Arc::clone(&self.blocking_slots), move |conn| {
             let execute_ddl = |sql: &str, description: &'static str| -> EtlResult<()> {
                 conn.execute_batch(sql).map_err(|source| {
                     etl_error!(
@@ -2150,7 +2212,7 @@ where
         };
         let table_name = table_name.clone();
 
-        run_duckdb_blocking(Arc::clone(&self.pool), Arc::clone(&self.blocking_slots), move |conn| {
+        run_duckdb_blocking(self.streaming_pool()?, Arc::clone(&self.blocking_slots), move |conn| {
             conn.execute_batch(&ddl).map_err(|source| {
                 etl_error!(
                     ErrorKind::DestinationQueryFailed,
@@ -2172,12 +2234,15 @@ where
         target_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         let table_name_for_read = table_name.clone();
-        let ducklake_columns = run_duckdb_blocking(
-            Arc::clone(&self.pool),
-            Arc::clone(&self.blocking_slots),
-            move |conn| read_ducklake_table_column_names_blocking(conn, &table_name_for_read),
-        )
-        .await?;
+        let ducklake_columns = {
+            let _checkpoint_guard = self.acquire_mutation_guard().await;
+            run_duckdb_blocking(
+                self.streaming_pool()?,
+                Arc::clone(&self.blocking_slots),
+                move |conn| read_ducklake_table_column_names_blocking(conn, &table_name_for_read),
+            )
+            .await?
+        };
         if ducklake_columns.is_empty() {
             return Err(etl_error!(
                 ErrorKind::DestinationTableMissing,
@@ -2224,7 +2289,7 @@ where
         let table_name = table_name.clone();
         let target_schema = target_schema.clone();
 
-        run_duckdb_blocking(Arc::clone(&self.pool), Arc::clone(&self.blocking_slots), move |conn| {
+        run_duckdb_blocking(self.streaming_pool()?, Arc::clone(&self.blocking_slots), move |conn| {
             let execute_ddl = |sql: &str, description: &'static str| -> EtlResult<()> {
                 conn.execute_batch(sql).map_err(|source| {
                     etl_error!(
@@ -2493,7 +2558,7 @@ where
                             }
                             let last_sequence_key =
                                 read_table_streaming_progress_sequence_key_blocking(
-                                    Arc::clone(&destination.pool),
+                                    destination.streaming_pool()?,
                                     Arc::clone(&destination.blocking_slots),
                                     destination_table_name.clone(),
                                     replay_epoch.clone(),
@@ -2525,7 +2590,7 @@ where
                                 pending_mutations,
                             )?;
                             apply_table_batches_with_retry(
-                                Arc::clone(&destination.pool),
+                                destination.streaming_pool()?,
                                 Arc::clone(&destination.blocking_slots),
                                 prepared_batches,
                             )
@@ -2586,11 +2651,12 @@ where
                     let table_write_permit = self.acquire_table_write_slot(&table_name).await?;
                     let replay_epoch = self.read_table_replay_epoch(&table_name).await?;
                     let checkpoint_gate = Arc::clone(&self.checkpoint_gate);
-                    let pool = Arc::clone(&self.pool);
+                    let pools = Arc::clone(&self.pools);
                     let blocking_slots = Arc::clone(&self.blocking_slots);
                     join_set.spawn(async move {
                         let _table_write_permit = table_write_permit;
                         let _checkpoint_guard = checkpoint_gate.read_owned().await;
+                        let pool = pools.streaming()?;
                         let last_sequence_key =
                             read_table_streaming_progress_sequence_key_blocking(
                                 Arc::clone(&pool),
@@ -2669,7 +2735,7 @@ where
         let _checkpoint_guard = self.acquire_mutation_guard().await;
 
         run_duckdb_blocking(
-            Arc::clone(&self.pool),
+            self.streaming_pool()?,
             Arc::clone(&self.blocking_slots),
             move |conn| -> EtlResult<()> {
                 debug!(table = %table_name, "ducklake create table begin");
@@ -2936,7 +3002,7 @@ where
     async fn ensure_applied_batches_table_exists(&self) -> EtlResult<()> {
         let _checkpoint_guard = self.acquire_mutation_guard().await;
         ensure_applied_batches_table_exists(
-            Arc::clone(&self.pool),
+            self.streaming_pool()?,
             Arc::clone(&self.blocking_slots),
             Arc::clone(&self.table_creation_slots),
             Arc::clone(&self.applied_batches_table_created),
@@ -2948,7 +3014,7 @@ where
     async fn ensure_streaming_progress_table_exists(&self) -> EtlResult<()> {
         let _checkpoint_guard = self.acquire_mutation_guard().await;
         ensure_streaming_progress_table_exists(
-            Arc::clone(&self.pool),
+            self.streaming_pool()?,
             Arc::clone(&self.blocking_slots),
             Arc::clone(&self.table_creation_slots),
             Arc::clone(&self.streaming_progress_table_created),
@@ -2996,6 +3062,55 @@ where
                 Err(etl_error!(ErrorKind::InvalidState, "DuckLake table write semaphore closed"))
             }
         }
+    }
+
+    /// Returns the currently installed streaming connection pool.
+    fn streaming_pool(&self) -> EtlResult<DuckLakePool> {
+        self.pools.streaming()
+    }
+
+    /// Returns the currently installed initial-copy connection pool.
+    fn copy_pool(&self) -> EtlResult<DuckLakePool> {
+        self.pools.copy()
+    }
+
+    /// Recreates and atomically installs both connection pools after successful
+    /// external maintenance.
+    ///
+    /// The caller must retain the exclusive external-maintenance pause until
+    /// this method returns. If either replacement pool fails to initialize, the
+    /// old pools are removed so later replication cannot reuse stale
+    /// connections after the pause guard is released.
+    pub(super) async fn recreate_pools_after_external_maintenance(&self) -> EtlResult<()> {
+        let streaming =
+            match build_warm_ducklake_pool(self.manager.as_ref().clone(), self.pool_size, "write")
+                .await
+            {
+                Ok(pool) => Arc::new(pool),
+                Err(error) => {
+                    drop(self.pools.invalidate());
+                    return Err(error);
+                }
+            };
+        let copy = match build_warm_ducklake_pool(self.copy_manager.clone(), self.pool_size, "copy")
+            .await
+        {
+            Ok(pool) => Arc::new(pool),
+            Err(error) => {
+                drop(streaming);
+                drop(self.pools.invalidate());
+                return Err(error);
+            }
+        };
+
+        let previous = self.pools.replace(DuckLakePools::new(streaming, copy));
+        drop(previous);
+        info!(
+            pool_size = self.pool_size,
+            "ducklake connection pools recreated after external maintenance"
+        );
+
+        Ok(())
     }
 
     /// Acquires shared mutation access so exclusive external maintenance cannot
@@ -3178,7 +3293,7 @@ where
         R: Send + 'static,
         F: FnOnce(&duckdb::Connection) -> EtlResult<R> + Send + 'static,
     {
-        run_duckdb_blocking(Arc::clone(&self.pool), Arc::clone(&self.blocking_slots), operation)
+        run_duckdb_blocking(self.streaming_pool()?, Arc::clone(&self.blocking_slots), operation)
             .await
     }
 
@@ -3207,6 +3322,13 @@ where
     #[cfg(feature = "test-utils")]
     pub fn copy_connection_open_count_for_tests(&self) -> usize {
         self.copy_manager.open_count_for_tests()
+    }
+
+    /// Returns how many streaming-pool DuckDB connections have been initialized
+    /// for tests.
+    #[cfg(feature = "test-utils")]
+    pub fn streaming_connection_open_count_for_tests(&self) -> usize {
+        self.manager.open_count_for_tests()
     }
 }
 
@@ -3326,6 +3448,19 @@ mod tests {
         assert!(!should_request_file_maintenance(true, 41, 40));
         assert!(!should_request_file_maintenance(false, 40, 40));
         assert!(should_request_file_maintenance(false, 41, 40));
+    }
+
+    #[test]
+    fn invalidated_connection_pools_return_destination_connection_error() {
+        let pools = DuckLakePoolHandle { current: ParkingLotRwLock::new(None) };
+
+        for result in [pools.streaming(), pools.copy()] {
+            let Err(error) = result else {
+                panic!("invalidated DuckLake pool handle should not return a pool");
+            };
+            assert_eq!(error.kind(), ErrorKind::DestinationConnectionFailed);
+            assert_eq!(error.description(), Some("DuckLake connection pools are unavailable"));
+        }
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -3082,6 +3082,16 @@ where
     /// old pools are removed so later replication cannot reuse stale
     /// connections after the pause guard is released.
     pub(super) async fn recreate_pools_after_external_maintenance(&self) -> EtlResult<()> {
+        #[cfg(feature = "test-utils")]
+        if FAIL_POOL_REFRESH_ONCE.swap(false, std::sync::atomic::Ordering::Relaxed) {
+            drop(self.pools.invalidate());
+            return Err(etl_error!(
+                ErrorKind::DestinationConnectionFailed,
+                "Failed to recreate DuckLake connection pools",
+                "Injected pool recreation failure"
+            ));
+        }
+
         let streaming =
             match build_warm_ducklake_pool(self.manager.as_ref().clone(), self.pool_size, "write")
                 .await
@@ -3358,6 +3368,26 @@ static PAUSED_STREAMING_WRITE_HOOK: std::sync::LazyLock<Mutex<Option<PausedStrea
 #[cfg(feature = "test-utils")]
 static PAUSED_STREAMING_WRITE_RESUME_TX: std::sync::LazyLock<Mutex<Option<oneshot::Sender<()>>>> =
     std::sync::LazyLock::new(|| Mutex::new(None));
+#[cfg(feature = "test-utils")]
+static FAIL_POOL_REFRESH_ONCE: AtomicBool = AtomicBool::new(false);
+
+/// Injects one pool-refresh failure for tests.
+#[cfg(feature = "test-utils")]
+pub fn arm_fail_pool_refresh_once_for_tests() {
+    FAIL_POOL_REFRESH_ONCE.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Returns whether the one-shot pool-refresh failure remains armed for tests.
+#[cfg(feature = "test-utils")]
+pub fn pool_refresh_failure_armed_for_tests() -> bool {
+    FAIL_POOL_REFRESH_ONCE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Clears the one-shot pool-refresh failure for tests.
+#[cfg(feature = "test-utils")]
+pub fn reset_pool_refresh_failure_for_tests() {
+    FAIL_POOL_REFRESH_ONCE.store(false, std::sync::atomic::Ordering::Relaxed);
+}
 
 /// Arms a one-shot hook that pauses the next streaming write before DuckLake
 /// starts applying it.

--- a/crates/etl-destinations/src/ducklake/external_maintenance.rs
+++ b/crates/etl-destinations/src/ducklake/external_maintenance.rs
@@ -145,7 +145,8 @@ where
                 }
 
                 expire_snapshots_gate.initialize_from_state_once(&state);
-                match reconcile_pause(&store, &config, &destination, &mut held_pause, &state).await {
+                match reconcile_pause(&store, &config, &destination, &mut held_pause, &state).await
+                {
                     Ok(()) => {
                         maybe_request_operations(
                             &store,
@@ -171,13 +172,9 @@ where
                     timeout_ms = config.store_timeout.as_millis() as u64,
                     "failed to read ducklake external maintenance state"
                 );
-                if let Err(error) = release_expired_pause_if_needed(
-                    &store,
-                    &config,
-                    &destination,
-                    &mut held_pause,
-                )
-                .await
+                if let Err(error) =
+                    release_expired_pause_if_needed(&store, &config, &destination, &mut held_pause)
+                        .await
                 {
                     warn!(
                         error = %error,
@@ -191,13 +188,9 @@ where
                     timeout_ms = config.store_timeout.as_millis() as u64,
                     "timed out reading ducklake external maintenance state"
                 );
-                if let Err(error) = release_expired_pause_if_needed(
-                    &store,
-                    &config,
-                    &destination,
-                    &mut held_pause,
-                )
-                .await
+                if let Err(error) =
+                    release_expired_pause_if_needed(&store, &config, &destination, &mut held_pause)
+                        .await
                 {
                     warn!(
                         error = %error,
@@ -458,7 +451,8 @@ fn active_pause_operations(
         .map_or(ExternalMaintenanceOperations::default(), |request| request.operations)
 }
 
-/// Returns whether one paused run successfully completed any selected operation.
+/// Returns whether one paused run successfully completed any selected
+/// operation.
 fn successful_maintenance_run(
     state: &ExternalMaintenanceState,
     held_run_id: &str,

--- a/crates/etl-destinations/src/ducklake/external_maintenance.rs
+++ b/crates/etl-destinations/src/ducklake/external_maintenance.rs
@@ -51,6 +51,8 @@ struct HeldPause {
     operations: ExternalMaintenanceOperations,
     quiesced_at: DateTime<Utc>,
     quiesced_reported: bool,
+    /// Whether fresh pools must be installed before releasing this pause.
+    pool_refresh_required: bool,
     _pause: DuckLakeExternalMaintenancePause,
 }
 
@@ -129,21 +131,39 @@ where
         match time::timeout(config.store_timeout, store.load_state()).await {
             Ok(Ok(state)) => {
                 if !state.exists {
-                    release_missing_state_pause(&store, &mut held_pause).await;
+                    if let Err(error) =
+                        release_missing_state_pause(&store, &destination, &mut held_pause).await
+                    {
+                        warn!(
+                            error = %error,
+                            "failed to refresh ducklake pools after maintenance state disappeared; \
+                             keeping foreground mutations paused"
+                        );
+                    }
                     time::sleep(config.poll_interval).await;
                     continue;
                 }
 
                 expire_snapshots_gate.initialize_from_state_once(&state);
-                reconcile_pause(&store, &config, &destination, &mut held_pause, &state).await?;
-                maybe_request_operations(
-                    &store,
-                    &destination,
-                    &state,
-                    &config,
-                    &mut expire_snapshots_gate,
-                )
-                .await;
+                match reconcile_pause(&store, &config, &destination, &mut held_pause, &state).await {
+                    Ok(()) => {
+                        maybe_request_operations(
+                            &store,
+                            &destination,
+                            &state,
+                            &config,
+                            &mut expire_snapshots_gate,
+                        )
+                        .await;
+                    }
+                    Err(error) => {
+                        warn!(
+                            error = %error,
+                            "failed to refresh ducklake pools after external maintenance; keeping \
+                             foreground mutations paused for retry"
+                        );
+                    }
+                }
             }
             Ok(Err(error)) => {
                 warn!(
@@ -151,14 +171,40 @@ where
                     timeout_ms = config.store_timeout.as_millis() as u64,
                     "failed to read ducklake external maintenance state"
                 );
-                release_expired_pause_if_needed(&store, &config, &mut held_pause).await;
+                if let Err(error) = release_expired_pause_if_needed(
+                    &store,
+                    &config,
+                    &destination,
+                    &mut held_pause,
+                )
+                .await
+                {
+                    warn!(
+                        error = %error,
+                        "failed to refresh ducklake pools after maintenance pause expired; keeping \
+                         foreground mutations paused for retry"
+                    );
+                }
             }
             Err(_) => {
                 warn!(
                     timeout_ms = config.store_timeout.as_millis() as u64,
                     "timed out reading ducklake external maintenance state"
                 );
-                release_expired_pause_if_needed(&store, &config, &mut held_pause).await;
+                if let Err(error) = release_expired_pause_if_needed(
+                    &store,
+                    &config,
+                    &destination,
+                    &mut held_pause,
+                )
+                .await
+                {
+                    warn!(
+                        error = %error,
+                        "failed to refresh ducklake pools after maintenance pause expired; keeping \
+                         foreground mutations paused for retry"
+                    );
+                }
             }
         }
 
@@ -166,10 +212,19 @@ where
     }
 }
 
-async fn release_missing_state_pause<M>(store: &M, held_pause: &mut Option<HeldPause>)
+async fn release_missing_state_pause<S, M>(
+    store: &M,
+    destination: &DuckLakeDestination<S>,
+    held_pause: &mut Option<HeldPause>,
+) -> EtlResult<()>
 where
+    S: DestinationStore,
     M: ExternalMaintenanceStore,
 {
+    if let Some(held) = held_pause.as_mut() {
+        refresh_pools_if_required(destination, held).await?;
+    }
+
     if let Some(held) = held_pause.take() {
         info!(
             run_id = %held.run_id,
@@ -183,6 +238,30 @@ where
             );
         }
     }
+
+    Ok(())
+}
+
+/// Recreates connection pools while retaining one held maintenance pause.
+async fn refresh_pools_if_required<S>(
+    destination: &DuckLakeDestination<S>,
+    held: &mut HeldPause,
+) -> EtlResult<()>
+where
+    S: DestinationStore,
+{
+    if !held.pool_refresh_required {
+        return Ok(());
+    }
+
+    info!(
+        run_id = %held.run_id,
+        "recreating ducklake connection pools before resuming foreground mutations"
+    );
+    destination.recreate_pools_after_external_maintenance().await?;
+    held.pool_refresh_required = false;
+
+    Ok(())
 }
 
 async fn reconcile_pause<S, M>(
@@ -196,17 +275,16 @@ where
     S: DestinationStore,
     M: ExternalMaintenanceStore,
 {
+    if let Some(held) = held_pause.as_mut()
+        && successful_maintenance_run(state, &held.run_id, held.operations, held.quiesced_at)
+    {
+        held.pool_refresh_required = true;
+    }
+
     let active_pause = bounded_active_pause_request(state, Utc::now());
     let Some(pause) = active_pause else {
-        if let Some(held) = held_pause.as_ref()
-            && successful_maintenance_run(state, &held.run_id, held.operations, held.quiesced_at)
-        {
-            info!(
-                run_id = %held.run_id,
-                "ducklake external maintenance completed, recreating connection pools before \
-                 resuming foreground mutations"
-            );
-            destination.recreate_pools_after_external_maintenance().await?;
+        if let Some(held) = held_pause.as_mut() {
+            refresh_pools_if_required(destination, held).await?;
         }
         if let Some(held) = held_pause.take() {
             info!(
@@ -236,7 +314,9 @@ where
         return Ok(());
     }
 
+    let mut pool_refresh_required = false;
     if let Some(held) = held_pause.take() {
+        pool_refresh_required = held.pool_refresh_required;
         info!(
             previous_run_id = %held.run_id,
             next_run_id = %pause.run_id,
@@ -270,6 +350,7 @@ where
                 operations,
                 quiesced_at: Utc::now(),
                 quiesced_reported: false,
+                pool_refresh_required: false,
                 _pause: external_pause,
             },
             "expired",
@@ -303,32 +384,45 @@ where
         operations,
         quiesced_at,
         quiesced_reported,
+        pool_refresh_required,
         _pause: external_pause,
     });
 
     Ok(())
 }
 
-async fn release_expired_pause_if_needed<M>(
+async fn release_expired_pause_if_needed<S, M>(
     store: &M,
     config: &ExternalMaintenanceWatcherConfig,
+    destination: &DuckLakeDestination<S>,
     held_pause: &mut Option<HeldPause>,
-) where
+) -> EtlResult<()>
+where
+    S: DestinationStore,
     M: ExternalMaintenanceStore,
 {
     if held_pause.as_ref().is_none_or(|pause| pause.expires_at > Utc::now()) {
-        return;
+        return Ok(());
+    }
+
+    if let Some(expired) = held_pause.as_mut() {
+        warn!(
+            run_id = %expired.run_id,
+            "ducklake maintenance pause expired while external maintenance store was unavailable"
+        );
+        // The maintenance outcome cannot be verified while the store is
+        // unavailable, so conservatively require fresh connections.
+        expired.pool_refresh_required = true;
+        refresh_pools_if_required(destination, expired).await?;
     }
 
     let Some(expired) = held_pause.take() else {
-        return;
+        return Ok(());
     };
-    warn!(
-        run_id = %expired.run_id,
-        "ducklake maintenance pause expired while external maintenance store was unavailable"
-    );
     release_held_pause(expired, "expired");
     report_running(store, config.store_timeout).await;
+
+    Ok(())
 }
 
 fn release_held_pause(held: HeldPause, outcome: &'static str) {

--- a/crates/etl-destinations/src/ducklake/external_maintenance.rs
+++ b/crates/etl-destinations/src/ducklake/external_maintenance.rs
@@ -135,7 +135,7 @@ where
                 }
 
                 expire_snapshots_gate.initialize_from_state_once(&state);
-                reconcile_pause(&store, &config, &destination, &mut held_pause, &state).await;
+                reconcile_pause(&store, &config, &destination, &mut held_pause, &state).await?;
                 maybe_request_operations(
                     &store,
                     &destination,
@@ -191,12 +191,23 @@ async fn reconcile_pause<S, M>(
     destination: &DuckLakeDestination<S>,
     held_pause: &mut Option<HeldPause>,
     state: &ExternalMaintenanceState,
-) where
+) -> EtlResult<()>
+where
     S: DestinationStore,
     M: ExternalMaintenanceStore,
 {
     let active_pause = bounded_active_pause_request(state, Utc::now());
     let Some(pause) = active_pause else {
+        if let Some(held) = held_pause.as_ref()
+            && successful_maintenance_run(state, &held.run_id, held.operations, held.quiesced_at)
+        {
+            info!(
+                run_id = %held.run_id,
+                "ducklake external maintenance completed, recreating connection pools before \
+                 resuming foreground mutations"
+            );
+            destination.recreate_pools_after_external_maintenance().await?;
+        }
         if let Some(held) = held_pause.take() {
             info!(
                 run_id = %held.run_id,
@@ -205,7 +216,7 @@ async fn reconcile_pause<S, M>(
             release_held_pause(held, "cleared");
             report_running(store, config.store_timeout).await;
         }
-        return;
+        return Ok(());
     };
 
     if let Some(held) = held_pause.as_mut()
@@ -222,7 +233,7 @@ async fn reconcile_pause<S, M>(
         {
             held.quiesced_reported = true;
         }
-        return;
+        return Ok(());
     }
 
     if let Some(held) = held_pause.take() {
@@ -264,7 +275,7 @@ async fn reconcile_pause<S, M>(
             "expired",
         );
         report_running(store, config.store_timeout).await;
-        return;
+        return Ok(());
     }
 
     let quiesced_at = Utc::now();
@@ -294,6 +305,8 @@ async fn reconcile_pause<S, M>(
         quiesced_reported,
         _pause: external_pause,
     });
+
+    Ok(())
 }
 
 async fn release_expired_pause_if_needed<M>(
@@ -349,6 +362,33 @@ fn active_pause_operations(
         .operation_request
         .as_ref()
         .map_or(ExternalMaintenanceOperations::default(), |request| request.operations)
+}
+
+/// Returns whether one paused run successfully completed any selected operation.
+fn successful_maintenance_run(
+    state: &ExternalMaintenanceState,
+    held_run_id: &str,
+    held_operations: ExternalMaintenanceOperations,
+    quiesced_at: DateTime<Utc>,
+) -> bool {
+    let completed_for_held_run = |run: Option<&ExternalMaintenanceOperationRun>| {
+        run.is_some_and(|run| {
+            run.run_id
+                .as_deref()
+                .map_or(run.completed_at >= quiesced_at, |run_id| run_id == held_run_id)
+        })
+    };
+    let successful = &state.last_successful_operations;
+
+    (held_operations.inline_flush && completed_for_held_run(successful.inline_flush.as_ref()))
+        || (held_operations.merge_adjacent_files
+            && completed_for_held_run(successful.merge_adjacent_files.as_ref()))
+        || (held_operations.rewrite_data_files
+            && completed_for_held_run(successful.rewrite_data_files.as_ref()))
+        || (held_operations.expire_snapshots
+            && completed_for_held_run(successful.expire_snapshots.as_ref()))
+        || (held_operations.cleanup_old_files
+            && completed_for_held_run(successful.cleanup_old_files.as_ref()))
 }
 
 /// Returns a pause request whose expiry is bounded by trusted policy.
@@ -728,7 +768,7 @@ mod tests {
         ExternalMaintenancePausePolicy, ExternalMaintenanceRun, ExternalMaintenanceState,
         OPERATION_EXPIRE_SNAPSHOTS, OPERATION_INLINE_FLUSH, OPERATION_REWRITE_DATA_FILES,
         OPERATION_UNKNOWN, active_pause_operations, bounded_active_pause_request,
-        record_external_maintenance_pause_active,
+        record_external_maintenance_pause_active, successful_maintenance_run,
     };
     use crate::ducklake::metrics::{
         ETL_DUCKLAKE_EXTERNAL_MAINTENANCE_PAUSE_ACTIVE, register_metrics,
@@ -871,6 +911,72 @@ mod tests {
         };
 
         assert_eq!(active_pause_operations(&state, &pause), request_operations);
+    }
+
+    #[test]
+    fn successful_maintenance_run_accepts_each_matching_selected_operation() {
+        let quiesced_at = Utc.with_ymd_and_hms(2026, 5, 12, 12, 0, 0).unwrap();
+        let successful_run = ExternalMaintenanceOperationRun {
+            run_id: Some("run-1".to_owned()),
+            completed_at: quiesced_at + chrono::Duration::minutes(1),
+        };
+        let mut state = ExternalMaintenanceState::present();
+        state.last_successful_operations.inline_flush = Some(successful_run.clone());
+        state.last_successful_operations.merge_adjacent_files = Some(successful_run.clone());
+        state.last_successful_operations.rewrite_data_files = Some(successful_run.clone());
+        state.last_successful_operations.expire_snapshots = Some(successful_run.clone());
+        state.last_successful_operations.cleanup_old_files = Some(successful_run);
+
+        let operation_cases = [
+            ExternalMaintenanceOperations {
+                inline_flush: true,
+                ..ExternalMaintenanceOperations::default()
+            },
+            ExternalMaintenanceOperations {
+                merge_adjacent_files: true,
+                ..ExternalMaintenanceOperations::default()
+            },
+            ExternalMaintenanceOperations {
+                rewrite_data_files: true,
+                ..ExternalMaintenanceOperations::default()
+            },
+            ExternalMaintenanceOperations {
+                expire_snapshots: true,
+                ..ExternalMaintenanceOperations::default()
+            },
+            ExternalMaintenanceOperations {
+                cleanup_old_files: true,
+                ..ExternalMaintenanceOperations::default()
+            },
+        ];
+
+        for operations in operation_cases {
+            assert!(successful_maintenance_run(&state, "run-1", operations, quiesced_at));
+            assert!(!successful_maintenance_run(&state, "run-2", operations, quiesced_at));
+        }
+        assert!(!successful_maintenance_run(
+            &state,
+            "run-1",
+            ExternalMaintenanceOperations::default(),
+            quiesced_at,
+        ));
+    }
+
+    #[test]
+    fn successful_maintenance_run_ignores_unselected_operation_success() {
+        let quiesced_at = Utc.with_ymd_and_hms(2026, 5, 12, 12, 0, 0).unwrap();
+        let operations = ExternalMaintenanceOperations {
+            rewrite_data_files: true,
+            ..ExternalMaintenanceOperations::default()
+        };
+        let mut state = ExternalMaintenanceState::present();
+        state.last_successful_operations.cleanup_old_files =
+            Some(ExternalMaintenanceOperationRun {
+                run_id: Some("run-1".to_owned()),
+                completed_at: quiesced_at + chrono::Duration::minutes(1),
+            });
+
+        assert!(!successful_maintenance_run(&state, "run-1", operations, quiesced_at));
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/mod.rs
+++ b/crates/etl-destinations/src/ducklake/mod.rs
@@ -117,8 +117,9 @@ pub use core::{
 };
 #[cfg(feature = "test-utils")]
 pub use core::{
-    arm_pause_next_streaming_write_for_tests, release_paused_streaming_write_for_tests,
-    reset_paused_streaming_write_for_tests,
+    arm_fail_pool_refresh_once_for_tests, arm_pause_next_streaming_write_for_tests,
+    pool_refresh_failure_armed_for_tests, release_paused_streaming_write_for_tests,
+    reset_paused_streaming_write_for_tests, reset_pool_refresh_failure_for_tests,
 };
 
 #[cfg(feature = "test-utils")]

--- a/crates/etl-destinations/tests/ducklake/destination.rs
+++ b/crates/etl-destinations/tests/ducklake/destination.rs
@@ -25,6 +25,8 @@ use std::sync::LazyLock;
 use std::{f64::consts::PI, path::Path, sync::Arc, time::Duration};
 
 use chrono::NaiveDate;
+#[cfg(feature = "test-utils")]
+use chrono::{TimeDelta, Utc};
 use duckdb::Connection;
 use etl::{
     data::{Cell, OldTableRow, PartialTableRow, TableRow, UpdatedTableRow},
@@ -44,10 +46,19 @@ use etl_destinations::ducklake::{
 use etl_destinations::ducklake::{
     arm_fail_after_atomic_batch_commit_once_for_tests,
     arm_fail_after_copy_batch_commit_once_for_tests, ducklake_staging_table_creations_for_tests,
-    reset_ducklake_test_hooks,
+    reset_ducklake_test_hooks, run_external_maintenance_watcher,
+};
+#[cfg(feature = "test-utils")]
+use etl_maintenance::{
+    ExternalMaintenanceOperationHistory, ExternalMaintenanceOperationPolicy,
+    ExternalMaintenanceOperationRun, ExternalMaintenanceOperations, ExternalMaintenancePause,
+    ExternalMaintenancePausePolicy, ExternalMaintenanceReplicatorState, ExternalMaintenanceRun,
+    ExternalMaintenanceStore, ExternalMaintenanceWatcherConfig, PostgresExternalMaintenanceStore,
 };
 use etl_telemetry::tracing::init_test_tracing;
 use pg_escape::{quote_identifier, quote_literal};
+#[cfg(feature = "test-utils")]
+use sqlx::{postgres::PgPoolOptions, types::Json};
 #[cfg(feature = "test-utils")]
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use url::Url;
@@ -175,6 +186,26 @@ async fn open_lake_conn_when_tables_visible(
             "timed out waiting for DuckLake tables to become visible: {table_names:?}"
         );
         tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[cfg(feature = "test-utils")]
+async fn wait_for_replicator_maintenance_state(
+    store: &PostgresExternalMaintenanceStore,
+    expected: ExternalMaintenanceReplicatorState,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let state = store.load_state().await.unwrap();
+        if state.replicator.as_ref().is_some_and(|status| status.state == expected) {
+            return;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for replicator maintenance state {expected:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
 
@@ -3050,6 +3081,176 @@ async fn write_events_restart_overlap_rebatches_only_pending_suffix() {
     assert_eq!(names.len(), 16);
     assert_eq!(names[0], "name-1");
     assert_eq!(names[15], "name-16");
+}
+
+/// Successful inline-flush maintenance must recreate every DuckDB connection
+/// before streaming replication resumes.
+#[cfg(feature = "test-utils")]
+#[tokio::test(flavor = "multi_thread")]
+async fn external_inline_flush_recreates_pools_before_replication_resumes() {
+    use etl::event::InsertEvent;
+
+    let lake = create_test_lake("external_inline_flush_recreates_pools").await;
+    let catalog_url = lake.catalog_url.clone();
+    let data_url = lake.data_url.clone();
+    let pipeline_id = 1047_i64;
+    let run_id = "pipe-1047-inline-flush";
+
+    let schema = make_schema(1047, "public", "inline_flush_pool_replacement");
+    let replicated_table_schema = make_replicated_table_schema(&schema);
+    let table_name = table_name_to_ducklake_table_name(&schema.name).unwrap();
+    let store = MemoryStore::new();
+    store.store_table_schema(schema).await.unwrap();
+
+    let destination = DuckLakeDestination::new(
+        catalog_url.clone(),
+        data_url.clone(),
+        1,
+        None,
+        None,
+        None,
+        None,
+        store,
+    )
+    .await
+    .unwrap();
+
+    destination
+        .write_events(
+            (0..8)
+                .map(|idx| {
+                    Event::Insert(InsertEvent {
+                        commit_lsn: PgLsn::from(1_047_000_u64 + idx as u64),
+                        tx_ordinal: 0,
+                        replicated_table_schema: replicated_table_schema.clone(),
+                        table_row: TableRow::new(vec![
+                            Cell::I32(idx + 1),
+                            Cell::String(format!("before-{}", idx + 1)),
+                        ]),
+                    })
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(destination.streaming_connection_open_count_for_tests(), 1);
+    assert_eq!(destination.copy_connection_open_count_for_tests(), 1);
+
+    let coordination_pool =
+        PgPoolOptions::new().max_connections(2).connect(catalog_url.as_str()).await.unwrap();
+    let coordination_store =
+        PostgresExternalMaintenanceStore::new(pipeline_id, coordination_pool.clone());
+    coordination_store.ensure_schema().await.unwrap();
+    coordination_store
+        .ensure_pipeline_state(
+            ExternalMaintenancePausePolicy::default(),
+            ExternalMaintenanceOperationPolicy::default(),
+        )
+        .await
+        .unwrap();
+
+    let watcher = tokio::spawn(run_external_maintenance_watcher(
+        destination.clone(),
+        coordination_store.clone(),
+        ExternalMaintenanceWatcherConfig {
+            poll_interval: Duration::from_millis(10),
+            request_cooldown: Duration::ZERO,
+            store_timeout: Duration::from_secs(1),
+            inline_flush_min_inlined_bytes: u64::MAX,
+            rewrite_data_files_min_active_data_files: i64::MAX,
+        },
+    ));
+
+    let now = Utc::now();
+    let operations = ExternalMaintenanceOperations {
+        inline_flush: true,
+        ..ExternalMaintenanceOperations::default()
+    };
+    sqlx::query(
+        "update etl.external_maintenance_state set active_run = $2, pause_request = $3, \
+         operation_request = null, updated_at = now() where pipeline_id = $1",
+    )
+    .bind(pipeline_id)
+    .bind(Json(ExternalMaintenanceRun {
+        run_id: run_id.to_owned(),
+        started_at: Some(now),
+        operations,
+    }))
+    .bind(Json(ExternalMaintenancePause {
+        run_id: run_id.to_owned(),
+        requested_at: Some(now),
+        expires_at: now + TimeDelta::minutes(5),
+    }))
+    .execute(&coordination_pool)
+    .await
+    .unwrap();
+
+    wait_for_replicator_maintenance_state(
+        &coordination_store,
+        ExternalMaintenanceReplicatorState::Quiesced,
+    )
+    .await;
+
+    let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
+    assert_eq!(flush_inlined_rows(&conn, &table_name), 8);
+    drop(conn);
+
+    let completed_at = Utc::now();
+    let successful_operations = ExternalMaintenanceOperationHistory {
+        inline_flush: Some(ExternalMaintenanceOperationRun {
+            run_id: Some(run_id.to_owned()),
+            completed_at,
+        }),
+        ..ExternalMaintenanceOperationHistory::default()
+    };
+    sqlx::query(
+        "update etl.external_maintenance_state set active_run = null, pause_request = null, \
+         last_successful_operations = $2, last_completed_at = $3, updated_at = now() where \
+         pipeline_id = $1",
+    )
+    .bind(pipeline_id)
+    .bind(Json(successful_operations))
+    .bind(completed_at)
+    .execute(&coordination_pool)
+    .await
+    .unwrap();
+
+    wait_for_replicator_maintenance_state(
+        &coordination_store,
+        ExternalMaintenanceReplicatorState::Running,
+    )
+    .await;
+
+    destination
+        .write_events(
+            (8..16)
+                .map(|idx| {
+                    Event::Insert(InsertEvent {
+                        commit_lsn: PgLsn::from(1_047_000_u64 + idx as u64),
+                        tx_ordinal: 0,
+                        replicated_table_schema: replicated_table_schema.clone(),
+                        table_row: TableRow::new(vec![
+                            Cell::I32(idx + 1),
+                            Cell::String(format!("after-{}", idx + 1)),
+                        ]),
+                    })
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(destination.streaming_connection_open_count_for_tests(), 2);
+    assert_eq!(destination.copy_connection_open_count_for_tests(), 2);
+
+    let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
+    assert_eq!(count_rows(&conn, &table_name), 16);
+    assert_eq!(read_streaming_progress(&conn, &table_name), Some((1_047_015, 0)));
+
+    watcher.abort();
+    assert!(watcher.await.unwrap_err().is_cancelled());
+    destination.shutdown().await.unwrap();
 }
 
 /// A mixed mutation batch should reuse one temp staging table for multiple

--- a/crates/etl-destinations/tests/ducklake/destination.rs
+++ b/crates/etl-destinations/tests/ducklake/destination.rs
@@ -47,10 +47,11 @@ use etl_destinations::ducklake::{
 };
 #[cfg(feature = "test-utils")]
 use etl_destinations::ducklake::{
-    arm_fail_after_atomic_batch_commit_once_for_tests, arm_fail_pool_refresh_once_for_tests,
-    arm_fail_after_copy_batch_commit_once_for_tests, ducklake_staging_table_creations_for_tests,
-    pool_refresh_failure_armed_for_tests, reset_ducklake_test_hooks,
-    reset_pool_refresh_failure_for_tests, run_external_maintenance_watcher,
+    arm_fail_after_atomic_batch_commit_once_for_tests,
+    arm_fail_after_copy_batch_commit_once_for_tests, arm_fail_pool_refresh_once_for_tests,
+    ducklake_staging_table_creations_for_tests, pool_refresh_failure_armed_for_tests,
+    reset_ducklake_test_hooks, reset_pool_refresh_failure_for_tests,
+    run_external_maintenance_watcher,
 };
 #[cfg(feature = "test-utils")]
 use etl_maintenance::{

--- a/crates/etl-destinations/tests/ducklake/destination.rs
+++ b/crates/etl-destinations/tests/ducklake/destination.rs
@@ -21,7 +21,10 @@
 //! ```
 
 #[cfg(feature = "test-utils")]
-use std::sync::LazyLock;
+use std::sync::{
+    LazyLock,
+    atomic::{AtomicBool, Ordering},
+};
 use std::{f64::consts::PI, path::Path, sync::Arc, time::Duration};
 
 use chrono::NaiveDate;
@@ -31,7 +34,7 @@ use duckdb::Connection;
 use etl::{
     data::{Cell, OldTableRow, PartialTableRow, TableRow, UpdatedTableRow},
     destination::{Destination, DestinationTableMetadata, DestinationTableSchema},
-    error::ErrorKind,
+    error::{ErrorKind, EtlResult},
     event::{DeleteEvent, Event},
     schema::{
         ColumnSchema, IdentityMask, PgLsn, ReplicatedTableSchema, ReplicationMask, SnapshotId,
@@ -44,15 +47,18 @@ use etl_destinations::ducklake::{
 };
 #[cfg(feature = "test-utils")]
 use etl_destinations::ducklake::{
-    arm_fail_after_atomic_batch_commit_once_for_tests,
+    arm_fail_after_atomic_batch_commit_once_for_tests, arm_fail_pool_refresh_once_for_tests,
     arm_fail_after_copy_batch_commit_once_for_tests, ducklake_staging_table_creations_for_tests,
-    reset_ducklake_test_hooks, run_external_maintenance_watcher,
+    pool_refresh_failure_armed_for_tests, reset_ducklake_test_hooks,
+    reset_pool_refresh_failure_for_tests, run_external_maintenance_watcher,
 };
 #[cfg(feature = "test-utils")]
 use etl_maintenance::{
     ExternalMaintenanceOperationHistory, ExternalMaintenanceOperationPolicy,
-    ExternalMaintenanceOperationRun, ExternalMaintenanceOperations, ExternalMaintenancePause,
-    ExternalMaintenancePausePolicy, ExternalMaintenanceReplicatorState, ExternalMaintenanceRun,
+    ExternalMaintenanceOperationRequest, ExternalMaintenanceOperationRun,
+    ExternalMaintenanceOperations, ExternalMaintenancePause, ExternalMaintenancePausePolicy,
+    ExternalMaintenanceReplicatorState, ExternalMaintenanceReplicatorStatus,
+    ExternalMaintenanceRequestOutcome, ExternalMaintenanceRun, ExternalMaintenanceState,
     ExternalMaintenanceStore, ExternalMaintenanceWatcherConfig, PostgresExternalMaintenanceStore,
 };
 use etl_telemetry::tracing::init_test_tracing;
@@ -74,6 +80,57 @@ use crate::support::ducklake::{
 #[cfg(feature = "test-utils")]
 static DUCKLAKE_TEST_HOOKS_GUARD: LazyLock<Arc<Semaphore>> =
     LazyLock::new(|| Arc::new(Semaphore::new(1)));
+
+/// Maintenance store wrapper that can suspend watcher state reads.
+#[cfg(feature = "test-utils")]
+#[derive(Clone)]
+struct LoadBlockingExternalMaintenanceStore {
+    inner: PostgresExternalMaintenanceStore,
+    load_blocked: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "test-utils")]
+impl LoadBlockingExternalMaintenanceStore {
+    /// Creates a wrapper with state reads initially enabled.
+    fn new(inner: PostgresExternalMaintenanceStore) -> Self {
+        Self { inner, load_blocked: Arc::new(AtomicBool::new(false)) }
+    }
+
+    /// Controls whether watcher state reads remain pending until timeout.
+    fn set_load_blocked(&self, blocked: bool) {
+        self.load_blocked.store(blocked, Ordering::Relaxed);
+    }
+}
+
+#[cfg(feature = "test-utils")]
+#[async_trait::async_trait]
+impl ExternalMaintenanceStore for LoadBlockingExternalMaintenanceStore {
+    async fn load_state(&self) -> EtlResult<ExternalMaintenanceState> {
+        if self.load_blocked.load(Ordering::Relaxed) {
+            return std::future::pending().await;
+        }
+
+        self.inner.load_state().await
+    }
+
+    async fn request_operations(
+        &self,
+        request: ExternalMaintenanceOperationRequest,
+    ) -> EtlResult<ExternalMaintenanceRequestOutcome> {
+        self.inner.request_operations(request).await
+    }
+
+    async fn report_replicator_status(
+        &self,
+        status: ExternalMaintenanceReplicatorStatus,
+    ) -> EtlResult<()> {
+        self.inner.report_replicator_status(status).await
+    }
+
+    async fn clear_replicator_status(&self) -> EtlResult<()> {
+        self.inner.clear_replicator_status().await
+    }
+}
 
 /// Creates a synthetic composite snapshot ID for tests.
 fn test_snapshot_id(commit_lsn: u64, message_lsn: u64) -> SnapshotId {
@@ -3083,14 +3140,17 @@ async fn write_events_restart_overlap_rebatches_only_pending_suffix() {
     assert_eq!(names[15], "name-16");
 }
 
-/// Successful inline-flush maintenance must recreate every DuckDB connection
-/// before streaming replication resumes.
+/// Pool refresh must survive a transient failure and an unreadable maintenance
+/// store without resuming streaming on stale connections.
 #[cfg(feature = "test-utils")]
 #[tokio::test(flavor = "multi_thread")]
-async fn external_inline_flush_recreates_pools_before_replication_resumes() {
+async fn external_inline_flush_retries_pool_refresh_before_replication_resumes() {
     use etl::event::InsertEvent;
 
-    let lake = create_test_lake("external_inline_flush_recreates_pools").await;
+    let _test_hook_guard = acquire_ducklake_test_hook_guard().await;
+    reset_ducklake_test_hooks();
+    reset_pool_refresh_failure_for_tests();
+    let lake = create_test_lake("external_inline_flush_retries_pool_refresh").await;
     let catalog_url = lake.catalog_url.clone();
     let data_url = lake.data_url.clone();
     let pipeline_id = 1047_i64;
@@ -3149,14 +3209,15 @@ async fn external_inline_flush_recreates_pools_before_replication_resumes() {
         )
         .await
         .unwrap();
+    let watcher_store = LoadBlockingExternalMaintenanceStore::new(coordination_store.clone());
 
     let watcher = tokio::spawn(run_external_maintenance_watcher(
         destination.clone(),
-        coordination_store.clone(),
+        watcher_store.clone(),
         ExternalMaintenanceWatcherConfig {
             poll_interval: Duration::from_millis(10),
             request_cooldown: Duration::ZERO,
-            store_timeout: Duration::from_secs(1),
+            store_timeout: Duration::from_millis(100),
             inline_flush_min_inlined_bytes: u64::MAX,
             rewrite_data_files_min_active_data_files: i64::MAX,
         },
@@ -3204,6 +3265,7 @@ async fn external_inline_flush_recreates_pools_before_replication_resumes() {
         }),
         ..ExternalMaintenanceOperationHistory::default()
     };
+    arm_fail_pool_refresh_once_for_tests();
     sqlx::query(
         "update etl.external_maintenance_state set active_run = null, pause_request = null, \
          last_successful_operations = $2, last_completed_at = $3, updated_at = now() where \
@@ -3221,6 +3283,8 @@ async fn external_inline_flush_recreates_pools_before_replication_resumes() {
         ExternalMaintenanceReplicatorState::Running,
     )
     .await;
+
+    assert!(!pool_refresh_failure_armed_for_tests());
 
     destination
         .write_events(
@@ -3243,6 +3307,69 @@ async fn external_inline_flush_recreates_pools_before_replication_resumes() {
 
     assert_eq!(destination.streaming_connection_open_count_for_tests(), 2);
     assert_eq!(destination.copy_connection_open_count_for_tests(), 2);
+
+    let second_run_id = "pipe-1047-inline-flush-store-timeout";
+    let second_requested_at = Utc::now();
+    sqlx::query(
+        "update etl.external_maintenance_state set active_run = $2, pause_request = $3, \
+         operation_request = null, updated_at = now() where pipeline_id = $1",
+    )
+    .bind(pipeline_id)
+    .bind(Json(ExternalMaintenanceRun {
+        run_id: second_run_id.to_owned(),
+        started_at: Some(second_requested_at),
+        operations,
+    }))
+    .bind(Json(ExternalMaintenancePause {
+        run_id: second_run_id.to_owned(),
+        requested_at: Some(second_requested_at),
+        expires_at: second_requested_at + TimeDelta::seconds(1),
+    }))
+    .execute(&coordination_pool)
+    .await
+    .unwrap();
+
+    wait_for_replicator_maintenance_state(
+        &coordination_store,
+        ExternalMaintenanceReplicatorState::Quiesced,
+    )
+    .await;
+
+    let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
+    assert_eq!(flush_inlined_rows(&conn, &table_name), 8);
+    drop(conn);
+
+    // Hide the completed run from the watcher until its local pause expires.
+    watcher_store.set_load_blocked(true);
+    let second_completed_at = Utc::now();
+    let second_successful_operations = ExternalMaintenanceOperationHistory {
+        inline_flush: Some(ExternalMaintenanceOperationRun {
+            run_id: Some(second_run_id.to_owned()),
+            completed_at: second_completed_at,
+        }),
+        ..ExternalMaintenanceOperationHistory::default()
+    };
+    sqlx::query(
+        "update etl.external_maintenance_state set active_run = null, pause_request = null, \
+         last_successful_operations = $2, last_completed_at = $3, updated_at = now() where \
+         pipeline_id = $1",
+    )
+    .bind(pipeline_id)
+    .bind(Json(second_successful_operations))
+    .bind(second_completed_at)
+    .execute(&coordination_pool)
+    .await
+    .unwrap();
+
+    wait_for_replicator_maintenance_state(
+        &coordination_store,
+        ExternalMaintenanceReplicatorState::Running,
+    )
+    .await;
+    watcher_store.set_load_blocked(false);
+
+    assert_eq!(destination.streaming_connection_open_count_for_tests(), 3);
+    assert_eq!(destination.copy_connection_open_count_for_tests(), 3);
 
     let conn = open_lake_conn_when_tables_visible(&catalog_url, &data_url, &[&table_name]).await;
     assert_eq!(count_rows(&conn, &table_name), 16);


### PR DESCRIPTION
This avoids having temporary and invalid state in long lived connection in duckdb. So each time a maintenance completed we recreate the pool to avoid having some inconsistencies like inlined tables not existing anymore because of a flush, snapshots not available anymore and so one.