### PR TITLE
fix: bound DDL metric label cardinality

### DIFF
--- a/crates/etl/src/observability.rs
+++ b/crates/etl/src/observability.rs
@@ -86,6 +86,19 @@ pub(crate) const CONFIRMATION_LABEL: &str = "confirmation";
 /// Label key for the destination write status ("accepted" or "durable").
 pub(crate) const WRITE_STATUS_LABEL: &str = "status";
 
+/// Returns a bounded DDL command tag for metrics and logging.
+///
+/// Source triggers emit `ALTER TABLE` and `ALTER PUBLICATION`. Logical messages
+/// can also be emitted directly, so all other tags map to `unknown`.
+/// Keep this classification separate from the raw tag used by replication.
+pub(crate) fn ddl_command_tag_label(command_tag: &str) -> &'static str {
+    match command_tag {
+        "ALTER TABLE" => "ALTER TABLE",
+        "ALTER PUBLICATION" => "ALTER PUBLICATION",
+        _ => "unknown",
+    }
+}
+
 /// Register metrics emitted by etl. This should be called before starting a
 /// pipeline. It is safe to call this method multiple times. It is guaranteed to
 /// register the metrics only once.
@@ -371,4 +384,29 @@ pub(crate) fn register_metrics() {
             "Difference between the source Postgres current WAL position and ETL's checkpoint LSN."
         );
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::observability::ddl_command_tag_label;
+
+    /// Preserves supported labels and bounds unexpected tag values.
+    #[test]
+    fn ddl_command_tag_labels_are_bounded() {
+        assert_eq!(ddl_command_tag_label("ALTER TABLE"), "ALTER TABLE");
+        assert_eq!(ddl_command_tag_label("ALTER PUBLICATION"), "ALTER PUBLICATION");
+
+        for command_tag in [
+            "",
+            "alter table",
+            "ALTER TABLE ",
+            "ALTER PUBLICATION extra",
+            "CREATE TABLE",
+            "ALTER TABLE\0",
+            "変更",
+            &"x".repeat(4096),
+        ] {
+            assert_eq!(ddl_command_tag_label(command_tag), "unknown");
+        }
+    }
 }

--- a/crates/etl/src/replication/apply.rs
+++ b/crates/etl/src/replication/apply.rs
@@ -58,7 +58,7 @@ use crate::{
         ETL_EVENTS_RECEIVED_TOTAL, ETL_REPLICATION_MESSAGES_TOTAL, ETL_SCHEMA_CLEANUP_ERRORS_TOTAL,
         ETL_SCHEMA_CLEANUP_PRUNED_VERSIONS_TOTAL, ETL_SCHEMA_CLEANUP_TABLES_TOTAL,
         ETL_SCHEMA_CLEANUPS_TOTAL, ETL_TRANSACTION_SIZE, ETL_TRANSACTIONS_TOTAL, OUTCOME_LABEL,
-        REPLICATION_PATH_LABEL, WORKER_TYPE_LABEL, WRITE_STATUS_LABEL,
+        REPLICATION_PATH_LABEL, WORKER_TYPE_LABEL, WRITE_STATUS_LABEL, ddl_command_tag_label,
     },
     pipeline::PipelineId,
     postgres::{
@@ -2529,7 +2529,7 @@ where
         };
 
         let table_id = schema_change_message.table_id();
-        let command_tag = schema_change_message.command_tag.clone();
+        let command_tag = ddl_command_tag_label(&schema_change_message.command_tag);
         let column_count = schema_change_message.columns.len();
 
         if !schema_change_message.applies_to_publication(&self.config.publication_name) {
@@ -2588,7 +2588,7 @@ where
             counter!(
                 ETL_DDL_SCHEMA_CHANGES_TOTAL,
                 WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-                COMMAND_TAG_LABEL => command_tag.clone(),
+                COMMAND_TAG_LABEL => command_tag,
                 OUTCOME_LABEL => "failed_store",
             )
             .increment(1);
@@ -2599,7 +2599,7 @@ where
         counter!(
             ETL_DDL_SCHEMA_CHANGES_TOTAL,
             WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-            COMMAND_TAG_LABEL => command_tag.clone(),
+            COMMAND_TAG_LABEL => command_tag,
             OUTCOME_LABEL => "applied",
         )
         .increment(1);
@@ -2607,7 +2607,7 @@ where
         histogram!(
             ETL_DDL_SCHEMA_CHANGE_COLUMNS,
             WORKER_TYPE_LABEL => self.worker_context.worker_type().as_str(),
-            COMMAND_TAG_LABEL => command_tag.clone(),
+            COMMAND_TAG_LABEL => command_tag,
         )
         .record(column_count as f64);
 

--- a/crates/etl/tests/pipeline_with_schema_changes.rs
+++ b/crates/etl/tests/pipeline_with_schema_changes.rs
@@ -21,7 +21,8 @@ use etl::{
     },
 };
 use etl_postgres::tokio::test_utils::TableModification;
-use etl_telemetry::tracing::init_test_tracing;
+use etl_telemetry::{metrics::init_metrics_handle, tracing::init_test_tracing};
+use pg_escape::quote_identifier;
 use rand::random;
 use tokio_postgres::types::Type;
 
@@ -1182,4 +1183,171 @@ async fn partitioned_table_schema_change_updates_relation_message() {
         ],
     );
     assert_eq!(snapshots[0].0, r.replicated_table_schema.inner().snapshot_id);
+}
+
+/// Verifies bounded DDL metric labels without changing schema application or
+/// publication filtering, using real trigger output and crafted logical
+/// messages.
+#[tokio::test(flavor = "multi_thread")]
+async fn ddl_metric_labels_preserve_supported_tags_and_bound_unknown_tags() {
+    /// Counter for DDL handling outcomes.
+    const DDL_COUNTER: &str = "etl_ddl_schema_changes_total";
+    /// Exported observation count for the DDL column histogram.
+    const DDL_COLUMN_COUNT: &str = "etl_ddl_schema_change_columns_count";
+
+    init_test_tracing();
+    let metrics_handle = init_metrics_handle().unwrap();
+    let (mut database, table_name, table_id, store, destination, pipeline, _, publication_name) =
+        create_database_and_sync_done_pipeline_with_table(
+            "ddl_metric_labels",
+            &[("value", "integer not null")],
+        )
+        .await;
+    let ready = store.notify_on_table_state_type(table_id, TableStateType::Ready).await;
+
+    // A new supported trigger tag must also be added to the metric mapping.
+    let mut trigger_tags: Vec<String> = database
+        .client
+        .as_ref()
+        .unwrap()
+        .query_one(
+            "select evttags from pg_catalog.pg_event_trigger
+             where evtname = 'supabase_etl_ddl_message_trigger'",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    trigger_tags.sort();
+    assert_eq!(trigger_tags, ["ALTER PUBLICATION", "ALTER TABLE"]);
+
+    // Exercise both tags through the installed trigger with unchanged columns.
+    database
+        .run_sql(&format!(
+            "alter table {} alter column value set default 7",
+            table_name.as_quoted_identifier()
+        ))
+        .await
+        .unwrap();
+    database
+        .run_sql(&format!(
+            "alter publication {} set (publish = 'insert')",
+            quote_identifier(&publication_name)
+        ))
+        .await
+        .unwrap();
+
+    let client = database.client.as_mut().unwrap();
+    let mut payload: serde_json::Value = client
+        .query_one(
+            "select pg_catalog.jsonb_build_object(
+                'nspname', n.nspname,
+                'relname', c.relname,
+                'oid', c.oid::bigint,
+                'identity', etl.describe_table_identity(c.oid),
+                'columns', (
+                    select pg_catalog.jsonb_agg(
+                        pg_catalog.jsonb_build_object(
+                            'attname', s.attname,
+                            'attnum', s.attnum,
+                            'atttypid', s.atttypid::bigint,
+                            'atttypmod', s.atttypmod,
+                            'attnotnull', s.attnotnull,
+                            'default_expression', s.default_expression
+                        ) order by s.attnum
+                    )
+                    from etl.describe_table_schema(c.oid) s
+                )
+             )
+             from pg_catalog.pg_class c
+             join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+             where c.oid = $1",
+            &[&table_id.into_inner()],
+        )
+        .await
+        .unwrap()
+        .get(0);
+
+    let unexpected_tags = ["unexpected_a".to_owned(), "unexpected_b".to_owned(), "x".repeat(4096)];
+    let transaction = client.transaction().await.unwrap();
+    for command_tag in &unexpected_tags {
+        payload["command_tag"] = command_tag.clone().into();
+        // Unknown tags retain existing behavior for tracked and untracked tables.
+        for oid in [table_id.into_inner(), 0] {
+            payload["oid"] = oid.into();
+            transaction
+                .query_one(
+                    "select pg_catalog.pg_logical_emit_message(true, 'supabase_etl_ddl', $1::text)",
+                    &[&payload.to_string()],
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    payload["oid"] = table_id.into_inner().into();
+    payload["command_tag"] = "ALTER PUBLICATION".into();
+    payload["publication_name"] = "other_publication".into();
+    // An invalid schema would break the following row if publication filtering
+    // were accidentally bypassed while normalizing labels.
+    payload["columns"] = serde_json::json!([]);
+    transaction
+        .query_one(
+            "select pg_catalog.pg_logical_emit_message(true, 'supabase_etl_ddl', $1::text)",
+            &[&payload.to_string()],
+        )
+        .await
+        .unwrap();
+    transaction.commit().await.unwrap();
+
+    // A subsequent row proves that all preceding messages have been handled.
+    let inserted = destination
+        .wait_for_events(vec![EventCondition::TableCount(EventType::Insert, table_id, 1)])
+        .await;
+    database.insert_values(table_name, &["value"], &[&7_i32]).await.unwrap();
+    inserted.notified().await;
+    ready.notified().await;
+    pipeline.shutdown_and_wait().await.unwrap();
+
+    let events = destination.get_events().await;
+    let Event::Insert(insert) = get_last_insert_event(&events, table_id) else {
+        panic!("expected insert event");
+    };
+    assert_eq!(insert.table_row.values(), &[Cell::I64(1), Cell::I32(7)]);
+
+    let metrics = metrics_handle.render();
+    let samples: Vec<_> = metrics
+        .lines()
+        .filter(|line| {
+            (line.starts_with(&format!("{DDL_COUNTER}{{"))
+                || line.starts_with(&format!("{DDL_COLUMN_COUNT}{{")))
+                && line.contains("worker_type=\"apply\"")
+        })
+        .collect();
+    let unknown_count = u64::try_from(unexpected_tags.len()).unwrap();
+    let expected = [
+        (DDL_COUNTER, "ALTER TABLE", Some("applied"), 1),
+        (DDL_COUNTER, "ALTER PUBLICATION", Some("applied"), 1),
+        (DDL_COUNTER, "ALTER PUBLICATION", Some("skipped_publication"), 1),
+        (DDL_COUNTER, "unknown", Some("applied"), unknown_count),
+        (DDL_COUNTER, "unknown", Some("skipped"), unknown_count),
+        (DDL_COLUMN_COUNT, "ALTER TABLE", None, 1),
+        (DDL_COLUMN_COUNT, "ALTER PUBLICATION", None, 1),
+        (DDL_COLUMN_COUNT, "unknown", None, unknown_count),
+    ];
+    assert_eq!(samples.len(), expected.len());
+    for (metric, command_tag, outcome, count) in expected {
+        let matching: Vec<_> = samples
+            .iter()
+            .filter(|line| {
+                line.starts_with(&format!("{metric}{{"))
+                    && line.contains(&format!("command_tag=\"{command_tag}\""))
+                    && outcome
+                        .is_none_or(|outcome| line.contains(&format!("outcome=\"{outcome}\"")))
+            })
+            .collect();
+        assert_eq!(matching.len(), 1);
+        let value: u64 = matching[0].rsplit_once(' ').unwrap().1.parse().unwrap();
+        assert_eq!(value, count);
+    }
 }


### PR DESCRIPTION
Normalize DDL command tags to `ALTER TABLE`, `ALTER PUBLICATION`, or `unknown` for metrics and logs. 

Replication behavior remains unchanged.
