### PR TITLE
fix(snowflake): isolate table setup locking

### DIFF
--- a/crates/etl-destinations/src/snowflake/client.rs
+++ b/crates/etl-destinations/src/snowflake/client.rs
@@ -9,7 +9,7 @@ use etl::{
 };
 use metrics::{counter, gauge, histogram};
 use tokio::{
-    sync::{Mutex, RwLock},
+    sync::{Mutex, OwnedMutexGuard, RwLock},
     time::{Instant, sleep},
 };
 use tracing::{debug, warn};
@@ -37,7 +37,19 @@ use crate::{
     },
 };
 
+/// Cached, successfully opened channels shared by client clones.
 type ChannelMap<C> = Arc<RwLock<HashMap<TableId, Arc<Mutex<ChannelHandle<C>>>>>>;
+
+/// Exclusive ownership of one table's setup or reset.
+///
+/// The table ID travels with the guard so preparation cannot accidentally use
+/// another table's gate. Initial copy retains it through metadata completion.
+pub(super) struct TableLifecycleGuard {
+    /// Table whose lifecycle is locked.
+    table_id: TableId,
+    /// Releases the stable per-table gate when the operation finishes.
+    _guard: OwnedMutexGuard<()>,
+}
 
 /// Process-local state carried between the two phases of a table-copy reset.
 ///
@@ -49,11 +61,15 @@ type ChannelMap<C> = Arc<RwLock<HashMap<TableId, Arc<Mutex<ChannelHandle<C>>>>>>
 /// [`Client::drop_detached_table_for_copy`] consumes the value outside that
 /// timeout to drop the Snowpipe channel and Snowflake table. This split keeps
 /// local draining and lock acquisition bounded without cancelling a remote
-/// drop whose outcome would then be unknown.
+/// drop whose outcome would then be unknown. The table lifecycle guard remains
+/// held through both phases, preventing setup from publishing a stale channel.
 ///
 /// This value does not block event admission. The caller must retain its
 /// [`etl::destination::TaskSetDrainGuard`] until the remote drop returns.
 pub(super) struct DetachedTableForCopy<C> {
+    /// Prevents setup from publishing a replacement before remote drop
+    /// finishes.
+    table: TableLifecycleGuard,
     /// Previously cached channel handle, when one existed in this process.
     channel: Option<Arc<Mutex<ChannelHandle<C>>>>,
     /// Snowflake table name to drop after retiring local state.
@@ -244,6 +260,8 @@ pub struct Client<T, C = RestStreamClient<T>> {
     schema: String,
     pipeline_id: PipelineId,
     channels: ChannelMap<C>,
+    /// Stable lifecycle gates retained across channel removal and recreation.
+    table_gates: Arc<Mutex<HashMap<TableId, Arc<Mutex<()>>>>>,
     pending_durability: Arc<Mutex<PendingDurabilityState>>,
 }
 
@@ -256,6 +274,7 @@ impl<T: TokenProvider, C: StreamClient> Clone for Client<T, C> {
             schema: self.schema.clone(),
             pipeline_id: self.pipeline_id,
             channels: Arc::clone(&self.channels),
+            table_gates: Arc::clone(&self.table_gates),
             pending_durability: Arc::clone(&self.pending_durability),
         }
     }
@@ -372,6 +391,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
             schema,
             pipeline_id,
             channels: Arc::new(RwLock::new(HashMap::new())),
+            table_gates: Arc::new(Mutex::new(HashMap::new())),
             pending_durability: Arc::new(Mutex::new(PendingDurabilityState::default())),
         }
     }
@@ -386,14 +406,13 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         self.sql_client.table_exists(table_name).await
     }
 
-    /// Creates a table when needed and prepares it for initial-copy writes.
-    pub(super) async fn initialize_table(
-        &self,
-        table_id: TableId,
-        table_name: &str,
-        columns: &[ColumnSchema],
-    ) -> Result<()> {
-        self.prepare_channel(table_id, table_name, columns, true).await
+    /// Locks one table's setup/reset lifecycle without retaining the registry.
+    pub(super) async fn lock_table(&self, table_id: TableId) -> TableLifecycleGuard {
+        let gate = {
+            let mut gates = self.table_gates.lock().await;
+            Arc::clone(gates.entry(table_id).or_insert_with(|| Arc::new(Mutex::new(()))))
+        };
+        TableLifecycleGuard { table_id, _guard: gate.lock_owned().await }
     }
 
     /// Opens and validates an existing table for streaming writes.
@@ -403,30 +422,26 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         table_name: &str,
         columns: &[ColumnSchema],
     ) -> Result<()> {
-        self.prepare_channel(table_id, table_name, columns, false).await
+        if self.has_channel(table_id).await {
+            return Ok(());
+        }
+
+        let table = self.lock_table(table_id).await;
+        self.prepare_table(&table, table_name, columns, false).await
     }
 
-    /// Prepares one table and caches its validated channel.
-    #[allow(clippy::map_entry)]
-    async fn prepare_channel(
+    /// Prepares a table under its lifecycle guard, optionally creating it.
+    ///
+    /// The caller retains the guard through any associated metadata transition.
+    pub(super) async fn prepare_table(
         &self,
-        table_id: TableId,
+        table: &TableLifecycleGuard,
         table_name: &str,
         columns: &[ColumnSchema],
         create_if_missing: bool,
     ) -> Result<()> {
-        // Fast path: read lock, check if already set up.
-        let channels = self.channels.read().await;
-        if channels.contains_key(&table_id) {
-            return Ok(());
-        }
-        drop(channels);
-
-        // Slow path: hold write lock for the entire setup. This runs once
-        // per table per process lifetime, so blocking other tables briefly
-        // during startup is acceptable.
-        let mut channels = self.channels.write().await;
-        if channels.contains_key(&table_id) {
+        // Another caller may have completed setup while this one waited.
+        if self.has_channel(table.table_id).await {
             return Ok(());
         }
 
@@ -448,7 +463,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         handle.open().await?;
 
         // Persist table-channel mapping.
-        channels.insert(table_id, Arc::new(Mutex::new(handle)));
+        self.channels.write().await.insert(table.table_id, Arc::new(Mutex::new(handle)));
         Ok(())
     }
 
@@ -651,14 +666,16 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         table_id: TableId,
         table_name: &str,
     ) -> Result<DetachedTableForCopy<C>> {
-        let mut channels = self.channels.write().await;
+        // Event tasks must be drained before taking this gate, since they may
+        // need it to finish opening a channel. Never wait on it under a registry.
+        let table = self.lock_table(table_id).await;
         let mut pending = self.pending_durability.lock().await;
         pending.discard(table_id)?;
 
-        let channel = channels.remove(&table_id);
+        let channel = self.channels.write().await.remove(&table_id);
         pending.observe_metrics();
 
-        Ok(DetachedTableForCopy { channel, table_name: table_name.to_owned() })
+        Ok(DetachedTableForCopy { table, channel, table_name: table_name.to_owned() })
     }
 
     /// Drops the remote channel and table for previously detached local state.
@@ -666,7 +683,7 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
         &self,
         detached: DetachedTableForCopy<C>,
     ) -> Result<()> {
-        let DetachedTableForCopy { channel, table_name } = detached;
+        let DetachedTableForCopy { table, channel, table_name } = detached;
 
         let drop_channel_result = if let Some(channel) = channel {
             let mut guard = channel.lock().await;
@@ -687,7 +704,9 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
             Err(error) => return Err(error),
         }
 
-        self.sql_client.drop_table(&table_name).await
+        let result = self.sql_client.drop_table(&table_name).await;
+        drop(table);
+        result
     }
 
     /// Validates and refreshes the table's ingestion state after a schema
@@ -837,7 +856,34 @@ impl<T: TokenProvider, C: StreamClient> Client<T, C> {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        future::{Future, pending},
+        pin::Pin,
+        sync::atomic::{AtomicUsize, Ordering},
+        task::{Context, Poll, Waker},
+    };
+
     use super::*;
+
+    /// Polls a future once to check a deliberately blocked operation.
+    fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+        future.poll(&mut Context::from_waker(Waker::noop()))
+    }
+
+    /// Pauses each SQL request at authentication without making a network call.
+    #[derive(Default)]
+    struct PendingTokenProvider {
+        calls: AtomicUsize,
+    }
+
+    impl TokenProvider for PendingTokenProvider {
+        async fn get_token(&self) -> Result<String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            pending().await
+        }
+
+        async fn invalidate_token(&self) {}
+    }
 
     struct UnusedTokenProvider;
 
@@ -859,9 +905,8 @@ mod tests {
         }
     }
 
-    fn test_client() -> Client<UnusedTokenProvider, RestStreamClient<UnusedTokenProvider>> {
+    fn test_client<T: TokenProvider + 'static>(auth: Arc<T>) -> Client<T> {
         let config = Config::new("example-account", "test-user", "test-db", "test-schema").unwrap();
-        let auth = Arc::new(UnusedTokenProvider);
         let http = reqwest::Client::new();
         let sql_client =
             SqlClient::new(config.clone_without_credentials(), Arc::clone(&auth), http.clone());
@@ -1009,10 +1054,120 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocked_setup_does_not_block_other_table_setup() {
+        let auth = Arc::new(PendingTokenProvider::default());
+        let client = test_client(Arc::clone(&auth));
+        let mut first = Box::pin(client.prepare_existing_table(TableId::new(1), "FIRST", &[]));
+        assert!(poll_once(first.as_mut()).is_pending());
+        assert_eq!(auth.calls.load(Ordering::SeqCst), 1);
+
+        let mut second = Box::pin(client.prepare_existing_table(TableId::new(2), "SECOND", &[]));
+        assert!(poll_once(second.as_mut()).is_pending());
+        assert_eq!(auth.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn blocked_setup_does_not_block_ready_channel() {
+        let client = test_client(Arc::new(PendingTokenProvider::default()));
+        let ready_id = TableId::new(2);
+        let channel = Arc::new(Mutex::new(ChannelHandle::new(
+            Arc::clone(&client.stream_client),
+            client.pipeline_id,
+            client.database.clone(),
+            client.schema.clone(),
+            "READY".to_owned(),
+        )));
+        client.channels.write().await.insert(ready_id, channel);
+
+        let mut setup = Box::pin(client.prepare_existing_table(TableId::new(1), "FIRST", &[]));
+        assert!(poll_once(setup.as_mut()).is_pending());
+
+        let offset = OffsetToken::new(10.into(), 1);
+        let mut lookup = Box::pin(client.is_offset_committed(ready_id, &offset));
+        assert!(matches!(poll_once(lookup.as_mut()), Poll::Ready(Ok(false))));
+    }
+
+    #[tokio::test]
+    async fn same_table_setup_waits_and_cancellation_releases_gate() {
+        let auth = Arc::new(PendingTokenProvider::default());
+        let client = test_client(Arc::clone(&auth));
+        let table_id = TableId::new(1);
+        let other = client.clone();
+        let mut first = Box::pin(client.prepare_existing_table(table_id, "TABLE", &[]));
+        let mut second = Box::pin(other.prepare_existing_table(table_id, "TABLE", &[]));
+        assert!(poll_once(first.as_mut()).is_pending());
+        assert!(poll_once(second.as_mut()).is_pending());
+        assert_eq!(auth.calls.load(Ordering::SeqCst), 1);
+
+        drop(first);
+        assert!(poll_once(second.as_mut()).is_pending());
+        assert_eq!(auth.calls.load(Ordering::SeqCst), 2);
+        assert!(!client.has_channel(table_id).await);
+    }
+
+    #[tokio::test]
+    async fn failed_setup_remains_retryable() {
+        let client = test_client(Arc::new(UnusedTokenProvider));
+        let table_id = TableId::new(1);
+        for _ in 0..2 {
+            let error = client.prepare_existing_table(table_id, "TABLE", &[]).await.unwrap_err();
+            assert!(matches!(error, Error::Auth(_)));
+            assert!(!client.has_channel(table_id).await);
+        }
+    }
+
+    #[tokio::test]
+    async fn waiting_setup_reuses_published_channel() {
+        let client = test_client(Arc::new(UnusedTokenProvider));
+        let table_id = TableId::new(1);
+        let table = client.lock_table(table_id).await;
+        let mut setup = Box::pin(client.prepare_existing_table(table_id, "TABLE", &[]));
+        assert!(poll_once(setup.as_mut()).is_pending());
+
+        // Model the first caller publishing while the second waits for its gate.
+        let channel = Arc::new(Mutex::new(ChannelHandle::new(
+            Arc::clone(&client.stream_client),
+            client.pipeline_id,
+            client.database.clone(),
+            client.schema.clone(),
+            "TABLE".to_owned(),
+        )));
+        client.channels.write().await.insert(table_id, Arc::clone(&channel));
+        drop(table);
+
+        setup.await.unwrap();
+        assert!(Arc::ptr_eq(&client.get_channel(table_id).await.unwrap(), &channel));
+    }
+
+    #[tokio::test]
+    async fn reset_waits_for_setup_and_blocks_reopening_during_remote_drop() {
+        let auth = Arc::new(PendingTokenProvider::default());
+        let client = test_client(Arc::clone(&auth));
+        let table_id = TableId::new(1);
+        let mut setup = Box::pin(client.prepare_existing_table(table_id, "TABLE", &[]));
+        assert!(poll_once(setup.as_mut()).is_pending());
+        let mut reset = Box::pin(client.detach_table_for_copy(table_id, "TABLE"));
+        assert!(poll_once(reset.as_mut()).is_pending());
+
+        drop(setup);
+        let detached = reset.await.unwrap();
+        assert!(!client.has_channel(table_id).await);
+        let mut reopen = Box::pin(client.prepare_existing_table(table_id, "TABLE", &[]));
+        assert!(poll_once(reopen.as_mut()).is_pending());
+        assert_eq!(auth.calls.load(Ordering::SeqCst), 1);
+
+        let mut remote_drop = Box::pin(client.drop_detached_table_for_copy(detached));
+        assert!(poll_once(remote_drop.as_mut()).is_pending());
+        assert_eq!(auth.calls.load(Ordering::SeqCst), 2);
+        assert!(poll_once(reopen.as_mut()).is_pending());
+        assert_eq!(auth.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
     async fn detach_table_for_copy_retires_channel_and_pending_target() {
         let table_id = TableId::new(1);
         let table_name = "TEST_TABLE";
-        let client = test_client();
+        let client = test_client(Arc::new(UnusedTokenProvider));
         let channel = Arc::new(Mutex::new(ChannelHandle::new(
             Arc::clone(&client.stream_client),
             client.pipeline_id,
@@ -1037,5 +1192,11 @@ mod tests {
         assert!(pending.is_empty());
         assert_eq!(pending.row_batches, 0);
         assert_eq!(pending.bytes, 0);
+        drop(pending);
+
+        let error = client.drop_detached_table_for_copy(detached).await.unwrap_err();
+        assert!(matches!(error, Error::Auth(_)));
+        let mut next_setup = Box::pin(client.lock_table(table_id));
+        assert!(poll_once(next_setup.as_mut()).is_ready());
     }
 }

--- a/crates/etl-destinations/src/snowflake/core.rs
+++ b/crates/etl-destinations/src/snowflake/core.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
     time::Duration,
 };
 
@@ -18,10 +17,7 @@ use etl::{
     schema::{ColumnSchema, ReplicatedTableSchema, TableId},
     store::DestinationStore,
 };
-use tokio::{
-    sync::{Mutex, Semaphore},
-    time::timeout,
-};
+use tokio::time::timeout;
 use tracing::{info, warn};
 
 use crate::{
@@ -84,48 +80,71 @@ fn take_truncate_operations(iter: &mut EventIter) -> Vec<(ReplicatedTableSchema,
     operations
 }
 
-/// Coordinates the initial Snowflake setup of each table.
-///
-/// Copy partitions can concurrently observe missing destination metadata. A
-/// per-table gate gives one caller ownership of the complete `Creating` ->
-/// remote setup -> `Applied` transition so a stale caller cannot overwrite
-/// completed metadata with `Creating`. The registry mutex is released before a
-/// caller waits for its table gate.
-#[derive(Clone)]
-struct TableInitializer {
-    /// Stable initialization gates retained for this destination's lifetime.
-    gates: Arc<Mutex<HashMap<TableId, Arc<Semaphore>>>>,
-}
+/// Initializes a table, channel, and durable metadata under one lifecycle gate.
+async fn initialize_table<S, T, C>(
+    client: &Client<T, C>,
+    store: &S,
+    table_schema: &ReplicatedTableSchema,
+) -> EtlResult<()>
+where
+    S: DestinationStore,
+    T: TokenProvider + 'static,
+    C: StreamClient,
+{
+    table_schema.validate_destination_column_names(SNOWFLAKE_COLUMN_NAME_MAPPING)?;
+    let table_id = table_schema.id();
+    let table_name = try_stringify_table_name(table_schema.name())?.to_uppercase();
+    let columns: Vec<_> =
+        table_schema.destination_column_schemas(SNOWFLAKE_COLUMN_NAME_MAPPING).collect();
 
-impl TableInitializer {
-    /// Creates an empty table-initialization registry.
-    fn new() -> Self {
-        Self { gates: Arc::new(Mutex::new(HashMap::new())) }
+    // Applied metadata needs no transition coordination, but this process
+    // may still need to reopen its local channel state.
+    if let Some(metadata) = store.get_destination_table_metadata(table_id).await?
+        && metadata.is_applied()
+    {
+        ensure_destination_schema_matches_metadata("Snowflake", table_id, &metadata, table_schema)?;
+        client
+            .prepare_existing_table(table_id, metadata.table_id(), &columns)
+            .await
+            .map_err(EtlError::from)?;
+        return Ok(());
     }
 
-    /// Initializes the Snowflake table, channel, and durable metadata for copy.
-    async fn initialize<S, T, C>(
-        &self,
-        client: &Client<T, C>,
-        store: &S,
-        table_schema: &ReplicatedTableSchema,
-    ) -> EtlResult<()>
-    where
-        S: DestinationStore,
-        T: TokenProvider + 'static,
-        C: StreamClient,
-    {
-        table_schema.validate_destination_column_names(SNOWFLAKE_COLUMN_NAME_MAPPING)?;
-        let table_id = table_schema.id();
-        let table_name = try_stringify_table_name(table_schema.name())?.to_uppercase();
-        let columns: Vec<_> =
-            table_schema.destination_column_schemas(SNOWFLAKE_COLUMN_NAME_MAPPING).collect();
+    // Own the complete Creating -> remote setup -> Applied transition with
+    // the same gate used by channel reopening and table-copy reset.
+    let table = client.lock_table(table_id).await;
 
-        // Applied metadata needs no transition coordination, but this process
-        // may still need to reopen its local channel state.
-        if let Some(metadata) = store.get_destination_table_metadata(table_id).await?
-            && metadata.is_applied()
-        {
+    // Re-read under the table gate because another copy partition may have
+    // completed setup after the fast-path read.
+    let snapshot_id = table_schema.inner().snapshot_id;
+    let replication_mask = table_schema.replication_mask().clone();
+    schema::validate_no_cdc_collisions(&columns).map_err(EtlError::from)?;
+    let creating_metadata = match store.get_destination_table_metadata(table_id).await? {
+        None => {
+            if client.table_exists(&table_name).await.map_err(EtlError::from)? {
+                bail!(
+                    ErrorKind::DestinationTableAlreadyExists,
+                    "Snowflake destination table already exists",
+                    format!(
+                        "Table {table_name} exists, but this pipeline has no destination metadata \
+                         proving ownership. Remove the table or use another destination schema \
+                         before retrying."
+                    )
+                );
+            }
+
+            // Record ownership before creating remote state so a restart can
+            // find and remove a partial setup.
+            let metadata = DestinationTableMetadata::new_creating(
+                table_name.clone(),
+                snapshot_id,
+                replication_mask.clone(),
+            );
+            store.store_destination_table_metadata(table_id, metadata.clone()).await?;
+            Some(metadata)
+        }
+        Some(metadata) if metadata.is_applied() => {
+            // Another copy partition completed setup while this caller waited.
             ensure_destination_schema_matches_metadata(
                 "Snowflake",
                 table_id,
@@ -133,120 +152,57 @@ impl TableInitializer {
                 table_schema,
             )?;
             client
-                .prepare_existing_table(table_id, metadata.table_id(), &columns)
+                .prepare_table(&table, metadata.table_id(), &columns, false)
                 .await
                 .map_err(EtlError::from)?;
             return Ok(());
         }
-
-        // Hold the registry only long enough to obtain the stable gate for this
-        // table; unrelated tables must not wait on its remote setup.
-        let gate = {
-            let mut gates = self.gates.lock().await;
-            Arc::clone(gates.entry(table_id).or_insert_with(|| Arc::new(Semaphore::new(1))))
-        };
-
-        // The permit owns the complete Creating -> remote setup -> Applied
-        // transition for this table.
-        let _permit = gate.acquire_owned().await.map_err(|error| {
-            etl_error!(
-                ErrorKind::InvalidState,
-                "Snowflake table initialization gate is closed",
-                format!("Table {table_id}"),
-                source: error
-            )
-        })?;
-
-        // Re-read under the table gate because another copy partition may have
-        // completed setup after the fast-path read.
-        let snapshot_id = table_schema.inner().snapshot_id;
-        let replication_mask = table_schema.replication_mask().clone();
-        schema::validate_no_cdc_collisions(&columns).map_err(EtlError::from)?;
-        let creating_metadata = match store.get_destination_table_metadata(table_id).await? {
-            None => {
-                if client.table_exists(&table_name).await.map_err(EtlError::from)? {
-                    bail!(
-                        ErrorKind::DestinationTableAlreadyExists,
-                        "Snowflake destination table already exists",
-                        format!(
-                            "Table {table_name} exists, but this pipeline has no destination \
-                             metadata proving ownership. Remove the table or use another \
-                             destination schema before retrying."
-                        )
-                    );
-                }
-
-                // Record ownership before creating remote state so a restart can
-                // find and remove a partial setup.
-                let metadata = DestinationTableMetadata::new_creating(
-                    table_name.clone(),
-                    snapshot_id,
-                    replication_mask.clone(),
-                );
-                store.store_destination_table_metadata(table_id, metadata.clone()).await?;
-                Some(metadata)
-            }
-            Some(metadata) if metadata.is_applied() => {
-                // Another copy partition completed setup while this caller waited.
-                ensure_destination_schema_matches_metadata(
-                    "Snowflake",
-                    table_id,
-                    &metadata,
-                    table_schema,
-                )?;
-                client
-                    .prepare_existing_table(table_id, metadata.table_id(), &columns)
-                    .await
-                    .map_err(EtlError::from)?;
-                return Ok(());
-            }
-            Some(metadata) if metadata.is_creating() => {
-                // Resume a matching initial setup left by an earlier failure or
-                // cancellation.
-                ensure_destination_schema_matches_metadata(
-                    "Snowflake",
-                    table_id,
-                    &metadata,
-                    table_schema,
-                )?;
-                if metadata.table_id() != table_name {
-                    bail!(
-                        ErrorKind::CorruptedTableSchema,
-                        "Interrupted Snowflake table setup metadata does not match current table",
-                        format!(
-                            "Table {table_id} has interrupted initial setup metadata for '{}', \
-                             but the current setup resolves to '{table_name}'.",
-                            metadata.table_id()
-                        )
-                    );
-                }
-
-                Some(metadata)
-            }
-            Some(_) => {
-                // Applying metadata belongs to schema evolution, which requires
-                // its separate recovery path.
+        Some(metadata) if metadata.is_creating() => {
+            // Resume a matching initial setup left by an earlier failure or
+            // cancellation.
+            ensure_destination_schema_matches_metadata(
+                "Snowflake",
+                table_id,
+                &metadata,
+                table_schema,
+            )?;
+            if metadata.table_id() != table_name {
                 bail!(
-                    ErrorKind::InvalidState,
-                    "Snowflake table schema is still being applied",
+                    ErrorKind::CorruptedTableSchema,
+                    "Interrupted Snowflake table setup metadata does not match current table",
                     format!(
-                        "Table {table_id} has an interrupted schema change and cannot be prepared \
-                         for streaming until that change is recovered."
+                        "Table {table_id} has interrupted initial setup metadata for '{}', but \
+                         the current setup resolves to '{table_name}'.",
+                        metadata.table_id()
                     )
                 );
             }
-        };
 
-        // Remote setup is retry-safe and remains inside the per-table permit.
-        client.initialize_table(table_id, &table_name, &columns).await.map_err(EtlError::from)?;
-
-        // Publish completion only after both the table and channel exist.
-        if let Some(metadata) = creating_metadata {
-            store.store_destination_table_metadata(table_id, metadata.to_applied()).await?;
+            Some(metadata)
         }
+        Some(_) => {
+            // Applying metadata belongs to schema evolution, which requires
+            // its separate recovery path.
+            bail!(
+                ErrorKind::InvalidState,
+                "Snowflake table schema is still being applied",
+                format!(
+                    "Table {table_id} has an interrupted schema change and cannot be prepared for \
+                     streaming until that change is recovered."
+                )
+            );
+        }
+    };
 
-        Ok(())
+    // Remote setup is retry-safe and remains inside the per-table permit.
+    client.prepare_table(&table, &table_name, &columns, true).await.map_err(EtlError::from)?;
+
+    // Publish completion only after both the table and channel exist.
+    if let Some(metadata) = creating_metadata {
+        store.store_destination_table_metadata(table_id, metadata.to_applied()).await?;
     }
+
+    Ok(())
 }
 
 /// Execution context captured by Snowflake background event tasks.
@@ -265,17 +221,11 @@ struct DestinationWriter<S, T, C> {
     client: Client<T, C>,
     /// Destination metadata store.
     store: S,
-    /// Per-table initial-setup coordinator.
-    table_initializer: TableInitializer,
 }
 
 impl<S: Clone, T: TokenProvider, C: StreamClient> Clone for DestinationWriter<S, T, C> {
     fn clone(&self) -> Self {
-        Self {
-            client: self.client.clone(),
-            store: self.store.clone(),
-            table_initializer: self.table_initializer.clone(),
-        }
+        Self { client: self.client.clone(), store: self.store.clone() }
     }
 }
 
@@ -304,10 +254,7 @@ where
     /// Create a new destination.
     pub fn new(client: Client<T, C>, store: S) -> Self {
         register_metrics();
-        Self {
-            writer: DestinationWriter { client, store, table_initializer: TableInitializer::new() },
-            tasks: TaskSet::new(),
-        }
+        Self { writer: DestinationWriter { client, store }, tasks: TaskSet::new() }
     }
 
     /// Fetches the latest committed offset for this table's channel.
@@ -327,7 +274,7 @@ where
 {
     /// Initializes a Snowflake table and channel for initial-copy writes.
     async fn initialize_table(&self, table_schema: &ReplicatedTableSchema) -> EtlResult<()> {
-        self.table_initializer.initialize(&self.client, &self.store, table_schema).await
+        initialize_table(&self.client, &self.store, table_schema).await
     }
 
     /// Loads the durable applied schema and prepares its existing table for
@@ -872,7 +819,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{
+        sync::Arc,
+        task::{Context, Poll, Waker},
+    };
 
     use etl::{
         data::{Cell, PartialTableRow},
@@ -1022,6 +972,36 @@ mod tests {
 
         let applied_metadata = creating_metadata.to_applied();
         ensure_snowflake_metadata_applied(table_id, &applied_metadata).unwrap();
+    }
+
+    #[tokio::test]
+    async fn waiting_initialization_rechecks_metadata_without_relocking() {
+        let (destination, store) = test_destination();
+        let schema = replicated_schema();
+        let table = destination.writer.client.lock_table(schema.id()).await;
+        let mut initialization = Box::pin(destination.writer.initialize_table(&schema));
+        assert!(initialization.as_mut().poll(&mut Context::from_waker(Waker::noop())).is_pending());
+
+        // Another copy partition completes while this caller waits for the gate.
+        let metadata = DestinationTableMetadata::new_applied(
+            try_stringify_table_name(schema.name()).unwrap().to_uppercase(),
+            schema.inner().snapshot_id,
+            schema.replication_mask().clone(),
+        );
+        store.store_destination_table_metadata(schema.id(), metadata).await.unwrap();
+        drop(table);
+
+        // Reopening reaches the deliberately failing token provider without
+        // recursively acquiring the lifecycle gate or changing Applied metadata.
+        let Poll::Ready(result) =
+            initialization.as_mut().poll(&mut Context::from_waker(Waker::noop()))
+        else {
+            panic!("initialization should not reacquire its table gate");
+        };
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::DestinationError);
+        assert!(
+            store.get_destination_table_metadata(schema.id()).await.unwrap().unwrap().is_applied()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Replace global channel-registry locking during Snowflake table setup with stable per-table lifecycle gates. Unrelated tables can prepare channels and access cached channels while another table waits on remote setup.

Share the same gate across initialization and reset, preserving the `Creating -> Applied` metadata transition and retaining reset ownership through remote-drop completion.

Synthetic contention measurements against `70356c2`:

| Measurement | Before | After |
| --- | ---: | ---: |
| Eight concurrent setup attempts | 415.2 ms | 52.5 ms |
| Cached-channel lookup while setup is blocked | 51.7 ms | <0.1 ms |

These are medians from three local debug runs per version. Each setup attempt receives an injected 50 ms authentication delay and then intentionally fails before network I/O. The prefilled-cache control completed in under 1 ms in both versions.