### PR TITLE
fix(replication): settle deferred CDC durability on idle keepalives

### DIFF
--- a/crates/etl/src/destination/async_result.rs
+++ b/crates/etl/src/destination/async_result.rs
@@ -35,8 +35,9 @@ pub enum DestinationWriteStatus {
     /// [`DestinationWriteStatus::Durable`] result covers it. If no later write
     /// is dispatched before shutdown, ETL normally leaves progress at the last
     /// persisted checkpoint so restart can replay the accepted write. A
-    /// terminal table-sync catchup may instead issue an empty
-    /// [`WriteEventsDurability::RequireDurable`] write to settle this debt.
+    /// keepalive while idle or a terminal table-sync catchup may instead issue
+    /// an empty [`WriteEventsDurability::RequireDurable`] write to settle this
+    /// debt.
     ///
     /// For table-copy writes through
     /// [`crate::destination::Destination::write_table_rows`], ETL may request

--- a/crates/etl/src/destination/base.rs
+++ b/crates/etl/src/destination/base.rs
@@ -183,6 +183,12 @@ pub trait Destination {
     /// cumulative: it must mean that later write and all earlier `Accepted`
     /// writes in the same apply-loop stream are durable.
     ///
+    /// When a keepalive observes an accepted commit with no open transaction,
+    /// buffered events, or pending write result, ETL may issue an empty
+    /// required-durability write. It may buffer subsequent events while that
+    /// barrier is pending, but cannot dispatch them until the barrier
+    /// completes.
+    ///
     /// If no later streaming write is dispatched before shutdown, ETL normally
     /// exits without checkpointing accepted-but-not-durable work. Restart then
     /// replays from the last persisted checkpoint. A terminal table-sync

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -1001,15 +1001,23 @@ impl ApplyLoopState {
     /// PostgreSQL feedback keeps reporting the last flush LSN until a later
     /// durable write proves the carried LSN safe.
     ///
-    /// Ordinarily, if no later batch arrives, durability for the accepted
-    /// write is deferred until replay or the next batch. A terminal table-sync
-    /// catchup is the exception: once keepalive progress reaches its target,
-    /// ETL dispatches an empty required-durability write through the same
-    /// pending-result path.
+    /// When no later batch arrives, a keepalive can dispatch an empty
+    /// required-durability write through the same pending-result path. The
+    /// loop remains non-quiescent until that result confirms durability.
     fn is_quiescent(&self) -> bool {
         !self.handling_transaction()
             && !self.has_unresolved_batch_work()
             && self.last_commit_end_lsn.is_none()
+    }
+
+    /// Returns whether a keepalive may settle an accepted commit without
+    /// interrupting a transaction or competing with buffered destination work.
+    fn can_settle_idle_durability(&self) -> bool {
+        self.exit_intent.is_none()
+            && !self.is_draining_for_shutdown()
+            && !self.handling_transaction()
+            && !self.has_unresolved_batch_work()
+            && self.last_commit_end_lsn.is_some()
     }
 
     /// Returns the checkpoint LSN to report to PostgreSQL.
@@ -1473,6 +1481,7 @@ where
 
                 self.state
                     .reset_keep_alive_deadline(self.keep_alive_deadline_duration);
+                self.maybe_settle_idle_durability().await?;
             }
         }
 
@@ -2088,12 +2097,13 @@ where
         // flushed now that the previous in-flight result has resolved.
         if processing_paused {
             if let Some(metadata) = metadata.as_ref() {
-                // A required-durability write is terminal, so `Complete` must have
-                // stopped intake before a successor batch could be queued behind it.
-                debug_assert_ne!(
-                    metadata.durability,
-                    WriteEventsDurability::RequireDurable,
-                    "required-durability write must not have a queued successor batch"
+                // A nonempty required-durability write is terminal and stops
+                // intake. An empty idle barrier may have a successor buffered
+                // while it confirms only its captured commit end LSN.
+                debug_assert!(
+                    metadata.durability != WriteEventsDurability::RequireDurable
+                        || metadata.event_count == 0,
+                    "terminal event write must not have a queued successor batch"
                 );
             }
 
@@ -2228,13 +2238,37 @@ where
 
         let event_batch = self.state.event_batch.take();
 
-        self.dispatch_write_events(event_batch, reason).await
+        // A terminal batch must settle all accepted writes before completion.
+        let durability = match self.state.exit_intent {
+            Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
+            Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,
+        };
+        self.dispatch_write_events(event_batch, durability, reason).await
+    }
+
+    /// Settles an idle accepted commit while leaving normal intake enabled.
+    ///
+    /// The empty write captures the carried commit in its result metadata.
+    /// Later events may fill the next batch, but cannot be dispatched until
+    /// this result completes. Shutdown never starts a new idle barrier.
+    async fn maybe_settle_idle_durability(&mut self) -> EtlResult<()> {
+        if !self.state.can_settle_idle_durability() {
+            return Ok(());
+        }
+
+        self.dispatch_write_events(
+            EventBatch::default(),
+            WriteEventsDurability::RequireDurable,
+            "keepalive settling idle durability",
+        )
+        .await
     }
 
     /// Dispatches one streaming write through the shared async-result path.
     async fn dispatch_write_events(
         &mut self,
         event_batch: EventBatch,
+        durability: WriteEventsDurability,
         reason: &str,
     ) -> EtlResult<()> {
         debug_assert!(!self.state.has_pending_flush_result());
@@ -2247,13 +2281,7 @@ where
         } = event_batch;
         let event_count = events.len();
 
-        // `Complete` is terminal, so no later write is guaranteed to settle an
-        // `Accepted` result. Its final batch must confirm cumulative durability
-        // before the apply loop can complete.
-        let durability = match self.state.exit_intent {
-            Some(ExitIntent::Complete) => WriteEventsDurability::RequireDurable,
-            Some(ExitIntent::Pause) | None => WriteEventsDurability::MayDefer,
-        };
+        debug_assert!(event_count > 0 || durability == WriteEventsDurability::RequireDurable);
         debug!(
             worker_type = %self.worker_context.worker_type(),
             event_count,
@@ -2367,6 +2395,7 @@ where
                 .await?;
 
                 self.state.reset_keep_alive_deadline(self.keep_alive_deadline_duration);
+                self.maybe_settle_idle_durability().await?;
 
                 Ok(HandleMessageResult::no_event())
             }
@@ -3494,11 +3523,12 @@ where
             && self.state.last_commit_end_lsn.is_some()
             && self.table_sync_catchup_target_reached().await
         {
-            // Record completion before dispatch so intake stops and the empty write
-            // requires durability.
+            // Record completion before dispatch so intake stops until the
+            // terminal durability barrier settles.
             self.state.record_exit_intent(Some(ExitIntent::Complete));
             self.dispatch_write_events(
                 EventBatch::default(),
+                WriteEventsDurability::RequireDurable,
                 "table sync catchup reached without a terminal event batch",
             )
             .await?;
@@ -4776,5 +4806,50 @@ mod tests {
             pending,
             TableDecodingState::PendingRelation { previous_relation_masks: None, .. }
         ));
+    }
+
+    #[test]
+    fn idle_durability_requires_idle_accepted_work() {
+        let mut state = ApplyLoopState::new(
+            ReplicationProgress::new(100.into()),
+            ReplicationLagMetrics::new(100.into()),
+            Duration::from_secs(6),
+            SnapshotId::initial(),
+            "test_slot".to_owned(),
+        );
+
+        // Only accepted work at an idle boundary may start a durability barrier.
+        assert!(!state.can_settle_idle_durability());
+        state.update_last_commit_end_lsn(Some(200.into()));
+        assert!(state.can_settle_idle_durability());
+
+        state.remote_final_lsn = Some(300.into());
+        assert!(!state.can_settle_idle_durability());
+        state.remote_final_lsn = None;
+
+        state.event_batch.push(Event::Unsupported, StreamingPayloadMetadata::default());
+        assert!(!state.can_settle_idle_durability());
+        state.event_batch.take();
+
+        let (_result, pending) = WriteEventsResult::new(ApplyLoopAsyncResultMetadata {
+            commit_end_lsn: Some(200.into()),
+            durability: WriteEventsDurability::RequireDurable,
+            event_count: 0,
+            relation_table_ids: HashSet::new(),
+            streaming_payload_metadata: StreamingPayloadMetadata::default(),
+            dispatched_at: Instant::now(),
+        });
+        state.pending_flush_result = Some(pending);
+        assert!(!state.can_settle_idle_durability());
+        state.pending_flush_result = None;
+
+        for exit_intent in [ExitIntent::Pause, ExitIntent::Complete] {
+            state.exit_intent = Some(exit_intent);
+            assert!(!state.can_settle_idle_durability());
+        }
+        state.exit_intent = None;
+
+        state.start_draining_for_shutdown();
+        assert!(!state.can_settle_idle_durability());
     }
 }

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -743,6 +743,11 @@ struct EventBatch {
 }
 
 impl EventBatch {
+    /// Creates an empty event batch.
+    fn empty() -> Self {
+        Self::default()
+    }
+
     /// Creates an empty event batch with the specified event capacity.
     fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -2257,7 +2262,7 @@ where
         }
 
         self.dispatch_write_events(
-            EventBatch::default(),
+            EventBatch::empty(),
             WriteEventsDurability::RequireDurable,
             "keepalive settling idle durability",
         )
@@ -3527,7 +3532,7 @@ where
             // terminal durability barrier settles.
             self.state.record_exit_intent(Some(ExitIntent::Complete));
             self.dispatch_write_events(
-                EventBatch::default(),
+                EventBatch::empty(),
                 WriteEventsDurability::RequireDurable,
                 "table sync catchup reached without a terminal event batch",
             )

--- a/crates/etl/tests/pipeline_with_failpoints.rs
+++ b/crates/etl/tests/pipeline_with_failpoints.rs
@@ -15,8 +15,8 @@ use etl::{
         START_TABLE_SYNC_BEFORE_DATA_SYNC_SLOT_CREATION_FP, START_TABLE_SYNC_DURING_DATA_SYNC_FP,
         STORE_REPLICATION_CHECKPOINT_FP, TABLE_SYNC_WORKER_BEFORE_STREAMING_FP,
     },
-    pipeline::PipelineId,
-    schema::{ReplicatedTableSchema, SnapshotId, TableId, TableSchema},
+    pipeline::{Pipeline, PipelineId},
+    schema::{ReplicatedTableSchema, SnapshotId, TableId, TableName, TableSchema},
     store::{StateStore, TableRetryPolicy, TableState, TableStateType, WorkerType},
     test_utils::{
         database::{
@@ -41,6 +41,7 @@ use etl::{
         },
     },
 };
+use etl_config::shared::TableSyncCopyConfig;
 use etl_postgres::{
     application_name::{apply_worker_application_name, table_sync_worker_application_name},
     below_version,
@@ -60,19 +61,19 @@ use tokio_postgres::{
 
 /// Relevant streaming write observed by [`DeferredEventsDestination`].
 enum DeferredEventsWrite {
-    /// Target-table event batch accepted at this commit end LSN.
-    Accepted { commit_end_lsn: PgLsn },
+    /// Target-table event batch held before reporting its write status.
+    Batch { commit_end_lsn: PgLsn, result: WriteEventsResult },
     /// Empty required-durability write whose result remains held by the test.
     DurabilityBarrier { result: WriteEventsResult },
 }
 
-/// Destination test double that accepts one table event batch and holds its
-/// barrier.
+/// Destination test double that exposes target-table writes and empty barriers
+/// so tests control their completion.
 #[derive(Clone)]
 struct DeferredEventsDestination {
-    /// Table whose next insert batch should be accepted.
+    /// Table whose insert batches should be held.
     table_id: TableId,
-    /// Channel used to expose the accepted batch and empty barrier to the test.
+    /// Channel used to expose event batches and empty barriers to the test.
     writes_tx: mpsc::UnboundedSender<DeferredEventsWrite>,
 }
 
@@ -136,14 +137,11 @@ impl Destination for DeferredEventsDestination {
                 })
                 .expect("accepted event batch should contain its commit");
 
-            // Expose A before resolving its result so the test observes protocol order.
             assert!(
-                self.writes_tx.send(DeferredEventsWrite::Accepted { commit_end_lsn }).is_ok(),
-                "streaming write observer should remain available"
+                self.writes_tx
+                    .send(DeferredEventsWrite::Batch { commit_end_lsn, result: async_result })
+                    .is_ok()
             );
-
-            // Accepted transfers ownership without proving durability, so ETL must carry A.
-            async_result.send(Ok(DestinationWriteStatus::Accepted));
 
             return Ok(());
         }
@@ -1043,10 +1041,12 @@ async fn table_sync_quiescent_handover_does_not_persist_received_progress() {
     // exists at the later catchup target T to settle A's durability debt.
     let (accepted_commit_end_lsn, barrier_result) =
         tokio::time::timeout(Duration::from_secs(30), async {
-            let Some(DeferredEventsWrite::Accepted { commit_end_lsn }) = writes_rx.recv().await
+            let Some(DeferredEventsWrite::Batch { commit_end_lsn, result }) =
+                writes_rx.recv().await
             else {
                 panic!("expected accepted target-table event batch");
             };
+            result.send(Ok(DestinationWriteStatus::Accepted));
             let Some(DeferredEventsWrite::DurabilityBarrier { result }) = writes_rx.recv().await
             else {
                 panic!("expected empty required-durability barrier");
@@ -2296,4 +2296,220 @@ async fn worker_connections_are_tagged_with_per_worker_application_names() {
     sync_complete_notify.notified().await;
 
     pipeline.shutdown_and_wait().await.unwrap();
+}
+
+/// Running apply-worker pipeline with externally controlled destination
+/// results.
+struct IdleDurabilityTest {
+    /// Isolated source database.
+    database: PgDatabase<Client>,
+    /// Published table receiving the test transactions.
+    table_name: TableName,
+    /// Pipeline whose initial copy was skipped to isolate apply-worker
+    /// behavior.
+    pipeline: Pipeline<NotifyingStore, DeferredEventsDestination>,
+    /// Store exposing the persisted apply checkpoint.
+    store: NotifyingStore,
+    /// Main replication slot name.
+    slot_name: String,
+    /// Ordered destination calls awaiting test-controlled results.
+    writes_rx: mpsc::UnboundedReceiver<DeferredEventsWrite>,
+}
+
+impl IdleDurabilityTest {
+    /// Starts an empty streaming table with controlled destination results.
+    async fn start() -> Self {
+        init_test_tracing();
+        let database = spawn_source_database().await;
+        let table_name = test_table_name("idle_durability");
+        let table_id = database
+            .create_table(table_name.clone(), true, &[("value", "int4 not null")])
+            .await
+            .unwrap();
+        let publication_name = "idle_durability_publication";
+        database
+            .create_publication(publication_name, std::slice::from_ref(&table_name))
+            .await
+            .unwrap();
+        let store = NotifyingStore::new();
+        let (destination, writes_rx) = DeferredEventsDestination::new(table_id);
+        let pipeline_id: PipelineId = random();
+        let slot_name = EtlReplicationSlot::for_apply_worker(pipeline_id).try_into().unwrap();
+        let mut pipeline = PipelineBuilder::new(
+            database.config.clone(),
+            pipeline_id,
+            publication_name.to_owned(),
+            store.clone(),
+            destination,
+        )
+        .with_table_sync_copy_config(TableSyncCopyConfig::SkipAllTables)
+        .build();
+        let synced = store.notify_on_table_sync_complete(table_id).await;
+        pipeline.start().await.unwrap();
+        synced.notified().await;
+        Self { database, table_name, pipeline, store, slot_name, writes_rx }
+    }
+
+    /// Inserts one row without producing any schema changes.
+    async fn insert(&self, value: i32) {
+        self.database.insert_values(self.table_name.clone(), &["value"], &[&value]).await.unwrap();
+    }
+
+    /// Receives the next event batch, failing if an unexpected barrier
+    /// overtakes it.
+    async fn next_batch(&mut self) -> (PgLsn, WriteEventsResult) {
+        let write = tokio::time::timeout(Duration::from_secs(50), self.writes_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let DeferredEventsWrite::Batch { commit_end_lsn, result } = write else {
+            panic!("expected an event batch");
+        };
+        (commit_end_lsn, result)
+    }
+
+    /// Receives an empty barrier, including the 36-second periodic fallback.
+    async fn next_barrier(&mut self) -> WriteEventsResult {
+        let write = tokio::time::timeout(Duration::from_secs(50), self.writes_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let DeferredEventsWrite::DurabilityBarrier { result } = write else {
+            panic!("expected an idle durability barrier");
+        };
+        result
+    }
+
+    /// Reads the source slot's acknowledged durable position.
+    async fn confirmed_lsn(&self) -> PgLsn {
+        replication_slot_state(self.database.client.as_ref().unwrap(), &self.slot_name).await.0
+    }
+
+    /// Waits for feedback covering durable destination work.
+    async fn wait_for_flush(&self, lsn: PgLsn) {
+        wait_for_replication_slot_flush_lsn(
+            self.database.client.as_ref().unwrap(),
+            &self.slot_name,
+            lsn,
+        )
+        .await;
+    }
+}
+
+/// A single accepted batch settles without another source write.
+#[tokio::test(flavor = "multi_thread")]
+async fn idle_durability_settles_on_primary_keepalive() {
+    let mut test = IdleDurabilityTest::start().await;
+    test.insert(1).await;
+    let (commit_lsn, result) = test.next_batch().await;
+    let checkpoint = test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap();
+    result.send(Ok(DestinationWriteStatus::Accepted));
+    let barrier = test.next_barrier().await;
+    assert_eq!(test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap(), checkpoint);
+    assert!(test.confirmed_lsn().await < commit_lsn);
+
+    barrier.send(Ok(DestinationWriteStatus::Durable));
+    test.wait_for_flush(commit_lsn).await;
+    test.pipeline.shutdown_and_wait().await.unwrap();
+    assert_eq!(
+        test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap(),
+        Some(commit_lsn)
+    );
+    assert!(test.writes_rx.try_recv().is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idle_durability_buffers_resumed_traffic_without_acknowledging_it() {
+    let mut test = IdleDurabilityTest::start().await;
+    test.insert(1).await;
+    let (first_lsn, result) = test.next_batch().await;
+    result.send(Ok(DestinationWriteStatus::Accepted));
+    let barrier = test.next_barrier().await;
+
+    let received_target = test.database.current_wal_flush_lsn().await.unwrap();
+    test.insert(2).await;
+    // Feedback proves the new transaction was decoded while the barrier was
+    // held. Waiting beyond the batch deadline also exercises queued flushing.
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let row = test
+                .database
+                .client
+                .as_ref()
+                .unwrap()
+                .query_one(
+                    "select r.write_lsn from pg_stat_replication r join pg_replication_slots s on \
+                     s.active_pid = r.pid where s.slot_name = $1",
+                    &[&test.slot_name],
+                )
+                .await
+                .unwrap();
+            if row.get::<_, Option<PgLsn>>(0).is_some_and(|lsn| lsn > received_target) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap();
+    assert!(tokio::time::timeout(Duration::from_secs(2), test.writes_rx.recv()).await.is_err());
+    assert!(test.confirmed_lsn().await < first_lsn);
+
+    barrier.send(Ok(DestinationWriteStatus::Durable));
+    let (second_lsn, second_result) = test.next_batch().await;
+    assert!(second_lsn > first_lsn);
+    test.wait_for_flush(first_lsn).await;
+    assert_eq!(test.confirmed_lsn().await, first_lsn);
+    assert_eq!(
+        test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap(),
+        Some(first_lsn)
+    );
+
+    second_result.send(Ok(DestinationWriteStatus::Durable));
+    test.wait_for_flush(second_lsn).await;
+    test.pipeline.shutdown_and_wait().await.unwrap();
+    assert_eq!(
+        test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap(),
+        Some(second_lsn)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idle_durability_failure_replays_the_unconfirmed_commit() {
+    let mut test = IdleDurabilityTest::start().await;
+    test.insert(1).await;
+    let (commit_lsn, result) = test.next_batch().await;
+    let checkpoint = test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap();
+    result.send(Ok(DestinationWriteStatus::Accepted));
+    let barrier = test.next_barrier().await;
+    barrier.send(Err(etl::etl_error!(ErrorKind::WithTimedRetry, "Test durability failure")));
+
+    let (replayed_lsn, replayed_result) = test.next_batch().await;
+    assert_eq!(replayed_lsn, commit_lsn);
+    assert_eq!(test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap(), checkpoint);
+    assert!(test.confirmed_lsn().await < commit_lsn);
+    replayed_result.send(Ok(DestinationWriteStatus::Durable));
+    test.wait_for_flush(commit_lsn).await;
+    test.pipeline.shutdown_and_wait().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn idle_durability_shutdown_drains_the_existing_barrier() {
+    let mut test = IdleDurabilityTest::start().await;
+    test.insert(1).await;
+    let (commit_lsn, result) = test.next_batch().await;
+    result.send(Ok(DestinationWriteStatus::Accepted));
+    let barrier = test.next_barrier().await;
+
+    test.pipeline.shutdown();
+    let shutdown = test.pipeline.wait();
+    tokio::pin!(shutdown);
+    assert!(tokio::time::timeout(Duration::from_millis(100), &mut shutdown).await.is_err());
+    barrier.send(Ok(DestinationWriteStatus::Durable));
+    tokio::time::timeout(Duration::from_secs(30), shutdown).await.unwrap().unwrap();
+    assert_eq!(
+        test.store.get_replication_checkpoint(WorkerType::Apply).await.unwrap(),
+        Some(commit_lsn)
+    );
+    assert!(test.writes_rx.try_recv().is_err());
 }


### PR DESCRIPTION
### TLDR;

An idle stream can leave the checkpoint pinned after Snowflake commits the last accepted CDC batch.

This PR uses existing keepalives to issue an empty `RequireDurable` write when the loop is idle with outstanding accepted work. It reuses the pending-result slot so resumed traffic can buffer behind the barrier, while checkpoint advancement remains limited to its captured commit LSN.

### Details

Snowflake can accept a CDC batch before confirming that it is durably committed. ETL consumes that write's `Accepted` result and carries its commit position forward, waiting for a later write to confirm cumulative durability. If source traffic stops, the checkpoint can remain pinned even after Snowflake commits the data, unnecessarily retaining PostgreSQL WAL.

Use incoming PostgreSQL keepalives and the existing periodic keepalive fallback to request durability confirmation when the apply loop has an outstanding accepted commit, no open transaction, no buffered events, and no pending write result. The request is an empty `RequireDurable` write, which Snowflake already supports by polling the status of previously accepted writes.

Settlement reuses the existing asynchronous result slot and batch buffer. If traffic resumes while confirmation is pending, ETL can buffer the next batch but waits for settlement before dispatching it. The barrier captures the earlier commit position, so its completion cannot acknowledge the newly buffered work.

Failures preserve the durable checkpoint for replay. Shutdown drains a barrier that has already started without initiating another idle settlement. The change introduces no new queue, timer, configuration, or destination API.