### PR TITLE
feat(api): Improve restart behavior

### DIFF
--- a/crates/etl-api/src/k8s/base.rs
+++ b/crates/etl-api/src/k8s/base.rs
@@ -30,6 +30,21 @@ pub enum K8sError {
     /// server.
     #[error("An error occurred with kube when dealing with K8s: {0}")]
     Kube(#[from] kube::Error),
+    /// A StatefulSet restart could not be initiated before its deadline.
+    #[error("Timed out initiating restart of Kubernetes StatefulSet '{name}'")]
+    StatefulSetRestartTimeout {
+        /// StatefulSet name.
+        name: String,
+    },
+    /// A restart encountered missing identity metadata or an unexpected pod
+    /// owner.
+    #[error("Invalid Kubernetes {kind} resource '{name}' encountered during restart")]
+    InvalidRestartResource {
+        /// Kubernetes resource kind.
+        kind: &'static str,
+        /// Kubernetes resource name.
+        name: String,
+    },
     /// A Kubernetes resource remained present after deletion was requested.
     #[error(
         "Timed out waiting for Kubernetes {kind} resource '{name}' to be deleted after \

--- a/crates/etl-api/src/k8s/http.rs
+++ b/crates/etl-api/src/k8s/http.rs
@@ -39,6 +39,7 @@ use crate::{
         ReplicatorWorkloadConfig,
         base::RESOURCE_DELETE_TIMEOUT,
         resources::{ReplicatorStatefulSetResourceRequirements, ReplicatorVpaResourcePolicy},
+        restart::{RESTARTED_AT_ANNOTATION, restart_outdated_pod},
     },
 };
 
@@ -884,9 +885,20 @@ impl K8sClient for HttpK8sClient {
         // fields. If there is an override (likely during an incident or SREs
         // intervention), we want to override their changes.
         let pp = PatchParams::apply(FIELD_MANAGER).force();
-        self.stateful_sets_api.patch(&stateful_set_name, &pp, &Patch::Apply(stateful_set)).await?;
+        let applied = self
+            .stateful_sets_api
+            .patch(&stateful_set_name, &pp, &Patch::Apply(stateful_set))
+            .await?;
 
-        Ok(())
+        // Apply the template before deleting any pod so its replacement uses
+        // the new configuration, even when an unready pod blocks rolling updates.
+        restart_outdated_pod(
+            &self.stateful_sets_api,
+            &self.pods_api,
+            &applied,
+            &create_pod_name(resource_prefix),
+        )
+        .await
     }
 
     async fn create_or_update_replicator_vertical_pod_autoscaler(
@@ -1788,7 +1800,7 @@ fn create_replicator_stateful_set_json(
             "labels": identity_labels,
             "annotations": {
               // Attach template annotations (e.g., restart checksum) to trigger a rolling restart.
-              "etl.supabase.com/restarted-at": restarted_at_annotation,
+              (RESTARTED_AT_ANNOTATION): restarted_at_annotation,
             }
           },
           "spec": {

--- a/crates/etl-api/src/k8s/mod.rs
+++ b/crates/etl-api/src/k8s/mod.rs
@@ -17,6 +17,7 @@ pub mod core;
 pub mod http;
 mod maintenance;
 mod resources;
+mod restart;
 pub mod source_tls;
 
 pub use base::*;

--- a/crates/etl-api/src/k8s/restart.rs
+++ b/crates/etl-api/src/k8s/restart.rs
@@ -127,6 +127,7 @@ pub(super) async fn restart_outdated_pod(
                 // deletion by name alone against a potentially different pod.
                 Err(kube::Error::Api(error)) if matches!(error.code, 404 | 409) => {
                     tokio::time::sleep(RESTART_POLL_INTERVAL).await;
+                    continue;
                 }
                 Err(error) => return Err(error.into()),
             }

--- a/crates/etl-api/src/k8s/restart.rs
+++ b/crates/etl-api/src/k8s/restart.rs
@@ -1,0 +1,137 @@
+//! Replacement of outdated StatefulSet pods, including blocked rolling updates.
+
+use std::time::Duration;
+
+use k8s_openapi::api::{apps::v1::StatefulSet, core::v1::Pod};
+use kube::{
+    Api, ResourceExt,
+    api::{DeleteParams, Preconditions},
+};
+
+use crate::k8s::K8sError;
+
+/// Pod template annotation identifying an API-requested restart.
+pub(super) const RESTARTED_AT_ANNOTATION: &str = "etl.supabase.com/restarted-at";
+/// Maximum time to observe a template update and request pod replacement.
+const RESTART_TIMEOUT: Duration = Duration::from_secs(30);
+/// Delay between controller observation or deletion conflict retries.
+const RESTART_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Ensures an outdated pod is replaced after its StatefulSet template is
+/// applied.
+///
+/// Ordered rolling updates can wait indefinitely for an unready pod. Once the
+/// controller observes the applied generation, delete that pod with a UID
+/// precondition so a concurrent replacement cannot be deleted accidentally.
+/// A newer generation supersedes this request. Missing or terminating resources
+/// are left to Kubernetes, and an already updated pod is never restarted again.
+///
+/// Returns after deletion is accepted, without waiting for termination or
+/// readiness. Default deletion options preserve the pod's shutdown grace
+/// period.
+pub(super) async fn restart_outdated_pod(
+    stateful_sets: &Api<StatefulSet>,
+    pods: &Api<Pod>,
+    applied: &StatefulSet,
+    pod_name: &str,
+) -> Result<(), K8sError> {
+    // Use the API server's accepted identity and template as the target for
+    // this request, rather than following later updates to the StatefulSet.
+    let name = applied.name_any();
+    let invalid_stateful_set =
+        || K8sError::InvalidRestartResource { kind: "StatefulSet", name: name.clone() };
+    let uid = applied.metadata.uid.as_ref().ok_or_else(invalid_stateful_set)?;
+    let generation = applied.metadata.generation.ok_or_else(invalid_stateful_set)?;
+    let restart = applied
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.metadata.as_ref())
+        .and_then(|metadata| metadata.annotations.as_ref())
+        .and_then(|annotations| annotations.get(RESTARTED_AT_ANNOTATION))
+        .ok_or_else(invalid_stateful_set)?;
+
+    // Bound controller observation and conflict retries together, without
+    // waiting for the pod's shutdown grace period or replacement readiness.
+    tokio::time::timeout(RESTART_TIMEOUT, async {
+        loop {
+            // Read the pod before checking the generation so a newer request's
+            // replacement cannot be mistaken for an outdated pod of this request.
+            let pod = pods.get_opt(pod_name).await?;
+            let Some(current) = stateful_sets.get_opt(&name).await? else {
+                return Ok(());
+            };
+
+            // A stop, recreation, or newer update supersedes this request.
+            // Leave the current workload to the operation that now owns it.
+            if current.metadata.deletion_timestamp.is_some()
+                || current.metadata.uid.as_ref() != Some(uid)
+                || current.metadata.generation != Some(generation)
+            {
+                return Ok(());
+            }
+
+            // The controller must know the new template before we ask it to
+            // replace a pod, otherwise it could recreate the old configuration.
+            let observed = current.status.and_then(|status| status.observed_generation);
+            if observed.is_none_or(|observed| observed < generation) {
+                tokio::time::sleep(RESTART_POLL_INTERVAL).await;
+                continue;
+            }
+
+            let Some(pod) = pod else {
+                // A pod could have been created from the previous template
+                // between the first read and controller observation.
+                if pods.get_opt(pod_name).await?.is_some() {
+                    continue;
+                }
+
+                return Ok(());
+            };
+
+            // Kubernetes already owns replacement of a terminating pod.
+            if pod.metadata.deletion_timestamp.is_some() {
+                return Ok(());
+            }
+
+            // A matching name alone does not establish ownership, especially
+            // if the StatefulSet was deleted and recreated.
+            if !pod.owner_references().iter().any(|owner| {
+                owner.controller == Some(true) && owner.kind == "StatefulSet" && &owner.uid == uid
+            }) {
+                return Err(K8sError::InvalidRestartResource {
+                    kind: "Pod",
+                    name: pod_name.to_owned(),
+                });
+            }
+
+            // An updated pod has already received this restart, even if its
+            // new configuration still fails. Do not create a restart loop.
+            if pod.annotations().get(RESTARTED_AT_ANNOTATION) == Some(restart) {
+                return Ok(());
+            }
+
+            // Pod names are reused. Guard deletion with the observed UID so
+            // a concurrent replacement survives, and retain normal graceful shutdown.
+            let pod_uid = pod.metadata.uid.ok_or_else(|| K8sError::InvalidRestartResource {
+                kind: "Pod",
+                name: pod_name.to_owned(),
+            })?;
+            let params = DeleteParams {
+                preconditions: Some(Preconditions { uid: Some(pod_uid), resource_version: None }),
+                ..Default::default()
+            };
+            match pods.delete(pod_name, &params).await {
+                // Acceptance is enough: the StatefulSet controller completes replacement.
+                Ok(_) => return Ok(()),
+                // Re-read both resources after a deletion race; never retry
+                // deletion by name alone against a potentially different pod.
+                Err(kube::Error::Api(error)) if matches!(error.code, 404 | 409) => {
+                    tokio::time::sleep(RESTART_POLL_INTERVAL).await;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    })
+    .await
+    .map_err(|_| K8sError::StatefulSetRestartTimeout { name })?
+}

--- a/crates/etl-api/src/routes/common.rs
+++ b/crates/etl-api/src/routes/common.rs
@@ -72,7 +72,9 @@ async fn restart_would_perform_table_sync(
 /// transaction. The helper reads that state once and uses the same loaded
 /// pipeline and source configuration for both sync preflight and Kubernetes
 /// materialization. Updating the StatefulSet changes the pod template restart
-/// annotation.
+/// annotation and requests deletion of an outdated pod, including when an
+/// unready pod blocks the native rolling update. This does not wait for the
+/// replacement to become ready.
 ///
 /// This forced recreation is part of the contract. The replicator loads its
 /// mounted config and secret-backed environment when the process starts, so a


### PR DESCRIPTION
An API-triggered configuration update or restart can leave an unready replicator pod running the previous configuration because the StatefulSet's ordered rolling update waits for readiness. After applying the new pod template, the API now waits for the controller to observe that generation and explicitly requests deletion of an outdated pod so Kubernetes can replace it.

The restart checks StatefulSet identity and generation, verifies pod ownership, and uses a pod UID precondition to protect concurrent replacements. Already-updated or terminating pods are left alone, and newer StatefulSet updates supersede the request. Controller observation and deletion-conflict retries share a 30-second timeout. Deletion preserves the normal shutdown grace period; the API does not wait for replacement readiness.
