### PR TITLE
feat: replicate stored generated columns on Postgres 18

### DIFF
--- a/crates/etl-destinations/src/clickhouse/client.rs
+++ b/crates/etl-destinations/src/clickhouse/client.rs
@@ -762,6 +762,7 @@ mod tests {
             ordinal_position: 1,
             primary_key_ordinal_position: Some(1),
             nullable: false,
+            generated: false,
             default_expression: None,
         }
     }

--- a/crates/etl-destinations/src/clickhouse/core.rs
+++ b/crates/etl-destinations/src/clickhouse/core.rs
@@ -168,13 +168,18 @@ fn ensure_clickhouse_renames_are_supported(table_name: &str, plan: &SchemaPlan) 
 /// source default. ClickHouse cannot represent a top-level nullable array, so a
 /// replication-mask expansion containing an array fails instead of silently
 /// exposing empty arrays for historical rows.
+///
+/// A generated column follows the same rule regardless of why it appeared. It
+/// carries source values that predate its arrival in the destination, so
+/// treating it as a plain table-schema addition would backfill historical rows
+/// with an empty array rather than the values the source already holds.
 fn clickhouse_add_column_definition(
     table_name: &str,
     after_column_schema: &ColumnSchema,
     reason: ColumnPresenceChangeReason,
 ) -> EtlResult<(ColumnSchema, bool)> {
     let mut destination_column_schema = after_column_schema.clone();
-    if reason == ColumnPresenceChangeReason::ReplicationMask {
+    if reason == ColumnPresenceChangeReason::ReplicationMask || after_column_schema.generated {
         if is_array_type(&after_column_schema.typ) {
             return Err(etl_error!(
                 ErrorKind::SourceSchemaError,

--- a/crates/etl-destinations/src/clickhouse/schema.rs
+++ b/crates/etl-destinations/src/clickhouse/schema.rs
@@ -375,6 +375,7 @@ mod tests {
             ordinal_position: 1,
             primary_key_ordinal_position: Some(1),
             nullable: false,
+            generated: false,
             default_expression: None,
         }];
         // Pre-encoded table name with embedded quotes to verify the SQL
@@ -446,6 +447,7 @@ mod tests {
                 ordinal_position: 1,
                 primary_key_ordinal_position: Some(1),
                 nullable: false,
+                generated: false,
                 default_expression: None,
             },
             ColumnSchema {
@@ -455,6 +457,7 @@ mod tests {
                 ordinal_position: 2,
                 primary_key_ordinal_position: None,
                 nullable: true,
+                generated: false,
                 default_expression: None,
             },
         ];
@@ -543,6 +546,7 @@ mod tests {
             ordinal_position: 1,
             primary_key_ordinal_position: Some(1),
             nullable: false,
+            generated: false,
             default_expression: None,
         }];
         let sql = create_merge_tree_sql("public_t", &schemas);
@@ -561,6 +565,7 @@ mod tests {
             ordinal_position: 1,
             primary_key_ordinal_position: None,
             nullable: false,
+            generated: false,
             default_expression: None,
         }];
         let sql = create_merge_tree_sql("public_t", &schemas);
@@ -581,6 +586,7 @@ mod tests {
                 ordinal_position: 1,
                 primary_key_ordinal_position: Some(1),
                 nullable: false,
+                generated: false,
                 default_expression: None,
             },
             ColumnSchema {
@@ -590,6 +596,7 @@ mod tests {
                 ordinal_position: 2,
                 primary_key_ordinal_position: None,
                 nullable: true,
+                generated: false,
                 default_expression: None,
             },
         ];
@@ -615,6 +622,7 @@ mod tests {
                 ordinal_position: 1,
                 primary_key_ordinal_position: Some(2),
                 nullable: false,
+                generated: false,
                 default_expression: None,
             },
             ColumnSchema {
@@ -624,6 +632,7 @@ mod tests {
                 ordinal_position: 2,
                 primary_key_ordinal_position: None,
                 nullable: true,
+                generated: false,
                 default_expression: None,
             },
             ColumnSchema {
@@ -633,6 +642,7 @@ mod tests {
                 ordinal_position: 3,
                 primary_key_ordinal_position: Some(1),
                 nullable: false,
+                generated: false,
                 default_expression: None,
             },
         ];
@@ -655,6 +665,7 @@ mod tests {
             ordinal_position: 1,
             primary_key_ordinal_position: None,
             nullable: true,
+            generated: false,
             default_expression: None,
         }];
         // --- WHEN: build the ReplacingMergeTree DDL ---
@@ -673,6 +684,7 @@ mod tests {
             ordinal_position: 1,
             primary_key_ordinal_position: Some(1),
             nullable: false,
+            generated: false,
             default_expression: None,
         }];
         // --- WHEN/THEN: dispatcher selects the matching engine branch ---
@@ -695,6 +707,7 @@ mod tests {
                 ordinal_position: 1,
                 primary_key_ordinal_position: Some(1),
                 nullable: false,
+                generated: false,
                 default_expression: None,
             },
             ColumnSchema {
@@ -704,6 +717,7 @@ mod tests {
                 ordinal_position: 2,
                 primary_key_ordinal_position: None,
                 nullable: true,
+                generated: false,
                 default_expression: None,
             },
         ];

--- a/crates/etl-postgres/src/schema.rs
+++ b/crates/etl-postgres/src/schema.rs
@@ -308,7 +308,7 @@ pub fn numeric_modifiers(modifier: TypeModifier) -> Option<NumericModifiers> {
 ///
 /// This type contains all metadata about a column including its name, data
 /// type, type modifier, ordinal position, primary key information, nullability,
-/// and default expression.
+/// generation kind, and default expression.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ColumnSchema {
     /// The name of the column.
@@ -324,7 +324,18 @@ pub struct ColumnSchema {
     pub primary_key_ordinal_position: Option<i32>,
     /// Whether the column can contain NULL values.
     pub nullable: bool,
+    /// Whether the column is a Postgres stored generated column.
+    ///
+    /// A stored generated column only reaches the logical stream on Postgres 18
+    /// with `publish_generated_columns = stored`; otherwise it stays in the
+    /// table schema but out of the replication mask. Virtual generated columns
+    /// are never represented because they are absent from the WAL.
+    pub generated: bool,
     /// The source default expression for this column, if one is defined.
+    ///
+    /// Always [`None`] for a generated column: Postgres stores the generation
+    /// expression in `pg_attrdef`, and that expression is not a destination
+    /// default.
     pub default_expression: Option<String>,
 }
 
@@ -344,6 +355,7 @@ impl ColumnSchema {
             ordinal_position,
             primary_key_ordinal_position: None,
             nullable,
+            generated: false,
             default_expression: None,
         }
     }
@@ -362,6 +374,12 @@ impl ColumnSchema {
     /// Sets the optional primary key ordinal position for this column.
     pub fn with_primary_key_ordinal_position(mut self, ordinal_position: Option<i32>) -> Self {
         self.primary_key_ordinal_position = ordinal_position;
+        self
+    }
+
+    /// Sets whether this column is a stored generated column.
+    pub fn with_generated(mut self, generated: bool) -> Self {
+        self.generated = generated;
         self
     }
 
@@ -392,6 +410,7 @@ pub struct ColumnSchemaBuilder {
     ordinal_position: i32,
     primary_key_ordinal_position: Option<i32>,
     nullable: bool,
+    generated: bool,
     default_expression: Option<String>,
 }
 
@@ -405,6 +424,7 @@ impl ColumnSchemaBuilder {
             ordinal_position,
             primary_key_ordinal_position: None,
             nullable: true,
+            generated: false,
             default_expression: None,
         }
     }
@@ -439,6 +459,12 @@ impl ColumnSchemaBuilder {
         self
     }
 
+    /// Marks the column as a stored generated column.
+    pub fn generated(mut self, generated: bool) -> Self {
+        self.generated = generated;
+        self
+    }
+
     /// Sets the source default expression for this column.
     pub fn default_expression(mut self, default_expression: String) -> Self {
         self.default_expression = Some(default_expression);
@@ -460,6 +486,7 @@ impl ColumnSchemaBuilder {
             ordinal_position: self.ordinal_position,
             primary_key_ordinal_position: self.primary_key_ordinal_position,
             nullable: self.nullable,
+            generated: self.generated,
             default_expression: self.default_expression,
         }
     }
@@ -614,7 +641,28 @@ mod tests {
         assert_eq!(schema.ordinal_position, 3);
         assert_eq!(schema.primary_key_ordinal_position, Some(1));
         assert!(!schema.nullable);
+        assert!(!schema.generated);
         assert_eq!(schema.default_expression.as_deref(), Some("'new'::text"));
+    }
+
+    #[test]
+    fn column_schema_defaults_to_not_generated() {
+        let schema = ColumnSchema::new("height_cm".to_owned(), Type::NUMERIC, -1, 2, true);
+
+        assert!(!schema.generated);
+        assert!(!ColumnSchema::builder("height_cm".to_owned(), Type::NUMERIC, 2).build().generated);
+    }
+
+    #[test]
+    fn column_schema_marks_generated_columns() {
+        let schema =
+            ColumnSchema::new("height_in".to_owned(), Type::NUMERIC, -1, 3, true).with_generated(true);
+        let built = ColumnSchema::builder("height_in".to_owned(), Type::NUMERIC, 3)
+            .generated(true)
+            .build();
+
+        assert!(schema.generated);
+        assert!(built.generated);
     }
 
     #[test]

--- a/crates/etl-postgres/src/store/schema.rs
+++ b/crates/etl-postgres/src/store/schema.rs
@@ -282,8 +282,8 @@ pub async fn store_table_schema(
             r#"
             insert into etl.table_columns
             (table_schema_id, column_name, column_type, type_modifier, nullable,
-             ordinal_position, primary_key_ordinal_position, default_expression)
-            values ($1, $2, $3, $4, $5, $6, $7, $8)
+             ordinal_position, primary_key_ordinal_position, generated, default_expression)
+            values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             "#,
         )
         .bind(table_schema_id)
@@ -293,6 +293,7 @@ pub async fn store_table_schema(
         .bind(column_schema.nullable)
         .bind(column_schema.ordinal_position)
         .bind(column_schema.primary_key_ordinal_position)
+        .bind(column_schema.generated)
         .bind(&column_schema.default_expression)
         .execute(&mut *tx)
         .await?;
@@ -345,6 +346,7 @@ pub async fn load_table_schema_at_snapshot(
             tc.nullable,
             tc.ordinal_position,
             tc.primary_key_ordinal_position,
+            tc.generated,
             tc.default_expression
         from etl.table_schemas ts
         inner join etl.table_columns tc on ts.id = tc.table_schema_id
@@ -446,6 +448,7 @@ pub async fn load_table_schemas_at_snapshot(
             tc.nullable,
             tc.ordinal_position,
             tc.primary_key_ordinal_position,
+            tc.generated,
             tc.default_expression
         from latest_schemas ls
         inner join etl.table_columns tc on ls.id = tc.table_schema_id
@@ -625,6 +628,7 @@ fn parse_column_schema(row: &PgRow) -> ColumnSchema {
     let ordinal_position: i32 = row.get("ordinal_position");
     let primary_key_ordinal_position: Option<i32> = row.get("primary_key_ordinal_position");
     let nullable: bool = row.get("nullable");
+    let generated: bool = row.get("generated");
     let default_expression: Option<String> = row.get("default_expression");
 
     ColumnSchema::new(
@@ -635,6 +639,7 @@ fn parse_column_schema(row: &PgRow) -> ColumnSchema {
         nullable,
     )
     .with_primary_key_ordinal_position(primary_key_ordinal_position)
+    .with_generated(generated)
     .with_default_expression_option(default_expression)
 }
 

--- a/crates/etl/migrations/postgres_store/20260908120000_table_column_generated.down.sql
+++ b/crates/etl/migrations/postgres_store/20260908120000_table_column_generated.down.sql
@@ -1,0 +1,10 @@
+-- Drops the stored generated-column flag.
+--
+-- Stored schemas become indistinguishable from non-generated ones, so the
+-- replication-mask fallbacks would treat generated columns as replicated and
+-- fail row decoding. Before running this down, revert the matching source
+-- migration so `etl.describe_table_schema` stops returning generated columns,
+-- and reset every publication to `publish_generated_columns = none`.
+
+alter table etl.table_columns
+    drop column if exists generated;

--- a/crates/etl/migrations/postgres_store/20260908120000_table_column_generated.up.sql
+++ b/crates/etl/migrations/postgres_store/20260908120000_table_column_generated.up.sql
@@ -1,0 +1,10 @@
+-- Records whether a stored table column is a PostgreSQL stored generated column.
+--
+-- Existing rows are correctly false: they were snapshotted by a
+-- `etl.describe_table_schema` version that excluded generated columns entirely,
+-- so no stored row can describe one. The constant default avoids a table
+-- rewrite and keeps the column readable by the previous release, which simply
+-- ignores it.
+
+alter table etl.table_columns
+    add column if not exists generated boolean not null default false;

--- a/crates/etl/migrations/source/20260908120000_generated_column_snapshots.down.sql
+++ b/crates/etl/migrations/source/20260908120000_generated_column_snapshots.down.sql
@@ -1,0 +1,311 @@
+-- Revert stored generated columns from table schema snapshots.
+--
+-- Restores the pre-generated-column `etl.describe_table_schema` OUT column list
+-- and filter, and the emitter payload that goes with it.
+--
+-- Run this only after resetting every publication to
+-- `publish_generated_columns = none`. Otherwise `pg_publication_tables.attnames`
+-- still reports a stored generated column that the restored snapshot omits, and
+-- building the replication mask fails with an unknown replicated column.
+
+drop function if exists etl.describe_table_schema(pg_catalog.oid);
+
+create function etl.describe_table_schema(
+    p_table pg_catalog.oid
+) returns table (
+    attname pg_catalog.text,
+    attnum pg_catalog.int4,
+    atttypid pg_catalog.oid,
+    typname pg_catalog.text,
+    formatted_type pg_catalog.text,
+    atttypmod pg_catalog.int4,
+    attnotnull pg_catalog.bool,
+    atthasdef pg_catalog.bool,
+    default_expression pg_catalog.text,
+    attidentity pg_catalog.text,
+    atthasmissing pg_catalog.bool
+)
+language sql
+stable
+strict
+set search_path = pg_catalog
+as
+$fnc$
+select
+    a.attname::pg_catalog.text,
+    a.attnum::pg_catalog.int4,
+    a.atttypid,
+    t.typname::pg_catalog.text,
+    pg_catalog.format_type(a.atttypid, a.atttypmod)::pg_catalog.text,
+    a.atttypmod::pg_catalog.int4,
+    a.attnotnull,
+    a.atthasdef,
+    case
+        when a.atthasdef then pg_catalog.pg_get_expr(ad.adbin, ad.adrelid)::pg_catalog.text
+        else null
+    end,
+    nullif(a.attidentity, '')::pg_catalog.text,
+    a.atthasmissing
+from pg_catalog.pg_attribute a
+join pg_catalog.pg_type t
+  on t.oid = a.atttypid
+left join pg_catalog.pg_attrdef ad
+  on ad.adrelid = a.attrelid
+ and ad.adnum = a.attnum
+where a.attrelid = p_table
+  and a.attnum > 0
+  and not a.attisdropped
+  and a.attgenerated = ''
+order by a.attnum;
+$fnc$;
+
+revoke all on function etl.describe_table_schema(pg_catalog.oid) from public;
+
+comment on function etl.describe_table_schema(pg_catalog.oid) is
+$$Returns the visible, non-generated column snapshot for one table after DDL has
+been applied.
+
+The result stays close to PostgreSQL catalog naming so the emitted JSON can act
+as a source-native snapshot rather than an ETL-specific schema representation.$$;
+
+create or replace function etl.emit_schema_change_messages()
+returns pg_catalog.event_trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as
+$fnc$
+declare
+    r record;
+    v_schema_json pg_catalog.jsonb;
+    v_identity_json pg_catalog.jsonb;
+    v_msg_json pg_catalog.jsonb;
+    v_statement_text pg_catalog.text;
+begin
+    if coalesce(pg_catalog.current_setting('supabase_etl.skip_ddl_log', true), 'false')::pg_catalog.bool then
+        return;
+    end if;
+
+    -- Without logical WAL there is no downstream consumer for emitted messages.
+    if pg_catalog.current_setting('wal_level', true) is distinct from 'logical' then
+        return;
+    end if;
+
+    -- `current_query()` is for observability only. It is the client-submitted
+    -- text and may include more than one statement.
+    v_statement_text := pg_catalog.current_query();
+
+    for r in
+        with event_commands as (
+            select
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                addr.type as object_address_type,
+                addr.object_names as object_address_names,
+                addr.object_args as object_address_args
+            from pg_catalog.pg_event_trigger_ddl_commands() d
+            left join lateral pg_catalog.pg_identify_object_as_address(
+                d.classid,
+                d.objid,
+                d.objsubid
+            )
+                as addr(type, object_names, object_args)
+                on true
+            where d.objid is not null
+              and not coalesce(d.in_extension, false)
+        ),
+        base as (
+            -- ALTER TABLE identifies the relation directly and is intentionally
+            -- unscoped: a table change applies to every publication containing
+            -- that table. Per-table ALTER PUBLICATION events instead identify a
+            -- surviving pg_publication_rel row, from which both relation and
+            -- publication are resolved. This branch uses only the explicitly
+            -- identified relation; it does not expand partition roots into their
+            -- effective leaf relations.
+            select
+                coalesce(pr.prrelid, d.objid) as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            left join pg_catalog.pg_publication_rel pr
+              on d.classid = 'pg_catalog.pg_publication_rel'::pg_catalog.regclass
+             and d.objid = pr.oid
+            left join pg_catalog.pg_publication p
+              on p.oid = pr.prpubid
+            where (
+                  d.object_type in ('table', 'table column')
+                  or pr.prrelid is not null
+              )
+            union all
+            -- Publication-level ALTER PUBLICATION events identify pg_publication
+            -- itself rather than a specific relation. The command parameters are
+            -- not inspected; every such event expands the publication's post-DDL
+            -- effective table set so each table receives a scoped snapshot.
+            select
+                c.oid as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            join pg_catalog.pg_publication p
+              on d.classid = 'pg_catalog.pg_publication'::pg_catalog.regclass
+             and d.objid = p.oid
+            join pg_catalog.pg_publication_tables pt
+              on pt.pubname = p.pubname
+            join pg_catalog.pg_namespace n
+              on n.nspname = pt.schemaname
+            join pg_catalog.pg_class c
+              on c.relnamespace = n.oid
+             and c.relname = pt.tablename
+        ),
+        ddl as (
+            select
+                b.table_oid,
+                b.publication_name,
+                pg_catalog.jsonb_agg(
+                    pg_catalog.jsonb_build_object(
+                        'classid', b.classid::pg_catalog.int8,
+                        'objid', b.objid::pg_catalog.int8,
+                        'objsubid', b.objsubid,
+                        'command_tag', b.command_tag,
+                        'object_type', b.object_type,
+                        'schema_name', b.schema_name,
+                        'object_identity', b.object_identity,
+                        'object_address_type', b.object_address_type,
+                        'object_address_names', b.object_address_names,
+                        'object_address_args', b.object_address_args
+                    )
+                    order by
+                        b.objsubid,
+                        b.classid,
+                        b.command_tag,
+                        b.object_type,
+                        b.schema_name,
+                        b.object_identity
+                ) as commands
+            from base b
+            group by b.table_oid, b.publication_name
+        )
+        select
+            c.oid as table_oid,
+            n.nspname,
+            c.relname,
+            c.relkind::pg_catalog.text as relkind,
+            ddl.publication_name,
+            ddl.commands
+        from ddl
+        join pg_catalog.pg_class c
+          on c.oid = ddl.table_oid
+        join pg_catalog.pg_namespace n
+          on n.oid = c.relnamespace
+        where c.relkind in ('r', 'p')
+          and c.relpersistence = 'p'
+          and exists (
+              -- Keep only relations that are effective in at least one
+              -- publication in this transaction's post-command catalog state.
+              select 1
+              from pg_catalog.pg_publication_tables pt
+              where pt.schemaname = n.nspname
+                and pt.tablename = c.relname
+          )
+        -- Make multi-table schema-message order deterministic.
+        order by c.oid
+    loop
+        select pg_catalog.jsonb_agg(
+            pg_catalog.jsonb_build_object(
+                'attname', s.attname,
+                'attnum', s.attnum,
+                'atttypid', s.atttypid::pg_catalog.int8,
+                'typname', s.typname,
+                'formatted_type', s.formatted_type,
+                'atttypmod', s.atttypmod,
+                'attnotnull', s.attnotnull,
+                'atthasdef', s.atthasdef,
+                'default_expression', s.default_expression,
+                'attidentity', s.attidentity,
+                'atthasmissing', s.atthasmissing
+            )
+            order by s.attnum
+        )
+        into v_schema_json
+        from etl.describe_table_schema(r.table_oid) s;
+
+        if v_schema_json is null then
+            continue;
+        end if;
+
+        select etl.describe_table_identity(r.table_oid)
+        into v_identity_json;
+
+        v_msg_json := pg_catalog.jsonb_build_object(
+            'trigger_event', tg_event,
+            'command_tag', tg_tag,
+            'current_query', v_statement_text,
+            'current_database', pg_catalog.current_database(),
+            'server_version_num', pg_catalog.current_setting('server_version_num')::pg_catalog.int4,
+            'nspname', r.nspname,
+            'relname', r.relname,
+            'oid', r.table_oid::pg_catalog.int8,
+            'relkind', r.relkind,
+            'commands', r.commands,
+            'identity', v_identity_json,
+            'columns', v_schema_json
+        );
+
+        if r.publication_name is not null then
+            v_msg_json := v_msg_json || pg_catalog.jsonb_build_object(
+                'publication_name', r.publication_name
+            );
+        end if;
+
+        perform pg_catalog.pg_logical_emit_message(
+            true,
+            'supabase_etl_ddl',
+            pg_catalog.convert_to(v_msg_json::pg_catalog.text, 'utf8')
+        );
+    end loop;
+end;
+$fnc$;
+
+revoke all on function etl.emit_schema_change_messages() from public;
+
+comment on function etl.emit_schema_change_messages() is
+$$Event trigger function that emits transactional logical schema snapshots for
+published permanent tables affected by supported ALTER TABLE and ALTER
+PUBLICATION events.
+
+ALTER TABLE events identify a relation directly and emit an unscoped snapshot.
+Surviving pg_publication_rel events resolve one explicitly identified relation
+and emit a snapshot scoped to that publication. Events identifying
+pg_publication itself expand the publication's post-command effective table set
+and emit one scoped snapshot per table. Other ALTER PUBLICATION catalog object
+types and removed pg_publication_rel rows emit no snapshots.
+
+The function inspects catalog state after each statement without parsing the
+client-submitted query text. Messages are transactional, disappear if the outer
+transaction rolls back, and retain statement order relative to relation and DML
+events. The function runs with its owner's privileges so table owners do not
+need direct execute access to ETL helper functions.$$;
+

--- a/crates/etl/migrations/source/20260908120000_generated_column_snapshots.up.sql
+++ b/crates/etl/migrations/source/20260908120000_generated_column_snapshots.up.sql
@@ -1,0 +1,343 @@
+-- Include stored generated columns in table schema snapshots.
+--
+-- This supersedes the `20260415100000` note that generated columns are
+-- intentionally omitted. PostgreSQL 18 added
+-- `publish_generated_columns = stored`, which puts stored generated columns in
+-- the logical stream, so ETL must be able to describe them. Columns are
+-- reported on every supported version; the replication mask, built from
+-- `pg_publication_tables.attnames` and from RELATION messages, decides whether
+-- a column actually replicates. On earlier versions the mask simply keeps them
+-- out, which reproduces the previous behavior.
+--
+-- Virtual generated columns (`attgenerated = 'v'`) stay excluded. They are
+-- never written to the WAL and can never be published, so representing them
+-- could only ever produce a permanently unreplicated column.
+--
+-- `default_expression` is forced to null for generated columns. PostgreSQL
+-- stores the generation expression in `pg_attrdef` and sets `atthasdef`, but a
+-- generation expression is not a column default and must never reach a
+-- destination as `DEFAULT`. `atthasdef` itself stays catalog-faithful because
+-- the payload is documented as a source-shaped snapshot, and the new
+-- `attgenerated` field disambiguates the resulting `atthasdef = true` with a
+-- null expression.
+--
+-- `etl.describe_table_schema` is dropped and recreated rather than replaced:
+-- `create or replace` cannot change a function's OUT column list. No `cascade`
+-- is needed because PostgreSQL records no dependency from a PL/pgSQL function
+-- body, so the event trigger function is not a dependent object. The event
+-- trigger itself is left in place; only the emitter body changes, which
+-- `create or replace` handles.
+
+drop function if exists etl.describe_table_schema(pg_catalog.oid);
+
+create function etl.describe_table_schema(
+    p_table pg_catalog.oid
+) returns table (
+    attname pg_catalog.text,
+    attnum pg_catalog.int4,
+    atttypid pg_catalog.oid,
+    typname pg_catalog.text,
+    formatted_type pg_catalog.text,
+    atttypmod pg_catalog.int4,
+    attnotnull pg_catalog.bool,
+    atthasdef pg_catalog.bool,
+    default_expression pg_catalog.text,
+    attidentity pg_catalog.text,
+    attgenerated pg_catalog.text,
+    atthasmissing pg_catalog.bool
+)
+language sql
+stable
+strict
+set search_path = pg_catalog
+as
+$fnc$
+select
+    a.attname::pg_catalog.text,
+    a.attnum::pg_catalog.int4,
+    a.atttypid,
+    t.typname::pg_catalog.text,
+    pg_catalog.format_type(a.atttypid, a.atttypmod)::pg_catalog.text,
+    a.atttypmod::pg_catalog.int4,
+    a.attnotnull,
+    a.atthasdef,
+    case
+        when a.attgenerated <> '' then null
+        when a.atthasdef then pg_catalog.pg_get_expr(ad.adbin, ad.adrelid)::pg_catalog.text
+        else null
+    end,
+    nullif(a.attidentity, '')::pg_catalog.text,
+    nullif(a.attgenerated, '')::pg_catalog.text,
+    a.atthasmissing
+from pg_catalog.pg_attribute a
+join pg_catalog.pg_type t
+  on t.oid = a.atttypid
+left join pg_catalog.pg_attrdef ad
+  on ad.adrelid = a.attrelid
+ and ad.adnum = a.attnum
+where a.attrelid = p_table
+  and a.attnum > 0
+  and not a.attisdropped
+  and a.attgenerated in ('', 's')
+order by a.attnum;
+$fnc$;
+
+revoke all on function etl.describe_table_schema(pg_catalog.oid) from public;
+
+comment on function etl.describe_table_schema(pg_catalog.oid) is
+$$Returns the visible column snapshot for one table after DDL has been applied,
+including stored generated columns and excluding virtual generated ones.
+
+`attgenerated` reports the generation kind, and `default_expression` is null for
+generated columns because their `pg_attrdef` entry holds a generation expression
+rather than a column default.
+
+The result stays close to PostgreSQL catalog naming so the emitted JSON can act
+as a source-native snapshot rather than an ETL-specific schema representation.$$;
+
+create or replace function etl.emit_schema_change_messages()
+returns pg_catalog.event_trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as
+$fnc$
+declare
+    r record;
+    v_schema_json pg_catalog.jsonb;
+    v_identity_json pg_catalog.jsonb;
+    v_msg_json pg_catalog.jsonb;
+    v_statement_text pg_catalog.text;
+begin
+    if coalesce(pg_catalog.current_setting('supabase_etl.skip_ddl_log', true), 'false')::pg_catalog.bool then
+        return;
+    end if;
+
+    -- Without logical WAL there is no downstream consumer for emitted messages.
+    if pg_catalog.current_setting('wal_level', true) is distinct from 'logical' then
+        return;
+    end if;
+
+    -- `current_query()` is for observability only. It is the client-submitted
+    -- text and may include more than one statement.
+    v_statement_text := pg_catalog.current_query();
+
+    for r in
+        with event_commands as (
+            select
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                addr.type as object_address_type,
+                addr.object_names as object_address_names,
+                addr.object_args as object_address_args
+            from pg_catalog.pg_event_trigger_ddl_commands() d
+            left join lateral pg_catalog.pg_identify_object_as_address(
+                d.classid,
+                d.objid,
+                d.objsubid
+            )
+                as addr(type, object_names, object_args)
+                on true
+            where d.objid is not null
+              and not coalesce(d.in_extension, false)
+        ),
+        base as (
+            -- ALTER TABLE identifies the relation directly and is intentionally
+            -- unscoped: a table change applies to every publication containing
+            -- that table. Per-table ALTER PUBLICATION events instead identify a
+            -- surviving pg_publication_rel row, from which both relation and
+            -- publication are resolved. This branch uses only the explicitly
+            -- identified relation; it does not expand partition roots into their
+            -- effective leaf relations.
+            select
+                coalesce(pr.prrelid, d.objid) as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            left join pg_catalog.pg_publication_rel pr
+              on d.classid = 'pg_catalog.pg_publication_rel'::pg_catalog.regclass
+             and d.objid = pr.oid
+            left join pg_catalog.pg_publication p
+              on p.oid = pr.prpubid
+            where (
+                  d.object_type in ('table', 'table column')
+                  or pr.prrelid is not null
+              )
+            union all
+            -- Publication-level ALTER PUBLICATION events identify pg_publication
+            -- itself rather than a specific relation. The command parameters are
+            -- not inspected; every such event expands the publication's post-DDL
+            -- effective table set so each table receives a scoped snapshot.
+            select
+                c.oid as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            join pg_catalog.pg_publication p
+              on d.classid = 'pg_catalog.pg_publication'::pg_catalog.regclass
+             and d.objid = p.oid
+            join pg_catalog.pg_publication_tables pt
+              on pt.pubname = p.pubname
+            join pg_catalog.pg_namespace n
+              on n.nspname = pt.schemaname
+            join pg_catalog.pg_class c
+              on c.relnamespace = n.oid
+             and c.relname = pt.tablename
+        ),
+        ddl as (
+            select
+                b.table_oid,
+                b.publication_name,
+                pg_catalog.jsonb_agg(
+                    pg_catalog.jsonb_build_object(
+                        'classid', b.classid::pg_catalog.int8,
+                        'objid', b.objid::pg_catalog.int8,
+                        'objsubid', b.objsubid,
+                        'command_tag', b.command_tag,
+                        'object_type', b.object_type,
+                        'schema_name', b.schema_name,
+                        'object_identity', b.object_identity,
+                        'object_address_type', b.object_address_type,
+                        'object_address_names', b.object_address_names,
+                        'object_address_args', b.object_address_args
+                    )
+                    order by
+                        b.objsubid,
+                        b.classid,
+                        b.command_tag,
+                        b.object_type,
+                        b.schema_name,
+                        b.object_identity
+                ) as commands
+            from base b
+            group by b.table_oid, b.publication_name
+        )
+        select
+            c.oid as table_oid,
+            n.nspname,
+            c.relname,
+            c.relkind::pg_catalog.text as relkind,
+            ddl.publication_name,
+            ddl.commands
+        from ddl
+        join pg_catalog.pg_class c
+          on c.oid = ddl.table_oid
+        join pg_catalog.pg_namespace n
+          on n.oid = c.relnamespace
+        where c.relkind in ('r', 'p')
+          and c.relpersistence = 'p'
+          and exists (
+              -- Keep only relations that are effective in at least one
+              -- publication in this transaction's post-command catalog state.
+              select 1
+              from pg_catalog.pg_publication_tables pt
+              where pt.schemaname = n.nspname
+                and pt.tablename = c.relname
+          )
+        -- Make multi-table schema-message order deterministic.
+        order by c.oid
+    loop
+        select pg_catalog.jsonb_agg(
+            pg_catalog.jsonb_build_object(
+                'attname', s.attname,
+                'attnum', s.attnum,
+                'atttypid', s.atttypid::pg_catalog.int8,
+                'typname', s.typname,
+                'formatted_type', s.formatted_type,
+                'atttypmod', s.atttypmod,
+                'attnotnull', s.attnotnull,
+                'atthasdef', s.atthasdef,
+                'default_expression', s.default_expression,
+                'attidentity', s.attidentity,
+                'attgenerated', s.attgenerated,
+                'atthasmissing', s.atthasmissing
+            )
+            order by s.attnum
+        )
+        into v_schema_json
+        from etl.describe_table_schema(r.table_oid) s;
+
+        if v_schema_json is null then
+            continue;
+        end if;
+
+        select etl.describe_table_identity(r.table_oid)
+        into v_identity_json;
+
+        v_msg_json := pg_catalog.jsonb_build_object(
+            'trigger_event', tg_event,
+            'command_tag', tg_tag,
+            'current_query', v_statement_text,
+            'current_database', pg_catalog.current_database(),
+            'server_version_num', pg_catalog.current_setting('server_version_num')::pg_catalog.int4,
+            'nspname', r.nspname,
+            'relname', r.relname,
+            'oid', r.table_oid::pg_catalog.int8,
+            'relkind', r.relkind,
+            'commands', r.commands,
+            'identity', v_identity_json,
+            'columns', v_schema_json
+        );
+
+        if r.publication_name is not null then
+            v_msg_json := v_msg_json || pg_catalog.jsonb_build_object(
+                'publication_name', r.publication_name
+            );
+        end if;
+
+        perform pg_catalog.pg_logical_emit_message(
+            true,
+            'supabase_etl_ddl',
+            pg_catalog.convert_to(v_msg_json::pg_catalog.text, 'utf8')
+        );
+    end loop;
+end;
+$fnc$;
+
+revoke all on function etl.emit_schema_change_messages() from public;
+
+comment on function etl.emit_schema_change_messages() is
+$$Event trigger function that emits transactional logical schema snapshots for
+published permanent tables affected by supported ALTER TABLE and ALTER
+PUBLICATION events.
+
+ALTER TABLE events identify a relation directly and emit an unscoped snapshot.
+Surviving pg_publication_rel events resolve one explicitly identified relation
+and emit a snapshot scoped to that publication. Events identifying
+pg_publication itself expand the publication's post-command effective table set
+and emit one scoped snapshot per table. Other ALTER PUBLICATION catalog object
+types and removed pg_publication_rel rows emit no snapshots.
+
+Column payloads carry `attgenerated` so consumers can tell stored generated
+columns apart from ordinary ones. Because publication-level events expand the
+whole effective table set, changing `publish_generated_columns` emits a fresh
+snapshot per table without requiring a resynchronization.
+
+The function inspects catalog state after each statement without parsing the
+client-submitted query text. Messages are transactional, disappear if the outer
+transaction rolls back, and retain statement order relative to relation and DML
+events. The function runs with its owner's privileges so table owners do not
+need direct execute access to ETL helper functions.$$;

--- a/crates/etl/src/postgres/client/transaction.rs
+++ b/crates/etl/src/postgres/client/transaction.rs
@@ -4,7 +4,6 @@ use etl_postgres::{below_version, version::POSTGRES_15};
 use pg_escape::{quote_identifier, quote_literal};
 use tokio::sync::watch;
 use tokio_postgres::{CopyOutStream, SimpleQueryMessage, Transaction};
-use tracing::warn;
 
 use super::{
     child::ChildPgReplicationClient,
@@ -20,6 +19,22 @@ use crate::{
     postgres::codec::{ColumnSchemaMessage, IdentityMessage, build_table_schema},
     schema::{ColumnSchema, SnapshotId, TableId, TableName, TableSchema},
 };
+
+/// Returns the names of the columns Postgres can publish for a table.
+///
+/// Generated columns are excluded because they only reach the logical stream on
+/// Postgres 18 with `publish_generated_columns = stored`, which the catalog
+/// reports through `pg_publication_tables.attnames`. Treating them as
+/// replicated on a server that cannot report that would widen the replication
+/// mask past the tuple width and fail decoding on the first row event.
+fn replicable_column_names(table_schema: &TableSchema) -> HashSet<String> {
+    table_schema
+        .column_schemas
+        .iter()
+        .filter(|column_schema| !column_schema.generated)
+        .map(|column_schema| column_schema.name.clone())
+        .collect()
+}
 
 /// Builds a `COPY ... TO STDOUT` query that selects rows within a ctid range.
 ///
@@ -265,13 +280,9 @@ impl<'a> PgReplicationTransactionCore<'a> {
         publication_name: &str,
     ) -> EtlResult<HashSet<String>> {
         // Column filtering in publications was added in Postgres 15. For earlier
-        // versions, all columns are replicated.
+        // versions, every replicable column is replicated.
         if below_version!(self.server_version, POSTGRES_15) {
-            return Ok(table_schema
-                .column_schemas
-                .iter()
-                .map(|column_schema| column_schema.name.clone())
-                .collect());
+            return Ok(replicable_column_names(table_schema));
         }
 
         // Query pg_publication_tables using unnest() to properly decode the attnames
@@ -316,11 +327,7 @@ impl<'a> PgReplicationTransactionCore<'a> {
         }
 
         if column_names.is_empty() {
-            return Ok(table_schema
-                .column_schemas
-                .iter()
-                .map(|column_schema| column_schema.name.clone())
-                .collect());
+            return Ok(replicable_column_names(table_schema));
         }
 
         Ok(column_names)
@@ -525,49 +532,11 @@ impl<'a> PgReplicationTransactionCore<'a> {
         );
     }
 
-    /// Warns when the source table contains generated columns.
-    async fn warn_if_generated_columns_exist(&self, table_id: TableId) -> EtlResult<()> {
-        let generated_columns_check_query = format!(
-            r#"select exists (
-                select 1
-                from pg_attribute
-                where attrelid = {table_id}
-                    and attnum > 0
-                    and not attisdropped
-                    and attgenerated != ''
-            ) as has_generated;"#
-        );
-
-        for message in self.transaction.simple_query(&generated_columns_check_query).await? {
-            if let SimpleQueryMessage::Row(row) = message {
-                let has_generated_columns =
-                    get_row_value::<String>(&row, "has_generated", "pg_attribute")? == "t";
-                if has_generated_columns {
-                    warn!(
-                        "table {} contains generated columns that will not be replicated. \
-                         generated columns are not supported in postgres logical replication and \
-                         will be excluded from the etl schema. these columns will not appear in \
-                         the destination.",
-                        table_id
-                    );
-                }
-
-                // Explicity break for clarity; this query returns a single
-                // SimpleQueryMessage::Row.
-                break;
-            }
-        }
-
-        Ok(())
-    }
-
     /// Retrieves the raw schema snapshot.
     async fn get_table_schema_snapshot(
         &self,
         table_id: TableId,
     ) -> EtlResult<(TableName, Vec<ColumnSchemaMessage>, IdentityMessage)> {
-        self.warn_if_generated_columns_exist(table_id).await?;
-
         let schema_snapshot_query = format!(
             r#"
             with table_info as (
@@ -587,6 +556,7 @@ impl<'a> PgReplicationTransactionCore<'a> {
                             'atttypid', s.atttypid::pg_catalog.int8,
                             'atttypmod', s.atttypmod,
                             'attnotnull', s.attnotnull,
+                            'attgenerated', s.attgenerated,
                             'default_expression', s.default_expression
                         )
                         order by s.attnum

--- a/crates/etl/src/postgres/codec/event.rs
+++ b/crates/etl/src/postgres/codec/event.rs
@@ -218,6 +218,13 @@ pub(crate) struct ColumnSchemaMessage {
     pub(crate) attnum: i32,
     /// Whether the column is marked `NOT NULL` in `pg_attribute.attnotnull`.
     pub(crate) attnotnull: bool,
+    /// The generation kind from `pg_attribute.attgenerated`, or [`None`] when
+    /// the column is not generated.
+    ///
+    /// Defaulted because messages emitted before generated-column support have
+    /// no such key, and those still replay from the WAL after an upgrade.
+    #[serde(default)]
+    pub(crate) attgenerated: Option<String>,
     /// The default expression from `pg_attrdef`, if one exists.
     pub(crate) default_expression: Option<String>,
 }
@@ -246,6 +253,11 @@ pub(crate) fn build_column_schemas(
         .into_iter()
         .map(|column| {
             let typ = convert_type_oid_to_type(column.atttypid);
+            // Any generation kind counts as generated. The source snapshot only
+            // reports stored columns, so treating an unexpected kind as generated
+            // keeps it out of the replication mask instead of widening it past the
+            // tuple width.
+            let generated = column.attgenerated.is_some();
             ColumnSchema::new(
                 column.attname,
                 typ,
@@ -254,6 +266,7 @@ pub(crate) fn build_column_schemas(
                 !column.attnotnull,
             )
             .with_primary_key_ordinal_position(primary_key_positions.get(&column.attnum).copied())
+            .with_generated(generated)
             .with_default_expression_option(column.default_expression)
         })
         .collect()

--- a/crates/etl/src/replication/table_sync/mod.rs
+++ b/crates/etl/src/replication/table_sync/mod.rs
@@ -35,6 +35,44 @@ use crate::{
     store::{PipelineStore, SchemaStore, StateStore},
 };
 
+/// Warns when a table has stored generated columns that do not replicate.
+///
+/// A stored generated column stays in the table schema on every version but
+/// only enters the replication mask on Postgres 18 with
+/// `publish_generated_columns = stored`. Anything left out of the mask never
+/// reaches the destination, so the operator needs to know which columns those
+/// are.
+fn warn_if_generated_columns_unreplicated(
+    table_id: TableId,
+    replicated_table_schema: &ReplicatedTableSchema,
+) {
+    let replicated_names = replicated_table_schema
+        .column_schemas()
+        .map(|column_schema| column_schema.name.as_str())
+        .collect::<Vec<_>>();
+    let unreplicated_generated_columns = replicated_table_schema
+        .inner()
+        .column_schemas
+        .iter()
+        .filter(|column_schema| {
+            column_schema.generated && !replicated_names.contains(&column_schema.name.as_str())
+        })
+        .map(|column_schema| column_schema.name.as_str())
+        .collect::<Vec<_>>();
+
+    if unreplicated_generated_columns.is_empty() {
+        return;
+    }
+
+    warn!(
+        %table_id,
+        columns = %unreplicated_generated_columns.join(","),
+        "table has generated columns that are not published and will not appear in the \
+         destination. postgres 18 can publish them with `alter publication ... set \
+         (publish_generated_columns = stored)`"
+    );
+}
+
 /// Result type for table synchronization operations.
 ///
 /// [`TableSyncResult`] indicates the outcome of a table sync operation,
@@ -302,6 +340,8 @@ where
             // without waiting for a fresh relation message after restarts.
             let replicated_table_schema =
                 ReplicatedTableSchema::from_masks(table_schema, replication_mask, identity_mask);
+
+            warn_if_generated_columns_unreplicated(table_id, &replicated_table_schema);
 
             let mut total_table_copy_rows = 0_u64;
             let mut total_table_copy_duration_secs = 0.0;

--- a/crates/etl/src/schema.rs
+++ b/crates/etl/src/schema.rs
@@ -152,6 +152,11 @@ impl ReplicationMask {
     /// stored schema is from an earlier point before DDL changes. Rather
     /// than failing, we enable all columns and let the system converge when
     /// the actual DDL message is replayed.
+    ///
+    /// The fallback is unsound for a schema containing generated columns: those
+    /// only reach the stream on Postgres 18 with
+    /// `publish_generated_columns = stored`, so an all-replicated mask can be
+    /// wider than the tuples that follow.
     pub fn build_or_all(
         table_schema: &TableSchema,
         replicated_column_names: &HashSet<String>,
@@ -1087,6 +1092,11 @@ impl ColumnAlteration {
             "column alteration should change its identified field"
         );
         let mut expected_after = before_column_schema.clone();
+        // The generated flag is deliberately not an alteration kind: it never changes
+        // destination DDL, so no destination operation is planned for it. Carry it
+        // through so a statement that both drops an expression and changes a classified
+        // field still validates against the field its kind identifies.
+        expected_after.generated = after_column_schema.generated;
         match kind {
             ColumnAlterationKind::Rename => {
                 expected_after.name.clone_from(&after_column_schema.name);


### PR DESCRIPTION
Include stored generated columns in table schema snapshots and let the replication mask decide whether they flow. With
`publish_generated_columns = stored` they now reach the destination via copy and CDC; on earlier versions they stay out of the mask, preserving existing behavior.

- Add `ColumnSchema.generated`, persisted in `etl.table_columns`
- Return `attgenerated` from `etl.describe_table_schema`, and null out `default_expression` so a generation expression never becomes a destination DEFAULT
- Exclude generated columns from the pre-PG15 and empty-attnames mask fallbacks, which would widen the mask past the tuple width
- Replace the stale "not supported" warning with a mask-aware one
- Reject array generated-column additions on ClickHouse

Solve: https://github.com/supabase/etl/issues/77

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
