### PR TITLE
fix(core): Fix noop DDL relation message handling

### DIFF
--- a/crates/etl/src/event.rs
+++ b/crates/etl/src/event.rs
@@ -201,10 +201,14 @@ impl TruncateEvent {
 /// PostgreSQL generates relation messages at runtime from `pgoutput`'s
 /// session-local schema cache; they are not WAL-backed changes. Which relation
 /// messages appear is therefore session-dependent: a fresh session resets the
-/// cache and can re-emit schema metadata during replay. This event
-/// intentionally has no LSN, transaction ordinal, or sequence key because such
-/// metadata would not be a durable replay identity. Consumers should instead
-/// treat it as an ordered schema barrier for the row events that follow it.
+/// cache and can re-emit schema metadata during replay. ETL also emits this
+/// event when a stored schema snapshot is materialized for a following insert,
+/// update, or delete because pgoutput omitted a protocol relation. Truncate
+/// does not use that path: pgoutput emits a protocol relation first. This
+/// event intentionally has no LSN, transaction ordinal, or sequence key
+/// because such metadata would not be a durable replay identity. Consumers
+/// should instead treat it as an ordered schema barrier for the row events
+/// that follow it.
 ///
 /// The carried [`crate::schema::SnapshotId`] identifies the underlying stored
 /// table schema, and it is created as `0:0` when a table is just copied. Then

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -2910,12 +2910,14 @@ where
         let replicated_table_schema =
             table_decoding_state.materialize(table_schema, sync_done_lsn)?;
 
-        info!(
-            worker_type = %WorkerType::Apply,
-            table_id = table_id.0,
+        debug!(
+            table_id = %table_id,
+            snapshot_id = %replicated_table_schema.inner().snapshot_id,
+            replication_mask = %replicated_table_schema.replication_mask(),
+            identity_mask = %replicated_table_schema.identity_mask(),
             %sync_done_lsn,
             %current_lsn,
-            "resolved sync_done table decoding state",
+            "resolved sync_done table decoding state"
         );
 
         Ok(Some(replicated_table_schema))
@@ -2955,6 +2957,7 @@ where
             table_id = %table_id,
             snapshot_id = %replicated_table_schema.inner().snapshot_id,
             replication_mask = %replicated_table_schema.replication_mask(),
+            identity_mask = %replicated_table_schema.identity_mask(),
             "materialized pending schema snapshot without protocol relation"
         );
 

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -371,12 +371,45 @@ impl ReplicationLagMetrics {
     }
 }
 
+/// Row-decoding schema resolved for a DML message.
+#[derive(Debug)]
+struct ResolvedTableSchema {
+    /// Complete decoder for the row payload.
+    replicated_table_schema: ReplicatedTableSchema,
+    /// Destination schema barrier to emit before the row.
+    ///
+    /// Set when this resolution materialized
+    /// [`TableDecodingState::PendingRelation`] because pgoutput omitted a
+    /// protocol relation after a stored schema snapshot.
+    relation: Option<RelationEvent>,
+}
+
+impl ResolvedTableSchema {
+    /// Returns a decoder that does not require a destination schema barrier.
+    fn with_schema(replicated_table_schema: ReplicatedTableSchema) -> Self {
+        Self { replicated_table_schema, relation: None }
+    }
+
+    /// Returns a decoder and the relation barrier for a materialized pending
+    /// schema snapshot.
+    fn with_pending_relation(replicated_table_schema: ReplicatedTableSchema) -> Self {
+        let relation = RelationEvent { replicated_table_schema: replicated_table_schema.clone() };
+
+        Self { replicated_table_schema, relation: Some(relation) }
+    }
+}
+
 /// Result returned from [`ApplyLoop::handle_replication_message`] and related
 /// functions.
 #[derive(Debug, Default)]
 struct HandleMessageResult {
-    /// The event converted from the replication message.
-    event: Option<Event>,
+    /// Converted event, with an optional destination schema barrier.
+    ///
+    /// The barrier is only representable when an event is present. When set, it
+    /// is written immediately before the event. Protocol relations remain in
+    /// the event itself. Truncate never sets the barrier: pgoutput emits a
+    /// protocol relation first, and a missing decoder is an error.
+    event: Option<(Event, Option<RelationEvent>)>,
     /// PostgreSQL source metadata represented by the returned event.
     streaming_payload_metadata: StreamingPayloadMetadata,
     /// Set to a commit message's end_lsn value, [`None`] otherwise.
@@ -394,15 +427,20 @@ impl HandleMessageResult {
 
     /// Creates a result that returns an event without affecting batch state.
     fn return_event(event: Event) -> Self {
-        Self { event: Some(event), ..Default::default() }
+        Self { event: Some((event, None)), ..Default::default() }
     }
 
     /// Creates a result containing a row event and its source metadata.
+    ///
+    /// `relation` is the destination schema barrier from
+    /// [`ResolvedTableSchema`], if a pending snapshot was materialized without
+    /// a protocol relation.
     fn return_row_event(
+        relation: Option<RelationEvent>,
         event: Event,
         streaming_payload_metadata: StreamingPayloadMetadata,
     ) -> Self {
-        Self { event: Some(event), streaming_payload_metadata, ..Default::default() }
+        Self { event: Some((event, relation)), streaming_payload_metadata, ..Default::default() }
     }
 }
 
@@ -2068,7 +2106,16 @@ where
         let result =
             self.handle_replication_message(replication_message_stream.as_mut(), message).await?;
 
-        if let Some(event) = result.event {
+        if let Some((event, relation)) = result.event {
+            // A schema snapshot that pgoutput did not accompany with a protocol
+            // relation is written first so destinations apply the new schema
+            // before the following row.
+            if let Some(relation) = relation {
+                self.state
+                    .event_batch
+                    .push(Event::Relation(relation), StreamingPayloadMetadata::default());
+            }
+
             // We add the element to the pending batch.
             self.state.event_batch.push(event, result.streaming_payload_metadata);
 
@@ -2535,7 +2582,7 @@ where
         let event = parse_event_from_commit_message(commit_lsn, tx_ordinal, message);
 
         let mut result = HandleMessageResult {
-            event: Some(Event::Commit(event)),
+            event: Some((Event::Commit(event), None)),
             end_lsn: Some(end_lsn),
             ..Default::default()
         };
@@ -2874,24 +2921,28 @@ where
         Ok(Some(replicated_table_schema))
     }
 
-    /// Materializes and installs `WithSchema` after DML arrives without a new
-    /// relation message.
+    /// Materializes and installs `WithSchema` after a row arrives without a
+    /// new protocol relation.
     ///
     /// The DDL event trigger emits a logical message for every handled schema
-    /// command, including commands whose successful no-op path does not
-    /// invalidate pgoutput's cached relation metadata. ETL therefore stores a
-    /// new table-schema snapshot and enters `PendingRelation`, but pgoutput may
-    /// send the next row without first sending another `RELATION`. In that
-    /// sequence, the stored snapshot is the current table schema and the masks
-    /// from the previous relation are still the current positional decoding
-    /// metadata. Combining them produces the complete decoder for the row and
-    /// returns the connection-local state to `WithSchema`.
+    /// command, including no-op DDL that does not invalidate pgoutput's cached
+    /// relation metadata. ETL therefore stores a new schema snapshot and
+    /// enters `PendingRelation`, but pgoutput may send the next row without
+    /// another protocol relation. In that sequence, the stored snapshot is the
+    /// current table schema and the masks from the previous relation are still
+    /// the current positional decoding metadata. Combining them produces the
+    /// complete decoder and returns the connection-local state to
+    /// `WithSchema`.
+    ///
+    /// The returned [`ResolvedTableSchema::relation`] is the destination schema
+    /// barrier for that snapshot. Destinations require a [`RelationEvent`]
+    /// before they will accept rows at a newer schema.
     async fn materialize_pending_replicated_table_schema(
         &mut self,
         table_id: TableId,
         snapshot_id: SnapshotId,
         previous_relation_masks: PreviousRelationMasks,
-    ) -> EtlResult<ReplicatedTableSchema> {
+    ) -> EtlResult<ResolvedTableSchema> {
         let table_schema = self
             .get_table_schema_for_relation(table_id, RelationSchemaSelection::Exact(snapshot_id))
             .await?;
@@ -2900,7 +2951,14 @@ where
         self.table_decoding_states
             .insert(table_id, TableDecodingState::WithSchema(replicated_table_schema.clone()));
 
-        Ok(replicated_table_schema)
+        debug!(
+            table_id = %table_id,
+            snapshot_id = %replicated_table_schema.inner().snapshot_id,
+            replication_mask = %replicated_table_schema.replication_mask(),
+            "materialized pending schema snapshot without protocol relation"
+        );
+
+        Ok(ResolvedTableSchema::with_pending_relation(replicated_table_schema))
     }
 
     /// Resolves the complete decoding schema for a row event.
@@ -2918,15 +2976,21 @@ where
     /// The last case covers a same-connection table-sync handover where apply
     /// skipped the relation while table sync still owned the table. PostgreSQL
     /// need not resend that relation before the first apply-owned DML.
+    ///
+    /// Materializing `PendingRelation` also returns a [`RelationEvent`] so the
+    /// destination can apply the stored schema snapshot before the row.
+    /// Restoring a complete `SyncDone` decoder does not, because that snapshot
+    /// was already applied during table sync. Truncate does not use this path:
+    /// pgoutput emits a protocol relation first.
     async fn get_replicated_table_schema(
         &mut self,
         table_id: TableId,
         remote_final_lsn: PgLsn,
-    ) -> EtlResult<ReplicatedTableSchema> {
+    ) -> EtlResult<ResolvedTableSchema> {
         let table_decoding_state = self.table_decoding_states.get(&table_id).cloned();
         match table_decoding_state {
             Some(TableDecodingState::WithSchema(replicated_table_schema)) => {
-                Ok(replicated_table_schema)
+                Ok(ResolvedTableSchema::with_schema(replicated_table_schema))
             }
             Some(TableDecodingState::PendingRelation { snapshot_id, previous_relation_masks }) => {
                 let previous_relation_masks = match previous_relation_masks {
@@ -2977,8 +3041,37 @@ where
                     TableDecodingState::WithSchema(replicated_table_schema.clone()),
                 );
 
-                Ok(replicated_table_schema)
+                Ok(ResolvedTableSchema::with_schema(replicated_table_schema))
             }
+        }
+    }
+
+    /// Returns the complete decoder required to handle a truncate message.
+    ///
+    /// pgoutput emits a protocol relation before truncate, so the connection
+    /// must already have [`TableDecodingState::WithSchema`]. A pending schema
+    /// snapshot or missing decoder means that relation did not arrive.
+    fn replicated_table_schema_for_truncate(
+        &self,
+        table_id: TableId,
+    ) -> EtlResult<ReplicatedTableSchema> {
+        match self.table_decoding_states.get(&table_id) {
+            Some(TableDecodingState::WithSchema(replicated_table_schema)) => {
+                Ok(replicated_table_schema.clone())
+            }
+            Some(TableDecodingState::PendingRelation { snapshot_id, .. }) => Err(etl_error!(
+                ErrorKind::InvalidState,
+                "Relation message missing before truncate",
+                format!(
+                    "Table {table_id} received a truncate event while waiting for relation \
+                     snapshot {snapshot_id}"
+                )
+            )),
+            None => Err(etl_error!(
+                ErrorKind::InvalidState,
+                "Relation state missing for truncate event",
+                format!("Table {table_id} has no relation decoder")
+            )),
         }
     }
 
@@ -3013,17 +3106,19 @@ where
             return Ok(HandleMessageResult::no_event());
         }
 
-        let replicated_table_schema =
-            self.get_replicated_table_schema(table_id, remote_final_lsn).await?;
-
+        let resolved = self.get_replicated_table_schema(table_id, remote_final_lsn).await?;
         let event = parse_event_from_insert_message(
-            replicated_table_schema,
+            resolved.replicated_table_schema,
             remote_final_lsn,
             tx_ordinal,
             message,
         )?;
 
-        Ok(HandleMessageResult::return_row_event(Event::Insert(event), streaming_payload_metadata))
+        Ok(HandleMessageResult::return_row_event(
+            resolved.relation,
+            Event::Insert(event),
+            streaming_payload_metadata,
+        ))
     }
 
     /// Handles Postgres UPDATE messages.
@@ -3057,17 +3152,19 @@ where
             return Ok(HandleMessageResult::no_event());
         }
 
-        let replicated_table_schema =
-            self.get_replicated_table_schema(table_id, remote_final_lsn).await?;
-
+        let resolved = self.get_replicated_table_schema(table_id, remote_final_lsn).await?;
         let event = parse_event_from_update_message(
-            replicated_table_schema,
+            resolved.replicated_table_schema,
             remote_final_lsn,
             tx_ordinal,
             message,
         )?;
 
-        Ok(HandleMessageResult::return_row_event(Event::Update(event), streaming_payload_metadata))
+        Ok(HandleMessageResult::return_row_event(
+            resolved.relation,
+            Event::Update(event),
+            streaming_payload_metadata,
+        ))
     }
 
     /// Handles Postgres DELETE messages.
@@ -3101,17 +3198,19 @@ where
             return Ok(HandleMessageResult::no_event());
         }
 
-        let replicated_table_schema =
-            self.get_replicated_table_schema(table_id, remote_final_lsn).await?;
-
+        let resolved = self.get_replicated_table_schema(table_id, remote_final_lsn).await?;
         let event = parse_event_from_delete_message(
-            replicated_table_schema,
+            resolved.replicated_table_schema,
             remote_final_lsn,
             tx_ordinal,
             message,
         )?;
 
-        Ok(HandleMessageResult::return_row_event(Event::Delete(event), streaming_payload_metadata))
+        Ok(HandleMessageResult::return_row_event(
+            resolved.relation,
+            Event::Delete(event),
+            streaming_payload_metadata,
+        ))
     }
 
     /// Handles Postgres TRUNCATE messages.
@@ -3139,9 +3238,7 @@ where
             // Exactly one worker owns protocol interpretation for a table at a time, so
             // non-owning workers skip truncation handling for that table as well.
             if self.should_apply_changes(table_id, remote_final_lsn).await? {
-                let replicated_table_schema =
-                    self.get_replicated_table_schema(table_id, remote_final_lsn).await?;
-                truncated_tables.push(replicated_table_schema);
+                truncated_tables.push(self.replicated_table_schema_for_truncate(table_id)?);
             }
         }
 

--- a/crates/etl/src/replication/decoding_state.rs
+++ b/crates/etl/src/replication/decoding_state.rs
@@ -11,15 +11,18 @@
 //!
 //! - [`TableDecodingState::WithSchema`] is a complete decoder and can decode a
 //!   row immediately.
-//! - [`TableDecodingState::PendingRelation`] records a DDL snapshot while ETL
-//!   waits to see whether pgoutput sends replacement relation metadata. When a
-//!   previous complete decoder exists, the pending state retains both of its
-//!   relation masks as a fallback. A new `RELATION` replaces those masks. If a
-//!   row arrives first, ETL combines the fallback masks with the stored schema
-//!   at the pending snapshot and transitions to `WithSchema`. Without locally
-//!   retained fallback masks, the apply worker can still resolve them from an
-//!   applicable complete `SyncDone` decoder; otherwise rows cannot be decoded
-//!   until a `RELATION` arrives.
+//! - [`TableDecodingState::PendingRelation`] records a schema snapshot while
+//!   ETL waits to see whether pgoutput sends replacement relation metadata.
+//!   When a previous complete decoder exists, the pending state retains both of
+//!   its relation masks as a fallback. A new protocol relation replaces those
+//!   masks. If a row arrives first, ETL combines the fallback masks with the
+//!   stored schema at the pending snapshot, transitions to `WithSchema`, and
+//!   emits a [`crate::event::RelationEvent`] so destinations apply that
+//!   snapshot before the row. Truncate does not use this fallback: pgoutput
+//!   emits a protocol relation first. Without locally retained fallback masks,
+//!   the apply worker can still resolve them from an applicable complete
+//!   `SyncDone` decoder; otherwise rows cannot be decoded until a protocol
+//!   relation arrives.
 //!
 //! An absent map entry is not another [`TableDecodingState`]: it means this
 //! connection has not established any state for the table. After table-sync

--- a/crates/etl/src/schema.rs
+++ b/crates/etl/src/schema.rs
@@ -66,6 +66,18 @@ fn build_mask_bytes(table_schema: &TableSchema, column_names: &HashSet<String>) 
         .collect()
 }
 
+/// Writes mask bytes as `(0,1,1)` for log and error display.
+fn write_mask_bytes(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    write!(f, "(")?;
+    for (i, &value) in bytes.iter().enumerate() {
+        if i > 0 {
+            write!(f, ",")?;
+        }
+        write!(f, "{value}")?;
+    }
+    write!(f, ")")
+}
+
 /// A bitmask indicating which columns are being replicated.
 ///
 /// Each element is either 0 (not replicated) or 1 (replicated), with indices
@@ -76,14 +88,7 @@ pub struct ReplicationMask(Arc<Vec<u8>>);
 
 impl fmt::Display for ReplicationMask {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(")?;
-        for (i, &v) in self.0.iter().enumerate() {
-            if i > 0 {
-                write!(f, ",")?;
-            }
-            write!(f, "{v}")?;
-        }
-        write!(f, ")")
+        write_mask_bytes(f, &self.0)
     }
 }
 
@@ -211,6 +216,12 @@ impl ReplicationMask {
 /// from schema metadata or raw bytes, then inspect the resulting bit pattern.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IdentityMask(Arc<Vec<u8>>);
+
+impl fmt::Display for IdentityMask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_mask_bytes(f, &self.0)
+    }
+}
 
 impl IdentityMask {
     /// Tries to create a new [`IdentityMask`] from a table schema and column

--- a/crates/etl/src/test_utils/memory_destination.rs
+++ b/crates/etl/src/test_utils/memory_destination.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::{
     data::TableRow,
@@ -9,11 +9,84 @@ use crate::{
         Destination, DestinationTableMetadata, DestinationWriteStatus, DropTableForCopyResult,
         TableCopyBatchId, WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
-    error::EtlResult,
+    error::{ErrorKind, EtlResult},
+    etl_error,
     event::Event,
-    schema::{ReplicatedTableSchema, TableId},
+    schema::{ReplicatedTableSchema, ReplicationMask, SnapshotId, TableId},
     store::SharedStateStore,
 };
+
+/// Display name used in destination schema-validation errors.
+const DESTINATION_NAME: &str = "memory";
+
+/// Validates that a relation can advance an applied destination schema.
+fn ensure_relation_schema_transition(
+    table_id: TableId,
+    applied_snapshot_id: SnapshotId,
+    applied_replication_mask: &ReplicationMask,
+    received_snapshot_id: SnapshotId,
+    received_replication_mask: &ReplicationMask,
+) -> EtlResult<()> {
+    if received_snapshot_id < applied_snapshot_id {
+        return Err(etl_error!(
+            ErrorKind::DestinationSchemaRewind,
+            "Destination schema is newer than the replayed schema snapshot",
+            format!(
+                "{DESTINATION_NAME} table {table_id} received schema snapshot \
+                 {received_snapshot_id}, but the destination already applied snapshot \
+                 {applied_snapshot_id}. Reverse DDL is not executed because it could delete newer \
+                 column data; resynchronize the table to recover."
+            )
+        ));
+    }
+
+    if received_snapshot_id == applied_snapshot_id
+        && received_replication_mask != applied_replication_mask
+    {
+        return Err(etl_error!(
+            ErrorKind::DestinationSchemaRewind,
+            "Relation reused an applied schema snapshot with a different replication mask",
+            format!(
+                "{DESTINATION_NAME} table {table_id} received schema snapshot \
+                 {received_snapshot_id} with replication mask {received_replication_mask}, but \
+                 the destination already applied the same snapshot with replication mask \
+                 {applied_replication_mask}. Supported publication column-list changes use a \
+                 newer schema snapshot, and equal-snapshot relations have no ordering with which \
+                 to choose a mask; resynchronize the table to recover."
+            )
+        ));
+    }
+
+    Ok(())
+}
+
+/// Requires an arriving row schema to match the exact destination metadata.
+fn ensure_destination_schema_matches_metadata(
+    table_id: TableId,
+    metadata: &DestinationTableMetadata,
+    received_schema: &ReplicatedTableSchema,
+) -> EtlResult<()> {
+    let received_snapshot_id = received_schema.inner().snapshot_id;
+    let received_replication_mask = received_schema.replication_mask();
+    if metadata.snapshot_id() == received_snapshot_id
+        && metadata.replication_mask() == received_replication_mask
+    {
+        return Ok(());
+    }
+
+    Err(etl_error!(
+        ErrorKind::DestinationSchemaRewind,
+        "Destination metadata does not match the received schema",
+        format!(
+            "{DESTINATION_NAME} table {table_id} has destination metadata for snapshot {} and \
+             replication mask {}, but received snapshot {received_snapshot_id} and replication \
+             mask {received_replication_mask}. Recover the recorded destination operation or \
+             resynchronize the table before retrying.",
+            metadata.snapshot_id(),
+            metadata.replication_mask(),
+        )
+    ))
+}
 
 #[derive(Debug)]
 struct Inner {
@@ -29,8 +102,10 @@ struct Inner {
 /// terminates.
 ///
 /// Like real destinations (BigQuery, Iceberg), this destination tracks table
-/// metadata (snapshot IDs and replication masks) in a state store to mirror
-/// destinations that persist table-copy state.
+/// metadata (snapshot IDs and replication masks) in a state store and validates
+/// incoming schemas against that metadata. Relation events may advance an
+/// applied snapshot; row events must match the applied snapshot and
+/// replication mask exactly.
 #[derive(Clone)]
 pub struct MemoryDestination<S> {
     inner: Arc<Mutex<Inner>>,
@@ -84,32 +159,92 @@ where
         inner.table_rows.clear();
     }
 
-    /// Stores or advances destination table metadata for a table.
-    async fn sync_destination_table_metadata(
+    /// Applies a relation event against stored destination table metadata.
+    ///
+    /// Missing metadata is treated as a broken invariant because initial copy
+    /// should have recorded it. A newer snapshot replaces the applied
+    /// metadata. An older snapshot, or an equal snapshot with a different
+    /// replication mask, is rejected.
+    async fn apply_relation_schema(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         let table_id = replicated_table_schema.id();
-        let existing_metadata = self.store.get_destination_table_metadata(table_id).await?;
-        let metadata = match existing_metadata {
-            Some(metadata)
-                if metadata.snapshot_id() == replicated_table_schema.inner().snapshot_id
-                    && metadata.replication_mask()
-                        == replicated_table_schema.replication_mask() =>
-            {
-                metadata.to_applied()
-            }
-            Some(metadata) => DestinationTableMetadata::new_applied(
-                metadata.table_id().to_owned(),
-                replicated_table_schema.inner().snapshot_id,
-                replicated_table_schema.replication_mask().clone(),
-            ),
-            None => Self::build_destination_table_metadata(replicated_table_schema),
+        let received_snapshot_id = replicated_table_schema.inner().snapshot_id;
+        let received_replication_mask = replicated_table_schema.replication_mask();
+        let Some(metadata) = self.store.get_destination_table_metadata(table_id).await? else {
+            return Err(etl_error!(
+                ErrorKind::CorruptedTableSchema,
+                "Destination metadata missing for memory schema change",
+                format!(
+                    "{DESTINATION_NAME} table {table_id} received schema snapshot \
+                     {received_snapshot_id}, but destination metadata from initial \
+                     synchronization was not found."
+                )
+            ));
         };
 
+        ensure_relation_schema_transition(
+            table_id,
+            metadata.snapshot_id(),
+            metadata.replication_mask(),
+            received_snapshot_id,
+            received_replication_mask,
+        )?;
+
+        if metadata.snapshot_id() == received_snapshot_id {
+            debug!(
+                table_id = %table_id,
+                snapshot_id = %received_snapshot_id,
+                replication_mask = %received_replication_mask,
+                "memory table schema unchanged"
+            );
+            return Ok(());
+        }
+
+        info!(
+            table_id = %table_id,
+            current_snapshot_id = %metadata.snapshot_id(),
+            new_snapshot_id = %received_snapshot_id,
+            current_replication_mask = %metadata.replication_mask(),
+            new_replication_mask = %received_replication_mask,
+            "memory table schema change applied"
+        );
+
+        let metadata = DestinationTableMetadata::new_applied(
+            metadata.table_id().to_owned(),
+            received_snapshot_id,
+            received_replication_mask.clone(),
+        );
         self.store.store_destination_table_metadata(table_id, metadata).await?;
 
         Ok(())
+    }
+
+    /// Requires a row schema to match applied destination metadata.
+    ///
+    /// The first write for a table records applied metadata, matching real
+    /// destinations that create the destination table during initial copy.
+    async fn ensure_row_schema(
+        &self,
+        replicated_table_schema: &ReplicatedTableSchema,
+    ) -> EtlResult<()> {
+        let table_id = replicated_table_schema.id();
+        match self.store.get_destination_table_metadata(table_id).await? {
+            Some(metadata) => ensure_destination_schema_matches_metadata(
+                table_id,
+                &metadata,
+                replicated_table_schema,
+            ),
+            None => {
+                self.store
+                    .store_destination_table_metadata(
+                        table_id,
+                        Self::build_destination_table_metadata(replicated_table_schema),
+                    )
+                    .await
+            }
+        }
     }
 
     /// Builds applied destination table metadata for a memory-backed table.
@@ -176,9 +311,7 @@ where
     ) -> EtlResult<()> {
         let table_id = replicated_table_schema.id();
 
-        // Store destination table metadata on first write, like real destinations
-        // (BigQuery, Iceberg) do.
-        self.sync_destination_table_metadata(replicated_table_schema).await?;
+        self.ensure_row_schema(replicated_table_schema).await?;
 
         let mut inner = self.inner.lock().await;
         info!(%table_id, row_count = table_rows.len(), "writing table rows");
@@ -195,45 +328,27 @@ where
         _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
-        let mut table_schemas = HashMap::new();
         for event in &events {
             match event {
+                Event::Relation(event) => {
+                    self.apply_relation_schema(&event.replicated_table_schema).await?;
+                }
                 Event::Insert(event) => {
-                    table_schemas.insert(
-                        event.replicated_table_schema.id(),
-                        event.replicated_table_schema.clone(),
-                    );
+                    self.ensure_row_schema(&event.replicated_table_schema).await?;
                 }
                 Event::Update(event) => {
-                    table_schemas.insert(
-                        event.replicated_table_schema.id(),
-                        event.replicated_table_schema.clone(),
-                    );
+                    self.ensure_row_schema(&event.replicated_table_schema).await?;
                 }
                 Event::Delete(event) => {
-                    table_schemas.insert(
-                        event.replicated_table_schema.id(),
-                        event.replicated_table_schema.clone(),
-                    );
-                }
-                Event::Relation(event) => {
-                    table_schemas.insert(
-                        event.replicated_table_schema.id(),
-                        event.replicated_table_schema.clone(),
-                    );
+                    self.ensure_row_schema(&event.replicated_table_schema).await?;
                 }
                 Event::Truncate(event) => {
                     for replicated_table_schema in &event.truncated_tables {
-                        table_schemas
-                            .insert(replicated_table_schema.id(), replicated_table_schema.clone());
+                        self.ensure_row_schema(replicated_table_schema).await?;
                     }
                 }
                 Event::Begin(_) | Event::Commit(_) | Event::Unsupported => {}
             }
-        }
-
-        for replicated_table_schema in table_schemas.into_values() {
-            self.sync_destination_table_metadata(&replicated_table_schema).await?;
         }
 
         let mut inner = self.inner.lock().await;
@@ -243,5 +358,166 @@ where
         async_result.send(Ok(DestinationWriteStatus::Durable));
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        destination::WriteEventsDurability,
+        event::{InsertEvent, RelationEvent},
+        schema::{
+            ColumnSchema, PgLsn, ReplicatedTableSchema, ReplicationMask, SnapshotId, TableId,
+            TableName, TableSchema, Type,
+        },
+        store::{MemoryStore, StateStore},
+        test_utils::destination::{write_events, write_table_rows},
+    };
+
+    fn test_snapshot_id(commit_lsn: u64, message_lsn: u64) -> SnapshotId {
+        SnapshotId::new(PgLsn::from(commit_lsn), PgLsn::from(message_lsn))
+    }
+
+    fn test_schema(snapshot_id: SnapshotId) -> ReplicatedTableSchema {
+        let table_schema = Arc::new(TableSchema::with_snapshot_id(
+            TableId::new(7),
+            TableName::new("public".to_owned(), "users".to_owned()),
+            vec![ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false)],
+            snapshot_id,
+        ));
+        ReplicatedTableSchema::all(table_schema)
+    }
+
+    fn relation_event(schema: ReplicatedTableSchema) -> Event {
+        Event::Relation(RelationEvent { replicated_table_schema: schema })
+    }
+
+    fn insert_event(schema: ReplicatedTableSchema) -> Event {
+        Event::Insert(InsertEvent {
+            commit_lsn: PgLsn::from(1),
+            tx_ordinal: 0,
+            replicated_table_schema: schema,
+            table_row: TableRow::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn relation_event_advances_applied_destination_metadata() {
+        let store = MemoryStore::new();
+        let destination = MemoryDestination::new(store.clone());
+        let initial_schema = test_schema(test_snapshot_id(100, 100));
+        let next_schema = test_schema(test_snapshot_id(200, 200));
+
+        write_table_rows(&destination, &initial_schema, Vec::new()).await.unwrap();
+        write_events(
+            &destination,
+            WriteEventsDurability::RequireDurable,
+            vec![relation_event(next_schema.clone())],
+        )
+        .await
+        .unwrap();
+
+        let metadata =
+            store.get_destination_table_metadata(TableId::new(7)).await.unwrap().unwrap();
+        assert_eq!(metadata.snapshot_id(), next_schema.inner().snapshot_id);
+        assert_eq!(metadata.replication_mask(), next_schema.replication_mask());
+    }
+
+    #[tokio::test]
+    async fn relation_then_insert_in_the_same_batch_uses_the_new_schema() {
+        let store = MemoryStore::new();
+        let destination = MemoryDestination::new(store);
+        let initial_schema = test_schema(test_snapshot_id(100, 100));
+        let next_schema = test_schema(test_snapshot_id(200, 200));
+
+        write_table_rows(&destination, &initial_schema, Vec::new()).await.unwrap();
+        write_events(
+            &destination,
+            WriteEventsDurability::RequireDurable,
+            vec![relation_event(next_schema.clone()), insert_event(next_schema)],
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn insert_without_relation_rejects_a_newer_schema() {
+        let store = MemoryStore::new();
+        let destination = MemoryDestination::new(store);
+        let initial_schema = test_schema(test_snapshot_id(100, 100));
+        let next_schema = test_schema(test_snapshot_id(200, 200));
+
+        write_table_rows(&destination, &initial_schema, Vec::new()).await.unwrap();
+        let error = write_events(
+            &destination,
+            WriteEventsDurability::RequireDurable,
+            vec![insert_event(next_schema)],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::DestinationSchemaRewind);
+    }
+
+    #[tokio::test]
+    async fn relation_event_rejects_an_older_schema_snapshot() {
+        let store = MemoryStore::new();
+        let destination = MemoryDestination::new(store);
+        let applied_schema = test_schema(test_snapshot_id(200, 200));
+        let older_schema = test_schema(test_snapshot_id(100, 100));
+
+        write_table_rows(&destination, &applied_schema, Vec::new()).await.unwrap();
+        let error = write_events(
+            &destination,
+            WriteEventsDurability::RequireDurable,
+            vec![relation_event(older_schema)],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::DestinationSchemaRewind);
+    }
+
+    #[tokio::test]
+    async fn relation_event_rejects_a_different_mask_at_the_same_snapshot() {
+        let store = MemoryStore::new();
+        let destination = MemoryDestination::new(store);
+        let snapshot_id = test_snapshot_id(200, 200);
+        let applied_schema = test_schema(snapshot_id);
+        let conflicting_schema = ReplicatedTableSchema::from_mask(
+            Arc::new(applied_schema.inner().clone()),
+            ReplicationMask::from_bytes(vec![0]),
+        );
+
+        write_table_rows(&destination, &applied_schema, Vec::new()).await.unwrap();
+        let error = write_events(
+            &destination,
+            WriteEventsDurability::RequireDurable,
+            vec![relation_event(conflicting_schema)],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::DestinationSchemaRewind);
+    }
+
+    #[tokio::test]
+    async fn relation_event_requires_destination_metadata_from_copy() {
+        let store = MemoryStore::new();
+        let destination = MemoryDestination::new(store);
+        let schema = test_schema(test_snapshot_id(100, 100));
+
+        let error = write_events(
+            &destination,
+            WriteEventsDurability::RequireDurable,
+            vec![relation_event(schema)],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::CorruptedTableSchema);
     }
 }

--- a/crates/etl/src/test_utils/memory_destination.rs
+++ b/crates/etl/src/test_utils/memory_destination.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use tokio::sync::Mutex;
-use tracing::{debug, info};
+use tracing::info;
 
 use crate::{
     data::TableRow,
@@ -9,84 +9,11 @@ use crate::{
         Destination, DestinationTableMetadata, DestinationWriteStatus, DropTableForCopyResult,
         TableCopyBatchId, WriteEventsDurability, WriteEventsResult, WriteTableRowsResult,
     },
-    error::{ErrorKind, EtlResult},
-    etl_error,
+    error::EtlResult,
     event::Event,
-    schema::{ReplicatedTableSchema, ReplicationMask, SnapshotId, TableId},
+    schema::{ReplicatedTableSchema, TableId},
     store::SharedStateStore,
 };
-
-/// Display name used in destination schema-validation errors.
-const DESTINATION_NAME: &str = "memory";
-
-/// Validates that a relation can advance an applied destination schema.
-fn ensure_relation_schema_transition(
-    table_id: TableId,
-    applied_snapshot_id: SnapshotId,
-    applied_replication_mask: &ReplicationMask,
-    received_snapshot_id: SnapshotId,
-    received_replication_mask: &ReplicationMask,
-) -> EtlResult<()> {
-    if received_snapshot_id < applied_snapshot_id {
-        return Err(etl_error!(
-            ErrorKind::DestinationSchemaRewind,
-            "Destination schema is newer than the replayed schema snapshot",
-            format!(
-                "{DESTINATION_NAME} table {table_id} received schema snapshot \
-                 {received_snapshot_id}, but the destination already applied snapshot \
-                 {applied_snapshot_id}. Reverse DDL is not executed because it could delete newer \
-                 column data; resynchronize the table to recover."
-            )
-        ));
-    }
-
-    if received_snapshot_id == applied_snapshot_id
-        && received_replication_mask != applied_replication_mask
-    {
-        return Err(etl_error!(
-            ErrorKind::DestinationSchemaRewind,
-            "Relation reused an applied schema snapshot with a different replication mask",
-            format!(
-                "{DESTINATION_NAME} table {table_id} received schema snapshot \
-                 {received_snapshot_id} with replication mask {received_replication_mask}, but \
-                 the destination already applied the same snapshot with replication mask \
-                 {applied_replication_mask}. Supported publication column-list changes use a \
-                 newer schema snapshot, and equal-snapshot relations have no ordering with which \
-                 to choose a mask; resynchronize the table to recover."
-            )
-        ));
-    }
-
-    Ok(())
-}
-
-/// Requires an arriving row schema to match the exact destination metadata.
-fn ensure_destination_schema_matches_metadata(
-    table_id: TableId,
-    metadata: &DestinationTableMetadata,
-    received_schema: &ReplicatedTableSchema,
-) -> EtlResult<()> {
-    let received_snapshot_id = received_schema.inner().snapshot_id;
-    let received_replication_mask = received_schema.replication_mask();
-    if metadata.snapshot_id() == received_snapshot_id
-        && metadata.replication_mask() == received_replication_mask
-    {
-        return Ok(());
-    }
-
-    Err(etl_error!(
-        ErrorKind::DestinationSchemaRewind,
-        "Destination metadata does not match the received schema",
-        format!(
-            "{DESTINATION_NAME} table {table_id} has destination metadata for snapshot {} and \
-             replication mask {}, but received snapshot {received_snapshot_id} and replication \
-             mask {received_replication_mask}. Recover the recorded destination operation or \
-             resynchronize the table before retrying.",
-            metadata.snapshot_id(),
-            metadata.replication_mask(),
-        )
-    ))
-}
 
 #[derive(Debug)]
 struct Inner {
@@ -102,10 +29,8 @@ struct Inner {
 /// terminates.
 ///
 /// Like real destinations (BigQuery, Iceberg), this destination tracks table
-/// metadata (snapshot IDs and replication masks) in a state store and validates
-/// incoming schemas against that metadata. Relation events may advance an
-/// applied snapshot; row events must match the applied snapshot and
-/// replication mask exactly.
+/// metadata (snapshot IDs and replication masks) in a state store to mirror
+/// destinations that persist table-copy state.
 #[derive(Clone)]
 pub struct MemoryDestination<S> {
     inner: Arc<Mutex<Inner>>,
@@ -159,92 +84,32 @@ where
         inner.table_rows.clear();
     }
 
-    /// Applies a relation event against stored destination table metadata.
-    ///
-    /// Missing metadata is treated as a broken invariant because initial copy
-    /// should have recorded it. A newer snapshot replaces the applied
-    /// metadata. An older snapshot, or an equal snapshot with a different
-    /// replication mask, is rejected.
-    async fn apply_relation_schema(
+    /// Stores or advances destination table metadata for a table.
+    async fn sync_destination_table_metadata(
         &self,
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         let table_id = replicated_table_schema.id();
-        let received_snapshot_id = replicated_table_schema.inner().snapshot_id;
-        let received_replication_mask = replicated_table_schema.replication_mask();
-        let Some(metadata) = self.store.get_destination_table_metadata(table_id).await? else {
-            return Err(etl_error!(
-                ErrorKind::CorruptedTableSchema,
-                "Destination metadata missing for memory schema change",
-                format!(
-                    "{DESTINATION_NAME} table {table_id} received schema snapshot \
-                     {received_snapshot_id}, but destination metadata from initial \
-                     synchronization was not found."
-                )
-            ));
+        let existing_metadata = self.store.get_destination_table_metadata(table_id).await?;
+        let metadata = match existing_metadata {
+            Some(metadata)
+                if metadata.snapshot_id() == replicated_table_schema.inner().snapshot_id
+                    && metadata.replication_mask()
+                        == replicated_table_schema.replication_mask() =>
+            {
+                metadata.to_applied()
+            }
+            Some(metadata) => DestinationTableMetadata::new_applied(
+                metadata.table_id().to_owned(),
+                replicated_table_schema.inner().snapshot_id,
+                replicated_table_schema.replication_mask().clone(),
+            ),
+            None => Self::build_destination_table_metadata(replicated_table_schema),
         };
 
-        ensure_relation_schema_transition(
-            table_id,
-            metadata.snapshot_id(),
-            metadata.replication_mask(),
-            received_snapshot_id,
-            received_replication_mask,
-        )?;
-
-        if metadata.snapshot_id() == received_snapshot_id {
-            debug!(
-                table_id = %table_id,
-                snapshot_id = %received_snapshot_id,
-                replication_mask = %received_replication_mask,
-                "memory table schema unchanged"
-            );
-            return Ok(());
-        }
-
-        info!(
-            table_id = %table_id,
-            current_snapshot_id = %metadata.snapshot_id(),
-            new_snapshot_id = %received_snapshot_id,
-            current_replication_mask = %metadata.replication_mask(),
-            new_replication_mask = %received_replication_mask,
-            "memory table schema change applied"
-        );
-
-        let metadata = DestinationTableMetadata::new_applied(
-            metadata.table_id().to_owned(),
-            received_snapshot_id,
-            received_replication_mask.clone(),
-        );
         self.store.store_destination_table_metadata(table_id, metadata).await?;
 
         Ok(())
-    }
-
-    /// Requires a row schema to match applied destination metadata.
-    ///
-    /// The first write for a table records applied metadata, matching real
-    /// destinations that create the destination table during initial copy.
-    async fn ensure_row_schema(
-        &self,
-        replicated_table_schema: &ReplicatedTableSchema,
-    ) -> EtlResult<()> {
-        let table_id = replicated_table_schema.id();
-        match self.store.get_destination_table_metadata(table_id).await? {
-            Some(metadata) => ensure_destination_schema_matches_metadata(
-                table_id,
-                &metadata,
-                replicated_table_schema,
-            ),
-            None => {
-                self.store
-                    .store_destination_table_metadata(
-                        table_id,
-                        Self::build_destination_table_metadata(replicated_table_schema),
-                    )
-                    .await
-            }
-        }
     }
 
     /// Builds applied destination table metadata for a memory-backed table.
@@ -311,7 +176,9 @@ where
     ) -> EtlResult<()> {
         let table_id = replicated_table_schema.id();
 
-        self.ensure_row_schema(replicated_table_schema).await?;
+        // Store destination table metadata on first write, like real destinations
+        // (BigQuery, Iceberg) do.
+        self.sync_destination_table_metadata(replicated_table_schema).await?;
 
         let mut inner = self.inner.lock().await;
         info!(%table_id, row_count = table_rows.len(), "writing table rows");
@@ -328,27 +195,45 @@ where
         _durability: WriteEventsDurability,
         async_result: WriteEventsResult,
     ) -> EtlResult<()> {
+        let mut table_schemas = HashMap::new();
         for event in &events {
             match event {
-                Event::Relation(event) => {
-                    self.apply_relation_schema(&event.replicated_table_schema).await?;
-                }
                 Event::Insert(event) => {
-                    self.ensure_row_schema(&event.replicated_table_schema).await?;
+                    table_schemas.insert(
+                        event.replicated_table_schema.id(),
+                        event.replicated_table_schema.clone(),
+                    );
                 }
                 Event::Update(event) => {
-                    self.ensure_row_schema(&event.replicated_table_schema).await?;
+                    table_schemas.insert(
+                        event.replicated_table_schema.id(),
+                        event.replicated_table_schema.clone(),
+                    );
                 }
                 Event::Delete(event) => {
-                    self.ensure_row_schema(&event.replicated_table_schema).await?;
+                    table_schemas.insert(
+                        event.replicated_table_schema.id(),
+                        event.replicated_table_schema.clone(),
+                    );
+                }
+                Event::Relation(event) => {
+                    table_schemas.insert(
+                        event.replicated_table_schema.id(),
+                        event.replicated_table_schema.clone(),
+                    );
                 }
                 Event::Truncate(event) => {
                     for replicated_table_schema in &event.truncated_tables {
-                        self.ensure_row_schema(replicated_table_schema).await?;
+                        table_schemas
+                            .insert(replicated_table_schema.id(), replicated_table_schema.clone());
                     }
                 }
                 Event::Begin(_) | Event::Commit(_) | Event::Unsupported => {}
             }
+        }
+
+        for replicated_table_schema in table_schemas.into_values() {
+            self.sync_destination_table_metadata(&replicated_table_schema).await?;
         }
 
         let mut inner = self.inner.lock().await;
@@ -358,166 +243,5 @@ where
         async_result.send(Ok(DestinationWriteStatus::Durable));
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use super::*;
-    use crate::{
-        destination::WriteEventsDurability,
-        event::{InsertEvent, RelationEvent},
-        schema::{
-            ColumnSchema, PgLsn, ReplicatedTableSchema, ReplicationMask, SnapshotId, TableId,
-            TableName, TableSchema, Type,
-        },
-        store::{MemoryStore, StateStore},
-        test_utils::destination::{write_events, write_table_rows},
-    };
-
-    fn test_snapshot_id(commit_lsn: u64, message_lsn: u64) -> SnapshotId {
-        SnapshotId::new(PgLsn::from(commit_lsn), PgLsn::from(message_lsn))
-    }
-
-    fn test_schema(snapshot_id: SnapshotId) -> ReplicatedTableSchema {
-        let table_schema = Arc::new(TableSchema::with_snapshot_id(
-            TableId::new(7),
-            TableName::new("public".to_owned(), "users".to_owned()),
-            vec![ColumnSchema::new("id".to_owned(), Type::INT4, -1, 1, false)],
-            snapshot_id,
-        ));
-        ReplicatedTableSchema::all(table_schema)
-    }
-
-    fn relation_event(schema: ReplicatedTableSchema) -> Event {
-        Event::Relation(RelationEvent { replicated_table_schema: schema })
-    }
-
-    fn insert_event(schema: ReplicatedTableSchema) -> Event {
-        Event::Insert(InsertEvent {
-            commit_lsn: PgLsn::from(1),
-            tx_ordinal: 0,
-            replicated_table_schema: schema,
-            table_row: TableRow::new(Vec::new()),
-        })
-    }
-
-    #[tokio::test]
-    async fn relation_event_advances_applied_destination_metadata() {
-        let store = MemoryStore::new();
-        let destination = MemoryDestination::new(store.clone());
-        let initial_schema = test_schema(test_snapshot_id(100, 100));
-        let next_schema = test_schema(test_snapshot_id(200, 200));
-
-        write_table_rows(&destination, &initial_schema, Vec::new()).await.unwrap();
-        write_events(
-            &destination,
-            WriteEventsDurability::RequireDurable,
-            vec![relation_event(next_schema.clone())],
-        )
-        .await
-        .unwrap();
-
-        let metadata =
-            store.get_destination_table_metadata(TableId::new(7)).await.unwrap().unwrap();
-        assert_eq!(metadata.snapshot_id(), next_schema.inner().snapshot_id);
-        assert_eq!(metadata.replication_mask(), next_schema.replication_mask());
-    }
-
-    #[tokio::test]
-    async fn relation_then_insert_in_the_same_batch_uses_the_new_schema() {
-        let store = MemoryStore::new();
-        let destination = MemoryDestination::new(store);
-        let initial_schema = test_schema(test_snapshot_id(100, 100));
-        let next_schema = test_schema(test_snapshot_id(200, 200));
-
-        write_table_rows(&destination, &initial_schema, Vec::new()).await.unwrap();
-        write_events(
-            &destination,
-            WriteEventsDurability::RequireDurable,
-            vec![relation_event(next_schema.clone()), insert_event(next_schema)],
-        )
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn insert_without_relation_rejects_a_newer_schema() {
-        let store = MemoryStore::new();
-        let destination = MemoryDestination::new(store);
-        let initial_schema = test_schema(test_snapshot_id(100, 100));
-        let next_schema = test_schema(test_snapshot_id(200, 200));
-
-        write_table_rows(&destination, &initial_schema, Vec::new()).await.unwrap();
-        let error = write_events(
-            &destination,
-            WriteEventsDurability::RequireDurable,
-            vec![insert_event(next_schema)],
-        )
-        .await
-        .unwrap_err();
-
-        assert_eq!(error.kind(), ErrorKind::DestinationSchemaRewind);
-    }
-
-    #[tokio::test]
-    async fn relation_event_rejects_an_older_schema_snapshot() {
-        let store = MemoryStore::new();
-        let destination = MemoryDestination::new(store);
-        let applied_schema = test_schema(test_snapshot_id(200, 200));
-        let older_schema = test_schema(test_snapshot_id(100, 100));
-
-        write_table_rows(&destination, &applied_schema, Vec::new()).await.unwrap();
-        let error = write_events(
-            &destination,
-            WriteEventsDurability::RequireDurable,
-            vec![relation_event(older_schema)],
-        )
-        .await
-        .unwrap_err();
-
-        assert_eq!(error.kind(), ErrorKind::DestinationSchemaRewind);
-    }
-
-    #[tokio::test]
-    async fn relation_event_rejects_a_different_mask_at_the_same_snapshot() {
-        let store = MemoryStore::new();
-        let destination = MemoryDestination::new(store);
-        let snapshot_id = test_snapshot_id(200, 200);
-        let applied_schema = test_schema(snapshot_id);
-        let conflicting_schema = ReplicatedTableSchema::from_mask(
-            Arc::new(applied_schema.inner().clone()),
-            ReplicationMask::from_bytes(vec![0]),
-        );
-
-        write_table_rows(&destination, &applied_schema, Vec::new()).await.unwrap();
-        let error = write_events(
-            &destination,
-            WriteEventsDurability::RequireDurable,
-            vec![relation_event(conflicting_schema)],
-        )
-        .await
-        .unwrap_err();
-
-        assert_eq!(error.kind(), ErrorKind::DestinationSchemaRewind);
-    }
-
-    #[tokio::test]
-    async fn relation_event_requires_destination_metadata_from_copy() {
-        let store = MemoryStore::new();
-        let destination = MemoryDestination::new(store);
-        let schema = test_schema(test_snapshot_id(100, 100));
-
-        let error = write_events(
-            &destination,
-            WriteEventsDurability::RequireDurable,
-            vec![relation_event(schema)],
-        )
-        .await
-        .unwrap_err();
-
-        assert_eq!(error.kind(), ErrorKind::CorruptedTableSchema);
     }
 }

--- a/crates/etl/tests/pipeline_with_failpoints.rs
+++ b/crates/etl/tests/pipeline_with_failpoints.rs
@@ -670,8 +670,8 @@ async fn table_sync_handover_preserves_decoder_across_post_handoff_noop_ddl() {
     sync_done_notify.notified().await;
 
     // Make the first apply-owned table event a no-op DDL. ETL stores a new
-    // snapshot for its transactional DDL message, but PostgreSQL keeps the
-    // warmed pgoutput relation cache and therefore emits no new Relation.
+    // schema snapshot for its transactional DDL message, but pgoutput keeps
+    // the warmed relation cache and therefore emits no protocol relation.
     let schema_stored_notify = store.notify_on_table_schema_count(table_id, 2).await;
 
     database
@@ -686,9 +686,9 @@ async fn table_sync_handover_preserves_decoder_across_post_handoff_noop_ddl() {
 
     // The apply connection already saw and skipped its copy of the relation
     // used by table sync. Because the no-op DDL does not invalidate that
-    // connection's pgoutput cache, this row arrives without another Relation.
-    // It can only be decoded by carrying the masks stored in SyncDone into the
-    // pending DDL snapshot.
+    // connection's relation cache, pgoutput sends no protocol relation. Apply
+    // still emits a destination schema barrier before decoding the row with the
+    // SyncDone masks and the pending schema snapshot.
     let post_handover_notify = destination
         .wait_for_all_events(vec![EventCondition::TableCount(
             EventType::Insert,
@@ -716,11 +716,11 @@ async fn table_sync_handover_preserves_decoder_across_post_handoff_noop_ddl() {
     let events = destination.get_events().await;
     let grouped_events = group_events_by_type_and_table_id(&events);
 
-    // The only destination-visible Relation came from table-sync streaming.
-    // Apply consumed its pre-handoff copy only to advance WAL, and pgoutput did
-    // not send another one after the no-op DDL.
+    // Table-sync streaming emitted the first relation event. pgoutput did not
+    // send another after the no-op DDL, so apply emits a destination schema
+    // barrier before the first apply-owned row at the new snapshot.
     let relation_events = grouped_events.get(&(EventType::Relation, table_id)).unwrap();
-    assert_eq!(relation_events.len(), 1);
+    assert_eq!(relation_events.len(), 2);
 
     let catchup_events = grouped_events.get(&(EventType::Insert, table_id)).unwrap();
     let expected_catchup_events = build_expected_users_inserts(
@@ -730,36 +730,51 @@ async fn table_sync_handover_preserves_decoder_across_post_handoff_noop_ddl() {
     );
     assert_events_equal(catchup_events, &expected_catchup_events);
 
-    let Event::Relation(relation) = &relation_events[0] else {
+    let Event::Relation(table_sync_relation) = &relation_events[0] else {
+        unreachable!("grouped relation event should be a relation");
+    };
+    let Event::Relation(pending_relation) = &relation_events[1] else {
         unreachable!("grouped relation event should be a relation");
     };
     let Event::Insert(post_handoff_insert) = catchup_events.last().unwrap() else {
         unreachable!("grouped insert event should be an insert");
     };
 
-    // The relation-less row must use the new schema snapshot stored for the
-    // no-op DDL, rather than the older snapshot attached to the table-sync
-    // Relation event.
+    // The row after the no-op DDL must use the new schema snapshot stored for
+    // that DDL, and the destination-visible relation barrier must carry the
+    // same snapshot before that row.
     let latest_table_schemas = store.get_latest_table_schemas().await;
     assert_eq!(
         post_handoff_insert.replicated_table_schema.inner(),
         latest_table_schemas.get(&table_id).unwrap()
     );
+    assert_eq!(
+        post_handoff_insert.replicated_table_schema.inner().snapshot_id,
+        pending_relation.replicated_table_schema.inner().snapshot_id
+    );
     assert_ne!(
         post_handoff_insert.replicated_table_schema.inner().snapshot_id,
-        relation.replicated_table_schema.inner().snapshot_id
+        table_sync_relation.replicated_table_schema.inner().snapshot_id
     );
 
-    // Only the snapshot changed. Since PostgreSQL sent no replacement
-    // Relation, both positional masks must come from the decoder persisted in
-    // SyncDone, which was built from the table-sync Relation above.
+    // Only the snapshot changed. Since pgoutput sent no replacement protocol
+    // relation, both positional masks must come from the decoder persisted in
+    // SyncDone, which was built from the table-sync relation above.
     assert_eq!(
         post_handoff_insert.replicated_table_schema.replication_mask(),
-        relation.replicated_table_schema.replication_mask()
+        pending_relation.replicated_table_schema.replication_mask()
     );
     assert_eq!(
         post_handoff_insert.replicated_table_schema.identity_mask(),
-        relation.replicated_table_schema.identity_mask()
+        pending_relation.replicated_table_schema.identity_mask()
+    );
+    assert_eq!(
+        pending_relation.replicated_table_schema.replication_mask(),
+        table_sync_relation.replicated_table_schema.replication_mask()
+    );
+    assert_eq!(
+        pending_relation.replicated_table_schema.identity_mask(),
+        table_sync_relation.replicated_table_schema.identity_mask()
     );
 }
 

--- a/crates/etl/tests/pipeline_with_schema_changes.rs
+++ b/crates/etl/tests/pipeline_with_schema_changes.rs
@@ -41,6 +41,65 @@ fn get_last_insert_event(events: &[Event], table_id: TableId) -> &Event {
         .expect("no insert events for table")
 }
 
+/// Returns the nearest preceding relation for `table_id` before `index`.
+fn get_relation_before_index(events: &[Event], table_id: TableId, index: usize) -> &Event {
+    events[..index]
+        .iter()
+        .rev()
+        .find(|event| {
+            matches!(
+                event,
+                Event::Relation(relation) if relation.replicated_table_schema.id() == table_id
+            )
+        })
+        .expect("no relation event before the target event")
+}
+
+/// Returns the nearest preceding relation for `table_id` before its last
+/// insert.
+fn get_relation_before_last_insert(events: &[Event], table_id: TableId) -> &Event {
+    let last_insert_index = events
+        .iter()
+        .rposition(|event| {
+            matches!(event, Event::Insert(insert) if insert.replicated_table_schema.id() == table_id)
+        })
+        .expect("no insert events for table");
+
+    get_relation_before_index(events, table_id, last_insert_index)
+}
+
+/// Returns the last truncate event that includes `table_id`.
+fn get_last_truncate_event(events: &[Event], table_id: TableId) -> &Event {
+    events
+        .iter()
+        .rev()
+        .find(|event| {
+            matches!(
+                event,
+                Event::Truncate(truncate)
+                    if truncate.truncated_tables.iter().any(|schema| schema.id() == table_id)
+            )
+        })
+        .expect("no truncate events for table")
+}
+
+/// Returns the nearest preceding relation for `table_id` before its last
+/// truncate.
+fn get_relation_before_last_truncate(events: &[Event], table_id: TableId) -> &Event {
+    let last_truncate_index = events
+        .iter()
+        .rposition(|event| {
+            matches!(
+                event,
+                Event::Truncate(truncate)
+                    if truncate.truncated_tables.iter().any(|schema| schema.id() == table_id)
+            )
+        })
+        .expect("no truncate events for table");
+
+    get_relation_before_index(events, table_id, last_truncate_index)
+}
+
 fn assert_column_default_contains<'a>(
     columns: impl IntoIterator<Item = &'a ColumnSchema>,
     column_name: &str,
@@ -322,8 +381,9 @@ async fn relationless_noop_schema_changes_reuse_previous_relation_masks() {
         .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 2)])
         .await;
 
-    // Both commands succeed and reach ddl_command_end, but neither changes a
-    // catalog tuple which invalidates pgoutput's cached relation state.
+    // Both commands are no-op DDL: they store schema snapshots but do not
+    // invalidate pgoutput's relation cache, so the following insert has no
+    // protocol relation.
     database
         .run_sql(&format!(
             "alter table {} owner to current_user",
@@ -338,47 +398,113 @@ async fn relationless_noop_schema_changes_reuse_previous_relation_masks() {
         ))
         .await
         .unwrap();
-    database.insert_values(table_name, &["name", "age"], &[&"Alice", &25]).await.unwrap();
+    database.insert_values(table_name.clone(), &["name", "age"], &[&"Alice", &25]).await.unwrap();
 
     schemas_stored_notify.notified().await;
     insert_notify.notified().await;
+
+    // Truncate after no-op DDL still needs a destination schema barrier.
+    // pgoutput emits a protocol relation before truncate, unlike insert.
+    let truncate_notify = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Truncate, table_id, 1)])
+        .await;
+
+    database
+        .run_sql(&format!(
+            "alter table {} owner to current_user",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+    database.truncate_table(table_name).await.unwrap();
+
+    truncate_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
 
     let events = destination.get_events().await;
     let grouped = group_events_by_type_and_table_id(&events);
-    assert_eq!(grouped.get(&(EventType::Relation, table_id)).unwrap().len(), 1);
+    let relations = grouped.get(&(EventType::Relation, table_id)).unwrap();
+    assert_eq!(relations.len(), 3);
     assert_eq!(grouped.get(&(EventType::Insert, table_id)).unwrap().len(), 2);
+    assert_eq!(grouped.get(&(EventType::Truncate, table_id)).unwrap().len(), 1);
 
     let Event::Insert(insert) = get_last_insert_event(&events, table_id) else {
         panic!("expected insert event");
     };
-    let Event::Relation(relation) = get_last_relation_event(&events, table_id) else {
-        panic!("expected relation event");
+    let Event::Truncate(truncate) = get_last_truncate_event(&events, table_id) else {
+        panic!("expected truncate event");
+    };
+    let Event::Relation(warm_relation) = &relations[0] else {
+        panic!("expected warm relation event");
+    };
+    let Event::Relation(insert_relation) = get_relation_before_last_insert(&events, table_id)
+    else {
+        panic!("expected relation event before last insert");
+    };
+    let Event::Relation(truncate_relation) = get_relation_before_last_truncate(&events, table_id)
+    else {
+        panic!("expected relation event before last truncate");
     };
     assert_eq!(insert.table_row.values()[1], Cell::String("Alice".to_owned()));
     assert_eq!(insert.table_row.values()[2], Cell::I32(25));
+    assert_eq!(truncate.truncated_tables.len(), 1);
+    assert_eq!(truncate.truncated_tables[0].id(), table_id);
+
+    // Insert after no-op DDL has no protocol relation, so apply emits the
+    // relation event from the pending schema snapshot. Truncate after no-op
+    // DDL receives a protocol relation first; apply does not synthesize one.
+    assert_eq!(
+        insert.replicated_table_schema.inner().snapshot_id,
+        insert_relation.replicated_table_schema.inner().snapshot_id
+    );
+    assert_eq!(
+        truncate.truncated_tables[0].inner().snapshot_id,
+        truncate_relation.replicated_table_schema.inner().snapshot_id
+    );
+    assert!(
+        insert.replicated_table_schema.inner().snapshot_id
+            > warm_relation.replicated_table_schema.inner().snapshot_id
+    );
+    assert!(
+        truncate.truncated_tables[0].inner().snapshot_id
+            > insert.replicated_table_schema.inner().snapshot_id
+    );
     assert_eq!(
         insert.replicated_table_schema.replication_mask(),
-        relation.replicated_table_schema.replication_mask()
+        insert_relation.replicated_table_schema.replication_mask()
     );
     assert_eq!(
         insert.replicated_table_schema.identity_mask(),
-        relation.replicated_table_schema.identity_mask()
+        insert_relation.replicated_table_schema.identity_mask()
+    );
+    assert_eq!(
+        truncate.truncated_tables[0].replication_mask(),
+        truncate_relation.replicated_table_schema.replication_mask()
+    );
+    assert_eq!(
+        truncate.truncated_tables[0].identity_mask(),
+        truncate_relation.replicated_table_schema.identity_mask()
+    );
+    assert_eq!(
+        insert_relation.replicated_table_schema.replication_mask(),
+        warm_relation.replicated_table_schema.replication_mask()
+    );
+    assert_eq!(
+        truncate_relation.replicated_table_schema.replication_mask(),
+        warm_relation.replicated_table_schema.replication_mask()
     );
 
     let table_schemas = store.get_table_schemas().await;
-    let (_, newest_table_schema) = table_schemas
-        .get(&table_id)
-        .unwrap()
-        .iter()
-        .max_by_key(|(snapshot_id, _)| *snapshot_id)
-        .unwrap();
-    assert_eq!(insert.replicated_table_schema.inner(), newest_table_schema);
-    assert_ne!(
-        insert.replicated_table_schema.inner().snapshot_id,
-        relation.replicated_table_schema.inner().snapshot_id
+    let snapshots = table_schemas.get(&table_id).unwrap();
+    let (_, newest_table_schema) =
+        snapshots.iter().max_by_key(|(snapshot_id, _)| *snapshot_id).unwrap();
+    assert_eq!(
+        insert.replicated_table_schema.inner(),
+        insert_relation.replicated_table_schema.inner()
     );
+    assert_eq!(truncate.truncated_tables[0].inner(), newest_table_schema);
+    assert_eq!(truncate_relation.replicated_table_schema.inner(), newest_table_schema);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/etl/tests/replication_stream.rs
+++ b/crates/etl/tests/replication_stream.rs
@@ -40,6 +40,7 @@ enum StreamMarker {
     DdlMessage(PgLsn, u32, Option<String>, Vec<String>),
     Relation(u32, Vec<String>),
     Insert(u32),
+    Truncate(Vec<u32>),
     Commit(PgLsn),
 }
 
@@ -50,6 +51,7 @@ enum ExpectedStreamMarker {
     DdlMessage(u32, Option<String>, Vec<String>),
     Relation(u32, Vec<String>),
     Insert(u32),
+    Truncate(Vec<u32>),
     Commit,
 }
 
@@ -69,6 +71,7 @@ impl StreamMarker {
                 ExpectedStreamMarker::Relation(*table_id, columns.clone())
             }
             Self::Insert(table_id) => ExpectedStreamMarker::Insert(*table_id),
+            Self::Truncate(table_ids) => ExpectedStreamMarker::Truncate(table_ids.clone()),
             Self::Commit(_) => ExpectedStreamMarker::Commit,
         }
     }
@@ -148,6 +151,9 @@ async fn collect_stream_markers(
                 }
                 LogicalReplicationMessage::Insert(insert) => {
                     markers.push(StreamMarker::Insert(insert.rel_id()));
+                }
+                LogicalReplicationMessage::Truncate(truncate) => {
+                    markers.push(StreamMarker::Truncate(truncate.rel_ids().to_vec()));
                 }
                 _ => {}
             }
@@ -1573,6 +1579,117 @@ async fn logical_replication_omits_relation_after_noop_alter_table_commands() {
         ExpectedStreamMarker::Insert(table_id.into_inner()),
         ExpectedStreamMarker::Commit,
     ]);
+
+    assert_stream_markers_and_replay(
+        client,
+        initial_stream,
+        &database,
+        publication_name,
+        &slot_name,
+        start_lsn,
+        &expected,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn logical_replication_emits_relation_before_truncate() {
+    init_test_tracing();
+    let database = spawn_source_database().await;
+
+    let first_table_name = test_table_name("truncate_relation_first");
+    let second_table_name = test_table_name("truncate_relation_second");
+    let first_quoted = first_table_name.as_quoted_identifier();
+    let second_quoted = second_table_name.as_quoted_identifier();
+    let first_table_id = database
+        .create_table(
+            first_table_name.clone(),
+            true,
+            &[("name", "text not null"), ("age", "integer")],
+        )
+        .await
+        .unwrap();
+    let second_table_id = database
+        .create_table(
+            second_table_name.clone(),
+            true,
+            &[("name", "text not null"), ("age", "integer")],
+        )
+        .await
+        .unwrap();
+
+    let publication_name = "truncate_relation_pub";
+    database
+        .create_publication(
+            publication_name,
+            &[first_table_name.clone(), second_table_name.clone()],
+        )
+        .await
+        .unwrap();
+
+    let (client, initial_stream, slot_name, start_lsn) =
+        start_replayable_stream(&database, publication_name, "truncate_relation_slot").await;
+
+    // Warm pgoutput's relation cache for both tables.
+    database
+        .insert_values(first_table_name.clone(), &["name", "age"], &[&"before", &1])
+        .await
+        .unwrap();
+    database
+        .insert_values(second_table_name.clone(), &["name", "age"], &[&"before", &1])
+        .await
+        .unwrap();
+
+    // No-op DDL stores a new schema snapshot without invalidating pgoutput's
+    // relation cache. Truncate still emits a protocol relation per table
+    // before the truncate message, unlike a later insert.
+    database.run_sql(&format!("alter table {first_quoted} owner to current_user")).await.unwrap();
+    database.run_sql(&format!("alter table {second_quoted} owner to current_user")).await.unwrap();
+    database.run_sql(&format!("truncate table {first_quoted}, {second_quoted}")).await.unwrap();
+
+    // A schema change that adds a column invalidates the relation cache.
+    // Truncate still emits a protocol relation, now including the new column.
+    database.run_sql(&format!("alter table {first_quoted} add column email text")).await.unwrap();
+    database.truncate_table(first_table_name).await.unwrap();
+
+    let columns = vec!["id".to_owned(), "name".to_owned(), "age".to_owned()];
+    let columns_with_email =
+        vec!["id".to_owned(), "name".to_owned(), "age".to_owned(), "email".to_owned()];
+    let expected = vec![
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::Relation(first_table_id.into_inner(), columns.clone()),
+        ExpectedStreamMarker::Insert(first_table_id.into_inner()),
+        ExpectedStreamMarker::Commit,
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::Relation(second_table_id.into_inner(), columns.clone()),
+        ExpectedStreamMarker::Insert(second_table_id.into_inner()),
+        ExpectedStreamMarker::Commit,
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::DdlMessage(first_table_id.into_inner(), None, columns.clone()),
+        ExpectedStreamMarker::Commit,
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::DdlMessage(second_table_id.into_inner(), None, columns.clone()),
+        ExpectedStreamMarker::Commit,
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::Relation(first_table_id.into_inner(), columns.clone()),
+        ExpectedStreamMarker::Relation(second_table_id.into_inner(), columns.clone()),
+        ExpectedStreamMarker::Truncate(vec![
+            first_table_id.into_inner(),
+            second_table_id.into_inner(),
+        ]),
+        ExpectedStreamMarker::Commit,
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::DdlMessage(
+            first_table_id.into_inner(),
+            None,
+            columns_with_email.clone(),
+        ),
+        ExpectedStreamMarker::Commit,
+        ExpectedStreamMarker::Begin,
+        ExpectedStreamMarker::Relation(first_table_id.into_inner(), columns_with_email),
+        ExpectedStreamMarker::Truncate(vec![first_table_id.into_inner()]),
+        ExpectedStreamMarker::Commit,
+    ];
 
     assert_stream_markers_and_replay(
         client,


### PR DESCRIPTION
## Summary

Destinations require a `Relation` event as the schema barrier before they will accept rows at a newer snapshot. After no-op DDL (`ALTER TABLE ... OWNER TO`, redundant `DROP NOT NULL`, and similar), ETL stored a new schema snapshot and entered `PendingRelation`, but pgoutput did not send a protocol `RELATION` before the next insert. Row events then arrived with the new snapshot while destination metadata was still on the old one, and BigQuery (and other destinations) failed closed with `DestinationSchemaRewind`.

This change emits a destination `RelationEvent` when a pending schema snapshot is materialized for an insert, update, or delete that had no protocol relation. Truncate does not use that path: pgoutput always sends a protocol relation first.

## Why insert and truncate differ

Both go through pgoutput `maybe_send_schema`, which skips `RELATION` when `schema_sent` is already true.

- No-op DDL does not invalidate the relcache, so `schema_sent` stays true. The next insert has no protocol relation.
- Truncate assigns a new relfilenumber and updates `pg_class`, which invalidates the relcache, clears `schema_sent`, and sends one protocol relation per truncated table before the truncate payload.

## Changes

- Row decoding that materializes `PendingRelation` returns a schema barrier together with the row. `HandleMessageResult` carries `Option<(Event, Option<RelationEvent>)>`, so a synthesized relation cannot exist without an event. The barrier is written immediately before the row.
- Truncate requires an already-complete `WithSchema` decoder. Missing or still-pending state is an error; SyncDone is not used as a fallback decoder for truncate.
- Protocol test `logical_replication_emits_relation_before_truncate` records the raw pgoutput stream for no-op DDL then multi-table truncate, and for `ADD COLUMN` then truncate.
- Pipeline tests assert the destination sees the synthesized relation before the post-DDL insert, and the protocol relation before truncate.