### PR TITLE
fix(etl): preserve pgvector and custom array values

### DIFF
--- a/crates/etl/migrations/source/20260909120000_extension_type_identity.down.sql
+++ b/crates/etl/migrations/source/20260909120000_extension_type_identity.down.sql
@@ -1,0 +1,221 @@
+-- Restore the previous schema-message payload without changing its trigger.
+create or replace function etl.emit_schema_change_messages()
+returns pg_catalog.event_trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as
+$fnc$
+declare
+    r record;
+    v_schema_json pg_catalog.jsonb;
+    v_identity_json pg_catalog.jsonb;
+    v_msg_json pg_catalog.jsonb;
+    v_statement_text pg_catalog.text;
+begin
+    if coalesce(pg_catalog.current_setting('supabase_etl.skip_ddl_log', true), 'false')::pg_catalog.bool then
+        return;
+    end if;
+
+    -- Without logical WAL there is no downstream consumer for emitted messages.
+    if pg_catalog.current_setting('wal_level', true) is distinct from 'logical' then
+        return;
+    end if;
+
+    -- `current_query()` is for observability only. It is the client-submitted
+    -- text and may include more than one statement.
+    v_statement_text := pg_catalog.current_query();
+
+    for r in
+        with event_commands as (
+            select
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                addr.type as object_address_type,
+                addr.object_names as object_address_names,
+                addr.object_args as object_address_args
+            from pg_catalog.pg_event_trigger_ddl_commands() d
+            left join lateral pg_catalog.pg_identify_object_as_address(
+                d.classid,
+                d.objid,
+                d.objsubid
+            )
+                as addr(type, object_names, object_args)
+                on true
+            where d.objid is not null
+              and not coalesce(d.in_extension, false)
+        ),
+        base as (
+            -- ALTER TABLE identifies the relation directly and is intentionally
+            -- unscoped: a table change applies to every publication containing
+            -- that table. Per-table ALTER PUBLICATION events instead identify a
+            -- surviving pg_publication_rel row, from which both relation and
+            -- publication are resolved. This branch uses only the explicitly
+            -- identified relation; it does not expand partition roots into their
+            -- effective leaf relations.
+            select
+                coalesce(pr.prrelid, d.objid) as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            left join pg_catalog.pg_publication_rel pr
+              on d.classid = 'pg_catalog.pg_publication_rel'::pg_catalog.regclass
+             and d.objid = pr.oid
+            left join pg_catalog.pg_publication p
+              on p.oid = pr.prpubid
+            where (
+                  d.object_type in ('table', 'table column')
+                  or pr.prrelid is not null
+              )
+            union all
+            -- Publication-level ALTER PUBLICATION events identify pg_publication
+            -- itself rather than a specific relation. The command parameters are
+            -- not inspected; every such event expands the publication's post-DDL
+            -- effective table set so each table receives a scoped snapshot.
+            select
+                c.oid as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            join pg_catalog.pg_publication p
+              on d.classid = 'pg_catalog.pg_publication'::pg_catalog.regclass
+             and d.objid = p.oid
+            join pg_catalog.pg_publication_tables pt
+              on pt.pubname = p.pubname
+            join pg_catalog.pg_namespace n
+              on n.nspname = pt.schemaname
+            join pg_catalog.pg_class c
+              on c.relnamespace = n.oid
+             and c.relname = pt.tablename
+        ),
+        ddl as (
+            select
+                b.table_oid,
+                b.publication_name,
+                pg_catalog.jsonb_agg(
+                    pg_catalog.jsonb_build_object(
+                        'classid', b.classid::pg_catalog.int8,
+                        'objid', b.objid::pg_catalog.int8,
+                        'objsubid', b.objsubid,
+                        'command_tag', b.command_tag,
+                        'object_type', b.object_type,
+                        'schema_name', b.schema_name,
+                        'object_identity', b.object_identity,
+                        'object_address_type', b.object_address_type,
+                        'object_address_names', b.object_address_names,
+                        'object_address_args', b.object_address_args
+                    )
+                    order by
+                        b.objsubid,
+                        b.classid,
+                        b.command_tag,
+                        b.object_type,
+                        b.schema_name,
+                        b.object_identity
+                ) as commands
+            from base b
+            group by b.table_oid, b.publication_name
+        )
+        select
+            c.oid as table_oid,
+            n.nspname,
+            c.relname,
+            c.relkind::pg_catalog.text as relkind,
+            ddl.publication_name,
+            ddl.commands
+        from ddl
+        join pg_catalog.pg_class c
+          on c.oid = ddl.table_oid
+        join pg_catalog.pg_namespace n
+          on n.oid = c.relnamespace
+        where c.relkind in ('r', 'p')
+          and c.relpersistence = 'p'
+          and exists (
+              -- Keep only relations that are effective in at least one
+              -- publication in this transaction's post-command catalog state.
+              select 1
+              from pg_catalog.pg_publication_tables pt
+              where pt.schemaname = n.nspname
+                and pt.tablename = c.relname
+          )
+        -- Make multi-table schema-message order deterministic.
+        order by c.oid
+    loop
+        select pg_catalog.jsonb_agg(
+            pg_catalog.jsonb_build_object(
+                'attname', s.attname,
+                'attnum', s.attnum,
+                'atttypid', s.atttypid::pg_catalog.int8,
+                'typname', s.typname,
+                'formatted_type', s.formatted_type,
+                'atttypmod', s.atttypmod,
+                'attnotnull', s.attnotnull,
+                'atthasdef', s.atthasdef,
+                'default_expression', s.default_expression,
+                'attidentity', s.attidentity,
+                'atthasmissing', s.atthasmissing
+            )
+            order by s.attnum
+        )
+        into v_schema_json
+        from etl.describe_table_schema(r.table_oid) s;
+
+        if v_schema_json is null then
+            continue;
+        end if;
+
+        select etl.describe_table_identity(r.table_oid)
+        into v_identity_json;
+
+        v_msg_json := pg_catalog.jsonb_build_object(
+            'trigger_event', tg_event,
+            'command_tag', tg_tag,
+            'current_query', v_statement_text,
+            'current_database', pg_catalog.current_database(),
+            'server_version_num', pg_catalog.current_setting('server_version_num')::pg_catalog.int4,
+            'nspname', r.nspname,
+            'relname', r.relname,
+            'oid', r.table_oid::pg_catalog.int8,
+            'relkind', r.relkind,
+            'commands', r.commands,
+            'identity', v_identity_json,
+            'columns', v_schema_json
+        );
+
+        if r.publication_name is not null then
+            v_msg_json := v_msg_json || pg_catalog.jsonb_build_object(
+                'publication_name', r.publication_name
+            );
+        end if;
+
+        perform pg_catalog.pg_logical_emit_message(
+            true,
+            'supabase_etl_ddl',
+            pg_catalog.convert_to(v_msg_json::pg_catalog.text, 'utf8')
+        );
+    end loop;
+end;
+$fnc$;

--- a/crates/etl/migrations/source/20260909120000_extension_type_identity.up.sql
+++ b/crates/etl/migrations/source/20260909120000_extension_type_identity.up.sql
@@ -172,6 +172,12 @@ begin
                 'attnum', s.attnum,
                 'atttypid', s.atttypid::pg_catalog.int8,
                 'typname', s.typname,
+                'array_delimiter', (
+                    select element.typdelim::pg_catalog.text
+                    from pg_catalog.pg_type array_type
+                    join pg_catalog.pg_type element on element.oid = array_type.typelem
+                    where array_type.oid = s.atttypid
+                ),
                 'type_extension_name', (
                     select e.extname::pg_catalog.text
                     from pg_catalog.pg_depend d

--- a/crates/etl/migrations/source/20260909120000_extension_type_identity.up.sql
+++ b/crates/etl/migrations/source/20260909120000_extension_type_identity.up.sql
@@ -1,0 +1,233 @@
+-- Capture the owning extension in the same transactional snapshot as its type.
+-- Existing trigger identity and privileges are preserved. Readers that predate
+-- this field ignore it; old WAL messages retain their previous text fallback.
+create or replace function etl.emit_schema_change_messages()
+returns pg_catalog.event_trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as
+$fnc$
+declare
+    r record;
+    v_schema_json pg_catalog.jsonb;
+    v_identity_json pg_catalog.jsonb;
+    v_msg_json pg_catalog.jsonb;
+    v_statement_text pg_catalog.text;
+begin
+    if coalesce(pg_catalog.current_setting('supabase_etl.skip_ddl_log', true), 'false')::pg_catalog.bool then
+        return;
+    end if;
+
+    -- Without logical WAL there is no downstream consumer for emitted messages.
+    if pg_catalog.current_setting('wal_level', true) is distinct from 'logical' then
+        return;
+    end if;
+
+    -- `current_query()` is for observability only. It is the client-submitted
+    -- text and may include more than one statement.
+    v_statement_text := pg_catalog.current_query();
+
+    for r in
+        with event_commands as (
+            select
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                addr.type as object_address_type,
+                addr.object_names as object_address_names,
+                addr.object_args as object_address_args
+            from pg_catalog.pg_event_trigger_ddl_commands() d
+            left join lateral pg_catalog.pg_identify_object_as_address(
+                d.classid,
+                d.objid,
+                d.objsubid
+            )
+                as addr(type, object_names, object_args)
+                on true
+            where d.objid is not null
+              and not coalesce(d.in_extension, false)
+        ),
+        base as (
+            -- ALTER TABLE identifies the relation directly and is intentionally
+            -- unscoped: a table change applies to every publication containing
+            -- that table. Per-table ALTER PUBLICATION events instead identify a
+            -- surviving pg_publication_rel row, from which both relation and
+            -- publication are resolved. This branch uses only the explicitly
+            -- identified relation; it does not expand partition roots into their
+            -- effective leaf relations.
+            select
+                coalesce(pr.prrelid, d.objid) as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            left join pg_catalog.pg_publication_rel pr
+              on d.classid = 'pg_catalog.pg_publication_rel'::pg_catalog.regclass
+             and d.objid = pr.oid
+            left join pg_catalog.pg_publication p
+              on p.oid = pr.prpubid
+            where (
+                  d.object_type in ('table', 'table column')
+                  or pr.prrelid is not null
+              )
+            union all
+            -- Publication-level ALTER PUBLICATION events identify pg_publication
+            -- itself rather than a specific relation. The command parameters are
+            -- not inspected; every such event expands the publication's post-DDL
+            -- effective table set so each table receives a scoped snapshot.
+            select
+                c.oid as table_oid,
+                d.classid,
+                d.objid,
+                d.objsubid,
+                d.command_tag,
+                d.object_type,
+                d.schema_name,
+                d.object_identity,
+                p.pubname as publication_name,
+                d.object_address_type,
+                d.object_address_names,
+                d.object_address_args
+            from event_commands d
+            join pg_catalog.pg_publication p
+              on d.classid = 'pg_catalog.pg_publication'::pg_catalog.regclass
+             and d.objid = p.oid
+            join pg_catalog.pg_publication_tables pt
+              on pt.pubname = p.pubname
+            join pg_catalog.pg_namespace n
+              on n.nspname = pt.schemaname
+            join pg_catalog.pg_class c
+              on c.relnamespace = n.oid
+             and c.relname = pt.tablename
+        ),
+        ddl as (
+            select
+                b.table_oid,
+                b.publication_name,
+                pg_catalog.jsonb_agg(
+                    pg_catalog.jsonb_build_object(
+                        'classid', b.classid::pg_catalog.int8,
+                        'objid', b.objid::pg_catalog.int8,
+                        'objsubid', b.objsubid,
+                        'command_tag', b.command_tag,
+                        'object_type', b.object_type,
+                        'schema_name', b.schema_name,
+                        'object_identity', b.object_identity,
+                        'object_address_type', b.object_address_type,
+                        'object_address_names', b.object_address_names,
+                        'object_address_args', b.object_address_args
+                    )
+                    order by
+                        b.objsubid,
+                        b.classid,
+                        b.command_tag,
+                        b.object_type,
+                        b.schema_name,
+                        b.object_identity
+                ) as commands
+            from base b
+            group by b.table_oid, b.publication_name
+        )
+        select
+            c.oid as table_oid,
+            n.nspname,
+            c.relname,
+            c.relkind::pg_catalog.text as relkind,
+            ddl.publication_name,
+            ddl.commands
+        from ddl
+        join pg_catalog.pg_class c
+          on c.oid = ddl.table_oid
+        join pg_catalog.pg_namespace n
+          on n.oid = c.relnamespace
+        where c.relkind in ('r', 'p')
+          and c.relpersistence = 'p'
+          and exists (
+              -- Keep only relations that are effective in at least one
+              -- publication in this transaction's post-command catalog state.
+              select 1
+              from pg_catalog.pg_publication_tables pt
+              where pt.schemaname = n.nspname
+                and pt.tablename = c.relname
+          )
+        -- Make multi-table schema-message order deterministic.
+        order by c.oid
+    loop
+        select pg_catalog.jsonb_agg(
+            pg_catalog.jsonb_build_object(
+                'attname', s.attname,
+                'attnum', s.attnum,
+                'atttypid', s.atttypid::pg_catalog.int8,
+                'typname', s.typname,
+                'type_extension_name', (
+                    select e.extname::pg_catalog.text
+                    from pg_catalog.pg_depend d
+                    join pg_catalog.pg_extension e on e.oid = d.refobjid
+                    where d.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
+                      and d.objid = s.atttypid
+                      and d.objsubid = 0
+                      and d.refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+                      and d.deptype = 'e'
+                ),
+                'formatted_type', s.formatted_type,
+                'atttypmod', s.atttypmod,
+                'attnotnull', s.attnotnull,
+                'atthasdef', s.atthasdef,
+                'default_expression', s.default_expression,
+                'attidentity', s.attidentity,
+                'atthasmissing', s.atthasmissing
+            )
+            order by s.attnum
+        )
+        into v_schema_json
+        from etl.describe_table_schema(r.table_oid) s;
+
+        if v_schema_json is null then
+            continue;
+        end if;
+
+        select etl.describe_table_identity(r.table_oid)
+        into v_identity_json;
+
+        v_msg_json := pg_catalog.jsonb_build_object(
+            'trigger_event', tg_event,
+            'command_tag', tg_tag,
+            'current_query', v_statement_text,
+            'current_database', pg_catalog.current_database(),
+            'server_version_num', pg_catalog.current_setting('server_version_num')::pg_catalog.int4,
+            'nspname', r.nspname,
+            'relname', r.relname,
+            'oid', r.table_oid::pg_catalog.int8,
+            'relkind', r.relkind,
+            'commands', r.commands,
+            'identity', v_identity_json,
+            'columns', v_schema_json
+        );
+
+        if r.publication_name is not null then
+            v_msg_json := v_msg_json || pg_catalog.jsonb_build_object(
+                'publication_name', r.publication_name
+            );
+        end if;
+
+        perform pg_catalog.pg_logical_emit_message(
+            true,
+            'supabase_etl_ddl',
+            pg_catalog.convert_to(v_msg_json::pg_catalog.text, 'utf8')
+        );
+    end loop;
+end;
+$fnc$;

--- a/crates/etl/src/postgres/client/transaction.rs
+++ b/crates/etl/src/postgres/client/transaction.rs
@@ -585,6 +585,17 @@ impl<'a> PgReplicationTransactionCore<'a> {
                             'attname', s.attname,
                             'attnum', s.attnum,
                             'atttypid', s.atttypid::pg_catalog.int8,
+                            'typname', s.typname,
+                            'type_extension_name', (
+                                select e.extname::pg_catalog.text
+                                from pg_catalog.pg_depend d
+                                join pg_catalog.pg_extension e on e.oid = d.refobjid
+                                where d.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
+                                  and d.objid = s.atttypid
+                                  and d.objsubid = 0
+                                  and d.refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+                                  and d.deptype = 'e'
+                            ),
                             'atttypmod', s.atttypmod,
                             'attnotnull', s.attnotnull,
                             'default_expression', s.default_expression

--- a/crates/etl/src/postgres/client/transaction.rs
+++ b/crates/etl/src/postgres/client/transaction.rs
@@ -587,6 +587,12 @@ impl<'a> PgReplicationTransactionCore<'a> {
                             'atttypid', s.atttypid::pg_catalog.int8,
                             'typname', s.typname,
                             'formatted_type', s.formatted_type,
+                            'array_delimiter', (
+                                select element.typdelim::pg_catalog.text
+                                from pg_catalog.pg_type array_type
+                                join pg_catalog.pg_type element on element.oid = array_type.typelem
+                                where array_type.oid = s.atttypid
+                            ),
                             'type_extension_name', (
                                 select e.extname::pg_catalog.text
                                 from pg_catalog.pg_depend d

--- a/crates/etl/src/postgres/client/transaction.rs
+++ b/crates/etl/src/postgres/client/transaction.rs
@@ -586,6 +586,7 @@ impl<'a> PgReplicationTransactionCore<'a> {
                             'attnum', s.attnum,
                             'atttypid', s.atttypid::pg_catalog.int8,
                             'typname', s.typname,
+                            'formatted_type', s.formatted_type,
                             'type_extension_name', (
                                 select e.extname::pg_catalog.text
                                 from pg_catalog.pg_depend d

--- a/crates/etl/src/postgres/codec/event.rs
+++ b/crates/etl/src/postgres/codec/event.rs
@@ -217,6 +217,9 @@ pub(crate) struct ColumnSchemaMessage {
     /// Formatted source type, including the array suffix for custom arrays.
     #[serde(default)]
     pub(crate) formatted_type: Option<String>,
+    /// Element delimiter for arrays, absent in older schema messages.
+    #[serde(default)]
+    pub(crate) array_delimiter: Option<String>,
     /// Owning extension, optional for snapshots emitted before this field
     /// existed.
     #[serde(default)]
@@ -264,7 +267,9 @@ pub(crate) fn build_column_schemas(
                 {
                     Type::FLOAT4_ARRAY
                 }
-                None if column.formatted_type.as_deref().is_some_and(|typ| typ.ends_with("[]")) => {
+                None if column.array_delimiter.as_deref() == Some(",")
+                    && column.formatted_type.as_deref().is_some_and(|typ| typ.ends_with("[]")) =>
+                {
                     Type::TEXT_ARRAY
                 }
                 None => Type::TEXT,
@@ -1914,7 +1919,7 @@ mod tests {
         use crate::data::ArrayCell;
         let column = serde_json::from_value::<super::ColumnSchemaMessage>(serde_json::json!({
             "attname": "statuses", "attnum": 1, "atttypid": 90_003,
-            "typname": "_status", "formatted_type": "status[]",
+            "typname": "_status", "formatted_type": "status[]", "array_delimiter": ",",
             "atttypmod": -1, "attnotnull": false
         }))
         .unwrap();
@@ -1933,5 +1938,24 @@ mod tests {
                 Some("done".to_owned())
             ]))]
         );
+    }
+    #[test]
+    fn custom_arrays_with_unknown_or_non_comma_delimiters_remain_text() {
+        for delimiter in [None, Some(";")] {
+            let column = serde_json::from_value::<super::ColumnSchemaMessage>(serde_json::json!({
+                "attname": "values", "attnum": 1, "atttypid": 90_004,
+                "formatted_type": "custom[]", "array_delimiter": delimiter,
+                "atttypmod": -1, "attnotnull": false
+            }))
+            .unwrap();
+            let columns = super::build_column_schemas(vec![column], vec![]);
+            assert_eq!(columns[0].typ, Type::TEXT);
+            let row = convert_tuple_to_row(
+                columns.iter(),
+                &[TupleData::Text(Bytes::from_static(b"{a;b}"))],
+            )
+            .unwrap();
+            assert_eq!(row.values(), &[Cell::String("{a;b}".to_owned())]);
+        }
     }
 }

--- a/crates/etl/src/postgres/codec/event.rs
+++ b/crates/etl/src/postgres/codec/event.rs
@@ -212,6 +212,13 @@ pub(crate) struct ColumnSchemaMessage {
     pub(crate) attname: String,
     /// The type OID from `pg_attribute.atttypid`.
     pub(crate) atttypid: u32,
+    /// Source type name, optional for older snapshots.
+    #[serde(default)]
+    pub(crate) typname: Option<String>,
+    /// Owning extension, optional for snapshots emitted before this field
+    /// existed.
+    #[serde(default)]
+    pub(crate) type_extension_name: Option<String>,
     /// The type modifier from `pg_attribute.atttypmod`.
     pub(crate) atttypmod: i32,
     /// The physical column number from `pg_attribute.attnum`.
@@ -245,7 +252,16 @@ pub(crate) fn build_column_schemas(
     columns
         .into_iter()
         .map(|column| {
-            let typ = convert_type_oid_to_type(column.atttypid);
+            // Extension OIDs are database-local. Reuse the durable float array
+            // representation for pgvector's single-precision vector values.
+            // An unrelated user-defined type named vector retains the fallback.
+            let typ = if column.typname.as_deref() == Some("vector")
+                && column.type_extension_name.as_deref() == Some("vector")
+            {
+                crate::schema::Type::FLOAT4_ARRAY
+            } else {
+                convert_type_oid_to_type(column.atttypid)
+            };
             ColumnSchema::new(
                 column.attname,
                 typ,
@@ -1820,5 +1836,69 @@ mod tests {
                 Cell::String("smith".to_owned()),
             ])))
         );
+    }
+
+    /// Builds the schema shape shared by COPY bootstrap and transactional DDL.
+    fn vector_column_message(oid: u32, extension: Option<&str>) -> super::ColumnSchemaMessage {
+        serde_json::from_value(serde_json::json!({
+            "attname": "embedding", "attnum": 1, "atttypid": oid,
+            "typname": "vector", "type_extension_name": extension,
+            "atttypmod": 3, "attnotnull": false
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn pgvector_copy_and_cdc_use_the_same_durable_value_type() {
+        use etl_postgres::store::schema::{postgres_type_to_string, string_to_postgres_type};
+
+        use crate::{
+            data::ArrayCell, postgres::codec::table_row::parse_table_row_from_postgres_copy_bytes,
+        };
+
+        // OIDs vary across databases. Persisted types must decode after restart.
+        for oid in [90_001, 90_002] {
+            let columns = super::build_column_schemas(
+                vec![vector_column_message(oid, Some("vector"))],
+                vec![],
+            );
+            assert_eq!(columns[0].typ, Type::FLOAT4_ARRAY);
+            let restored_type = string_to_postgres_type(&postgres_type_to_string(&columns[0].typ));
+            assert_eq!(restored_type, Type::FLOAT4_ARRAY);
+            let copy =
+                parse_table_row_from_postgres_copy_bytes(b"[0.1,-2,3.5]\n", &columns).unwrap();
+            let cdc = convert_tuple_to_row(
+                columns.iter(),
+                &[TupleData::Text(Bytes::from_static(b"[0.1,-2,3.5]"))],
+            )
+            .unwrap();
+            assert_eq!(copy, cdc);
+            assert_eq!(
+                copy.values(),
+                &[Cell::Array(ArrayCell::F32(vec![Some(0.1), Some(-2.0), Some(3.5)]))]
+            );
+            let null_copy = parse_table_row_from_postgres_copy_bytes(b"\\N\n", &columns).unwrap();
+            let null_cdc = convert_tuple_to_row(columns.iter(), &[TupleData::Null]).unwrap();
+            assert_eq!(null_copy, null_cdc);
+            assert_eq!(null_copy.values(), &[Cell::Null]);
+        }
+    }
+
+    #[test]
+    fn pgvector_mapping_requires_extension_identity() {
+        for extension in [None, Some("unrelated")] {
+            let columns =
+                super::build_column_schemas(vec![vector_column_message(90_001, extension)], vec![]);
+            assert_eq!(columns[0].typ, Type::TEXT);
+        }
+        let old = serde_json::from_value::<super::ColumnSchemaMessage>(serde_json::json!({
+            "attname": "embedding", "attnum": 1, "atttypid": 90_001,
+            "typname": "vector", "atttypmod": 3, "attnotnull": false
+        }))
+        .unwrap();
+        assert_eq!(super::build_column_schemas(vec![old], vec![])[0].typ, Type::TEXT);
+        let mut builtin = vector_column_message(Type::FLOAT4_ARRAY.oid(), None);
+        builtin.typname = Some("_float4".to_owned());
+        assert_eq!(super::build_column_schemas(vec![builtin], vec![])[0].typ, Type::FLOAT4_ARRAY);
     }
 }

--- a/crates/etl/src/postgres/codec/event.rs
+++ b/crates/etl/src/postgres/codec/event.rs
@@ -4,7 +4,6 @@ use std::{
     str::FromStr,
 };
 
-use etl_postgres::type_utils::convert_type_oid_to_type;
 use postgres_replication::protocol;
 use serde::Deserialize;
 use tokio_postgres::types::PgLsn;
@@ -18,7 +17,7 @@ use crate::{
     postgres::codec::text::parse_cell_from_postgres_text,
     schema::{
         ColumnSchema, IdentityMask, ReplicatedTableSchema, ReplicationMask, SnapshotId, TableId,
-        TableName, TableSchema,
+        TableName, TableSchema, Type,
     },
 };
 
@@ -215,6 +214,9 @@ pub(crate) struct ColumnSchemaMessage {
     /// Source type name, optional for older snapshots.
     #[serde(default)]
     pub(crate) typname: Option<String>,
+    /// Formatted source type, including the array suffix for custom arrays.
+    #[serde(default)]
+    pub(crate) formatted_type: Option<String>,
     /// Owning extension, optional for snapshots emitted before this field
     /// existed.
     #[serde(default)]
@@ -255,12 +257,17 @@ pub(crate) fn build_column_schemas(
             // Extension OIDs are database-local. Reuse the durable float array
             // representation for pgvector's single-precision vector values.
             // An unrelated user-defined type named vector retains the fallback.
-            let typ = if column.typname.as_deref() == Some("vector")
-                && column.type_extension_name.as_deref() == Some("vector")
-            {
-                crate::schema::Type::FLOAT4_ARRAY
-            } else {
-                convert_type_oid_to_type(column.atttypid)
+            let typ = match Type::from_oid(column.atttypid) {
+                Some(typ) => typ,
+                None if column.typname.as_deref() == Some("vector")
+                    && column.type_extension_name.as_deref() == Some("vector") =>
+                {
+                    Type::FLOAT4_ARRAY
+                }
+                None if column.formatted_type.as_deref().is_some_and(|typ| typ.ends_with("[]")) => {
+                    Type::TEXT_ARRAY
+                }
+                None => Type::TEXT,
             };
             ColumnSchema::new(
                 column.attname,
@@ -1900,5 +1907,31 @@ mod tests {
         let mut builtin = vector_column_message(Type::FLOAT4_ARRAY.oid(), None);
         builtin.typname = Some("_float4".to_owned());
         assert_eq!(super::build_column_schemas(vec![builtin], vec![])[0].typ, Type::FLOAT4_ARRAY);
+    }
+
+    #[test]
+    fn custom_enum_arrays_keep_array_shape_and_null_elements() {
+        use crate::data::ArrayCell;
+        let column = serde_json::from_value::<super::ColumnSchemaMessage>(serde_json::json!({
+            "attname": "statuses", "attnum": 1, "atttypid": 90_003,
+            "typname": "_status", "formatted_type": "status[]",
+            "atttypmod": -1, "attnotnull": false
+        }))
+        .unwrap();
+        let columns = super::build_column_schemas(vec![column], vec![]);
+        assert_eq!(columns[0].typ, Type::TEXT_ARRAY);
+        let row = convert_tuple_to_row(
+            columns.iter(),
+            &[TupleData::Text(Bytes::from_static(b"{queued,NULL,done}"))],
+        )
+        .unwrap();
+        assert_eq!(
+            row.values(),
+            &[Cell::Array(ArrayCell::String(vec![
+                Some("queued".to_owned()),
+                None,
+                Some("done".to_owned())
+            ]))]
+        );
     }
 }

--- a/crates/etl/src/postgres/codec/text.rs
+++ b/crates/etl/src/postgres/codec/text.rs
@@ -50,6 +50,15 @@ pub(crate) fn parse_cell_from_postgres_text(typ: &Type, str: &str) -> EtlResult<
             parse_cell_from_postgres_text_array(str, |str| Ok(Some(str.parse()?)), ArrayCell::I64)
         }
         Type::FLOAT4 => Ok(Cell::F32(str.parse()?)),
+        // pgvector is lowered to FLOAT4_ARRAY in the schema snapshot. Its
+        // scalar text format uses brackets, unlike PostgreSQL array literals.
+        Type::FLOAT4_ARRAY if str.starts_with('[') && str.ends_with(']') => {
+            let values = str[1..str.len() - 1]
+                .split(',')
+                .map(|value| Ok(Some(value.trim().parse::<f32>()?)))
+                .collect::<EtlResult<Vec<_>>>()?;
+            Ok(Cell::Array(ArrayCell::F32(values)))
+        }
         Type::FLOAT4_ARRAY => {
             parse_cell_from_postgres_text_array(str, |str| Ok(Some(str.parse()?)), ArrayCell::F32)
         }
@@ -1000,5 +1009,18 @@ mod tests {
 
         let cell = parse_cell_from_postgres_text(&custom_type, "test").unwrap();
         assert_eq!(cell, Cell::String("test".to_owned()));
+    }
+
+    #[test]
+    fn pgvector_text_preserves_float_values_and_native_array_syntax() {
+        let vector = parse_cell_from_postgres_text(&Type::FLOAT4_ARRAY, "[0.1,-0,1e-30]").unwrap();
+        let native =
+            parse_cell_from_postgres_text(&Type::FLOAT4_ARRAY, "[0:2]={0.1,-0,1e-30}").unwrap();
+        assert_eq!(vector, native);
+        let Cell::Array(ArrayCell::F32(values)) = vector else { panic!("expected float array") };
+        assert!(values[1].unwrap().is_sign_negative());
+        for input in ["[]", "[1,]", "[NULL]", "[1,invalid]", "[1,2"] {
+            assert!(parse_cell_from_postgres_text(&Type::FLOAT4_ARRAY, input).is_err());
+        }
     }
 }

--- a/crates/etl/tests/migrations.rs
+++ b/crates/etl/tests/migrations.rs
@@ -1089,8 +1089,10 @@ async fn split_migrations_can_be_reverted_independently() {
     assert_eq!(applied_migration_versions(&database).await, all_split_migration_versions());
 
     let client = database.client.as_ref().expect("database client should be initialized");
-    let previous_source_version =
-        source_migration_versions().into_iter().rev().nth(1).expect("a previous migration exists");
+    let previous_source_version = source_migration_versions()
+        .into_iter()
+        .rfind(|version| *version < 20260724120000)
+        .expect("a previous migration exists");
     let mut conn = migration_connection(&database.config).await;
     source_migrator().undo(&mut conn, previous_source_version).await.unwrap();
     drop(conn);


### PR DESCRIPTION
A pgvector `vector` column currently reaches destinations as TEXT because its database-local OID is not in the built-in type registry. COPY and CDC consequently lose the numeric array representation even though destinations already support float arrays.

Resolve scalar `vector` columns only when the schema snapshot identifies the owning `vector` extension, and decode their bracketed text into the existing `FLOAT4_ARRAY` / `ArrayCell::F32` representation. DuckLake can then use its existing `float[]` mapping without a destination-specific converter. Unrelated types named `vector`, built-in arrays, and older snapshots without extension identity retain their previous behavior. Unknown array types (such as enum arrays) use TEXT_ARRAY only when the snapshot confirms a comma element delimiter. Non-comma or missing delimiters retain the complete TEXT value. Unknown scalar fallback remains TEXT. This does not add numeric support for halfvec, sparsevec or arrays of vectors.

The new source migration adds extension ownership and array element delimiters to transactional DDL snapshots; bootstrap reads the same identity. Its size comes from replacing/restoring the existing trigger function definition. Existing migrations, trigger identity and privileges are unchanged. The durable value type already round-trips through PostgresStore, so no store migration or new value model is needed.

Validation:
- 103 codec unit tests passed, including COPY/CDC agreement, NULL, database-local OIDs, durable type serialization, same-name non-extension types, old messages, native array lower bounds and malformed input.
- `cargo clippy -j1 -p etl --all-targets --features test-utils -- -D warnings` passed.
- Pinned formatter and `git diff --check` passed.
- Live PostgreSQL migration and pgvector-to-DuckLake integration runs have not been executed locally. That validation and review of the value representation contract remain required.

Compatibility: historical snapshots without extension identity are not reinterpreted. Existing destinations created as TEXT require an explicit schema migration/resync to adopt the numeric representation; the change does not silently rewrite historical state.
