### PR TITLE
fix(postgres): distinguish unknown from older server versions

### DIFF
--- a/crates/etl-postgres/src/version.rs
+++ b/crates/etl-postgres/src/version.rs
@@ -31,6 +31,14 @@ pub fn meets_version(server_version: Option<NonZeroI32>, required_version: i32) 
     server_version.is_some_and(|v| v.get() >= required_version)
 }
 
+/// Returns [`true`] if the known server version is below the required version.
+///
+/// An unavailable server version returns [`false`] so it is not classified as a
+/// known older version.
+pub fn is_below_version(server_version: Option<NonZeroI32>, required_version: i32) -> bool {
+    server_version.is_some_and(|v| v.get() < required_version)
+}
+
 /// Checks if the server version meets or exceeds the required version.
 ///
 /// This macro provides ergonomic version checking by accepting various input
@@ -46,11 +54,12 @@ macro_rules! requires_version {
 /// Checks if the server version is below the specified version.
 ///
 /// This macro is useful for conditional logic when features are not available
-/// in older PostgreSQL versions.
+/// in older PostgreSQL versions. It returns [`false`] when the server version
+/// is unavailable.
 #[macro_export]
 macro_rules! below_version {
     ($server_version:expr, $required:expr) => {
-        !$crate::version::meets_version($server_version, $required)
+        $crate::version::is_below_version($server_version, $required)
     };
 }
 
@@ -110,6 +119,13 @@ mod tests {
         assert!(below_version!(version, POSTGRES_16));
         assert!(below_version!(version, POSTGRES_17));
         assert!(below_version!(version, POSTGRES_18));
+    }
+
+    #[test]
+    fn below_version_with_none() {
+        let version: Option<NonZeroI32> = None;
+        assert!(!below_version!(version, POSTGRES_14));
+        assert!(!below_version!(version, POSTGRES_18));
     }
 
     #[test]

--- a/crates/etl-postgres/src/version.rs
+++ b/crates/etl-postgres/src/version.rs
@@ -31,14 +31,6 @@ pub fn meets_version(server_version: Option<NonZeroI32>, required_version: i32) 
     server_version.is_some_and(|v| v.get() >= required_version)
 }
 
-/// Returns [`true`] if the known server version is below the required version.
-///
-/// An unavailable server version returns [`false`] so it is not classified as a
-/// known older version.
-pub fn is_below_version(server_version: Option<NonZeroI32>, required_version: i32) -> bool {
-    server_version.is_some_and(|v| v.get() < required_version)
-}
-
 /// Checks if the server version meets or exceeds the required version.
 ///
 /// This macro provides ergonomic version checking by accepting various input
@@ -54,12 +46,13 @@ macro_rules! requires_version {
 /// Checks if the server version is below the specified version.
 ///
 /// This macro is useful for conditional logic when features are not available
-/// in older PostgreSQL versions. It returns [`false`] when the server version
-/// is unavailable.
+/// in older PostgreSQL versions. An unavailable server version is not
+/// considered below the required version, so this macro returns [`false`] for
+/// [`None`].
 #[macro_export]
 macro_rules! below_version {
     ($server_version:expr, $required:expr) => {
-        $crate::version::is_below_version($server_version, $required)
+        ($server_version).is_some_and(|version| version.get() < ($required))
     };
 }
 


### PR DESCRIPTION
## Summary

- Make `below_version!` return false when the server version is unavailable.
- Preserve compatibility fallbacks only for known older PostgreSQL versions.
- Prevent unknown versions from bypassing publication row and column filters during initial sync.