### PR TITLE
feat(ducklake): support host-owned destination setup and maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ constant_time_eq = { version = "0.4.2" }
 duckdb = { version = "1", default-features = false }
 etl = { path = "crates/etl", default-features = false }
 etl-config = { path = "crates/etl-config", default-features = false }
-etl-destinations = { path = "crates/etl-destinations", default-features = false }
+etl-destinations = { path = "crates/etl-destinations", default-features = false, features = ["bundled"] }
 etl-maintenance = { path = "crates/etl-maintenance", default-features = false }
 etl-postgres = { path = "crates/etl-postgres", default-features = false }
 etl-telemetry = { path = "crates/etl-telemetry", default-features = false }

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -13,6 +13,8 @@ homepage.workspace = true
 doctest = false
 
 [features]
+# Explicit opt-in: database errors and SQL may contain source row values.
+ducklake-query-error-details = ["ducklake"]
 default = ["tls-rustls-ring", "bundled"]
 bundled = ["duckdb?/bundled", "duckdb?/json", "duckdb?/parquet", "etl-maintenance?/bundled"]
 tls-rustls-ring = [

--- a/crates/etl-destinations/Cargo.toml
+++ b/crates/etl-destinations/Cargo.toml
@@ -13,7 +13,8 @@ homepage.workspace = true
 doctest = false
 
 [features]
-default = ["tls-rustls-ring"]
+default = ["tls-rustls-ring", "bundled"]
+bundled = ["duckdb?/bundled", "duckdb?/json", "duckdb?/parquet", "etl-maintenance?/bundled"]
 tls-rustls-ring = [
     "etl/tls-rustls-ring",
     "etl-maintenance?/tls-rustls-ring",
@@ -112,7 +113,7 @@ base64 = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 chrono = { workspace = true, features = ["serde"] }
 clickhouse = { workspace = true, optional = true, features = ["inserter", "lz4", "rustls-tls"] }
-duckdb = { workspace = true, optional = true, features = ["appender-arrow", "bundled", "json", "parquet", "r2d2"] }
+duckdb = { workspace = true, optional = true, features = ["appender-arrow", "r2d2"] }
 etl = { workspace = true }
 etl-config = { workspace = true }
 etl-maintenance = { workspace = true, optional = true }

--- a/crates/etl-destinations/README.md
+++ b/crates/etl-destinations/README.md
@@ -24,3 +24,30 @@ DuckLake external maintenance is configured at runtime with
 `ETL_DUCKLAKE_MAINTENANCE_CR_NAMESPACE`. Postgres coordination uses the same
 Postgres catalog connection as DuckLake and stores coordination state in the
 `etl` schema.
+
+When embedding DuckLake, the builder also accepts a `connection_initializer`
+and a `table_name_mapper`. The initializer returns a fresh DuckDB instance with
+`lake` already attached to the configured catalog and data path. It owns
+extension loading, credentials, resource/spill limits and catalog options,
+including schema-scoped options and the attachment's data inlining limit. ETL
+continues to own COPY, CDC, replay state, pooled connection clones and session
+settings. The initializer runs again on instance replacement; it must not retain
+connections to retired instances. Existing persisted table names take precedence
+over a new mapping, and sorting configuration uses destination names.
+
+`DuckLakeDestination::run_maintenance` runs caller-selected work on the writer's
+instance under the existing mutation pause and query watchdog. The caller owns
+the schedule and table selection. Cancellation does not release the pause until
+the blocking operation exits. Callbacks must finish transactions and must not
+retain cloned connections outside the operation.
+
+The builder's `cdc_batch_size` controls the transaction cap for mutations already
+received from the pipeline (default: 16). Increasing it can reduce file creation
+with inlining disabled, with longer transactions and larger retry units. It does
+not change how long the pipeline waits to fill an input batch.
+
+The `bundled` feature is enabled by default and keeps the bundled DuckDB/JSON/
+Parquet build. Hosts supplying a compatible native DuckDB library can disable
+default features and select `ducklake` plus their TLS feature. Their initializer
+must load extensions matching that library. Other dependencies enabling `bundled`
+will still enable it through Cargo feature unification.

--- a/crates/etl-destinations/README.md
+++ b/crates/etl-destinations/README.md
@@ -29,8 +29,9 @@ When embedding DuckLake, the builder also accepts a `connection_initializer`
 and a `table_name_mapper`. The initializer returns a fresh DuckDB instance with
 `lake` already attached to the configured catalog and data path. It owns
 extension loading, credentials, resource/spill limits and catalog options,
-including schema-scoped options and the attachment's data inlining limit. ETL
-continues to own COPY, CDC, replay state, pooled connection clones and session
+including schema-scoped options and the attachment's data inlining limit for both
+COPY and CDC. Host initialization bypasses the standalone COPY inlining override.
+ETL continues to own COPY, CDC, replay state, pooled connection clones and session
 settings. The initializer runs again on instance replacement; it must not retain
 connections to retired instances. Existing persisted table names take precedence
 over a new mapping, and sorting configuration uses destination names.
@@ -53,7 +54,8 @@ must load extensions matching that library. Other dependencies enabling `bundled
 will still enable it through Cargo feature unification.
 
 `ducklake-query-error-details` explicitly includes original DuckDB UPDATE/DELETE
-errors, their source chains and SQL in diagnostics. These can contain row values;
+errors, their source chains and SQL in returned errors. Automatic mutation/task
+logs retain structural context without rendering those errors. Returned errors can contain row values;
 leave the feature disabled to retain the default redaction. Concurrent table
 failures are logged individually and accepted table tasks finish before the
 first error is returned to the apply loop.

--- a/crates/etl-destinations/README.md
+++ b/crates/etl-destinations/README.md
@@ -51,3 +51,9 @@ Parquet build. Hosts supplying a compatible native DuckDB library can disable
 default features and select `ducklake` plus their TLS feature. Their initializer
 must load extensions matching that library. Other dependencies enabling `bundled`
 will still enable it through Cargo feature unification.
+
+`ducklake-query-error-details` explicitly includes original DuckDB UPDATE/DELETE
+errors, their source chains and SQL in diagnostics. These can contain row values;
+leave the feature disabled to retain the default redaction. Concurrent table
+failures are logged individually and accepted table tasks finish before the
+first error is returned to the apply loop.

--- a/crates/etl-destinations/src/ducklake/batches.rs
+++ b/crates/etl-destinations/src/ducklake/batches.rs
@@ -112,17 +112,33 @@ fn is_duckdb_interrupt_error(error: &duckdb::Error) -> bool {
     error.to_string().contains("INTERRUPT Error: Interrupted")
 }
 
-/// Sanitized DuckDB query failure for statements that may contain row values.
-#[derive(Debug)]
-struct DuckDbSensitiveQueryError;
-
+/// Query failure whose value-bearing diagnostics require explicit opt-in.
+struct DuckDbSensitiveQueryError {
+    error: duckdb::Error,
+    sql: String,
+}
 impl fmt::Display for DuckDbSensitiveQueryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "DuckDB query failed; error message omitted because it may contain row values")
+        if cfg!(feature = "ducklake-query-error-details") {
+            write!(f, "{}; SQL: {}", self.error, self.sql)
+        } else {
+            write!(
+                f,
+                "DuckDB query failed; error message omitted because it may contain row values"
+            )
+        }
     }
 }
-
-impl error::Error for DuckDbSensitiveQueryError {}
+impl fmt::Debug for DuckDbSensitiveQueryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+impl error::Error for DuckDbSensitiveQueryError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        if cfg!(feature = "ducklake-query-error-details") { Some(&self.error) } else { None }
+    }
+}
 
 /// Formats query context for a delete mutation without row values.
 fn format_delete_mutation_error_detail(
@@ -2320,8 +2336,9 @@ fn apply_delete_mutation(
         let sql_query = format!("DELETE FROM {target_table} WHERE {where_clause};");
         conn.execute_batch(&sql_query).map_err(|error| {
             let duckdb_interrupted = is_duckdb_interrupt_error(&error);
+            let error = DuckDbSensitiveQueryError { error, sql: sql_query.clone() };
             tracing::error!(
-                error = %DuckDbSensitiveQueryError,
+                error = %error,
                 table = %batch.table_name,
                 batch_id = %batch.batch_id,
                 batch_kind = batch.batch_kind.as_str(),
@@ -2351,7 +2368,7 @@ fn apply_delete_mutation(
                     chunk_count,
                     chunk.len(),
                 ),
-                source: DuckDbSensitiveQueryError
+                source: error
             )
         })?;
     }
@@ -2373,13 +2390,14 @@ fn apply_update_mutation(
     let set_clause = assignments.join(", ");
     let target_table = qualified_lake_table_name(table_name);
     let sql_query = format!("UPDATE {target_table} SET {set_clause} WHERE {predicate};");
-    conn.execute_batch(&sql_query).map_err(|_err| {
-        tracing::error!(error = %DuckDbSensitiveQueryError, "error updating rows");
+    conn.execute_batch(&sql_query).map_err(|error| {
+        let error = DuckDbSensitiveQueryError { error, sql: sql_query.clone() };
+        tracing::error!(error = %error, "error updating rows");
         etl_error!(
             ErrorKind::DestinationQueryFailed,
             "DuckLake UPDATE failed",
             format_update_mutation_error_detail(&target_table, assignments.len(), !predicate.is_empty()),
-            source: DuckDbSensitiveQueryError
+            source: error
         )
     })?;
 
@@ -2642,6 +2660,11 @@ mod tests {
     ) {
         assert_eq!(error.kind(), ErrorKind::DestinationQueryFailed);
         assert_eq!(error.description(), Some(description));
+        if cfg!(feature = "ducklake-query-error-details") {
+            assert!(error.to_string().contains(sensitive_value));
+            assert!(error.to_string().contains("SQL:"));
+            return;
+        }
         assert!(!error.to_string().contains(sensitive_value));
         assert!(!error.detail().is_some_and(|detail| detail.contains(sensitive_value)));
         let source = error.source().expect("expected sanitized source");

--- a/crates/etl-destinations/src/ducklake/batches.rs
+++ b/crates/etl-destinations/src/ducklake/batches.rs
@@ -2338,7 +2338,7 @@ fn apply_delete_mutation(
             let duckdb_interrupted = is_duckdb_interrupt_error(&error);
             let error = DuckDbSensitiveQueryError { error, sql: sql_query.clone() };
             tracing::error!(
-                error = %error,
+                error = "DuckDB DELETE failed; row-bearing diagnostics omitted from logs",
                 table = %batch.table_name,
                 batch_id = %batch.batch_id,
                 batch_kind = batch.batch_kind.as_str(),
@@ -2392,7 +2392,7 @@ fn apply_update_mutation(
     let sql_query = format!("UPDATE {target_table} SET {set_clause} WHERE {predicate};");
     conn.execute_batch(&sql_query).map_err(|error| {
         let error = DuckDbSensitiveQueryError { error, sql: sql_query.clone() };
-        tracing::error!(error = %error, "error updating rows");
+        tracing::error!(error = "DuckDB UPDATE failed; row-bearing diagnostics omitted from logs", table = %table_name, "error updating rows");
         etl_error!(
             ErrorKind::DestinationQueryFailed,
             "DuckLake UPDATE failed",

--- a/crates/etl-destinations/src/ducklake/batches.rs
+++ b/crates/etl-destinations/src/ducklake/batches.rs
@@ -789,17 +789,19 @@ pub(super) async fn apply_table_batch_with_retry(
 /// mixed CDC streams can commit larger insert groups without breaking atomic
 /// ordering.
 pub(super) fn prepare_mutation_table_batches(
+    batch_size: Option<std::num::NonZeroUsize>,
     replicated_table_schema: &ReplicatedTableSchema,
     table_name: DuckLakeTableName,
     replay_epoch: String,
     tracked_mutations: Vec<TrackedTableMutation>,
 ) -> EtlResult<Vec<PreparedDuckLakeTableBatch>> {
+    let batch_size = batch_size.map_or(CDC_MUTATION_BATCH_SIZE, std::num::NonZeroUsize::get);
     let mut prepared_batches = Vec::new();
     let mut pending_mutations = Vec::new();
 
     for tracked_mutation in tracked_mutations {
         pending_mutations.push(tracked_mutation);
-        if pending_mutations.len() >= CDC_MUTATION_BATCH_SIZE {
+        if pending_mutations.len() >= batch_size {
             push_prepared_mutation_batch(
                 &mut prepared_batches,
                 replicated_table_schema,
@@ -3157,6 +3159,7 @@ mod tests {
     fn prepare_mutation_table_batches_insert_only_uses_single_upsert_operation() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
+            None,
             &replicated_table_schema,
             ducklake_table_name(),
             LEGACY_REPLAY_EPOCH.to_owned(),
@@ -3207,6 +3210,7 @@ mod tests {
     fn prepare_mutation_table_batches_split_mixed_cdc_at_delete_boundaries() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
+            None,
             &replicated_table_schema,
             ducklake_table_name(),
             LEGACY_REPLAY_EPOCH.to_owned(),
@@ -3259,6 +3263,7 @@ mod tests {
     fn prepare_mutation_table_batches_group_contiguous_deletes() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
+            None,
             &replicated_table_schema,
             ducklake_table_name(),
             LEGACY_REPLAY_EPOCH.to_owned(),
@@ -3306,6 +3311,7 @@ mod tests {
     fn prepare_mutation_table_batches_group_contiguous_updates() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
+            None,
             &replicated_table_schema,
             ducklake_table_name(),
             LEGACY_REPLAY_EPOCH.to_owned(),
@@ -3361,50 +3367,55 @@ mod tests {
 
     #[test]
     fn prepare_mutation_table_batches_split_non_inserts_at_cap() {
-        let replicated_table_schema = make_replicated_schema();
-        let tracked = (0..=CDC_MUTATION_BATCH_SIZE)
-            .map(|idx| {
-                TrackedTableMutation::new(
-                    EventSequenceKey::new(PgLsn::from(200 + idx as u64), 0),
-                    TableMutation::Delete(OldTableRow::Full(TableRow::new(vec![
-                        Cell::I32(idx as i32),
-                        Cell::String(format!("name-{idx}")),
-                    ]))),
-                )
-            })
-            .collect();
-        let batches = prepare_mutation_table_batches(
-            &replicated_table_schema,
-            ducklake_table_name(),
-            LEGACY_REPLAY_EPOCH.to_owned(),
-            tracked,
-        )
-        .unwrap();
+        for configured_size in [None, std::num::NonZeroUsize::new(CDC_MUTATION_BATCH_SIZE * 2)] {
+            let replicated_table_schema = make_replicated_schema();
+            let batch_size =
+                configured_size.map_or(CDC_MUTATION_BATCH_SIZE, std::num::NonZeroUsize::get);
+            let tracked = (0..=batch_size)
+                .map(|idx| {
+                    TrackedTableMutation::new(
+                        EventSequenceKey::new(PgLsn::from(200 + idx as u64), 0),
+                        TableMutation::Delete(OldTableRow::Full(TableRow::new(vec![
+                            Cell::I32(idx as i32),
+                            Cell::String(format!("name-{idx}")),
+                        ]))),
+                    )
+                })
+                .collect();
+            let batches = prepare_mutation_table_batches(
+                configured_size,
+                &replicated_table_schema,
+                ducklake_table_name(),
+                LEGACY_REPLAY_EPOCH.to_owned(),
+                tracked,
+            )
+            .unwrap();
 
-        assert_eq!(batches.len(), 2);
+            assert_eq!(batches.len(), 2);
 
-        match &batches[0].action {
-            PreparedDuckLakeTableBatchAction::Mutation(prepared) => match &prepared[0] {
-                PreparedTableMutation::Delete { predicates, .. } => {
-                    assert_eq!(predicates.len(), CDC_MUTATION_BATCH_SIZE);
-                }
-                PreparedTableMutation::Upsert(_) | PreparedTableMutation::Update { .. } => {
-                    panic!("expected delete batch")
-                }
-            },
-            PreparedDuckLakeTableBatchAction::Truncate => panic!("expected mutation batch"),
-        }
+            match &batches[0].action {
+                PreparedDuckLakeTableBatchAction::Mutation(prepared) => match &prepared[0] {
+                    PreparedTableMutation::Delete { predicates, .. } => {
+                        assert_eq!(predicates.len(), batch_size);
+                    }
+                    PreparedTableMutation::Upsert(_) | PreparedTableMutation::Update { .. } => {
+                        panic!("expected delete batch")
+                    }
+                },
+                PreparedDuckLakeTableBatchAction::Truncate => panic!("expected mutation batch"),
+            }
 
-        match &batches[1].action {
-            PreparedDuckLakeTableBatchAction::Mutation(prepared) => match &prepared[0] {
-                PreparedTableMutation::Delete { predicates, .. } => {
-                    assert_eq!(predicates.len(), 1);
-                }
-                PreparedTableMutation::Upsert(_) | PreparedTableMutation::Update { .. } => {
-                    panic!("expected delete batch")
-                }
-            },
-            PreparedDuckLakeTableBatchAction::Truncate => panic!("expected mutation batch"),
+            match &batches[1].action {
+                PreparedDuckLakeTableBatchAction::Mutation(prepared) => match &prepared[0] {
+                    PreparedTableMutation::Delete { predicates, .. } => {
+                        assert_eq!(predicates.len(), 1);
+                    }
+                    PreparedTableMutation::Upsert(_) | PreparedTableMutation::Update { .. } => {
+                        panic!("expected delete batch")
+                    }
+                },
+                PreparedDuckLakeTableBatchAction::Truncate => panic!("expected mutation batch"),
+            }
         }
     }
 
@@ -3412,6 +3423,7 @@ mod tests {
     fn prepare_mutation_table_batches_isolate_update_in_its_own_atomic_batch() {
         let replicated_table_schema = make_replicated_schema();
         let batches = prepare_mutation_table_batches(
+            None,
             &replicated_table_schema,
             ducklake_table_name(),
             LEGACY_REPLAY_EPOCH.to_owned(),

--- a/crates/etl-destinations/src/ducklake/client.rs
+++ b/crates/etl-destinations/src/ducklake/client.rs
@@ -1006,7 +1006,12 @@ where
 {
     let operation_kind = DUCKDB_BLOCKING_OPERATION_KIND;
     let operation_id = NEXT_DUCKDB_BLOCKING_OPERATION_ID.fetch_add(1, Ordering::Relaxed);
-    let deadline = Instant::now() + timeout;
+    let deadline = Instant::now().checked_add(timeout).ok_or_else(|| {
+        etl_error!(ErrorKind::ConfigError, "DuckLake operation timeout is too large")
+    })?;
+    let abort_deadline = deadline.checked_add(BLOCKING_ABORT_GRACE).ok_or_else(|| {
+        etl_error!(ErrorKind::ConfigError, "DuckLake operation timeout leaves no abort grace")
+    })?;
     let slot_wait_started = Instant::now();
     let permit = tokio::time::timeout_at(deadline, Arc::clone(&blocking_slots).acquire_owned())
         .await
@@ -1026,7 +1031,6 @@ where
     // connection active.
     let mut watchdog = DuckDbQueryWatchdog::spawn(deadline);
     let watchdog_task = watchdog.async_task_handle()?;
-    let abort_deadline = deadline + BLOCKING_ABORT_GRACE;
 
     let blocking_task = tokio::task::spawn_blocking(move || -> EtlResult<R> {
         // Please if you modify the code inside this blocking task do not add any
@@ -1342,6 +1346,26 @@ mod tests {
             expected_timed_out,
             "unexpected timeout state for watchdog sequence `{name}`"
         );
+    }
+
+    #[tokio::test]
+    async fn overflowing_timeout_returns_config_error_before_running_operation() {
+        let pool = Arc::new(
+            build_warm_ducklake_pool(make_blocking_test_manager(), 1, "test").await.unwrap(),
+        );
+        let slots = Arc::new(Semaphore::new(1));
+        let error = run_duckdb_blocking_with_timeout(
+            pool,
+            Arc::clone(&slots),
+            Duration::MAX,
+            |_| -> EtlResult<()> {
+                panic!("an invalid timeout must not start native work");
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ConfigError);
+        assert_eq!(slots.available_permits(), 1);
     }
 
     #[tokio::test]

--- a/crates/etl-destinations/src/ducklake/client.rs
+++ b/crates/etl-destinations/src/ducklake/client.rs
@@ -26,6 +26,7 @@ use tracing::{info, trace, warn};
 
 use crate::ducklake::{
     config::{DuckLakeSetupPlan, DuckLakeSetupStep},
+    embedding::ConnectionInitializer,
     metrics::{
         ETL_DUCKLAKE_BLOCKING_OPERATION_DURATION_SECONDS, ETL_DUCKLAKE_BLOCKING_SLOT_WAIT_SECONDS,
         ETL_DUCKLAKE_POOL_CHECKOUT_WAIT_SECONDS,
@@ -363,6 +364,9 @@ pub(super) struct DuckLakeConnectionManager {
     pub(super) shutdown_requested: Arc<AtomicBool>,
     /// Anchor connection used to clone pooled connections from one database.
     shared_instance: Arc<Mutex<duckdb::Connection>>,
+    /// Recreates host-specific configuration and credentials on every
+    /// generation.
+    connection_initializer: Option<ConnectionInitializer>,
     /// Counts successfully initialized DuckDB connections for tests.
     #[cfg(feature = "test-utils")]
     pub(super) open_count: Arc<AtomicUsize>,
@@ -562,8 +566,30 @@ impl DuckLakeConnectionManager {
         interrupt_registry: Arc<DuckLakeInterruptRegistry>,
         shutdown_requested: Arc<AtomicBool>,
     ) -> EtlResult<Self> {
+        Self::new_with_initializer(
+            setup_plan,
+            disable_extension_autoload,
+            interrupt_registry,
+            shutdown_requested,
+            None,
+        )
+        .await
+    }
+
+    /// Creates a manager with an optional host-owned instance initializer.
+    pub(super) async fn new_with_initializer(
+        setup_plan: Arc<DuckLakeSetupPlan>,
+        disable_extension_autoload: bool,
+        interrupt_registry: Arc<DuckLakeInterruptRegistry>,
+        shutdown_requested: Arc<AtomicBool>,
+        connection_initializer: Option<ConnectionInitializer>,
+    ) -> EtlResult<Self> {
+        let initialize = connection_initializer.clone();
         let setup_plan_for_initialization = Arc::clone(&setup_plan);
         let instance = tokio::task::spawn_blocking(move || {
+            if let Some(initialize) = initialize {
+                return initialize();
+            }
             Self::open_initialized_duckdb_instance(
                 setup_plan_for_initialization.as_ref(),
                 disable_extension_autoload,
@@ -590,6 +616,7 @@ impl DuckLakeConnectionManager {
             interrupt_registry,
             shutdown_requested,
             shared_instance: Arc::new(Mutex::new(instance)),
+            connection_initializer,
             #[cfg(feature = "test-utils")]
             open_count: Arc::new(AtomicUsize::new(0)),
         })
@@ -603,6 +630,7 @@ impl DuckLakeConnectionManager {
             interrupt_registry: Arc::clone(&self.interrupt_registry),
             shutdown_requested: Arc::clone(&self.shutdown_requested),
             shared_instance: Arc::clone(&self.shared_instance),
+            connection_initializer: self.connection_initializer.clone(),
             #[cfg(feature = "test-utils")]
             open_count: Arc::new(AtomicUsize::new(0)),
         }
@@ -700,18 +728,23 @@ impl DuckLakeConnectionManager {
         let shared_instance = Arc::clone(&self.shared_instance);
         let setup_plan = Arc::clone(&self.setup_plan);
         let disable_extension_autoload = self.disable_extension_autoload;
+        let initialize = self.connection_initializer.clone();
         tokio::task::spawn_blocking(move || -> EtlResult<()> {
-            let instance = Self::open_initialized_duckdb_instance(
-                setup_plan.as_ref(),
-                disable_extension_autoload,
-            )
-            .map_err(|error| {
-                etl_error!(
-                    ErrorKind::DestinationConnectionFailed,
-                    "Failed to recreate shared DuckLake DuckDB instance",
-                    source: error
+            let instance = if let Some(initialize) = initialize {
+                initialize()?
+            } else {
+                Self::open_initialized_duckdb_instance(
+                    setup_plan.as_ref(),
+                    disable_extension_autoload,
                 )
-            })?;
+                .map_err(|error| {
+                    etl_error!(
+                        ErrorKind::DestinationConnectionFailed,
+                        "Failed to recreate shared DuckLake DuckDB instance",
+                        source: error
+                    )
+                })?
+            };
             let mut current = shared_instance.lock().map_err(|_| {
                 etl_error!(
                     ErrorKind::InvalidState,
@@ -1099,6 +1132,7 @@ mod tests {
             interrupt_registry: Arc::new(DuckLakeInterruptRegistry::default()),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
             shared_instance: Arc::new(Mutex::new(duckdb::Connection::open_in_memory().unwrap())),
+            connection_initializer: None,
             #[cfg(feature = "test-utils")]
             open_count: Arc::new(AtomicUsize::new(0)),
         }
@@ -1861,5 +1895,73 @@ mod tests {
 
         let error = run_duckdb_blocking(pool, blocking_slots, |_| Ok(())).await.unwrap_err();
         assert!(is_ducklake_shutdown_requested_error(&error));
+    }
+
+    #[tokio::test]
+    async fn embedded_initializer_is_shared_and_repeated_on_recreation() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let initialize_calls = Arc::clone(&calls);
+        let initialize: ConnectionInitializer = Arc::new(move || {
+            let generation = initialize_calls.fetch_add(1, Ordering::SeqCst);
+            let connection = duckdb::Connection::open_in_memory().map_err(|source| {
+                etl_error!(ErrorKind::DestinationConnectionFailed, "Open failed", source: source)
+            })?;
+            connection.execute_batch(&format!(
+                "create table generation as select {generation} as id;"
+            )).map_err(|source| {
+                etl_error!(ErrorKind::DestinationQueryFailed, "Setup failed", source: source)
+            })?;
+            Ok(connection)
+        });
+        let manager = DuckLakeConnectionManager::new_with_initializer(
+            Arc::new(DuckLakeSetupPlan::for_embedded_instance()),
+            false,
+            Arc::new(DuckLakeInterruptRegistry::default()),
+            Arc::new(AtomicBool::new(false)),
+            Some(initialize),
+        )
+        .await
+        .unwrap();
+        let copy_manager = manager.new_pool_manager();
+        let first = manager.open_duckdb_connection().unwrap();
+        first.conn.execute_batch("insert into generation values (42)").unwrap();
+        let second = copy_manager.open_duckdb_connection().unwrap();
+        assert_eq!(
+            second
+                .conn
+                .query_row("select count(*) from generation", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        drop(first);
+        drop(second);
+        manager.recreate_shared_instance().await.unwrap();
+        let recreated = copy_manager.open_duckdb_connection().unwrap();
+        assert_eq!(
+            recreated
+                .conn
+                .query_row("select id from generation", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn embedded_initializer_propagates_failures() {
+        let result = DuckLakeConnectionManager::new_with_initializer(
+            Arc::new(DuckLakeSetupPlan::for_embedded_instance()),
+            false,
+            Arc::new(DuckLakeInterruptRegistry::default()),
+            Arc::new(AtomicBool::new(false)),
+            Some(Arc::new(|| {
+                Err(etl_error!(ErrorKind::ConfigError, "Host initialization failed"))
+            })),
+        )
+        .await;
+        let error = result.err().unwrap();
+        assert_eq!(error.kind(), ErrorKind::ConfigError);
+        assert!(error.to_string().contains("Host initialization failed"));
     }
 }

--- a/crates/etl-destinations/src/ducklake/config.rs
+++ b/crates/etl-destinations/src/ducklake/config.rs
@@ -103,6 +103,17 @@ pub(super) struct DuckLakeSetupPlan {
 }
 
 impl DuckLakeSetupPlan {
+    /// Retains connection-local writer settings for a host-initialized
+    /// database.
+    pub(super) fn for_embedded_instance() -> Self {
+        Self {
+            steps: vec![DuckLakeSetupStep {
+                label: "configure_writer_session",
+                sql: configure_writer_session_sql(),
+            }],
+        }
+    }
+
     /// Returns the ordered setup steps.
     pub(super) fn steps(&self) -> &[DuckLakeSetupStep] {
         &self.steps

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -190,7 +190,9 @@ async fn finish_table_tasks(tasks: &mut tokio::task::JoinSet<EtlResult<()>>) -> 
     while let Some(result) = tasks.join_next().await {
         let result = result.map_err(|source| etl_error!(ErrorKind::ApplyWorkerPanic, "DuckLake table task failed", source: source)).and_then(|result| result);
         if let Err(error) = result {
-            tracing::error!(error = %error, detail = error.detail(), "ducklake table task failed");
+            // A returned error may carry opt-in row-bearing diagnostics.
+            // Automatic logs keep only the owned description and error kind.
+            tracing::error!(error = error.description().unwrap_or("DuckLake table task failed"), error_kind = ?error.kind(), "ducklake table task failed");
             if first_error.is_none() {
                 first_error = Some(error);
             }
@@ -200,6 +202,32 @@ async fn finish_table_tasks(tasks: &mut tokio::task::JoinSet<EtlResult<()>>) -> 
         Some(error) => Err(error),
         None => Ok(()),
     }
+}
+
+/// Rejects another source's durable claim before creating or recovering a
+/// table. Callers serialize initial creation with `table_creation_slots`;
+/// pending metadata reserves a name even when physical DDL has not completed.
+async fn ensure_unique_table_identity<S: DestinationStore>(
+    store: &S,
+    table_id: TableId,
+    table_name: &DuckLakeTableName,
+) -> EtlResult<()> {
+    for schema in store.get_table_schemas().await? {
+        if schema.id != table_id
+            && let Some(metadata) = store.get_destination_table_metadata(schema.id).await?
+            && DuckLakeTableName::from_metadata_id(metadata.table_id())? == *table_name
+        {
+            return Err(etl_error!(
+                ErrorKind::InvalidState,
+                "DuckLake destination table is already owned by another source",
+                format!(
+                    "Table {table_name} is owned by source {}; cannot assign it to {table_id}",
+                    schema.id
+                )
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Returns whether a DuckLake DDL error indicates another transaction already
@@ -648,7 +676,8 @@ impl<S> DuckLakeDestinationBuilder<S> {
     /// Return a fresh instance with DuckLake attached as `lake`, using the same
     /// catalog, metadata schema and data path passed to this builder. The host
     /// owns extension loading, secrets, resource limits, attachment options and
-    /// catalog writer options. The standalone S3 and Parquet setup is bypassed.
+    /// catalog writer options for both COPY and CDC. Standalone S3, Parquet
+    /// setup and temporary COPY inlining overrides are bypassed.
     /// ETL still configures writer sessions and manages replay helper tables.
     /// Do not retain connections to retired instances in the callback.
     pub fn connection_initializer<F>(mut self, initialize: F) -> Self
@@ -2332,6 +2361,12 @@ where
         &self,
         table_name: &DuckLakeTableName,
     ) -> EtlResult<()> {
+        // Host setup owns inlining for both COPY and CDC. Do not introduce a
+        // table override that would mask its attachment or schema settings.
+        if self.embedding.connection_initializer.is_some() {
+            return Ok(());
+        }
+
         if self.copy_direct_to_parquet_tables.lock().contains(table_name) {
             return Ok(());
         }
@@ -2347,6 +2382,12 @@ where
         &self,
         table_name: &DuckLakeTableName,
     ) -> EtlResult<()> {
+        // Host setup owns inlining for both COPY and CDC. Do not introduce a
+        // table override that would mask its attachment or schema settings.
+        if self.embedding.connection_initializer.is_some() {
+            return Ok(());
+        }
+
         self.set_copy_data_inlining_row_limit(table_name, ATTACH_DATA_INLINING_ROW_LIMIT).await?;
         self.copy_direct_to_parquet_tables.lock().remove(table_name);
         Ok(())
@@ -3174,6 +3215,7 @@ where
             };
 
             let table_name = DuckLakeTableName::from_metadata_id(metadata.table_id())?;
+            ensure_unique_table_identity(&self.store, table_id, &table_name).await?;
             if metadata.is_pending() {
                 self.recover_pending_metadata(table_id, &table_name, metadata, None).await?;
                 continue;
@@ -3507,6 +3549,7 @@ where
         replicated_table_schema: &ReplicatedTableSchema,
     ) -> EtlResult<()> {
         validate_ducklake_table_shape(replicated_table_schema)?;
+        ensure_unique_table_identity(&self.store, table_id, table_name).await?;
         let metadata = DestinationTableMetadata::new_creating(
             table_name.to_metadata_id()?,
             replicated_table_schema.inner().snapshot_id,
@@ -4453,7 +4496,7 @@ mod tests {
             ColumnMetadataChange, ColumnSchema, IdentityMask, ReplicationMask, SchemaDiff,
             TableSchema, Type as PgType,
         },
-        store::{MemoryStore, SchemaStore},
+        store::{MemoryStore, SchemaStore, StateStore},
     };
     use etl_maintenance::ducklake::flush_table_inlined_data;
     use etl_postgres::{test_utils::local_tls_config_from_env, tokio::test_utils::PgDatabase};
@@ -5839,6 +5882,34 @@ mod tests {
             assert!(metrics.files_scheduled_for_deletion_total >= 0);
             assert!(metrics.files_scheduled_for_deletion_bytes >= 0);
             assert!(metrics.oldest_scheduled_deletion_age_seconds >= 0);
+        }
+    }
+    #[tokio::test]
+    async fn mapped_table_identity_rejects_pending_and_applied_owners() {
+        let store = MemoryStore::new();
+        let first = make_schema(1, "public", "first");
+        let second = make_schema(2, "public", "second");
+        store.store_table_schema(first.clone()).await.unwrap();
+        store.store_table_schema(second.clone()).await.unwrap();
+        let name = ducklake_table_name();
+        let schema = ReplicatedTableSchema::all(Arc::new(first.clone()));
+        let pending = DestinationTableMetadata::new_creating(
+            name.to_metadata_id().unwrap(),
+            first.snapshot_id,
+            schema.replication_mask().clone(),
+        );
+        for metadata in [pending.clone(), pending.to_applied()] {
+            store.store_destination_table_metadata(first.id, metadata).await.unwrap();
+            ensure_unique_table_identity(&store, first.id, &name).await.unwrap();
+            let error = ensure_unique_table_identity(&store, second.id, &name).await.unwrap_err();
+            assert_eq!(error.kind(), ErrorKind::InvalidState);
+            ensure_unique_table_identity(
+                &store,
+                second.id,
+                &DuckLakeTableName::new("other", "users"),
+            )
+            .await
+            .unwrap();
         }
     }
 }

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -204,6 +204,18 @@ async fn finish_table_tasks(tasks: &mut tokio::task::JoinSet<EtlResult<()>>) -> 
     }
 }
 
+/// Rejects destination names reserved for ETL replay bookkeeping.
+fn validate_ducklake_table_name(table_name: &DuckLakeTableName) -> EtlResult<()> {
+    if table_name.is_internal_helper() {
+        return Err(etl_error!(
+            ErrorKind::InvalidState,
+            "DuckLake destination table uses a reserved ETL helper name",
+            format!("Table {table_name} cannot be used for replication")
+        ));
+    }
+    Ok(())
+}
+
 /// Rejects another source's durable claim before creating or recovering a
 /// table. Callers serialize initial creation with `table_creation_slots`;
 /// pending metadata reserves a name even when physical DDL has not completed.
@@ -212,10 +224,14 @@ async fn ensure_unique_table_identity<S: DestinationStore>(
     table_id: TableId,
     table_name: &DuckLakeTableName,
 ) -> EtlResult<()> {
+    validate_ducklake_table_name(table_name)?;
     for schema in store.get_table_schemas().await? {
         if schema.id != table_id
             && let Some(metadata) = store.get_destination_table_metadata(schema.id).await?
-            && DuckLakeTableName::from_metadata_id(metadata.table_id())? == *table_name
+            && let owner = DuckLakeTableName::from_metadata_id(metadata.table_id())?
+            // DuckDB resolves even quoted identifiers using ASCII case folding.
+            && owner.schema().eq_ignore_ascii_case(table_name.schema())
+            && owner.table().eq_ignore_ascii_case(table_name.table())
         {
             return Err(etl_error!(
                 ErrorKind::InvalidState,
@@ -690,10 +706,13 @@ impl<S> DuckLakeDestinationBuilder<S> {
 
     /// Maps newly discovered tables to their durable destination names.
     ///
-    /// The mapping must be deterministic, injective and avoid ETL helper
-    /// names. Existing tables retain their stored identity, including after a
-    /// restart or a source rename; changing this callback does not move data.
-    /// Table sorting policies refer to the resulting destination names.
+    /// The mapping must be deterministic, injective under ASCII
+    /// case-insensitive identifier comparison, and avoid the reserved
+    /// `__etl_` prefix in any case. Invalid names and identities already
+    /// owned by another source are rejected. Existing tables retain their
+    /// stored identity, including after a restart or a source rename;
+    /// changing this callback does not move data. Table sorting policies
+    /// refer to the resulting destination names.
     pub fn table_name_mapper<F>(mut self, map: F) -> Self
     where
         F: Fn(&TableName) -> EtlResult<DuckLakeTableName> + Send + Sync + 'static,
@@ -3901,10 +3920,12 @@ where
 
     /// Maps a table only before its durable destination identity exists.
     fn map_new_table_name(&self, source: &TableName) -> EtlResult<DuckLakeTableName> {
-        match &self.embedding.table_name_mapper {
+        let table_name = match &self.embedding.table_name_mapper {
             Some(map) => map(source),
             None => table_name_to_ducklake_table_name(source),
-        }
+        }?;
+        validate_ducklake_table_name(&table_name)?;
+        Ok(table_name)
     }
 
     /// Returns the stored destination table name or the deterministic default.
@@ -5901,8 +5922,18 @@ mod tests {
         for metadata in [pending.clone(), pending.to_applied()] {
             store.store_destination_table_metadata(first.id, metadata).await.unwrap();
             ensure_unique_table_identity(&store, first.id, &name).await.unwrap();
-            let error = ensure_unique_table_identity(&store, second.id, &name).await.unwrap_err();
-            assert_eq!(error.kind(), ErrorKind::InvalidState);
+            for candidate in [
+                name.clone(),
+                DuckLakeTableName::new("PUBLIC", "users"),
+                DuckLakeTableName::new("public", "Users"),
+                DuckLakeTableName::new("PUBLIC", "USERS"),
+            ] {
+                ensure_unique_table_identity(&store, first.id, &candidate).await.unwrap();
+                let error =
+                    ensure_unique_table_identity(&store, second.id, &candidate).await.unwrap_err();
+                assert_eq!(error.kind(), ErrorKind::InvalidState);
+                assert!(store.get_destination_table_metadata(second.id).await.unwrap().is_none());
+            }
             ensure_unique_table_identity(
                 &store,
                 second.id,
@@ -5911,5 +5942,61 @@ mod tests {
             .await
             .unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn mapped_table_identity_rejects_reserved_helpers() {
+        let store = MemoryStore::new();
+        let schema = make_schema(1, "public", "users");
+        store.store_table_schema(schema.clone()).await.unwrap();
+        for table in [
+            "__etl_applied_table_batches",
+            "__etl_streaming_progress",
+            "__ETL_APPLIED_TABLE_BATCHES",
+            "__EtL_streaming_progress",
+        ] {
+            for namespace in ["main", "MAIN", "public"] {
+                let name = DuckLakeTableName::new(namespace, table);
+                let error =
+                    ensure_unique_table_identity(&store, schema.id, &name).await.unwrap_err();
+                assert_eq!(error.kind(), ErrorKind::InvalidState);
+                assert!(store.get_destination_table_metadata(schema.id).await.unwrap().is_none());
+            }
+        }
+        for table in ["__etl", "__et", "users", "éééusers", "__étl_users"] {
+            ensure_unique_table_identity(&store, schema.id, &DuckLakeTableName::new("main", table))
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn mapped_table_identity_preserves_non_ascii_distinctions() {
+        let store = MemoryStore::new();
+        let first = make_schema(1, "public", "first");
+        let second = make_schema(2, "public", "second");
+        store.store_table_schema(first.clone()).await.unwrap();
+        store.store_table_schema(second.clone()).await.unwrap();
+        let name = DuckLakeTableName::new("schéma", "Üsers");
+        let schema = ReplicatedTableSchema::all(Arc::new(first.clone()));
+        let metadata = DestinationTableMetadata::new_creating(
+            name.to_metadata_id().unwrap(),
+            first.snapshot_id,
+            schema.replication_mask().clone(),
+        );
+        store.store_destination_table_metadata(first.id, metadata).await.unwrap();
+        for candidate in
+            [DuckLakeTableName::new("schéma", "üsers"), DuckLakeTableName::new("schÉma", "Üsers")]
+        {
+            ensure_unique_table_identity(&store, second.id, &candidate).await.unwrap();
+        }
+        let error = ensure_unique_table_identity(
+            &store,
+            second.id,
+            &DuckLakeTableName::new("SCHéMA", "ÜSERS"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidState);
     }
 }

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -184,6 +184,24 @@ fn build_ducklake_metadata_pg_pool(catalog_url: &Url) -> EtlResult<PgPool> {
         .connect_lazy_with(options))
 }
 
+/// Drains accepted table work and reports every failure before returning one.
+async fn finish_table_tasks(tasks: &mut tokio::task::JoinSet<EtlResult<()>>) -> EtlResult<()> {
+    let mut first_error = None;
+    while let Some(result) = tasks.join_next().await {
+        let result = result.map_err(|source| etl_error!(ErrorKind::ApplyWorkerPanic, "DuckLake table task failed", source: source)).and_then(|result| result);
+        if let Err(error) = result {
+            tracing::error!(error = %error, detail = error.detail(), "ducklake table task failed");
+            if first_error.is_none() {
+                first_error = Some(error);
+            }
+        }
+    }
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
 /// Returns whether a DuckLake DDL error indicates another transaction already
 /// created the requested table.
 pub(super) fn is_create_table_conflict(error: &duckdb::Error, table_name: &str) -> bool {
@@ -3383,11 +3401,7 @@ where
                     });
                 }
 
-                while let Some(result) = join_set.join_next().await {
-                    result.map_err(|_| {
-                        etl_error!(ErrorKind::ApplyWorkerPanic, "DuckLake write task panicked")
-                    })??;
-                }
+                finish_table_tasks(&mut join_set).await?;
             }
 
             // Apply schema changes sequentially before any later row events
@@ -3477,11 +3491,7 @@ where
                     });
                 }
 
-                while let Some(result) = join_set.join_next().await {
-                    result.map_err(|_| {
-                        etl_error!(ErrorKind::ApplyWorkerPanic, "DuckLake truncate task panicked")
-                    })??;
-                }
+                finish_table_tasks(&mut join_set).await?;
             }
         }
 
@@ -4468,6 +4478,24 @@ mod tests {
 
         let batch_id = NEXT_BATCH_ID.fetch_add(1, Ordering::Relaxed);
         TableCopyBatchId::new(TableCopyAttemptId::from_u128(1), batch_id)
+    }
+
+    #[tokio::test]
+    async fn failing_table_does_not_abort_other_accepted_work() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let other_completed = Arc::clone(&completed);
+        let mut tasks = tokio::task::JoinSet::new();
+        tasks.spawn(async {
+            Err(etl_error!(ErrorKind::DestinationQueryFailed, "First write failed"))
+        });
+        tasks.spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            other_completed.store(true, Ordering::SeqCst);
+            Err(etl_error!(ErrorKind::DestinationQueryFailed, "Second write failed"))
+        });
+        assert!(finish_table_tasks(&mut tasks).await.is_err());
+        assert!(completed.load(Ordering::SeqCst));
+        assert!(tasks.is_empty());
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/core.rs
+++ b/crates/etl-destinations/src/ducklake/core.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    num::NonZeroUsize,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -68,10 +69,11 @@ use crate::{
             run_duckdb_dedicated_blocking_with_context,
         },
         config::{
-            MIN_EXPIRE_SNAPSHOTS_OLDER_THAN, build_setup_plan, current_duckdb_extension_strategy,
-            maintenance_target_file_size_sql, resolve_expire_snapshots_older_than,
-            validate_expire_snapshots_older_than_sql,
+            DuckLakeSetupPlan, MIN_EXPIRE_SNAPSHOTS_OLDER_THAN, build_setup_plan,
+            current_duckdb_extension_strategy, maintenance_target_file_size_sql,
+            resolve_expire_snapshots_older_than, validate_expire_snapshots_older_than_sql,
         },
+        embedding::EmbeddingOptions,
         external_maintenance::ExternalMaintenanceOperations,
         inline_size::DuckLakePendingInlineSizeSampler,
         metrics::{
@@ -509,6 +511,8 @@ impl DuckLakePoolHandle {
 /// deferred to coordinated maintenance.
 #[derive(Clone)]
 pub struct DuckLakeDestination<S> {
+    /// Host policies retained across destination clones and pool replacement.
+    embedding: EmbeddingOptions,
     manager: Arc<DuckLakeConnectionManager>,
     /// Connection manager for the pool dedicated to initial-copy writes.
     copy_manager: DuckLakeConnectionManager,
@@ -568,6 +572,8 @@ pub struct DuckLakeDestination<S> {
 /// policies start with their existing defaults and can be configured without
 /// adding another constructor for each combination.
 pub struct DuckLakeDestinationBuilder<S> {
+    /// Optional host initialization and table mapping.
+    embedding: EmbeddingOptions,
     /// DuckLake PostgreSQL catalog URL.
     catalog_url: Url,
     /// Parquet data path.
@@ -601,6 +607,7 @@ impl<S> DuckLakeDestinationBuilder<S> {
     /// defaulted.
     fn new(catalog_url: Url, data_path: Url, pool_size: u32, store: S) -> Self {
         Self {
+            embedding: EmbeddingOptions::default(),
             catalog_url,
             data_path,
             pool_size,
@@ -615,6 +622,48 @@ impl<S> DuckLakeDestinationBuilder<S> {
             external_maintenance: DuckLakeExternalMaintenanceConfig::default(),
             store,
         }
+    }
+
+    /// Uses a host-initialized DuckDB instance instead of the default setup.
+    ///
+    /// Called on a blocking thread at startup and on each pool replacement.
+    /// Return a fresh instance with DuckLake attached as `lake`, using the same
+    /// catalog, metadata schema and data path passed to this builder. The host
+    /// owns extension loading, secrets, resource limits, attachment options and
+    /// catalog writer options. The standalone S3 and Parquet setup is bypassed.
+    /// ETL still configures writer sessions and manages replay helper tables.
+    /// Do not retain connections to retired instances in the callback.
+    pub fn connection_initializer<F>(mut self, initialize: F) -> Self
+    where
+        F: Fn() -> EtlResult<duckdb::Connection> + Send + Sync + 'static,
+    {
+        self.embedding.connection_initializer = Some(Arc::new(initialize));
+        self
+    }
+
+    /// Maps newly discovered tables to their durable destination names.
+    ///
+    /// The mapping must be deterministic, injective and avoid ETL helper
+    /// names. Existing tables retain their stored identity, including after a
+    /// restart or a source rename; changing this callback does not move data.
+    /// Table sorting policies refer to the resulting destination names.
+    pub fn table_name_mapper<F>(mut self, map: F) -> Self
+    where
+        F: Fn(&TableName) -> EtlResult<DuckLakeTableName> + Send + Sync + 'static,
+    {
+        self.embedding.table_name_mapper = Some(Arc::new(map));
+        self
+    }
+
+    /// Sets the maximum number of CDC mutations in one DuckLake transaction.
+    ///
+    /// Defaults to 16. Larger transactions can reduce file creation when data
+    /// inlining is disabled, at the cost of longer transactions and retries.
+    /// This only groups mutations already delivered by the pipeline; it does
+    /// not wait for additional events or change the pipeline batch limits.
+    pub fn cdc_batch_size(mut self, size: NonZeroUsize) -> Self {
+        self.embedding.cdc_batch_size = Some(size);
+        self
     }
 
     /// Sets optional S3 credentials and endpoint configuration.
@@ -706,6 +755,7 @@ where
             self.copy_buffer_config,
             self.table_sorting,
             self.external_maintenance,
+            self.embedding,
             self.store,
         )
         .await
@@ -1743,6 +1793,7 @@ where
             DuckLakeCopyBufferConfig::default(),
             DuckLakeTableSortingConfig::default(),
             DuckLakeExternalMaintenanceConfig::default(),
+            EmbeddingOptions::default(),
             store,
         )
         .await
@@ -1811,6 +1862,7 @@ where
         copy_buffer_config: DuckLakeCopyBufferConfig,
         table_sorting: DuckLakeTableSortingConfig,
         external_maintenance: DuckLakeExternalMaintenanceConfig,
+        embedding: EmbeddingOptions,
         store: S,
     ) -> EtlResult<Self> {
         register_metrics();
@@ -1848,60 +1900,80 @@ where
         }
         let table_sorting = Arc::new(index_table_sorting_config(table_sorting)?);
 
-        let extension_strategy = current_duckdb_extension_strategy()?;
-        let disable_extension_autoload = extension_strategy.disables_autoload();
         let target_file_size = Arc::<str>::from(writer_config.target_file_size());
         let expire_snapshots_older_than = Arc::<str>::from(
             resolve_expire_snapshots_older_than(expire_snapshots_older_than.as_deref()).to_owned(),
         );
-        if let crate::ducklake::config::DuckDbExtensionStrategy::VendoredLocal { platform_dir } =
-            extension_strategy
-        {
-            info!(platform = platform_dir, "using vendored duckdb extensions");
-        }
-        let setup_plan = Arc::new(build_setup_plan(
-            &catalog_url,
-            &data_path,
-            s3.as_ref(),
-            metadata_schema.as_deref(),
-            &writer_config,
-            ATTACH_DATA_INLINING_ROW_LIMIT,
-        )?);
+        let custom_initialization = embedding.connection_initializer.is_some();
+        let (setup_plan, disable_extension_autoload) = if custom_initialization {
+            (Arc::new(DuckLakeSetupPlan::for_embedded_instance()), false)
+        } else {
+            let extension_strategy = current_duckdb_extension_strategy()?;
+            let disable_extension_autoload = extension_strategy.disables_autoload();
+            if let crate::ducklake::config::DuckDbExtensionStrategy::VendoredLocal {
+                platform_dir,
+            } = extension_strategy
+            {
+                info!(platform = platform_dir, "using vendored duckdb extensions");
+            }
+            let setup_plan = Arc::new(build_setup_plan(
+                &catalog_url,
+                &data_path,
+                s3.as_ref(),
+                metadata_schema.as_deref(),
+                &writer_config,
+                ATTACH_DATA_INLINING_ROW_LIMIT,
+            )?);
+
+            (setup_plan, disable_extension_autoload)
+        };
 
         let interrupt_registry = Arc::new(DuckLakeInterruptRegistry::default());
         let shutdown_requested = Arc::new(AtomicBool::new(false));
-        let manager = DuckLakeConnectionManager::new(
-            setup_plan,
-            disable_extension_autoload,
-            interrupt_registry,
-            shutdown_requested,
-        )
-        .await?;
+        let manager = if embedding.connection_initializer.is_some() {
+            DuckLakeConnectionManager::new_with_initializer(
+                setup_plan,
+                disable_extension_autoload,
+                interrupt_registry,
+                shutdown_requested,
+                embedding.connection_initializer.clone(),
+            )
+            .await?
+        } else {
+            DuckLakeConnectionManager::new(
+                setup_plan,
+                disable_extension_autoload,
+                interrupt_registry,
+                shutdown_requested,
+            )
+            .await?
+        };
         let copy_manager = manager.new_pool_manager();
         let manager = Arc::new(manager);
         let pool =
             Arc::new(build_warm_ducklake_pool(manager.as_ref().clone(), pool_size, "write").await?);
         let blocking_slots = Arc::new(Semaphore::new(pool_size as usize));
 
-        // `target_file_size` is a catalog-wide DuckLake option consumed during
-        // compaction. Apply it once on the write pool so foreground writes and
-        // external maintenance jobs use the same configured catalog option.
-        let target_file_size_sql = maintenance_target_file_size_sql(target_file_size.as_ref());
-        run_duckdb_blocking(
-            Arc::clone(&pool),
-            Arc::clone(&blocking_slots),
-            move |conn| -> EtlResult<()> {
-                conn.execute_batch(&target_file_size_sql).map_err(|error| {
-                    etl_error!(
-                        ErrorKind::DestinationQueryFailed,
-                        "DuckLake target_file_size configuration failed",
-                        source: error
-                    )
-                })?;
-                Ok(())
-            },
-        )
-        .await?;
+        // A host initializer owns catalog options, including schema-scoped
+        // target sizes. Only standalone setup applies the catalog-wide default.
+        if !custom_initialization {
+            let target_file_size_sql = maintenance_target_file_size_sql(target_file_size.as_ref());
+            run_duckdb_blocking(
+                Arc::clone(&pool),
+                Arc::clone(&blocking_slots),
+                move |conn| -> EtlResult<()> {
+                    conn.execute_batch(&target_file_size_sql).map_err(|error| {
+                        etl_error!(
+                            ErrorKind::DestinationQueryFailed,
+                            "DuckLake target_file_size configuration failed",
+                            source: error
+                        )
+                    })?;
+                    Ok(())
+                },
+            )
+            .await?;
+        }
         let expire_snapshots_validation_sql =
             validate_expire_snapshots_older_than_sql(expire_snapshots_older_than.as_ref());
         let expire_snapshots_older_than_for_error = Arc::clone(&expire_snapshots_older_than);
@@ -2004,6 +2076,7 @@ where
         let checkpoint_gate = Arc::new(RwLock::new(()));
         let copy_session_gate = Arc::new(RwLock::new(()));
         let mut destination = Self {
+            embedding,
             manager: Arc::clone(&manager),
             copy_manager,
             pools,
@@ -3287,6 +3360,7 @@ where
                             );
 
                             let prepared_batches = prepare_mutation_table_batches(
+                                destination.embedding.cdc_batch_size,
                                 &segment.replicated_table_schema,
                                 destination_table_name.clone(),
                                 replay_epoch,
@@ -3620,7 +3694,7 @@ where
         let table_id = replicated_table_schema.id();
         let metadata = self.store.get_destination_table_metadata(table_id).await?;
         let table_name = metadata.as_ref().map_or_else(
-            || table_name_to_ducklake_table_name(replicated_table_schema.name()),
+            || self.map_new_table_name(replicated_table_schema.name()),
             |metadata| DuckLakeTableName::from_metadata_id(metadata.table_id()),
         )?;
 
@@ -3654,7 +3728,7 @@ where
 
         let metadata = self.store.get_destination_table_metadata(table_id).await?;
         let table_name = metadata.as_ref().map_or_else(
-            || table_name_to_ducklake_table_name(replicated_table_schema.name()),
+            || self.map_new_table_name(replicated_table_schema.name()),
             |metadata| DuckLakeTableName::from_metadata_id(metadata.table_id()),
         )?;
 
@@ -3772,6 +3846,14 @@ where
         .await
     }
 
+    /// Maps a table only before its durable destination identity exists.
+    fn map_new_table_name(&self, source: &TableName) -> EtlResult<DuckLakeTableName> {
+        match &self.embedding.table_name_mapper {
+            Some(map) => map(source),
+            None => table_name_to_ducklake_table_name(source),
+        }
+    }
+
     /// Returns the stored destination table name or the deterministic default.
     async fn resolve_destination_table_name(
         &self,
@@ -3783,7 +3865,7 @@ where
             return DuckLakeTableName::from_metadata_id(existing.table_id());
         }
 
-        table_name_to_ducklake_table_name(replicated_table_schema.name())
+        self.map_new_table_name(replicated_table_schema.name())
     }
 
     /// Serializes table-local truncate and CDC mutation writes.
@@ -4313,6 +4395,34 @@ fn wait_if_copy_append_paused_for_tests() {
 /// becomes the DuckLake table `lake.public.my_table`.
 pub fn table_name_to_ducklake_table_name(table_name: &TableName) -> EtlResult<DuckLakeTableName> {
     Ok(DuckLakeTableName::from_source(table_name))
+}
+
+impl<S: DestinationStore> DuckLakeDestination<S> {
+    /// Runs host maintenance on the writer instance while mutations are paused.
+    ///
+    /// The operation runs on a blocking thread under the normal query watchdog.
+    /// Its pause guard survives cancellation until the native operation exits.
+    /// Finish all transactions before returning, and do not retain or clone the
+    /// connection outside the operation. Scheduling and table selection belong
+    /// to the caller; this method does not retry a partially completed
+    /// operation.
+    pub async fn run_maintenance<R, F>(&self, timeout: Duration, operation: F) -> EtlResult<R>
+    where
+        R: Send + 'static,
+        F: FnOnce(&duckdb::Connection) -> EtlResult<R> + Send + 'static,
+    {
+        let pause = self.acquire_external_maintenance_pause().await;
+        crate::ducklake::client::run_duckdb_blocking_with_timeout(
+            self.streaming_pool()?,
+            Arc::clone(&self.blocking_slots),
+            timeout,
+            move |connection| {
+                let _pause = pause;
+                operation(connection)
+            },
+        )
+        .await
+    }
 }
 
 #[cfg(test)]

--- a/crates/etl-destinations/src/ducklake/embedding.rs
+++ b/crates/etl-destinations/src/ducklake/embedding.rs
@@ -1,0 +1,23 @@
+//! Host configuration for an embedded DuckLake destination.
+
+use std::{num::NonZeroUsize, sync::Arc};
+
+use etl::{error::EtlResult, schema::TableName};
+
+use crate::ducklake::DuckLakeTableName;
+
+/// Creates a fully initialized database for a new connection-pool generation.
+pub(super) type ConnectionInitializer =
+    Arc<dyn Fn() -> EtlResult<duckdb::Connection> + Send + Sync>;
+
+/// Maps a source table before its destination identity is persisted.
+pub(super) type TableNameMapper =
+    Arc<dyn Fn(&TableName) -> EtlResult<DuckLakeTableName> + Send + Sync>;
+
+/// Optional host policies; absent callbacks retain the standalone defaults.
+#[derive(Clone, Default)]
+pub(super) struct EmbeddingOptions {
+    pub(super) connection_initializer: Option<ConnectionInitializer>,
+    pub(super) table_name_mapper: Option<TableNameMapper>,
+    pub(super) cdc_batch_size: Option<NonZeroUsize>,
+}

--- a/crates/etl-destinations/src/ducklake/encoding.rs
+++ b/crates/etl-destinations/src/ducklake/encoding.rs
@@ -607,7 +607,8 @@ fn float_literal(value: f64, is_double: bool) -> String {
         };
     }
 
-    value.to_string()
+    let typ = if is_double { "DOUBLE" } else { "FLOAT" };
+    format!("CAST('{value:e}' AS {typ})")
 }
 
 /// Encodes bytes as uppercase hexadecimal for DuckDB's `from_hex`.
@@ -728,6 +729,28 @@ mod tests {
             TableName::new("public".to_owned(), "users".to_owned()),
             columns,
         )))
+    }
+
+    #[test]
+    fn sql_float_literals_preserve_bits() {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        for value in [-0.0_f64, f64::MIN_POSITIVE, f64::from_bits(1), 1.0000000000000002, f64::MAX]
+        {
+            let actual: f64 = conn
+                .query_row(&format!("select {}", float_literal(value, true)), [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(actual.to_bits(), value.to_bits());
+        }
+        for value in [-0.0_f32, f32::MIN_POSITIVE, f32::from_bits(1), 1.0000001, f32::MAX] {
+            let actual: f32 = conn
+                .query_row(
+                    &format!("select {}", float_literal(f64::from(value), false)),
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(actual.to_bits(), value.to_bits());
+        }
     }
 
     #[test]

--- a/crates/etl-destinations/src/ducklake/mod.rs
+++ b/crates/etl-destinations/src/ducklake/mod.rs
@@ -89,7 +89,7 @@ impl DuckLakeTableName {
 
     /// Returns whether this is an internal ETL helper table.
     pub(super) fn is_internal_helper(&self) -> bool {
-        self.table.starts_with("__etl_")
+        self.table.get(..6).is_some_and(|prefix| prefix.eq_ignore_ascii_case("__etl_"))
     }
 }
 

--- a/crates/etl-destinations/src/ducklake/mod.rs
+++ b/crates/etl-destinations/src/ducklake/mod.rs
@@ -2,6 +2,7 @@ mod batches;
 mod client;
 mod config;
 mod core;
+mod embedding;
 mod encoding;
 mod external_maintenance;
 mod inline_size;
@@ -133,6 +134,7 @@ pub use batches::{
     reset_ducklake_test_hooks,
 };
 pub use config::S3Config;
+pub use duckdb::Connection;
 pub use etl_maintenance::ducklake::{
     CleanupOldFilesMaintenanceConfig, DuckLakeMaintenanceConfig, DuckLakeMaintenanceOutcome,
     ExpireSnapshotsMaintenanceConfig, InlineFlushMaintenanceConfig,

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -1915,3 +1915,96 @@ async fn schema_change_matches_simulator_generated_column_types() {
         }
     );
 }
+
+/// Embeds the stock destination with host setup, routing and maintenance.
+#[tokio::test(flavor = "multi_thread")]
+async fn embedded_destination_keeps_copy_cdc_and_maintenance_on_one_instance() {
+    use std::time::Duration;
+
+    use etl::{error::ErrorKind, etl_error};
+
+    init_test_tracing();
+    let database = spawn_source_database().await;
+    let schema = setup_test_database_schema(&database, TableSelection::UsersOnly).await;
+    let users = schema.users_schema();
+    database.insert_values(users.name.clone(), &["name", "age"], &[&"before", &1]).await.unwrap();
+    let lake = create_test_lake("embedded_destination").await;
+    let store = NotifyingStore::new();
+    let setup = format!(
+        "{} attach {} as lake (data_path {}, data_inlining_row_limit 0); create table host_marker \
+         as select 42 as id;",
+        ducklake_load_sql(),
+        quote_literal(&format!("ducklake:{}", catalog_attach_target(&lake.catalog_url))),
+        quote_literal(lake.data_url.as_str()),
+    );
+    let raw = DuckLakeDestination::builder(lake.catalog_url.clone(), lake.data_url.clone(), 1, store.clone())
+        .connection_initializer(move || {
+            let conn = Connection::open_in_memory().map_err(|source| {
+                etl_error!(ErrorKind::DestinationConnectionFailed, "Host open failed", source: source)
+            })?;
+            conn.execute_batch(&setup).map_err(|source| {
+                etl_error!(ErrorKind::DestinationQueryFailed, "Host setup failed", source: source)
+            })?;
+            Ok(conn)
+        })
+        .table_name_mapper(|name| Ok(DuckLakeTableName::new("replicated", format!("{}_{}", name.schema, name.name))))
+        .build().await.unwrap();
+    let wrapped = TestDestinationWrapper::wrap(raw.clone());
+    let ready = store.notify_on_table_sync_complete(users.id).await;
+    let mut pipeline = create_pipeline(
+        &database.config,
+        random(),
+        schema.publication_name(),
+        store.clone(),
+        wrapped.clone(),
+    );
+    pipeline.start().await.unwrap();
+    ready.notified().await;
+
+    // Cancelling the caller must not release the pause around native work.
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let maintenance_destination = raw.clone();
+    let maintenance = tokio::spawn(async move {
+        maintenance_destination.run_maintenance(Duration::from_secs(30), move |conn| {
+            let marker: i64 = conn.query_row("select id from host_marker", [], |row| row.get(0)).map_err(|source| {
+                etl_error!(ErrorKind::DestinationQueryFailed, "Marker query failed", source: source)
+            })?;
+            assert_eq!(marker, 42);
+            started_tx.send(()).unwrap();
+            release_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+            Ok(())
+        }).await
+    });
+    started_rx.await.unwrap();
+    maintenance.abort();
+    assert!(maintenance.await.unwrap_err().is_cancelled());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), raw.acquire_external_maintenance_pause())
+            .await
+            .is_err()
+    );
+    release_tx.send(()).unwrap();
+    drop(
+        tokio::time::timeout(Duration::from_secs(10), raw.acquire_external_maintenance_pause())
+            .await
+            .unwrap(),
+    );
+
+    let inserted = wrapped
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, users.id, 1)])
+        .await;
+    database.insert_values(users.name.clone(), &["name", "age"], &[&"after", &2]).await.unwrap();
+    inserted.notified().await;
+    pipeline.shutdown_and_wait().await.unwrap();
+    drop(wrapped);
+    drop(raw);
+    checkpoint_lake(&lake.catalog_url, &lake.data_url);
+    let conn = open_lake_conn(&lake.catalog_url, &lake.data_url);
+    let mapped =
+        DuckLakeTableName::new("replicated", format!("{}_{}", users.name.schema, users.name.name));
+    assert_eq!(
+        query_user_rows(&conn, &mapped),
+        vec![(1, "before".to_owned(), 1), (2, "after".to_owned(), 2)]
+    );
+}

--- a/crates/etl-destinations/tests/ducklake/pipeline.rs
+++ b/crates/etl-destinations/tests/ducklake/pipeline.rs
@@ -1996,6 +1996,15 @@ async fn embedded_destination_keeps_copy_cdc_and_maintenance_on_one_instance() {
         .await;
     database.insert_values(users.name.clone(), &["name", "age"], &[&"after", &2]).await.unwrap();
     inserted.notified().await;
+    let mapped_for_inline_check =
+        DuckLakeTableName::new("replicated", format!("{}_{}", users.name.schema, users.name.name));
+    let flushed = raw.run_maintenance(Duration::from_secs(30), move |conn| {
+        let sql = format!("select coalesce(sum(rows_flushed), 0) from ducklake_flush_inlined_data('lake', {}, schema => {})", quote_literal(mapped_for_inline_check.table()), quote_literal(mapped_for_inline_check.schema()));
+        conn.query_row(&sql, [], |row| row.get::<_, i64>(0)).map_err(|source| {
+            etl_error!(ErrorKind::DestinationQueryFailed, "Inline verification failed", source: source)
+        })
+    }).await.unwrap();
+    assert_eq!(flushed, 0);
     pipeline.shutdown_and_wait().await.unwrap();
     drop(wrapped);
     drop(raw);

--- a/crates/etl-maintenance/Cargo.toml
+++ b/crates/etl-maintenance/Cargo.toml
@@ -11,7 +11,8 @@ homepage.workspace = true
 doctest = false
 
 [features]
-default = ["tls-rustls-ring"]
+default = ["tls-rustls-ring", "bundled"]
+bundled = ["duckdb?/bundled", "duckdb?/json", "duckdb?/parquet"]
 tls-rustls-ring = ["sqlx/tls-rustls-ring", "etl/tls-rustls-ring"]
 tls-rustls-aws-lc-rs = ["sqlx/tls-rustls-aws-lc-rs", "etl/tls-rustls-aws-lc-rs"]
 ducklake = [
@@ -31,7 +32,7 @@ test-utils = []
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
-duckdb = { workspace = true, optional = true, features = ["bundled", "json", "parquet", "r2d2"] }
+duckdb = { workspace = true, optional = true, features = ["r2d2"] }
 etl = { workspace = true }
 etl-config = { workspace = true }
 kube = { workspace = true, optional = true, features = ["client", "rustls-tls"] }


### PR DESCRIPTION
An embedded application currently has to copy the DuckLake destination to initialize its own DuckDB runtime, route tables into its existing schema, or execute maintenance on the writer instance. This adds builder hooks while retaining the existing COPY/CDC writer, replay markers, connection clones, pool recovery and maintenance pause.

- `connection_initializer` supplies a fresh, attached instance at startup and replacement. The host owns extensions, credentials, resource limits and attachment/catalog options throughout COPY and CDC; standalone COPY inline overrides are bypassed; ETL configures writer sessions and replay helpers.
- `table_name_mapper` controls only new destination identities. Persisted identities remain authoritative across restart and source rename. Creation and startup reject identities already owned by another source.
- `run_maintenance` executes a callback on the writer instance under the existing exclusive pause and watchdog. Cancellation holds the pause until blocking native work exits. Scheduling and table selection remain in the application.
- `cdc_batch_size` allows inline-disabled hosts to increase the existing 16-mutation transaction cap. Pipeline batch limits alone do not change that cap. The default remains 16; no throughput claim is made without load measurements.
- A default-enabled `bundled` feature lets external consumers supply a compatible native DuckDB library. Workspace applications retain bundling.

Adoption also exposed two correctness gaps that cannot be fixed by a host callback: SQL floating-point literals can lose signed zero or precision, and returning on the first joined table error cancels other accepted work and hides its failures. This preserves finite float bits through typed string casts and drains/logs all accepted table tasks. An explicit `ducklake-query-error-details` feature preserves original UPDATE/DELETE errors and SQL in returned errors for hosts requiring full diagnostics. Automatic mutation/task logs retain structural context without formatting those row-bearing errors; default returned-error redaction is unchanged.

These are generic embedding boundaries, with no application schema names, scheduling policy, resource presets or duplicate destination implementation. They do not expose pools or writer internals. This PR is independent of the pgvector change in #1022.

Validation:
- 24 in-memory connection, timeout and shutdown unit tests passed, including shared host initialization, instance replacement and initialization error propagation.
- 6 mutation preparation tests passed, covering ordered batching and both the default and configurable cap.
- Clippy passed for all destination targets, including a new PostgreSQL/DuckLake integration test for host setup, mapped COPY/CDC, maintenance cancellation and resumed writes.
- Formatting and diff whitespace checks passed. The unreachable-public check reports one pre-existing export in `external_maintenance.rs`, outside this change.
- An external consumer's Cargo dependency graph resolves one DuckDB version without enabling bundled native compilation.

Live PostgreSQL/DuckLake integration tests were not run locally. The new integration test and existing destination suite must pass before merge. This is an embedding API change, not evidence that an application's historical state can be migrated without validation. Persisted metadata, scalar/array value behavior, error diagnostics and workload throughput still need application-level adoption tests; this PR does not migrate historical state or change default diagnostic redaction.

Additional validation: 9 encoding/concurrency tests passed, including f32/f64 bit preservation and drain-after-failure; the 2 error-diagnostic tests passed with the opt-in both enabled and disabled. Clippy passed with the opt-in enabled.

Review fixes: overflowing query/abort deadlines return ConfigError; 4 focused tests passed with diagnostics enabled and disabled, covering pending/applied identity collisions, excessive timeouts and error diagnostics. Clippy passed for all destination targets. The compiled integration test additionally checks zero flushable inline rows after COPY and CDC with a host inlining limit of zero; live execution remains pending.
