### PR TITLE
chore(nix): update flake for improved dependencies and build configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,13 +4,3 @@
 [alias]
 xtask = "run --target-dir target/xtask --package xtask --"
 x = "run --quiet --target-dir target/xtask --package xtask --"
-
-# Use lld linker for faster linking (1.5-2x faster than default ld)
-# lld is part of the LLVM toolchain and widely available
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
-
-[target.aarch64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/flake.lock
+++ b/flake.lock
@@ -20,32 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -59,14 +43,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1775013181,
-        "narHash": "sha256-zPrt6oNM1r/RO5bWYaZ3hthfG9vzkr6kQdoqDd5x4Qw=",
+        "lastModified": 1789024335,
+        "narHash": "sha256-kCy/MVLRIr95DJ4vspVzWj+kO/x+JuwSHmYZCvShg8w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e8046c1d9ccadd497c2344d8fa49dab62f22f7be",
+        "rev": "577bb1e1fc5af0713169176c5c76622c21fa3ec0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -18,6 +21,11 @@
             extensions = [ "rust-src" "rust-analyzer" ];
           };
 
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+
         buildDeps = with pkgs; [
           cmake
           openssl
@@ -25,23 +33,84 @@
           protobuf
         ];
 
+        # Nix enables `_FORTIFY_SOURCE` by default; jemalloc's configure runs
+        # detection tests at `-O0`, which turns that into a hard error and
+        # mis-detects `strerror_r` (tikv-jemalloc-sys).
+        jemallocHardening = {
+          hardeningDisable = [ "fortify" ];
+        };
+
         devTools = with pkgs; [
-          cargo-deny
-          cargo-edit
-          cargo-llvm-cov
+          cargo-nextest
           cargo-sort
-          cargo-udeps
-          git-cliff
+          postgresql
           python3
         ];
 
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            let
+              base = baseNameOf path;
+            in
+            pkgs.lib.cleanSourceFilter path type
+            && base != "target"
+            && base != "site"
+            && base != "node_modules";
+        };
+
+        etl-replicator = rustPlatform.buildRustPackage (jemallocHardening // {
+          pname = "etl-replicator";
+          version = "0.1.0";
+          inherit src;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "gcp-bigquery-client-0.28.0" = "sha256-nAkVZrzVFEm7MZdSJJZ/FEbFX7gclmFfMdzerOzoSOY=";
+              "postgres-protocol-0.6.12" = "sha256-4NdccoaaQ4KQAMTLAxoiv6cg2hrKzYy5Nu8nBPOGvqo=";
+              "postgres-replication-0.6.7" = "sha256-4NdccoaaQ4KQAMTLAxoiv6cg2hrKzYy5Nu8nBPOGvqo=";
+              "postgres-types-0.2.14" = "sha256-4NdccoaaQ4KQAMTLAxoiv6cg2hrKzYy5Nu8nBPOGvqo=";
+              "tokio-postgres-0.7.18" = "sha256-4NdccoaaQ4KQAMTLAxoiv6cg2hrKzYy5Nu8nBPOGvqo=";
+            };
+          };
+
+          buildAndTestSubdir = "crates/etl-replicator";
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            pkg-config
+            protobuf
+            python3
+          ];
+          buildInputs = with pkgs; [ openssl ];
+
+          # Integration tests need a live Postgres cluster.
+          doCheck = false;
+
+          meta = {
+            description = "Standalone binary for Supabase ETL Postgres replication pipelines.";
+            mainProgram = "etl-replicator";
+          };
+        });
+
       in {
-        devShells.default = pkgs.mkShell {
+        packages = {
+          default = etl-replicator;
+          inherit etl-replicator;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${etl-replicator}/bin/etl-replicator";
+        };
+
+        devShells.default = pkgs.mkShell (jemallocHardening // {
           packages = [ rustToolchain ] ++ buildDeps ++ devTools;
 
           shellHook = ''
             export RUST_SRC_PATH=${rustToolchain}/lib/rustlib/src/rust/library
           '';
-        };
+        });
       });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Update `flake.lock` (nixpkgs, rust-overlay) and make rust-overlay follow nixpkgs
- Add a Nix `etl-replicator` package (default `nix build` / `nix run` target)
- Drop the Linux `clang`/`lld` workaround from `.cargo/config.toml` (repo-wide)

## What is the current behavior?

`nix develop` fails: `flake.lock` is too old for rust-overlay to provide rustc 1.95.0.

## What is the new behavior?

- `nix develop` enters a working shell; `cargo build` succeeds inside it
- `nix build` / `nix run` build and run `etl-replicator`
- `nix profile install github:supabase/etl#etl-replicator` installs the binary

## Additional context

- x86_64 Linux still uses LLD: rustc’s bundled `rust-lld` since 1.90.0, so the old `clang` + system `lld` flags are redundant ([Rust blog](https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/)). aarch64 Linux now uses rustc’s default system linker
- Dev shell and the package disable Nix `fortify` hardening so `tikv-jemalloc-sys` configure tests succeed
- `nix build` skips tests (`doCheck = false`); they need Postgres
- Refresh `cargoLock.outputHashes` if git dependency revs change
- Dev shell now has `cargo-nextest` and `postgresql`; CI/release-only cargo tools were removed